### PR TITLE
[#19] add-compiler-plugin-support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Gradle
 .gradle/
-build/
+/build/
 !gradle/wrapper/gradle-wrapper.jar
 
 # IDE

--- a/src/nativeMain/kotlin/keel/build/Builder.kt
+++ b/src/nativeMain/kotlin/keel/build/Builder.kt
@@ -11,7 +11,11 @@ data class BuildCommand(
     val outputPath: String
 )
 
-fun checkCommand(config: KeelConfig, classpath: String? = null): List<String> = buildList {
+fun checkCommand(
+    config: KeelConfig,
+    classpath: String? = null,
+    pluginArgs: List<String> = emptyList()
+): List<String> = buildList {
     add("kotlinc")
     if (!classpath.isNullOrEmpty()) {
         add("-cp")
@@ -20,9 +24,14 @@ fun checkCommand(config: KeelConfig, classpath: String? = null): List<String> = 
     addAll(config.sources)
     add("-jvm-target")
     add(config.jvmTarget)
+    addAll(pluginArgs)
 }
 
-fun buildCommand(config: KeelConfig, classpath: String? = null): BuildCommand {
+fun buildCommand(
+    config: KeelConfig,
+    classpath: String? = null,
+    pluginArgs: List<String> = emptyList()
+): BuildCommand {
     val outputPath = jarPath(config)
     val args = buildList {
         add("kotlinc")
@@ -33,6 +42,7 @@ fun buildCommand(config: KeelConfig, classpath: String? = null): BuildCommand {
         addAll(config.sources)
         add("-jvm-target")
         add(config.jvmTarget)
+        addAll(pluginArgs)
         add("-include-runtime")
         add("-d")
         add(outputPath)

--- a/src/nativeMain/kotlin/keel/build/CompilerPlugin.kt
+++ b/src/nativeMain/kotlin/keel/build/CompilerPlugin.kt
@@ -1,0 +1,30 @@
+package keel.build
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+
+data class UnknownPlugin(val name: String)
+
+private val PLUGIN_JAR_NAMES = mapOf(
+    "serialization" to "kotlinx-serialization-compiler-plugin.jar",
+    "allopen" to "allopen-compiler-plugin.jar",
+    "noarg" to "noarg-compiler-plugin.jar"
+)
+
+fun pluginArgs(
+    plugins: Map<String, Boolean>,
+    kotlinHome: String
+): Result<List<String>, UnknownPlugin> {
+    val args = mutableListOf<String>()
+    for ((name, enabled) in plugins) {
+        if (!enabled) continue
+        val jarName = PLUGIN_JAR_NAMES[name] ?: return Err(UnknownPlugin(name))
+        args.add("-Xplugin=$kotlinHome/lib/$jarName")
+    }
+    return Ok(args)
+}
+
+fun parseKotlinHome(kotlincPath: String): String {
+    return kotlincPath.removeSuffix("/bin/kotlinc")
+}

--- a/src/nativeMain/kotlin/keel/build/TestBuilder.kt
+++ b/src/nativeMain/kotlin/keel/build/TestBuilder.kt
@@ -12,7 +12,8 @@ fun testJarPath(config: KeelConfig): String = "$BUILD_DIR/${config.name}-test.ja
 fun testBuildCommand(
     config: KeelConfig,
     mainJarPath: String,
-    classpath: String? = null
+    classpath: String? = null,
+    pluginArgs: List<String> = emptyList()
 ): TestBuildCommand {
     val outputPath = testJarPath(config)
     val cp = buildList {
@@ -26,6 +27,7 @@ fun testBuildCommand(
         addAll(config.testSources)
         add("-jvm-target")
         add(config.jvmTarget)
+        addAll(pluginArgs)
         add("-d")
         add(outputPath)
     }

--- a/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
@@ -14,7 +14,7 @@ internal const val LOCK_FILE = "keel.lock"
 private const val WORKSPACE_JSON = "workspace.json"
 private const val KLS_CLASSPATH = "kls-classpath"
 
-internal data class BuildResult(val config: KeelConfig, val classpath: String?)
+internal data class BuildResult(val config: KeelConfig, val classpath: String?, val pluginArgs: List<String> = emptyList())
 
 internal fun loadProjectConfig(): KeelConfig {
     val tomlString = readFileAsString(KEEL_TOML).getOrElse { error ->
@@ -50,7 +50,8 @@ internal fun doCheck() {
     checkVersion(config)
 
     val classpath = resolveDependencies(config)
-    val cmd = checkCommand(config, classpath)
+    val pArgs = resolvePluginArgs(config)
+    val cmd = checkCommand(config, classpath, pArgs)
 
     println("checking ${config.name}...")
     executeCommand(cmd).getOrElse { error ->
@@ -91,12 +92,13 @@ internal fun doBuild(): BuildResult {
     if (isBuildUpToDate(current = currentState, cached = cachedState)) {
         val elapsed = startMark.elapsedNow()
         println("${config.name} is up to date (${formatDuration(elapsed)})")
-        return BuildResult(config, cachedState!!.classpath)
+        return BuildResult(config, cachedState!!.classpath, resolvePluginArgs(config))
     }
 
     checkVersion(config)
     val classpath = resolveDependencies(config)
-    val cmd = buildCommand(config, classpath)
+    val pArgs = resolvePluginArgs(config)
+    val cmd = buildCommand(config, classpath, pArgs)
     ensureDirectory(BUILD_DIR).getOrElse { error ->
         eprintln("error: could not create directory ${error.path}")
         exitProcess(EXIT_BUILD_ERROR)
@@ -119,7 +121,7 @@ internal fun doBuild(): BuildResult {
 
     val elapsed = startMark.elapsedNow()
     println("built ${cmd.outputPath} in ${formatDuration(elapsed)}")
-    return BuildResult(config, classpath)
+    return BuildResult(config, classpath, pArgs)
 }
 
 internal fun doRun(config: KeelConfig, classpath: String?, appArgs: List<String> = emptyList()) {
@@ -139,7 +141,7 @@ internal fun doRun(config: KeelConfig, classpath: String?, appArgs: List<String>
 }
 
 internal fun doTest(testArgs: List<String> = emptyList()) {
-    val (config, classpath) = doBuild()
+    val (config, classpath, pArgs) = doBuild()
 
     val existingTestSources = config.testSources.filter { fileExists(it) }
     if (existingTestSources.isEmpty()) {
@@ -154,7 +156,7 @@ internal fun doTest(testArgs: List<String> = emptyList()) {
 
     val testConfig = config.copy(testSources = existingTestSources)
     val mainJar = jarPath(config)
-    val testCmd = testBuildCommand(testConfig, mainJar, classpath)
+    val testCmd = testBuildCommand(testConfig, mainJar, classpath, pArgs)
     println("compiling tests...")
     executeCommand(testCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "test compilation"))

--- a/src/nativeMain/kotlin/keel/cli/PluginSupport.kt
+++ b/src/nativeMain/kotlin/keel/cli/PluginSupport.kt
@@ -1,0 +1,35 @@
+package keel.cli
+
+import com.github.michaelbull.result.getOrElse
+import keel.build.parseKotlinHome
+import keel.build.pluginArgs
+import keel.config.KeelConfig
+import keel.infra.eprintln
+import keel.infra.executeAndCapture
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
+import kotlin.system.exitProcess
+
+@OptIn(ExperimentalForeignApi::class)
+internal fun resolveKotlinHome(): String {
+    val envHome = getenv("KOTLIN_HOME")?.toKString()
+    if (!envHome.isNullOrEmpty()) return envHome
+
+    val kotlincPath = executeAndCapture("which kotlinc").getOrElse {
+        eprintln("error: KOTLIN_HOME is not set and kotlinc is not found in PATH")
+        exitProcess(EXIT_BUILD_ERROR)
+    }.trim()
+    return parseKotlinHome(kotlincPath)
+}
+
+internal fun resolvePluginArgs(config: KeelConfig): List<String> {
+    val enabled = config.plugins.filterValues { it }
+    if (enabled.isEmpty()) return emptyList()
+
+    val kotlinHome = resolveKotlinHome()
+    return pluginArgs(config.plugins, kotlinHome).getOrElse { error ->
+        eprintln("error: unknown plugin '${error.name}'")
+        exitProcess(EXIT_CONFIG_ERROR)
+    }
+}

--- a/src/nativeMain/kotlin/keel/config/Config.kt
+++ b/src/nativeMain/kotlin/keel/config/Config.kt
@@ -25,7 +25,8 @@ data class KeelConfig(
     @SerialName("test_sources") val testSources: List<String> = listOf("test"),
     val dependencies: Map<String, String> = emptyMap(),
     @SerialName("test-dependencies") val testDependencies: Map<String, String> = emptyMap(),
-    @SerialName("fmt_style") val fmtStyle: String = "google"
+    @SerialName("fmt_style") val fmtStyle: String = "google",
+    val plugins: Map<String, Boolean> = emptyMap()
 )
 
 private val toml = Toml(

--- a/src/nativeTest/kotlin/keel/TestFixtures.kt
+++ b/src/nativeTest/kotlin/keel/TestFixtures.kt
@@ -8,7 +8,8 @@ fun testConfig(
     jvmTarget: String = "17",
     dependencies: Map<String, String> = emptyMap(),
     testSources: List<String> = listOf("test"),
-    testDependencies: Map<String, String> = emptyMap()
+    testDependencies: Map<String, String> = emptyMap(),
+    plugins: Map<String, Boolean> = emptyMap()
 ) = KeelConfig(
     name = name,
     version = "0.1.0",
@@ -19,5 +20,6 @@ fun testConfig(
     sources = sources,
     dependencies = dependencies,
     testSources = testSources,
-    testDependencies = testDependencies
+    testDependencies = testDependencies,
+    plugins = plugins
 )

--- a/src/nativeTest/kotlin/keel/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/keel/build/BuilderTest.kt
@@ -92,4 +92,91 @@ class BuilderTest {
             cmd
         )
     }
+
+    @Test
+    fun buildCommandWithPluginArgs() {
+        val pluginArgs = listOf("-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar")
+
+        val cmd = buildCommand(testConfig(), pluginArgs = pluginArgs)
+
+        assertEquals(
+            listOf(
+                "kotlinc", "src", "-jvm-target", "17",
+                "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
+                "-include-runtime", "-d", "build/my-app.jar"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun buildCommandWithMultiplePluginArgs() {
+        val pluginArgs = listOf(
+            "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
+            "-Xplugin=/usr/local/kotlinc/lib/allopen-compiler-plugin.jar"
+        )
+
+        val cmd = buildCommand(testConfig(), pluginArgs = pluginArgs)
+
+        assertEquals(
+            listOf(
+                "kotlinc", "src", "-jvm-target", "17",
+                "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
+                "-Xplugin=/usr/local/kotlinc/lib/allopen-compiler-plugin.jar",
+                "-include-runtime", "-d", "build/my-app.jar"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun buildCommandWithEmptyPluginArgs() {
+        val cmd = buildCommand(testConfig(), pluginArgs = emptyList())
+
+        assertEquals(
+            listOf("kotlinc", "src", "-jvm-target", "17", "-include-runtime", "-d", "build/my-app.jar"),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun buildCommandWithClasspathAndPluginArgs() {
+        val pluginArgs = listOf("-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar")
+
+        val cmd = buildCommand(testConfig(), classpath = "/cache/a.jar", pluginArgs = pluginArgs)
+
+        assertEquals(
+            listOf(
+                "kotlinc", "-cp", "/cache/a.jar", "src", "-jvm-target", "17",
+                "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
+                "-include-runtime", "-d", "build/my-app.jar"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun checkCommandWithPluginArgs() {
+        val pluginArgs = listOf("-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar")
+
+        val cmd = checkCommand(testConfig(), pluginArgs = pluginArgs)
+
+        assertEquals(
+            listOf(
+                "kotlinc", "src", "-jvm-target", "17",
+                "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar"
+            ),
+            cmd
+        )
+    }
+
+    @Test
+    fun checkCommandWithEmptyPluginArgs() {
+        val cmd = checkCommand(testConfig(), pluginArgs = emptyList())
+
+        assertEquals(
+            listOf("kotlinc", "src", "-jvm-target", "17"),
+            cmd
+        )
+    }
 }

--- a/src/nativeTest/kotlin/keel/build/CompilerPluginTest.kt
+++ b/src/nativeTest/kotlin/keel/build/CompilerPluginTest.kt
@@ -1,0 +1,139 @@
+package keel.build
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class CompilerPluginTest {
+
+    private val kotlinHome = "/usr/local/kotlinc"
+
+    // --- pluginArgs ---
+
+    @Test
+    fun pluginArgsSingleEnabledPlugin() {
+        val plugins = mapOf("serialization" to true)
+
+        val result = pluginArgs(plugins, kotlinHome)
+
+        val args = assertNotNull(result.get())
+        assertEquals(
+            listOf("-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar"),
+            args
+        )
+    }
+
+    @Test
+    fun pluginArgsMultipleEnabledPlugins() {
+        val plugins = mapOf("serialization" to true, "allopen" to true)
+
+        val result = pluginArgs(plugins, kotlinHome)
+
+        val args = assertNotNull(result.get())
+        assertEquals(2, args.size)
+        assertEquals(
+            "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
+            args[0]
+        )
+        assertEquals(
+            "-Xplugin=/usr/local/kotlinc/lib/allopen-compiler-plugin.jar",
+            args[1]
+        )
+    }
+
+    @Test
+    fun pluginArgsDisabledPluginIsExcluded() {
+        val plugins = mapOf("serialization" to false)
+
+        val result = pluginArgs(plugins, kotlinHome)
+
+        val args = assertNotNull(result.get())
+        assertEquals(emptyList(), args)
+    }
+
+    @Test
+    fun pluginArgsMixedEnabledAndDisabled() {
+        val plugins = mapOf("serialization" to true, "allopen" to false, "noarg" to true)
+
+        val result = pluginArgs(plugins, kotlinHome)
+
+        val args = assertNotNull(result.get())
+        assertEquals(2, args.size)
+        assertEquals(
+            "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
+            args[0]
+        )
+        assertEquals(
+            "-Xplugin=/usr/local/kotlinc/lib/noarg-compiler-plugin.jar",
+            args[1]
+        )
+    }
+
+    @Test
+    fun pluginArgsEmptyMapReturnsEmptyList() {
+        val result = pluginArgs(emptyMap(), kotlinHome)
+
+        val args = assertNotNull(result.get())
+        assertEquals(emptyList(), args)
+    }
+
+    @Test
+    fun pluginArgsUnknownPluginReturnsError() {
+        val plugins = mapOf("unknown-plugin" to true)
+
+        val result = pluginArgs(plugins, kotlinHome)
+
+        assertNull(result.get())
+        val error = assertNotNull(result.getError())
+        assertIs<UnknownPlugin>(error)
+        assertEquals("unknown-plugin", error.name)
+    }
+
+    @Test
+    fun pluginArgsUnknownDisabledPluginIsIgnored() {
+        val plugins = mapOf("unknown-plugin" to false)
+
+        val result = pluginArgs(plugins, kotlinHome)
+
+        val args = assertNotNull(result.get())
+        assertEquals(emptyList(), args)
+    }
+
+    @Test
+    fun pluginArgsUsesKotlinHomePath() {
+        val plugins = mapOf("serialization" to true)
+        val customHome = "/home/user/.sdkman/candidates/kotlin/current"
+
+        val result = pluginArgs(plugins, customHome)
+
+        val args = assertNotNull(result.get())
+        assertEquals(
+            listOf("-Xplugin=/home/user/.sdkman/candidates/kotlin/current/lib/kotlinx-serialization-compiler-plugin.jar"),
+            args
+        )
+    }
+
+    // --- parseKotlinHome ---
+
+    @Test
+    fun parseKotlinHomeFromStandardPath() {
+        assertEquals("/usr/local/kotlinc", parseKotlinHome("/usr/local/kotlinc/bin/kotlinc"))
+    }
+
+    @Test
+    fun parseKotlinHomeFromSdkmanPath() {
+        assertEquals(
+            "/home/user/.sdkman/candidates/kotlin/current",
+            parseKotlinHome("/home/user/.sdkman/candidates/kotlin/current/bin/kotlinc")
+        )
+    }
+
+    @Test
+    fun parseKotlinHomeFromMinimalPath() {
+        assertEquals("/opt/kotlin", parseKotlinHome("/opt/kotlin/bin/kotlinc"))
+    }
+}

--- a/src/nativeTest/kotlin/keel/build/TestBuilderTest.kt
+++ b/src/nativeTest/kotlin/keel/build/TestBuilderTest.kt
@@ -86,4 +86,83 @@ class TestBuilderTest {
         assertEquals("build/my-app-test.jar", testJarPath(testConfig()))
         assertEquals("build/hello-test.jar", testJarPath(testConfig(name = "hello")))
     }
+
+    @Test
+    fun testBuildCommandWithPluginArgs() {
+        val pluginArgs = listOf("-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar")
+
+        val cmd = testBuildCommand(
+            config = testConfig(),
+            mainJarPath = "build/my-app.jar",
+            pluginArgs = pluginArgs
+        )
+
+        assertEquals(
+            listOf(
+                "kotlinc", "-cp", "build/my-app.jar", "test", "-jvm-target", "17",
+                "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
+                "-d", "build/my-app-test.jar"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun testBuildCommandWithMultiplePluginArgs() {
+        val pluginArgs = listOf(
+            "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
+            "-Xplugin=/usr/local/kotlinc/lib/allopen-compiler-plugin.jar"
+        )
+
+        val cmd = testBuildCommand(
+            config = testConfig(),
+            mainJarPath = "build/my-app.jar",
+            pluginArgs = pluginArgs
+        )
+
+        assertEquals(
+            listOf(
+                "kotlinc", "-cp", "build/my-app.jar", "test", "-jvm-target", "17",
+                "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
+                "-Xplugin=/usr/local/kotlinc/lib/allopen-compiler-plugin.jar",
+                "-d", "build/my-app-test.jar"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun testBuildCommandWithEmptyPluginArgs() {
+        val cmd = testBuildCommand(
+            config = testConfig(),
+            mainJarPath = "build/my-app.jar",
+            pluginArgs = emptyList()
+        )
+
+        assertEquals(
+            listOf("kotlinc", "-cp", "build/my-app.jar", "test", "-jvm-target", "17", "-d", "build/my-app-test.jar"),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun testBuildCommandWithClasspathAndPluginArgs() {
+        val pluginArgs = listOf("-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar")
+
+        val cmd = testBuildCommand(
+            config = testConfig(),
+            mainJarPath = "build/my-app.jar",
+            classpath = "/cache/dep.jar",
+            pluginArgs = pluginArgs
+        )
+
+        assertEquals(
+            listOf(
+                "kotlinc", "-cp", "build/my-app.jar:/cache/dep.jar", "test", "-jvm-target", "17",
+                "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
+                "-d", "build/my-app-test.jar"
+            ),
+            cmd.args
+        )
+    }
 }

--- a/src/nativeTest/kotlin/keel/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/keel/config/ConfigTest.kt
@@ -265,6 +265,76 @@ class ConfigTest {
     }
 
     @Test
+    fun parseMinimalConfigHasNoPlugins() {
+        val config = assertNotNull(parseConfig(minimalToml).get())
+        assertEquals(emptyMap(), config.plugins)
+    }
+
+    @Test
+    fun parseConfigWithPlugins() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+
+            [plugins]
+            serialization = true
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals(1, config.plugins.size)
+        assertEquals(true, config.plugins["serialization"])
+    }
+
+    @Test
+    fun parseConfigWithMultiplePlugins() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+
+            [plugins]
+            serialization = true
+            allopen = true
+            noarg = false
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals(3, config.plugins.size)
+        assertEquals(true, config.plugins["serialization"])
+        assertEquals(true, config.plugins["allopen"])
+        assertEquals(false, config.plugins["noarg"])
+    }
+
+    @Test
+    fun parseConfigWithPluginsAndDependencies() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+
+            [dependencies]
+            "org.jetbrains.kotlinx:kotlinx-serialization-json" = "1.7.0"
+
+            [plugins]
+            serialization = true
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals(1, config.plugins.size)
+        assertEquals(1, config.dependencies.size)
+    }
+
+    @Test
     fun commentsAreIgnored() {
         val toml = """
             # Project configuration


### PR DESCRIPTION
## Summary

## Summary

Add support for Kotlin compiler plugins so that projects can use kotlinx-serialization, all-open, no-arg, and other compiler plugins.

## Motivation

Kotlinx-serialization is one of the most widely used Kotlin libraries and requires a compiler plugin. Without compiler plugin support, keel cannot build most real-world Kotlin projects.

## Proposed Config

```toml
[plugins]
serialization = true
# or with version pinning:
# serialization = "2.1.0"
```

## How Kotlin Compiler Plugins Work

Compiler plugins are passed to `kotlinc` via `-Xplugin=<path-to-plugin-jar>`. The plugin JARs ship with the Kotlin compiler distribution:

- `kotlinx-serialization-compiler-plugin.jar`
- `allopen-compiler-plugin.jar`
- `noarg-compiler-plugin.jar`

These are located in `$KOTLIN_HOME/lib/` for bundled plugins.

## What Needs to Change

- **Config.kt**: Add `plugins` section to `KeelConfig`
- **Builder.kt**: Append `-Xplugin=<path>` to kotlinc args when plugins are enabled
- **TestBuilder.kt**: Same for test compilation
- Locate plugin JARs from the Kotlin compiler distribution (ties into #17 toolchain management)

## Priority

Must-have — blocking for most real-world projects using serialization.

## Execution Report

Workflow `default` completed successfully.

Closes #19