### PR TITLE
[#35] refactor-build-to-classes-dir

### DIFF
--- a/src/nativeMain/kotlin/keel/build/BuildCache.kt
+++ b/src/nativeMain/kotlin/keel/build/BuildCache.kt
@@ -11,7 +11,7 @@ internal const val BUILD_STATE_FILE = "$BUILD_DIR/.keel-state.json"
 data class BuildState(
     @SerialName("config_mtime") val configMtime: Long,
     @SerialName("sources_newest_mtime") val sourcesNewestMtime: Long,
-    @SerialName("output_mtime") val outputMtime: Long?,
+    @SerialName("classes_dir_mtime") val classesDirMtime: Long?,
     @SerialName("lockfile_mtime") val lockfileMtime: Long?,
     val classpath: String? = null
 )
@@ -20,7 +20,7 @@ fun isBuildUpToDate(current: BuildState, cached: BuildState?): Boolean {
     if (cached == null) return false
     return current.configMtime == cached.configMtime &&
         current.sourcesNewestMtime == cached.sourcesNewestMtime &&
-        current.outputMtime == cached.outputMtime &&
+        current.classesDirMtime == cached.classesDirMtime &&
         current.lockfileMtime == cached.lockfileMtime
 }
 

--- a/src/nativeMain/kotlin/keel/build/Builder.kt
+++ b/src/nativeMain/kotlin/keel/build/Builder.kt
@@ -3,6 +3,7 @@ package keel.build
 import keel.config.KeelConfig
 
 internal const val BUILD_DIR = "build"
+internal const val CLASSES_DIR = "$BUILD_DIR/classes"
 
 internal fun jarPath(config: KeelConfig): String = "$BUILD_DIR/${config.name}.jar"
 
@@ -32,7 +33,6 @@ fun buildCommand(
     classpath: String? = null,
     pluginArgs: List<String> = emptyList()
 ): BuildCommand {
-    val outputPath = jarPath(config)
     val args = buildList {
         add("kotlinc")
         if (!classpath.isNullOrEmpty()) {
@@ -43,9 +43,16 @@ fun buildCommand(
         add("-jvm-target")
         add(config.jvmTarget)
         addAll(pluginArgs)
-        add("-include-runtime")
         add("-d")
-        add(outputPath)
+        add(CLASSES_DIR)
     }
-    return BuildCommand(args = args, outputPath = outputPath)
+    return BuildCommand(args = args, outputPath = CLASSES_DIR)
+}
+
+fun jarCommand(config: KeelConfig): BuildCommand {
+    val outputPath = jarPath(config)
+    return BuildCommand(
+        args = listOf("jar", "cf", outputPath, "-C", CLASSES_DIR, "."),
+        outputPath = outputPath
+    )
 }

--- a/src/nativeMain/kotlin/keel/build/Runner.kt
+++ b/src/nativeMain/kotlin/keel/build/Runner.kt
@@ -3,15 +3,12 @@ package keel.build
 import keel.config.KeelConfig
 
 data class RunCommand(
-    val args: List<String>,
-    val jarPath: String
+    val args: List<String>
 )
 
 fun runCommand(config: KeelConfig, classpath: String? = null, appArgs: List<String> = emptyList()): RunCommand {
-    val path = jarPath(config)
-    val cp = if (!classpath.isNullOrEmpty()) "$path:$classpath" else path
+    val cp = if (!classpath.isNullOrEmpty()) "$CLASSES_DIR:$classpath" else CLASSES_DIR
     return RunCommand(
-        args = listOf("java", "-cp", cp, config.main) + appArgs,
-        jarPath = path
+        args = listOf("java", "-cp", cp, config.main) + appArgs
     )
 }

--- a/src/nativeMain/kotlin/keel/build/TestBuilder.kt
+++ b/src/nativeMain/kotlin/keel/build/TestBuilder.kt
@@ -2,22 +2,21 @@ package keel.build
 
 import keel.config.KeelConfig
 
+internal const val TEST_CLASSES_DIR = "$BUILD_DIR/test-classes"
+
 data class TestBuildCommand(
     val args: List<String>,
     val outputPath: String
 )
 
-fun testJarPath(config: KeelConfig): String = "$BUILD_DIR/${config.name}-test.jar"
-
 fun testBuildCommand(
     config: KeelConfig,
-    mainJarPath: String,
+    classesDir: String,
     classpath: String? = null,
     pluginArgs: List<String> = emptyList()
 ): TestBuildCommand {
-    val outputPath = testJarPath(config)
     val cp = buildList {
-        add(mainJarPath)
+        add(classesDir)
         if (!classpath.isNullOrEmpty()) add(classpath)
     }.joinToString(":")
     val args = buildList {
@@ -29,7 +28,7 @@ fun testBuildCommand(
         add(config.jvmTarget)
         addAll(pluginArgs)
         add("-d")
-        add(outputPath)
+        add(TEST_CLASSES_DIR)
     }
-    return TestBuildCommand(args = args, outputPath = outputPath)
+    return TestBuildCommand(args = args, outputPath = TEST_CLASSES_DIR)
 }

--- a/src/nativeMain/kotlin/keel/build/TestRunner.kt
+++ b/src/nativeMain/kotlin/keel/build/TestRunner.kt
@@ -5,15 +5,15 @@ data class TestRunCommand(
 )
 
 fun testRunCommand(
-    mainJarPath: String,
-    testJarPath: String,
+    classesDir: String,
+    testClassesDir: String,
     consoleLauncherPath: String,
     classpath: String? = null,
     testArgs: List<String> = emptyList()
 ): TestRunCommand {
     val cp = buildList {
-        add(mainJarPath)
-        add(testJarPath)
+        add(classesDir)
+        add(testClassesDir)
         if (!classpath.isNullOrEmpty()) add(classpath)
     }.joinToString(":")
     val args = buildList {

--- a/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
@@ -78,12 +78,10 @@ internal fun doBuild(): BuildResult {
     val startMark = TimeSource.Monotonic.markNow()
     val config = loadProjectConfig()
 
-    val outputPath = jarPath(config)
-
     val currentState = BuildState(
         configMtime = fileMtime(KEEL_TOML) ?: 0L,
         sourcesNewestMtime = newestMtime(config.sources),
-        outputMtime = fileMtime(outputPath),
+        classesDirMtime = if (fileExists(CLASSES_DIR)) newestMtimeAll(CLASSES_DIR) else null,
         lockfileMtime = if (fileExists(LOCK_FILE)) fileMtime(LOCK_FILE) else null
     )
     val cachedState = readFileAsString(BUILD_STATE_FILE).getOrElse { null }
@@ -98,20 +96,26 @@ internal fun doBuild(): BuildResult {
     checkVersion(config)
     val classpath = resolveDependencies(config)
     val pArgs = resolvePluginArgs(config)
-    val cmd = buildCommand(config, classpath, pArgs)
-    ensureDirectory(BUILD_DIR).getOrElse { error ->
+    val buildCmd = buildCommand(config, classpath, pArgs)
+    ensureDirectoryRecursive(CLASSES_DIR).getOrElse { error ->
         eprintln("error: could not create directory ${error.path}")
         exitProcess(EXIT_BUILD_ERROR)
     }
 
     println("compiling ${config.name}...")
-    executeCommand(cmd.args).getOrElse { error ->
+    executeCommand(buildCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "compilation"))
         exitProcess(EXIT_BUILD_ERROR)
     }
 
+    val jarCmd = jarCommand(config)
+    executeCommand(jarCmd.args).getOrElse { error ->
+        eprintln(formatProcessError(error, "jar packaging"))
+        exitProcess(EXIT_BUILD_ERROR)
+    }
+
     val newState = currentState.copy(
-        outputMtime = fileMtime(cmd.outputPath),
+        classesDirMtime = newestMtimeAll(CLASSES_DIR),
         lockfileMtime = if (fileExists(LOCK_FILE)) fileMtime(LOCK_FILE) else null,
         classpath = classpath
     )
@@ -120,18 +124,17 @@ internal fun doBuild(): BuildResult {
     }
 
     val elapsed = startMark.elapsedNow()
-    println("built ${cmd.outputPath} in ${formatDuration(elapsed)}")
+    println("built ${jarCmd.outputPath} in ${formatDuration(elapsed)}")
     return BuildResult(config, classpath, pArgs)
 }
 
 internal fun doRun(config: KeelConfig, classpath: String?, appArgs: List<String> = emptyList()) {
-    val cmd = runCommand(config, classpath, appArgs)
-
-    if (!fileExists(cmd.jarPath)) {
-        eprintln("error: ${cmd.jarPath} not found. Run 'keel build' first.")
+    if (!fileExists(CLASSES_DIR)) {
+        eprintln("error: $CLASSES_DIR not found. Run 'keel build' first.")
         exitProcess(EXIT_BUILD_ERROR)
     }
 
+    val cmd = runCommand(config, classpath, appArgs)
     executeCommand(cmd.args).getOrElse { error ->
         when (error) {
             is ProcessError.NonZeroExit -> exitProcess(error.exitCode)
@@ -155,15 +158,14 @@ internal fun doTest(testArgs: List<String> = emptyList()) {
     val consoleLauncherPath = ensureTool(paths, CONSOLE_LAUNCHER_SPEC, EXIT_TEST_ERROR)
 
     val testConfig = config.copy(testSources = existingTestSources)
-    val mainJar = jarPath(config)
-    val testCmd = testBuildCommand(testConfig, mainJar, classpath, pArgs)
+    val testCmd = testBuildCommand(testConfig, CLASSES_DIR, classpath, pArgs)
     println("compiling tests...")
     executeCommand(testCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "test compilation"))
         exitProcess(EXIT_BUILD_ERROR)
     }
 
-    val runCmd = testRunCommand(mainJar, testCmd.outputPath, consoleLauncherPath, classpath, testArgs)
+    val runCmd = testRunCommand(CLASSES_DIR, testCmd.outputPath, consoleLauncherPath, classpath, testArgs)
     println("running tests...")
     executeCommand(runCmd.args).getOrElse { error ->
         when (error) {

--- a/src/nativeMain/kotlin/keel/infra/FileSystem.kt
+++ b/src/nativeMain/kotlin/keel/infra/FileSystem.kt
@@ -153,6 +153,38 @@ private fun collectNewestMtime(directory: String, onFile: (Long) -> Unit) {
     }
 }
 
+/** Return the newest mtime among all files (any extension) in the given directory tree. 0 if no files found. */
+@OptIn(ExperimentalForeignApi::class)
+fun newestMtimeAll(directory: String): Long {
+    var newest = 0L
+    collectAllFileMtimes(directory) { mtime ->
+        if (mtime > newest) newest = mtime
+    }
+    return newest
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun collectAllFileMtimes(directory: String, onFile: (Long) -> Unit) {
+    if (!fileExists(directory)) return
+    val dir = opendir(directory) ?: return
+    try {
+        while (true) {
+            val entry = readdir(dir) ?: break
+            val name = entry.pointed.d_name.toKString()
+            if (name == "." || name == "..") continue
+            val childPath = "$directory/$name"
+            if (isDirectory(childPath)) {
+                collectAllFileMtimes(childPath, onFile)
+            } else {
+                val mtime = fileMtime(childPath) ?: continue
+                onFile(mtime)
+            }
+        }
+    } finally {
+        closedir(dir)
+    }
+}
+
 data class ListFilesFailed(val path: String)
 
 @OptIn(ExperimentalForeignApi::class)

--- a/src/nativeTest/kotlin/keel/build/BuildCacheTest.kt
+++ b/src/nativeTest/kotlin/keel/build/BuildCacheTest.kt
@@ -13,7 +13,7 @@ class BuildCacheTest {
         val state = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            outputMtime = 3000L,
+            classesDirMtime = 3000L,
             lockfileMtime = 500L
         )
         assertTrue(isBuildUpToDate(current = state, cached = state))
@@ -24,7 +24,7 @@ class BuildCacheTest {
         val state = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            outputMtime = 3000L,
+            classesDirMtime = 3000L,
             lockfileMtime = null
         )
         assertFalse(isBuildUpToDate(current = state, cached = null))
@@ -35,7 +35,7 @@ class BuildCacheTest {
         val cached = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            outputMtime = 3000L,
+            classesDirMtime = 3000L,
             lockfileMtime = null
         )
         val current = cached.copy(configMtime = 1500L)
@@ -47,7 +47,7 @@ class BuildCacheTest {
         val cached = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            outputMtime = 3000L,
+            classesDirMtime = 3000L,
             lockfileMtime = null
         )
         val current = cached.copy(sourcesNewestMtime = 2500L)
@@ -55,26 +55,26 @@ class BuildCacheTest {
     }
 
     @Test
-    fun notUpToDateWhenOutputMtimeChanged() {
+    fun notUpToDateWhenClassesDirMtimeChanged() {
         val cached = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            outputMtime = 3000L,
+            classesDirMtime = 3000L,
             lockfileMtime = null
         )
-        val current = cached.copy(outputMtime = 3500L)
+        val current = cached.copy(classesDirMtime = 3500L)
         assertFalse(isBuildUpToDate(current = current, cached = cached))
     }
 
     @Test
-    fun notUpToDateWhenOutputMtimeIsNull() {
+    fun notUpToDateWhenClassesDirMtimeIsNull() {
         val cached = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            outputMtime = 3000L,
+            classesDirMtime = 3000L,
             lockfileMtime = null
         )
-        val current = cached.copy(outputMtime = null)
+        val current = cached.copy(classesDirMtime = null)
         assertFalse(isBuildUpToDate(current = current, cached = cached))
     }
 
@@ -83,7 +83,7 @@ class BuildCacheTest {
         val cached = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            outputMtime = 3000L,
+            classesDirMtime = 3000L,
             lockfileMtime = 500L
         )
         val current = cached.copy(lockfileMtime = 600L)
@@ -95,7 +95,7 @@ class BuildCacheTest {
         val state = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            outputMtime = 3000L,
+            classesDirMtime = 3000L,
             lockfileMtime = null
         )
         assertTrue(isBuildUpToDate(current = state, cached = state))
@@ -106,7 +106,7 @@ class BuildCacheTest {
         val state = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            outputMtime = 3000L,
+            classesDirMtime = 3000L,
             lockfileMtime = 500L,
             classpath = "/cache/a.jar:/cache/b.jar"
         )
@@ -120,7 +120,7 @@ class BuildCacheTest {
         val state = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            outputMtime = 3000L,
+            classesDirMtime = 3000L,
             lockfileMtime = null
         )
         val json = serializeBuildState(state)
@@ -134,13 +134,33 @@ class BuildCacheTest {
         val state = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            outputMtime = 3000L,
+            classesDirMtime = 3000L,
             lockfileMtime = 500L,
             classpath = "/cache/okhttp-jvm-5.3.2.jar:/cache/okio-jvm-3.16.4.jar"
         )
         val json = serializeBuildState(state)
         val parsed = parseBuildState(json)
         assertEquals("/cache/okhttp-jvm-5.3.2.jar:/cache/okio-jvm-3.16.4.jar", parsed!!.classpath)
+    }
+
+    @Test
+    fun serializationUsesClassesDirMtimeKey() {
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null
+        )
+        val json = serializeBuildState(state)
+        assertTrue(json.contains("classes_dir_mtime"), "Expected JSON key 'classes_dir_mtime' in: $json")
+        assertFalse(json.contains("output_mtime"), "Unexpected legacy key 'output_mtime' in: $json")
+    }
+
+    @Test
+    fun oldFormatWithOutputMtimeKeyReturnsNull() {
+        // Old format used output_mtime; parseBuildState must not accept it as classesDirMtime
+        val oldJson = """{"config_mtime":1000,"sources_newest_mtime":2000,"output_mtime":3000,"lockfile_mtime":null}"""
+        assertNull(parseBuildState(oldJson))
     }
 
     @Test
@@ -152,5 +172,4 @@ class BuildCacheTest {
     fun parseEmptyStringReturnsNull() {
         assertNull(parseBuildState(""))
     }
-
 }

--- a/src/nativeTest/kotlin/keel/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/keel/build/BuilderTest.kt
@@ -3,18 +3,28 @@ package keel.build
 import keel.testConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class BuilderTest {
 
+    // --- buildCommand ---
+
     @Test
-    fun buildCommandSingleSource() {
+    fun buildCommandOutputsToClassesDir() {
         val cmd = buildCommand(testConfig())
 
         assertEquals(
-            listOf("kotlinc", "src", "-jvm-target", "17", "-include-runtime", "-d", "build/my-app.jar"),
+            listOf("kotlinc", "src", "-jvm-target", "17", "-d", "build/classes"),
             cmd.args
         )
-        assertEquals("build/my-app.jar", cmd.outputPath)
+        assertEquals("build/classes", cmd.outputPath)
+    }
+
+    @Test
+    fun buildCommandDoesNotIncludeRuntime() {
+        val cmd = buildCommand(testConfig())
+
+        assertFalse(cmd.args.contains("-include-runtime"))
     }
 
     @Test
@@ -22,7 +32,7 @@ class BuilderTest {
         val cmd = buildCommand(testConfig(sources = listOf("src", "generated")))
 
         assertEquals(
-            listOf("kotlinc", "src", "generated", "-jvm-target", "17", "-include-runtime", "-d", "build/my-app.jar"),
+            listOf("kotlinc", "src", "generated", "-jvm-target", "17", "-d", "build/classes"),
             cmd.args
         )
     }
@@ -32,7 +42,7 @@ class BuilderTest {
         val cmd = buildCommand(testConfig(), classpath = "/cache/a.jar:/cache/b.jar")
 
         assertEquals(
-            listOf("kotlinc", "-cp", "/cache/a.jar:/cache/b.jar", "src", "-jvm-target", "17", "-include-runtime", "-d", "build/my-app.jar"),
+            listOf("kotlinc", "-cp", "/cache/a.jar:/cache/b.jar", "src", "-jvm-target", "17", "-d", "build/classes"),
             cmd.args
         )
     }
@@ -42,15 +52,16 @@ class BuilderTest {
         val cmd = buildCommand(testConfig(jvmTarget = "21"))
 
         assertEquals(
-            listOf("kotlinc", "src", "-jvm-target", "21", "-include-runtime", "-d", "build/my-app.jar"),
+            listOf("kotlinc", "src", "-jvm-target", "21", "-d", "build/classes"),
             cmd.args
         )
     }
 
     @Test
-    fun outputPathUsesProjectName() {
+    fun buildCommandOutputPathIsClassesDir() {
+        // outputPath is always build/classes regardless of project name
         val cmd = buildCommand(testConfig(name = "hello-world"))
-        assertEquals("build/hello-world.jar", cmd.outputPath)
+        assertEquals("build/classes", cmd.outputPath)
     }
 
     @Test
@@ -58,7 +69,7 @@ class BuilderTest {
         val cmd = buildCommand(testConfig(), classpath = "")
 
         assertEquals(
-            listOf("kotlinc", "src", "-jvm-target", "17", "-include-runtime", "-d", "build/my-app.jar"),
+            listOf("kotlinc", "src", "-jvm-target", "17", "-d", "build/classes"),
             cmd.args
         )
     }
@@ -68,28 +79,8 @@ class BuilderTest {
         val cmd = buildCommand(testConfig(sources = emptyList()))
 
         assertEquals(
-            listOf("kotlinc", "-jvm-target", "17", "-include-runtime", "-d", "build/my-app.jar"),
+            listOf("kotlinc", "-jvm-target", "17", "-d", "build/classes"),
             cmd.args
-        )
-    }
-
-    @Test
-    fun checkCommandDoesNotIncludeRuntimeOrOutput() {
-        val cmd = checkCommand(testConfig())
-
-        assertEquals(
-            listOf("kotlinc", "src", "-jvm-target", "17"),
-            cmd
-        )
-    }
-
-    @Test
-    fun checkCommandWithClasspath() {
-        val cmd = checkCommand(testConfig(), classpath = "/cache/a.jar")
-
-        assertEquals(
-            listOf("kotlinc", "-cp", "/cache/a.jar", "src", "-jvm-target", "17"),
-            cmd
         )
     }
 
@@ -103,7 +94,7 @@ class BuilderTest {
             listOf(
                 "kotlinc", "src", "-jvm-target", "17",
                 "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
-                "-include-runtime", "-d", "build/my-app.jar"
+                "-d", "build/classes"
             ),
             cmd.args
         )
@@ -123,7 +114,7 @@ class BuilderTest {
                 "kotlinc", "src", "-jvm-target", "17",
                 "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
                 "-Xplugin=/usr/local/kotlinc/lib/allopen-compiler-plugin.jar",
-                "-include-runtime", "-d", "build/my-app.jar"
+                "-d", "build/classes"
             ),
             cmd.args
         )
@@ -134,7 +125,7 @@ class BuilderTest {
         val cmd = buildCommand(testConfig(), pluginArgs = emptyList())
 
         assertEquals(
-            listOf("kotlinc", "src", "-jvm-target", "17", "-include-runtime", "-d", "build/my-app.jar"),
+            listOf("kotlinc", "src", "-jvm-target", "17", "-d", "build/classes"),
             cmd.args
         )
     }
@@ -149,9 +140,31 @@ class BuilderTest {
             listOf(
                 "kotlinc", "-cp", "/cache/a.jar", "src", "-jvm-target", "17",
                 "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
-                "-include-runtime", "-d", "build/my-app.jar"
+                "-d", "build/classes"
             ),
             cmd.args
+        )
+    }
+
+    // --- checkCommand ---
+
+    @Test
+    fun checkCommandDoesNotIncludeRuntimeOrOutput() {
+        val cmd = checkCommand(testConfig())
+
+        assertEquals(
+            listOf("kotlinc", "src", "-jvm-target", "17"),
+            cmd
+        )
+    }
+
+    @Test
+    fun checkCommandWithClasspath() {
+        val cmd = checkCommand(testConfig(), classpath = "/cache/a.jar")
+
+        assertEquals(
+            listOf("kotlinc", "-cp", "/cache/a.jar", "src", "-jvm-target", "17"),
+            cmd
         )
     }
 
@@ -178,5 +191,39 @@ class BuilderTest {
             listOf("kotlinc", "src", "-jvm-target", "17"),
             cmd
         )
+    }
+
+    // --- jarCommand ---
+
+    @Test
+    fun jarCommandPackagesClassesDirToJar() {
+        val cmd = jarCommand(testConfig())
+
+        assertEquals(
+            listOf("jar", "cf", "build/my-app.jar", "-C", "build/classes", "."),
+            cmd.args
+        )
+        assertEquals("build/my-app.jar", cmd.outputPath)
+    }
+
+    @Test
+    fun jarCommandOutputPathUsesProjectName() {
+        val cmd = jarCommand(testConfig(name = "hello-world"))
+
+        assertEquals("build/hello-world.jar", cmd.outputPath)
+        assertEquals(
+            listOf("jar", "cf", "build/hello-world.jar", "-C", "build/classes", "."),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun jarCommandSourceDirectoryIsAlwaysClassesDir() {
+        // jar source is always build/classes regardless of project name
+        val cmd1 = jarCommand(testConfig(name = "app-a"))
+        val cmd2 = jarCommand(testConfig(name = "app-b"))
+
+        assertEquals("build/classes", cmd1.args[4])
+        assertEquals("build/classes", cmd2.args[4])
     }
 }

--- a/src/nativeTest/kotlin/keel/build/RunnerTest.kt
+++ b/src/nativeTest/kotlin/keel/build/RunnerTest.kt
@@ -7,32 +7,25 @@ import kotlin.test.assertEquals
 class RunnerTest {
 
     @Test
-    fun runCommandWithoutClasspath() {
+    fun runCommandUsesClassesDirAsClasspath() {
         val cmd = runCommand(testConfig(), null)
-        assertEquals(listOf("java", "-cp", "build/my-app.jar", "com.example.MainKt"), cmd.args)
-        assertEquals("build/my-app.jar", cmd.jarPath)
+        assertEquals(listOf("java", "-cp", "build/classes", "com.example.MainKt"), cmd.args)
     }
 
     @Test
-    fun runCommandWithClasspath() {
+    fun runCommandWithClasspathAppendedToClassesDir() {
         val cmd = runCommand(testConfig(), "/cache/lib.jar:/cache/util.jar")
         assertEquals(
-            listOf("java", "-cp", "build/my-app.jar:/cache/lib.jar:/cache/util.jar", "com.example.MainKt"),
+            listOf("java", "-cp", "build/classes:/cache/lib.jar:/cache/util.jar", "com.example.MainKt"),
             cmd.args
         )
-    }
-
-    @Test
-    fun runCommandUsesProjectName() {
-        val cmd = runCommand(testConfig(name = "hello-world"), null)
-        assertEquals("build/hello-world.jar", cmd.jarPath)
     }
 
     @Test
     fun runCommandWithAppArgs() {
         val cmd = runCommand(testConfig(), null, listOf("--port", "8080"))
         assertEquals(
-            listOf("java", "-cp", "build/my-app.jar", "com.example.MainKt", "--port", "8080"),
+            listOf("java", "-cp", "build/classes", "com.example.MainKt", "--port", "8080"),
             cmd.args
         )
     }
@@ -40,6 +33,12 @@ class RunnerTest {
     @Test
     fun runCommandWithEmptyAppArgs() {
         val cmd = runCommand(testConfig(), null, emptyList())
-        assertEquals(listOf("java", "-cp", "build/my-app.jar", "com.example.MainKt"), cmd.args)
+        assertEquals(listOf("java", "-cp", "build/classes", "com.example.MainKt"), cmd.args)
+    }
+
+    @Test
+    fun runCommandEmptyClasspathIsIgnored() {
+        val cmd = runCommand(testConfig(), "")
+        assertEquals(listOf("java", "-cp", "build/classes", "com.example.MainKt"), cmd.args)
     }
 }

--- a/src/nativeTest/kotlin/keel/build/TestBuilderTest.kt
+++ b/src/nativeTest/kotlin/keel/build/TestBuilderTest.kt
@@ -11,26 +11,26 @@ class TestBuilderTest {
     fun testBuildCommandBasic() {
         val cmd = testBuildCommand(
             config = testConfig(),
-            mainJarPath = "build/my-app.jar"
+            classesDir = "build/classes"
         )
 
         assertEquals(
-            listOf("kotlinc", "-cp", "build/my-app.jar", "test", "-jvm-target", "17", "-d", "build/my-app-test.jar"),
+            listOf("kotlinc", "-cp", "build/classes", "test", "-jvm-target", "17", "-d", "build/test-classes"),
             cmd.args
         )
-        assertEquals("build/my-app-test.jar", cmd.outputPath)
+        assertEquals("build/test-classes", cmd.outputPath)
     }
 
     @Test
     fun testBuildCommandWithClasspath() {
         val cmd = testBuildCommand(
             config = testConfig(),
-            mainJarPath = "build/my-app.jar",
+            classesDir = "build/classes",
             classpath = "/cache/dep.jar:/cache/junit.jar"
         )
 
         assertEquals(
-            listOf("kotlinc", "-cp", "build/my-app.jar:/cache/dep.jar:/cache/junit.jar", "test", "-jvm-target", "17", "-d", "build/my-app-test.jar"),
+            listOf("kotlinc", "-cp", "build/classes:/cache/dep.jar:/cache/junit.jar", "test", "-jvm-target", "17", "-d", "build/test-classes"),
             cmd.args
         )
     }
@@ -39,11 +39,11 @@ class TestBuilderTest {
     fun testBuildCommandCustomTestSources() {
         val cmd = testBuildCommand(
             config = testConfig(testSources = listOf("test", "integration-test")),
-            mainJarPath = "build/my-app.jar"
+            classesDir = "build/classes"
         )
 
         assertEquals(
-            listOf("kotlinc", "-cp", "build/my-app.jar", "test", "integration-test", "-jvm-target", "17", "-d", "build/my-app-test.jar"),
+            listOf("kotlinc", "-cp", "build/classes", "test", "integration-test", "-jvm-target", "17", "-d", "build/test-classes"),
             cmd.args
         )
     }
@@ -52,39 +52,34 @@ class TestBuilderTest {
     fun testBuildCommandDifferentJvmTarget() {
         val cmd = testBuildCommand(
             config = testConfig(jvmTarget = "21"),
-            mainJarPath = "build/my-app.jar"
+            classesDir = "build/classes"
         )
 
         assertEquals(
-            listOf("kotlinc", "-cp", "build/my-app.jar", "test", "-jvm-target", "21", "-d", "build/my-app-test.jar"),
+            listOf("kotlinc", "-cp", "build/classes", "test", "-jvm-target", "21", "-d", "build/test-classes"),
             cmd.args
         )
     }
 
     @Test
-    fun testBuildCommandUsesProjectName() {
+    fun testBuildCommandOutputPathIsTestClassesDir() {
+        // outputPath is always build/test-classes regardless of project name
         val cmd = testBuildCommand(
             config = testConfig(name = "hello-world"),
-            mainJarPath = "build/hello-world.jar"
+            classesDir = "build/classes"
         )
 
-        assertEquals("build/hello-world-test.jar", cmd.outputPath)
+        assertEquals("build/test-classes", cmd.outputPath)
     }
 
     @Test
     fun testBuildCommandNoIncludeRuntime() {
         val cmd = testBuildCommand(
             config = testConfig(),
-            mainJarPath = "build/my-app.jar"
+            classesDir = "build/classes"
         )
 
         assertFalse(cmd.args.contains("-include-runtime"))
-    }
-
-    @Test
-    fun testJarPath() {
-        assertEquals("build/my-app-test.jar", testJarPath(testConfig()))
-        assertEquals("build/hello-test.jar", testJarPath(testConfig(name = "hello")))
     }
 
     @Test
@@ -93,15 +88,15 @@ class TestBuilderTest {
 
         val cmd = testBuildCommand(
             config = testConfig(),
-            mainJarPath = "build/my-app.jar",
+            classesDir = "build/classes",
             pluginArgs = pluginArgs
         )
 
         assertEquals(
             listOf(
-                "kotlinc", "-cp", "build/my-app.jar", "test", "-jvm-target", "17",
+                "kotlinc", "-cp", "build/classes", "test", "-jvm-target", "17",
                 "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
-                "-d", "build/my-app-test.jar"
+                "-d", "build/test-classes"
             ),
             cmd.args
         )
@@ -116,16 +111,16 @@ class TestBuilderTest {
 
         val cmd = testBuildCommand(
             config = testConfig(),
-            mainJarPath = "build/my-app.jar",
+            classesDir = "build/classes",
             pluginArgs = pluginArgs
         )
 
         assertEquals(
             listOf(
-                "kotlinc", "-cp", "build/my-app.jar", "test", "-jvm-target", "17",
+                "kotlinc", "-cp", "build/classes", "test", "-jvm-target", "17",
                 "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
                 "-Xplugin=/usr/local/kotlinc/lib/allopen-compiler-plugin.jar",
-                "-d", "build/my-app-test.jar"
+                "-d", "build/test-classes"
             ),
             cmd.args
         )
@@ -135,12 +130,12 @@ class TestBuilderTest {
     fun testBuildCommandWithEmptyPluginArgs() {
         val cmd = testBuildCommand(
             config = testConfig(),
-            mainJarPath = "build/my-app.jar",
+            classesDir = "build/classes",
             pluginArgs = emptyList()
         )
 
         assertEquals(
-            listOf("kotlinc", "-cp", "build/my-app.jar", "test", "-jvm-target", "17", "-d", "build/my-app-test.jar"),
+            listOf("kotlinc", "-cp", "build/classes", "test", "-jvm-target", "17", "-d", "build/test-classes"),
             cmd.args
         )
     }
@@ -151,16 +146,16 @@ class TestBuilderTest {
 
         val cmd = testBuildCommand(
             config = testConfig(),
-            mainJarPath = "build/my-app.jar",
+            classesDir = "build/classes",
             classpath = "/cache/dep.jar",
             pluginArgs = pluginArgs
         )
 
         assertEquals(
             listOf(
-                "kotlinc", "-cp", "build/my-app.jar:/cache/dep.jar", "test", "-jvm-target", "17",
+                "kotlinc", "-cp", "build/classes:/cache/dep.jar", "test", "-jvm-target", "17",
                 "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
-                "-d", "build/my-app-test.jar"
+                "-d", "build/test-classes"
             ),
             cmd.args
         )

--- a/src/nativeTest/kotlin/keel/build/TestRunnerTest.kt
+++ b/src/nativeTest/kotlin/keel/build/TestRunnerTest.kt
@@ -8,8 +8,8 @@ class TestRunnerTest {
     @Test
     fun testRunCommandBasic() {
         val cmd = testRunCommand(
-            mainJarPath = "build/my-app.jar",
-            testJarPath = "build/my-app-test.jar",
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
             consoleLauncherPath = "/home/user/.keel/tools/junit-platform-console-standalone-1.11.4.jar"
         )
 
@@ -17,7 +17,7 @@ class TestRunnerTest {
             listOf(
                 "java", "-jar",
                 "/home/user/.keel/tools/junit-platform-console-standalone-1.11.4.jar",
-                "--class-path", "build/my-app.jar:build/my-app-test.jar",
+                "--class-path", "build/classes:build/test-classes",
                 "--scan-class-path"
             ),
             cmd.args
@@ -27,8 +27,8 @@ class TestRunnerTest {
     @Test
     fun testRunCommandWithClasspath() {
         val cmd = testRunCommand(
-            mainJarPath = "build/my-app.jar",
-            testJarPath = "build/my-app-test.jar",
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
             consoleLauncherPath = "/tools/launcher.jar",
             classpath = "/cache/dep.jar:/cache/junit.jar"
         )
@@ -36,7 +36,7 @@ class TestRunnerTest {
         assertEquals(
             listOf(
                 "java", "-jar", "/tools/launcher.jar",
-                "--class-path", "build/my-app.jar:build/my-app-test.jar:/cache/dep.jar:/cache/junit.jar",
+                "--class-path", "build/classes:build/test-classes:/cache/dep.jar:/cache/junit.jar",
                 "--scan-class-path"
             ),
             cmd.args
@@ -46,8 +46,8 @@ class TestRunnerTest {
     @Test
     fun testRunCommandWithTestArgs() {
         val cmd = testRunCommand(
-            mainJarPath = "build/my-app.jar",
-            testJarPath = "build/my-app-test.jar",
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
             consoleLauncherPath = "/tools/launcher.jar",
             testArgs = listOf("--include-classname", ".*Test")
         )
@@ -55,9 +55,28 @@ class TestRunnerTest {
         assertEquals(
             listOf(
                 "java", "-jar", "/tools/launcher.jar",
-                "--class-path", "build/my-app.jar:build/my-app-test.jar",
+                "--class-path", "build/classes:build/test-classes",
                 "--scan-class-path",
                 "--include-classname", ".*Test"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun testRunCommandWithEmptyClasspath() {
+        val cmd = testRunCommand(
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
+            consoleLauncherPath = "/tools/launcher.jar",
+            classpath = ""
+        )
+
+        assertEquals(
+            listOf(
+                "java", "-jar", "/tools/launcher.jar",
+                "--class-path", "build/classes:build/test-classes",
+                "--scan-class-path"
             ),
             cmd.args
         )

--- a/src/nativeTest/kotlin/keel/infra/FileSystemTest.kt
+++ b/src/nativeTest/kotlin/keel/infra/FileSystemTest.kt
@@ -220,6 +220,65 @@ class FileSystemTest {
         }
     }
 
+    @Test
+    fun newestMtimeAllReturnsNewestFileInDirectory() {
+        val dir = "/tmp/keel_test_newest_mtime_all"
+        platform.posix.mkdir(dir, 0b111111101u)
+        writeTestFile("$dir/a.txt", "a")
+        // ext4 has 1-second mtime granularity; sleep to ensure distinct mtimes
+        platform.posix.sleep(1u)
+        writeTestFile("$dir/b.class", "b")
+        try {
+            val newest = newestMtimeAll(dir)
+            val bMtime = fileMtime("$dir/b.class")
+            assertNotNull(bMtime)
+            assertEquals(bMtime, newest)
+        } finally {
+            remove("$dir/a.txt")
+            remove("$dir/b.class")
+            platform.posix.rmdir(dir)
+        }
+    }
+
+    @Test
+    fun newestMtimeAllReturnsZeroForEmptyDirectory() {
+        val dir = "/tmp/keel_test_newest_all_empty"
+        platform.posix.mkdir(dir, 0b111111101u)
+        try {
+            assertEquals(0L, newestMtimeAll(dir))
+        } finally {
+            platform.posix.rmdir(dir)
+        }
+    }
+
+    @Test
+    fun newestMtimeAllReturnsZeroForNonExistentDirectory() {
+        assertEquals(0L, newestMtimeAll("/tmp/keel_nonexistent_dir_mtime_all"))
+    }
+
+    @Test
+    fun newestMtimeAllRecursesIntoSubdirectories() {
+        val dir = "/tmp/keel_test_newest_all_recursive"
+        val sub = "$dir/sub"
+        platform.posix.mkdir(dir, 0b111111101u)
+        platform.posix.mkdir(sub, 0b111111101u)
+        writeTestFile("$dir/a.txt", "a")
+        // ext4 has 1-second mtime granularity; sleep to ensure distinct mtimes
+        platform.posix.sleep(1u)
+        writeTestFile("$sub/b.class", "b")
+        try {
+            val newest = newestMtimeAll(dir)
+            val bMtime = fileMtime("$sub/b.class")
+            assertNotNull(bMtime)
+            assertEquals(bMtime, newest)
+        } finally {
+            remove("$dir/a.txt")
+            remove("$sub/b.class")
+            platform.posix.rmdir(sub)
+            platform.posix.rmdir(dir)
+        }
+    }
+
     private fun writeTestFile(path: String, content: String) {
         val fp = platform.posix.fopen(path, "w") ?: error("could not create test file: $path")
         if (content.isNotEmpty()) {


### PR DESCRIPTION
## Summary

## Summary

Refactor the build pipeline from direct JAR output (`kotlinc -d output.jar -include-runtime`) to a classes directory approach (`kotlinc -d build/classes/`).

This lays the foundation for:
- Resource file support (#20)
- Incremental build
- Future daemon mode
- `--fat-jar` option (separate issue)

## User-Facing Impact

**`keel run`**: No change in behavior. Internally faster (skips JAR packaging).

**`keel build`**: Output JAR changes from fat JAR (with Kotlin runtime) to thin JAR (classes only). The JAR is no longer standalone-executable via `java -jar`. Use `keel run` to execute, or `java -cp build/app.jar:deps/ MainKt`. A future `--fat-jar` flag will restore standalone JAR support.

**`keel test`**: No change in behavior.

## Current State

```
keel build → kotlinc -include-runtime -d build/{name}.jar  (fat JAR directly from kotlinc)
keel run   → doBuild() then java -cp build/{name}.jar:deps MainKt
keel test  → doBuild() then kotlinc -d build/{name}-test.jar, java -jar consoleLauncher --class-path ...
```

Key observations:
- `Runner.kt` already uses `java -cp`, not `java -jar`
- `-include-runtime` embeds Kotlin stdlib into the JAR (~1.5MB overhead per build)
- `BuildCache.kt` tracks JAR mtime for up-to-date checks

## Target State

```
keel build → kotlinc -d build/classes/  then  jar cf build/{name}.jar -C build/classes/ .
keel run   → kotlinc -d build/classes/  then  java -cp build/classes/:deps MainKt  (no JAR packaging)
keel test  → kotlinc -d build/classes/  then  kotlinc -d build/test-classes/  then  java ... --class-path build/classes/:build/test-classes/:deps
```

## Implementation Details

### 1. Builder.kt

**buildCommand()**: Change output from JAR to classes directory.

```
Before: kotlinc [sources] -include-runtime -d build/{name}.jar
After:  kotlinc [sources] -d build/classes/
```

- Remove `-include-runtime` flag
- Change `-d` target from `jarPath(config)` to `build/classes/`

Add a new **jarCommand()** pure function for thin JAR packaging:

```
jar cf build/{name}.jar -C build/classes/ .
```

**checkCommand()**: No change needed (already doesn't produce output).

### 2. Runner.kt

**runCommand()**: Run directly from classes directory, not from JAR.

```
Before: java -cp build/{name}.jar:deps MainKt
After:  java -cp build/classes/:deps MainKt
```

- Remove `jarPath` field from `RunCommand` (no longer needed — existence check moves to classes dir)

### 3. TestBuilder.kt

**testBuildCommand()**: Output to classes directory instead of JAR.

```
Before: kotlinc -cp build/{name}.jar:deps -d build/{name}-test.jar
After:  kotlinc -cp build/classes/:deps -d build/test-classes/
```

- `mainJarPath` parameter becomes `classesDir` parameter

### 4. TestRunner.kt

**testRunCommand()**: Use directories on classpath.

```
Before: java -jar consoleLauncher --class-path build/{name}.jar:build/{name}-test.jar:deps
After:  java -jar consoleLauncher --class-path build/classes/:build/test-classes/:deps
```

- `mainJarPath` / `testJarPath` parameters become `classesDir` / `testClassesDir`

### 5. BuildCache.kt

- `output_mtime` (single JAR mtime) → track `classes_dir_mtime` (newest mtime in `build/classes/`)
- This aligns with the existing `newestMtime()` approach used for source tracking

### 6. BuildCommands.kt

**doBuild()**:
- Compile to `build/classes/` (always)
- Package thin JAR via `jar cf` (always — `keel build` produces a JAR)
- Return classpath info as before

**doRun()** (called from Main.kt after `doBuild()`):
- Change existence check from JAR to `build/classes/` directory
- `doBuild()` now compiles to classes dir, `doRun()` runs from classes dir
- Note: `doBuild()` still packages JAR, but `doRun()` doesn't use it. This is intentional — `keel build` always produces a JAR artifact. A future optimization can skip JAR packaging when called from `keel run`.

**doTest()**:
- Use `build/classes/` instead of main JAR for test compilation classpath
- Use `build/test-classes/` instead of test JAR for test execution classpath

### 7. `jar` command dependency

`jar` is part of the JDK (same as `java` which is already required). No separate tool management needed. If `jar` is not found, report the same kind of error as when `kotlinc` or `java` is missing.

## Out of Scope

- `--fat-jar` flag (separate issue)
- Resource file support (#20 — depends on this issue)
- Skipping JAR packaging for `keel run` (optimization, can do later)

## Execution Report

Workflow `keel` completed successfully.

Closes #35