### PR TITLE
[#18] add-custom-maven-repos

### DIFF
--- a/src/nativeMain/kotlin/keel/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/DependencyCommands.kt
@@ -1,5 +1,6 @@
 package keel.cli
 
+import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
 import keel.build.*
 import keel.config.*
@@ -94,19 +95,26 @@ internal fun doAdd(args: List<String>) {
         exitProcess(EXIT_DEPENDENCY_ERROR)
     }
 
-    val version = if (addArgs.version != null) {
-        addArgs.version
-    } else {
-        println("fetching latest version for ${addArgs.group}:${addArgs.artifact}...")
-        fetchLatestVersion(addArgs.group, addArgs.artifact)
-    }
-
-    val groupArtifact = "${addArgs.group}:${addArgs.artifact}"
     val toml = readFileAsString(KEEL_TOML).getOrElse { error ->
         eprintln("error: could not read ${error.path}")
         exitProcess(EXIT_CONFIG_ERROR)
     }
 
+    val config = parseConfig(toml).getOrElse { error ->
+        when (error) {
+            is ConfigError.ParseFailed -> eprintln("error: ${error.message}")
+        }
+        exitProcess(EXIT_CONFIG_ERROR)
+    }
+
+    val version = if (addArgs.version != null) {
+        addArgs.version
+    } else {
+        println("fetching latest version for ${addArgs.group}:${addArgs.artifact}...")
+        fetchLatestVersion(addArgs.group, addArgs.artifact, config.repositories.values.toList())
+    }
+
+    val groupArtifact = "${addArgs.group}:${addArgs.artifact}"
     val updatedToml = addDependencyToToml(toml, groupArtifact, version, addArgs.isTest).getOrElse { error ->
         when (error) {
             is AlreadyExists -> eprintln("error: '${error.groupArtifact}' already exists in ${if (addArgs.isTest) "[test-dependencies]" else "[dependencies]"}")
@@ -125,22 +133,27 @@ internal fun doAdd(args: List<String>) {
     doInstall()
 }
 
-private fun fetchLatestVersion(group: String, artifact: String): String {
+private fun fetchLatestVersion(group: String, artifact: String, repos: List<String>): String {
     val paths = resolveKeelPaths(EXIT_DEPENDENCY_ERROR)
     val groupPath = group.replace('.', '/')
     val metadataPath = "${paths.cacheBase}/$groupPath/$artifact/maven-metadata.xml"
 
-    val url = buildMetadataDownloadUrl(group, artifact)
     ensureDirectoryRecursive("${paths.cacheBase}/$groupPath/$artifact").getOrElse { error ->
         eprintln("error: could not create directory ${error.path}")
         exitProcess(EXIT_DEPENDENCY_ERROR)
     }
 
-    downloadFile(url, metadataPath).getOrElse { error ->
-        when (error) {
-            is DownloadError.HttpFailed -> eprintln("error: could not fetch metadata for $group:$artifact (HTTP ${error.statusCode})")
-            is DownloadError.WriteFailed -> eprintln("error: could not write metadata to ${error.path}")
-            is DownloadError.NetworkError -> eprintln("error: network error fetching metadata for $group:$artifact: ${error.message}")
+    val fetchErr = downloadFromRepositories(
+        repos,
+        metadataPath,
+        { repo -> buildMetadataDownloadUrl(group, artifact, repo) },
+        ::downloadFile
+    ).getError()
+    if (fetchErr != null) {
+        when (fetchErr) {
+            is DownloadError.HttpFailed -> eprintln("error: could not fetch metadata for $group:$artifact (HTTP ${fetchErr.statusCode})")
+            is DownloadError.WriteFailed -> eprintln("error: could not write metadata to ${fetchErr.path}")
+            is DownloadError.NetworkError -> eprintln("error: network error fetching metadata for $group:$artifact: ${fetchErr.message}")
         }
         exitProcess(EXIT_DEPENDENCY_ERROR)
     }
@@ -206,7 +219,7 @@ internal fun doTree() {
 
     val paths = resolveKeelPaths(EXIT_DEPENDENCY_ERROR)
 
-    val pomLookup = createPomLookup(paths.cacheBase, createResolverDeps())
+    val pomLookup = createPomLookup(config.repositories.values.toList(), paths.cacheBase, createResolverDeps())
     if (config.dependencies.isNotEmpty()) {
         val tree = buildDependencyTree(config.dependencies, pomLookup)
         println(formatDependencyTree(tree))

--- a/src/nativeMain/kotlin/keel/config/Config.kt
+++ b/src/nativeMain/kotlin/keel/config/Config.kt
@@ -9,6 +9,8 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 
+const val MAVEN_CENTRAL_BASE = "https://repo1.maven.org/maven2"
+
 sealed class ConfigError {
     data class ParseFailed(val message: String) : ConfigError()
 }
@@ -26,7 +28,8 @@ data class KeelConfig(
     val dependencies: Map<String, String> = emptyMap(),
     @SerialName("test-dependencies") val testDependencies: Map<String, String> = emptyMap(),
     @SerialName("fmt_style") val fmtStyle: String = "google",
-    val plugins: Map<String, Boolean> = emptyMap()
+    val plugins: Map<String, Boolean> = emptyMap(),
+    val repositories: Map<String, String> = mapOf("central" to MAVEN_CENTRAL_BASE)
 )
 
 private val toml = Toml(
@@ -39,7 +42,10 @@ fun parseConfig(tomlString: String): Result<KeelConfig, ConfigError> {
         // ktoml preserves quotes in map keys; strip them
         val cleanedDeps = config.dependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }
         val cleanedTestDeps = config.testDependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }
-        Ok(config.copy(dependencies = cleanedDeps, testDependencies = cleanedTestDeps))
+        val cleanedRepos = config.repositories
+            .mapKeys { (key, _) -> key.removeSurrounding("\"") }
+            .mapValues { (_, url) -> url.trimEnd('/') }
+        Ok(config.copy(dependencies = cleanedDeps, testDependencies = cleanedTestDeps, repositories = cleanedRepos))
     } catch (e: SerializationException) {
         Err(ConfigError.ParseFailed("failed to parse keel.toml: ${e.message}"))
     } catch (e: IllegalArgumentException) {

--- a/src/nativeMain/kotlin/keel/resolve/Dependency.kt
+++ b/src/nativeMain/kotlin/keel/resolve/Dependency.kt
@@ -12,8 +12,6 @@ data class Coordinate(
     val version: String
 )
 
-const val MAVEN_CENTRAL_BASE = "https://repo1.maven.org/maven2"
-
 fun parseCoordinate(groupArtifact: String, version: String): Result<Coordinate, InvalidCoordinate> {
     val parts = groupArtifact.split(":")
     if (parts.size != 2) {
@@ -26,9 +24,9 @@ fun parseCoordinate(groupArtifact: String, version: String): Result<Coordinate, 
     return Ok(Coordinate(group, artifact, version))
 }
 
-private fun buildMavenUrl(coord: Coordinate, extension: String): String {
+private fun buildMavenUrl(coord: Coordinate, baseUrl: String, extension: String): String {
     val groupPath = coord.group.replace('.', '/')
-    return "$MAVEN_CENTRAL_BASE/$groupPath/${coord.artifact}/${coord.version}/${coord.artifact}-${coord.version}.$extension"
+    return "$baseUrl/$groupPath/${coord.artifact}/${coord.version}/${coord.artifact}-${coord.version}.$extension"
 }
 
 private fun buildRelativePath(coord: Coordinate, extension: String): String {
@@ -36,15 +34,15 @@ private fun buildRelativePath(coord: Coordinate, extension: String): String {
     return "$groupPath/${coord.artifact}/${coord.version}/${coord.artifact}-${coord.version}.$extension"
 }
 
-fun buildDownloadUrl(coord: Coordinate): String = buildMavenUrl(coord, "jar")
+fun buildDownloadUrl(coord: Coordinate, baseUrl: String): String = buildMavenUrl(coord, baseUrl, "jar")
 
 fun buildCachePath(coord: Coordinate): String = buildRelativePath(coord, "jar")
 
-fun buildPomDownloadUrl(coord: Coordinate): String = buildMavenUrl(coord, "pom")
+fun buildPomDownloadUrl(coord: Coordinate, baseUrl: String): String = buildMavenUrl(coord, baseUrl, "pom")
 
 fun buildPomCachePath(coord: Coordinate): String = buildRelativePath(coord, "pom")
 
-fun buildModuleDownloadUrl(coord: Coordinate): String = buildMavenUrl(coord, "module")
+fun buildModuleDownloadUrl(coord: Coordinate, baseUrl: String): String = buildMavenUrl(coord, baseUrl, "module")
 
 fun buildModuleCachePath(coord: Coordinate): String = buildRelativePath(coord, "module")
 

--- a/src/nativeMain/kotlin/keel/resolve/Metadata.kt
+++ b/src/nativeMain/kotlin/keel/resolve/Metadata.kt
@@ -16,9 +16,9 @@ fun parseMetadataXml(xml: String): Result<String, MetadataParseError> {
     return Err(MetadataParseError("No release or latest version found in metadata"))
 }
 
-fun buildMetadataDownloadUrl(group: String, artifact: String): String {
+fun buildMetadataDownloadUrl(group: String, artifact: String, baseUrl: String): String {
     val groupPath = group.replace('.', '/')
-    return "$MAVEN_CENTRAL_BASE/$groupPath/$artifact/maven-metadata.xml"
+    return "$baseUrl/$groupPath/$artifact/maven-metadata.xml"
 }
 
 private fun extractSimpleTag(xml: String, tagName: String): String? {

--- a/src/nativeMain/kotlin/keel/resolve/TransitiveResolver.kt
+++ b/src/nativeMain/kotlin/keel/resolve/TransitiveResolver.kt
@@ -3,8 +3,10 @@ package keel.resolve
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
 import keel.config.KeelConfig
+import keel.infra.DownloadError
 
 /**
  * Resolves dependencies transitively. Orchestrates I/O (POM/JAR fetching,
@@ -21,12 +23,14 @@ fun resolveTransitive(
     cacheBase: String,
     deps: ResolverDeps
 ): Result<ResolveResult, ResolveError> {
+    val repos = config.repositories.values.toList()
+
     // Create POM lookup backed by cache + download
-    val basePomLookup = createPomLookup(cacheBase, deps)
+    val basePomLookup = createPomLookup(repos, cacheBase, deps)
 
     // Track KMP redirects: original groupArtifact -> redirected groupArtifact
     val redirects = mutableMapOf<String, String>()
-    val moduleLookup = createModuleLookup(cacheBase, deps)
+    val moduleLookup = createModuleLookup(repos, cacheBase, deps)
 
     val pomLookup: (String, String) -> PomInfo? = { groupArtifact, version ->
         val redirect = moduleLookup(groupArtifact, version)
@@ -45,7 +49,31 @@ fun resolveTransitive(
     }
 
     // Download JARs and compute hashes
-    return materialize(nodes, redirects, config, existingLock, cacheBase, deps)
+    return materialize(nodes, redirects, config, existingLock, cacheBase, deps, repos)
+}
+
+/**
+ * Tries each repository in order, downloading to [destPath].
+ * Falls back to the next repository only on HTTP 404. Any other error stops immediately.
+ */
+internal fun downloadFromRepositories(
+    repos: List<String>,
+    destPath: String,
+    urlBuilder: (String) -> String,
+    download: (String, String) -> Result<Unit, DownloadError>
+): Result<Unit, DownloadError> {
+    var lastError: DownloadError? = null
+    for (repo in repos) {
+        val url = urlBuilder(repo)
+        val error = download(url, destPath).getError()
+        if (error == null) return Ok(Unit)
+        if (error is DownloadError.HttpFailed && error.statusCode == 404) {
+            lastError = error
+        } else {
+            return Err(error)
+        }
+    }
+    return Err(lastError ?: DownloadError.NetworkError("", "no repositories configured"))
 }
 
 /**
@@ -54,6 +82,7 @@ fun resolveTransitive(
  * the same POM (e.g., shared parent POMs in diamond dependencies).
  */
 internal fun createPomLookup(
+    repos: List<String>,
     cacheBase: String,
     deps: ResolverDeps
 ): (String, String) -> PomInfo? {
@@ -72,7 +101,7 @@ internal fun createPomLookup(
                     val parentDir = pomCachePath.substringBeforeLast('/')
                     val dirOk = deps.ensureDirectoryRecursive(parentDir).getOrElse { null }
                     if (dirOk != null) {
-                        deps.downloadFile(buildPomDownloadUrl(coord), pomCachePath).getOrElse { null }
+                        downloadFromRepositories(repos, pomCachePath, { buildPomDownloadUrl(coord, it) }, deps::downloadFile).getOrElse { null }
                     }
                 }
 
@@ -92,6 +121,7 @@ internal fun createPomLookup(
  * .module file downloads for the same coordinate.
  */
 private fun createModuleLookup(
+    repos: List<String>,
     cacheBase: String,
     deps: ResolverDeps
 ): (String, String) -> JvmRedirect? {
@@ -105,7 +135,7 @@ private fun createModuleLookup(
         if (cached != null) {
             if (cached === noRedirect) null else cached
         } else {
-            val result = checkModuleFile(groupArtifact, version, cacheBase, deps)
+            val result = checkModuleFile(groupArtifact, version, repos, cacheBase, deps)
             cache[cacheKey] = result ?: noRedirect
             result
         }
@@ -115,6 +145,7 @@ private fun createModuleLookup(
 private fun checkModuleFile(
     groupArtifact: String,
     version: String,
+    repos: List<String>,
     cacheBase: String,
     deps: ResolverDeps
 ): JvmRedirect? {
@@ -127,7 +158,7 @@ private fun checkModuleFile(
     if (!deps.fileExists(moduleCachePath)) {
         val parentDir = moduleCachePath.substringBeforeLast('/')
         deps.ensureDirectoryRecursive(parentDir).getOrElse { return null }
-        deps.downloadFile(buildModuleDownloadUrl(coord), moduleCachePath).getOrElse { return null }
+        downloadFromRepositories(repos, moduleCachePath, { buildModuleDownloadUrl(coord, it) }, deps::downloadFile).getOrElse { return null }
     }
 
     val content = deps.readFileContent(moduleCachePath).getOrElse { return null }
@@ -150,7 +181,8 @@ private fun materialize(
     config: KeelConfig,
     existingLock: Lockfile?,
     cacheBase: String,
-    deps: ResolverDeps
+    deps: ResolverDeps,
+    repos: List<String>
 ): Result<ResolveResult, ResolveError> {
     var lockChanged = false
     val resolvedDeps = mutableListOf<ResolvedDep>()
@@ -172,7 +204,7 @@ private fun materialize(
             deps.ensureDirectoryRecursive(parentDir).getOrElse {
                 return Err(ResolveError.DirectoryCreateFailed(parentDir))
             }
-            deps.downloadFile(buildDownloadUrl(coord), fullCachePath).getOrElse { error ->
+            downloadFromRepositories(repos, fullCachePath, { buildDownloadUrl(coord, it) }, deps::downloadFile).getOrElse { error ->
                 return Err(ResolveError.DownloadFailed(node.groupArtifact, error))
             }
             lockChanged = true

--- a/src/nativeMain/kotlin/keel/tool/ToolManager.kt
+++ b/src/nativeMain/kotlin/keel/tool/ToolManager.kt
@@ -3,7 +3,7 @@ package keel.tool
 import com.github.michaelbull.result.getOrElse
 import keel.config.KeelPaths
 import keel.infra.*
-import keel.resolve.MAVEN_CENTRAL_BASE
+import keel.config.MAVEN_CENTRAL_BASE
 import kotlin.system.exitProcess
 
 internal data class ToolSpec(

--- a/src/nativeTest/kotlin/keel/TestFixtures.kt
+++ b/src/nativeTest/kotlin/keel/TestFixtures.kt
@@ -1,6 +1,7 @@
 package keel
 
 import keel.config.KeelConfig
+import keel.config.MAVEN_CENTRAL_BASE
 
 fun testConfig(
     name: String = "my-app",
@@ -9,7 +10,8 @@ fun testConfig(
     dependencies: Map<String, String> = emptyMap(),
     testSources: List<String> = listOf("test"),
     testDependencies: Map<String, String> = emptyMap(),
-    plugins: Map<String, Boolean> = emptyMap()
+    plugins: Map<String, Boolean> = emptyMap(),
+    repositories: Map<String, String> = mapOf("central" to MAVEN_CENTRAL_BASE)
 ) = KeelConfig(
     name = name,
     version = "0.1.0",
@@ -21,5 +23,6 @@ fun testConfig(
     dependencies = dependencies,
     testSources = testSources,
     testDependencies = testDependencies,
-    plugins = plugins
+    plugins = plugins,
+    repositories = repositories
 )

--- a/src/nativeTest/kotlin/keel/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/keel/config/ConfigTest.kt
@@ -335,6 +335,107 @@ class ConfigTest {
     }
 
     @Test
+    fun parseMinimalConfigHasDefaultRepositories() {
+        // Given: no [repositories] section in TOML
+        // When: config is parsed
+        val config = assertNotNull(parseConfig(minimalToml).get())
+
+        // Then: default is Maven Central
+        assertEquals(1, config.repositories.size)
+        assertEquals(MAVEN_CENTRAL_BASE, config.repositories["central"])
+    }
+
+    @Test
+    fun parseConfigWithRepositories() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+
+            [repositories]
+            myrepo = "https://nexus.example.com/repository/maven-public"
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals(1, config.repositories.size)
+        assertEquals("https://nexus.example.com/repository/maven-public", config.repositories["myrepo"])
+    }
+
+    @Test
+    fun parseConfigWithMultipleRepositoriesPreservesOrder() {
+        // Given: two repositories declared in a specific order
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+
+            [repositories]
+            internal = "https://nexus.example.com/repository/internal"
+            central = "https://repo1.maven.org/maven2"
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals(2, config.repositories.size)
+        // Map preserves insertion order
+        val entries = config.repositories.entries.toList()
+        assertEquals("internal", entries[0].key)
+        assertEquals("https://nexus.example.com/repository/internal", entries[0].value)
+        assertEquals("central", entries[1].key)
+        assertEquals("https://repo1.maven.org/maven2", entries[1].value)
+    }
+
+    @Test
+    fun parseConfigWithRepositoriesAndDependencies() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+
+            [dependencies]
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core" = "1.9.0"
+
+            [repositories]
+            central = "https://repo1.maven.org/maven2"
+            internal = "https://nexus.example.com/repository/maven-public"
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals(1, config.dependencies.size)
+        assertEquals(2, config.repositories.size)
+    }
+
+    @Test
+    fun repositoryTrailingSlashIsNormalized() {
+        // Given: a repository URL with a trailing slash
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+
+            [repositories]
+            jitpack = "https://jitpack.io/"
+            central = "https://repo1.maven.org/maven2/"
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        // Trailing slashes must be stripped to prevent double-slash in constructed URLs
+        assertEquals("https://jitpack.io", config.repositories["jitpack"])
+        assertEquals(MAVEN_CENTRAL_BASE, config.repositories["central"])
+    }
+
+    @Test
     fun commentsAreIgnored() {
         val toml = """
             # Project configuration
@@ -348,5 +449,14 @@ class ConfigTest {
 
         val config = assertNotNull(parseConfig(toml).get())
         assertEquals("my-app", config.name)
+    }
+
+    @Test
+    fun mavenCentralBaseDefinedInConfigPackage() {
+        // Verifies MAVEN_CENTRAL_BASE is defined in keel.config (not scattered to resolve/tool),
+        // and matches the canonical Maven Central URL used as the default repository.
+        assertEquals("https://repo1.maven.org/maven2", MAVEN_CENTRAL_BASE)
+        val config = assertNotNull(parseConfig(minimalToml).get())
+        assertEquals(MAVEN_CENTRAL_BASE, config.repositories["central"])
     }
 }

--- a/src/nativeTest/kotlin/keel/resolve/DependencyTest.kt
+++ b/src/nativeTest/kotlin/keel/resolve/DependencyTest.kt
@@ -2,6 +2,7 @@ package keel.resolve
 
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
+import keel.config.MAVEN_CENTRAL_BASE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -54,7 +55,7 @@ class DependencyTest {
     @Test
     fun buildDownloadUrlProducesCorrectMavenCentralUrl() {
         val coord = Coordinate("org.jetbrains.kotlinx", "kotlinx-coroutines-core", "1.9.0")
-        val url = buildDownloadUrl(coord)
+        val url = buildDownloadUrl(coord, MAVEN_CENTRAL_BASE)
         assertEquals(
             "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.9.0/kotlinx-coroutines-core-1.9.0.jar",
             url
@@ -64,9 +65,19 @@ class DependencyTest {
     @Test
     fun buildDownloadUrlWithSingleSegmentGroup() {
         val coord = Coordinate("junit", "junit", "4.13.2")
-        val url = buildDownloadUrl(coord)
+        val url = buildDownloadUrl(coord, MAVEN_CENTRAL_BASE)
         assertEquals(
             "https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar",
+            url
+        )
+    }
+
+    @Test
+    fun buildDownloadUrlWithCustomBaseUrl() {
+        val coord = Coordinate("com.example", "lib", "1.0.0")
+        val url = buildDownloadUrl(coord, "https://nexus.example.com/repository/maven-public")
+        assertEquals(
+            "https://nexus.example.com/repository/maven-public/com/example/lib/1.0.0/lib-1.0.0.jar",
             url
         )
     }
@@ -101,7 +112,7 @@ class DependencyTest {
     @Test
     fun buildPomDownloadUrlProducesCorrectMavenCentralUrl() {
         val coord = Coordinate("org.jetbrains.kotlinx", "kotlinx-coroutines-core", "1.9.0")
-        val url = buildPomDownloadUrl(coord)
+        val url = buildPomDownloadUrl(coord, MAVEN_CENTRAL_BASE)
         assertEquals(
             "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.9.0/kotlinx-coroutines-core-1.9.0.pom",
             url
@@ -111,9 +122,29 @@ class DependencyTest {
     @Test
     fun buildPomDownloadUrlWithSingleSegmentGroup() {
         val coord = Coordinate("junit", "junit", "4.13.2")
-        val url = buildPomDownloadUrl(coord)
+        val url = buildPomDownloadUrl(coord, MAVEN_CENTRAL_BASE)
         assertEquals(
             "https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.pom",
+            url
+        )
+    }
+
+    @Test
+    fun buildPomDownloadUrlWithCustomBaseUrl() {
+        val coord = Coordinate("com.example", "lib", "1.0.0")
+        val url = buildPomDownloadUrl(coord, "https://nexus.example.com/repository/maven-public")
+        assertEquals(
+            "https://nexus.example.com/repository/maven-public/com/example/lib/1.0.0/lib-1.0.0.pom",
+            url
+        )
+    }
+
+    @Test
+    fun buildModuleDownloadUrlWithCustomBaseUrl() {
+        val coord = Coordinate("com.example", "lib", "1.0.0")
+        val url = buildModuleDownloadUrl(coord, "https://nexus.example.com/repository/maven-public")
+        assertEquals(
+            "https://nexus.example.com/repository/maven-public/com/example/lib/1.0.0/lib-1.0.0.module",
             url
         )
     }

--- a/src/nativeTest/kotlin/keel/resolve/MetadataTest.kt
+++ b/src/nativeTest/kotlin/keel/resolve/MetadataTest.kt
@@ -2,6 +2,7 @@ package keel.resolve
 
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
+import keel.config.MAVEN_CENTRAL_BASE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -101,9 +102,22 @@ class MetadataTest {
 
     @Test
     fun buildMetadataUrl() {
-        val url = buildMetadataDownloadUrl("org.jetbrains.kotlinx", "kotlinx-coroutines-core")
+        val url = buildMetadataDownloadUrl("org.jetbrains.kotlinx", "kotlinx-coroutines-core", MAVEN_CENTRAL_BASE)
         assertEquals(
             "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core/maven-metadata.xml",
+            url
+        )
+    }
+
+    @Test
+    fun buildMetadataUrlWithCustomBaseUrl() {
+        val url = buildMetadataDownloadUrl(
+            "com.example",
+            "lib",
+            "https://nexus.example.com/repository/maven-public"
+        )
+        assertEquals(
+            "https://nexus.example.com/repository/maven-public/com/example/lib/maven-metadata.xml",
             url
         )
     }

--- a/src/nativeTest/kotlin/keel/resolve/TransitiveResolverTest.kt
+++ b/src/nativeTest/kotlin/keel/resolve/TransitiveResolverTest.kt
@@ -825,6 +825,192 @@ class TransitiveResolverTest {
         }
     }
 
+    // ---- Multi-repository fallback tests ----
+
+    @Test
+    fun downloadFromRepositoriesSucceedsOnFirstRepo() {
+        // Given: two repos, first repo returns the artifact
+        val coord = Coordinate("com.example", "lib", "1.0.0")
+        val downloadedUrls = mutableListOf<String>()
+
+        // When: downloading with two repos
+        val result = downloadFromRepositories(
+            repos = listOf("https://repo1.example.com", "https://repo2.example.com"),
+            destPath = "/cache/lib.jar",
+            urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
+            download = { url, _ -> downloadedUrls.add(url); Ok(Unit) }
+        )
+
+        // Then: succeeds, only contacts first repo
+        assertNotNull(result.get())
+        assertEquals(1, downloadedUrls.size)
+        assertEquals(
+            "https://repo1.example.com/com/example/lib/1.0.0/lib-1.0.0.jar",
+            downloadedUrls[0]
+        )
+    }
+
+    @Test
+    fun downloadFromRepositoriesFallsBackToSecondRepoOn404() {
+        // Given: first repo returns 404, second repo has the artifact
+        val coord = Coordinate("com.example", "lib", "1.0.0")
+        val downloadedUrls = mutableListOf<String>()
+        val repo1Base = "https://repo1.example.com"
+        val repo2Base = "https://repo2.example.com"
+
+        // When: downloading with two repos
+        val result = downloadFromRepositories(
+            repos = listOf(repo1Base, repo2Base),
+            destPath = "/cache/lib.jar",
+            urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
+            download = { url, _ ->
+                downloadedUrls.add(url)
+                if (url.startsWith(repo1Base)) Err(DownloadError.HttpFailed(url, 404)) else Ok(Unit)
+            }
+        )
+
+        // Then: succeeds using second repo
+        assertNotNull(result.get())
+        assertEquals(2, downloadedUrls.size)
+        assertEquals("https://repo1.example.com/com/example/lib/1.0.0/lib-1.0.0.jar", downloadedUrls[0])
+        assertEquals("https://repo2.example.com/com/example/lib/1.0.0/lib-1.0.0.jar", downloadedUrls[1])
+    }
+
+    @Test
+    fun downloadFromRepositoriesReturnsErrWhenAllRepos404() {
+        // Given: all repos return 404
+        val coord = Coordinate("com.example", "lib", "1.0.0")
+
+        // When: all repos 404
+        val result = downloadFromRepositories(
+            repos = listOf("https://repo1.example.com", "https://repo2.example.com"),
+            destPath = "/cache/lib.jar",
+            urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
+            download = { url, _ -> Err(DownloadError.HttpFailed(url, 404)) }
+        )
+
+        // Then: returns the last 404 error
+        val error = assertIs<DownloadError.HttpFailed>(result.getError())
+        assertEquals(404, error.statusCode)
+    }
+
+    @Test
+    fun downloadFromRepositoriesStopsOnNon404Error() {
+        // Given: first repo returns a non-404 error (network failure)
+        val coord = Coordinate("com.example", "lib", "1.0.0")
+        val downloadedUrls = mutableListOf<String>()
+
+        // When: first repo has a non-404 error
+        val result = downloadFromRepositories(
+            repos = listOf("https://repo1.example.com", "https://repo2.example.com"),
+            destPath = "/cache/lib.jar",
+            urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
+            download = { url, _ ->
+                downloadedUrls.add(url)
+                Err(DownloadError.NetworkError(url, "connection refused"))
+            }
+        )
+
+        // Then: stops immediately, returns the network error without trying second repo
+        assertIs<DownloadError.NetworkError>(result.getError())
+        assertEquals(1, downloadedUrls.size)
+    }
+
+    @Test
+    fun resolveWithCustomRepositoryUrl() {
+        // Given: config with a custom repository instead of Maven Central
+        val customRepoBase = "https://nexus.example.com/repository/maven-public"
+        val config = testConfig(
+            dependencies = mapOf("com.example:lib" to "1.0.0"),
+            repositories = mapOf("myrepo" to customRepoBase)
+        )
+        val pomXml = """
+            <project>
+                <groupId>com.example</groupId>
+                <artifactId>lib</artifactId>
+                <version>1.0.0</version>
+            </project>
+        """.trimIndent()
+
+        val downloadedUrls = mutableListOf<String>()
+        val deps = object : ResolverDeps {
+            val cachedFiles = mutableSetOf<String>()
+            val fileContents = mapOf(
+                "/cache/com/example/lib/1.0.0/lib-1.0.0.pom" to pomXml
+            )
+
+            override fun fileExists(path: String) = path in cachedFiles
+            override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+            override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+                downloadedUrls.add(url)
+                cachedFiles.add(destPath)
+                return Ok(Unit)
+            }
+            override fun computeSha256(filePath: String): Result<String, Sha256Error> = Ok("hash1")
+            override fun readFileContent(path: String): Result<String, OpenFailed> {
+                val content = fileContents[path] ?: return Err(OpenFailed(path))
+                return Ok(content)
+            }
+        }
+
+        // When: resolving dependencies
+        val result = resolveTransitive(config, null, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+
+        // Then: downloaded from custom repo
+        assertEquals(1, resolved.deps.size)
+        assertTrue(downloadedUrls.any { it.startsWith(customRepoBase) })
+    }
+
+    @Test
+    fun resolveWithMultipleRepositoriesFallsBackOn404() {
+        // Given: config with two repos; jar is only in the second repo
+        val repo1Base = "https://repo1.example.com"
+        val repo2Base = "https://repo2.example.com"
+        val config = testConfig(
+            dependencies = mapOf("com.example:lib" to "1.0.0"),
+            repositories = mapOf("primary" to repo1Base, "fallback" to repo2Base)
+        )
+        val pomXml = """
+            <project>
+                <groupId>com.example</groupId>
+                <artifactId>lib</artifactId>
+                <version>1.0.0</version>
+            </project>
+        """.trimIndent()
+
+        val cachedFiles = mutableSetOf<String>()
+        val deps = object : ResolverDeps {
+            val fileContents = mapOf(
+                "/cache/com/example/lib/1.0.0/lib-1.0.0.pom" to pomXml
+            )
+
+            override fun fileExists(path: String) = path in cachedFiles
+            override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+            override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+                return if (url.startsWith(repo1Base)) {
+                    Err(DownloadError.HttpFailed(url, 404))
+                } else {
+                    cachedFiles.add(destPath)
+                    Ok(Unit)
+                }
+            }
+            override fun computeSha256(filePath: String): Result<String, Sha256Error> = Ok("hash1")
+            override fun readFileContent(path: String): Result<String, OpenFailed> {
+                val content = fileContents[path] ?: return Err(OpenFailed(path))
+                return Ok(content)
+            }
+        }
+
+        // When: resolving with first repo returning 404 for jar
+        val result = resolveTransitive(config, null, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+
+        // Then: resolves successfully using the second repo
+        assertEquals(1, resolved.deps.size)
+        assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
+    }
+
     // Helper: like fakeTransitiveDeps but tracks readFileContent call counts
     private fun countingDeps(
         cachedFiles: MutableSet<String> = mutableSetOf(),

--- a/src/nativeTest/kotlin/keel/tool/ToolManagerTest.kt
+++ b/src/nativeTest/kotlin/keel/tool/ToolManagerTest.kt
@@ -1,6 +1,6 @@
 package keel.tool
 
-import keel.resolve.MAVEN_CENTRAL_BASE
+import keel.config.MAVEN_CENTRAL_BASE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue


### PR DESCRIPTION
## Summary

## Summary

Currently keel only resolves dependencies from Maven Central. Add support for configuring custom Maven repositories (e.g., JitPack, corporate proxies).

## Proposed Config

```toml
[repositories]
central = "https://repo1.maven.org/maven2"
jitpack = "https://jitpack.io"
```

When omitted, default to Maven Central only (current behavior).

## What Needs to Change

- **Config.kt**: Add `repositories` field to `KeelConfig` (ordered map of name → URL)
- **Dependency.kt**: `buildDownloadUrl` / `buildPomDownloadUrl` should accept repository base URL instead of hardcoding Maven Central
- **Metadata.kt**: `buildMetadataDownloadUrl` should also accept repository base URL
- **TransitiveResolver.kt**: Try repositories in order, fall back to next on 404

## Out of Scope

Authentication for private repositories (GitHub Packages, corporate Nexus) is tracked separately in #33.

## Priority

Must-have — required for any project using non-Central dependencies.

## Execution Report

Workflow `keel` completed successfully.

Closes #18