### PR TITLE
[#20] add-resource-files-support

### DIFF
--- a/src/nativeMain/kotlin/keel/build/BuildCache.kt
+++ b/src/nativeMain/kotlin/keel/build/BuildCache.kt
@@ -13,7 +13,8 @@ data class BuildState(
     @SerialName("sources_newest_mtime") val sourcesNewestMtime: Long,
     @SerialName("classes_dir_mtime") val classesDirMtime: Long?,
     @SerialName("lockfile_mtime") val lockfileMtime: Long?,
-    val classpath: String? = null
+    val classpath: String? = null,
+    @SerialName("resources_newest_mtime") val resourcesNewestMtime: Long? = null
 )
 
 fun isBuildUpToDate(current: BuildState, cached: BuildState?): Boolean {
@@ -21,7 +22,8 @@ fun isBuildUpToDate(current: BuildState, cached: BuildState?): Boolean {
     return current.configMtime == cached.configMtime &&
         current.sourcesNewestMtime == cached.sourcesNewestMtime &&
         current.classesDirMtime == cached.classesDirMtime &&
-        current.lockfileMtime == cached.lockfileMtime
+        current.lockfileMtime == cached.lockfileMtime &&
+        current.resourcesNewestMtime == cached.resourcesNewestMtime
 }
 
 private val json = Json { prettyPrint = true }

--- a/src/nativeMain/kotlin/keel/build/TestRunner.kt
+++ b/src/nativeMain/kotlin/keel/build/TestRunner.kt
@@ -8,12 +8,14 @@ fun testRunCommand(
     classesDir: String,
     testClassesDir: String,
     consoleLauncherPath: String,
+    testResourceDirs: List<String> = emptyList(),
     classpath: String? = null,
     testArgs: List<String> = emptyList()
 ): TestRunCommand {
     val cp = buildList {
         add(classesDir)
         add(testClassesDir)
+        addAll(testResourceDirs)
         if (!classpath.isNullOrEmpty()) add(classpath)
     }.joinToString(":")
     val args = buildList {

--- a/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
@@ -82,7 +82,9 @@ internal fun doBuild(): BuildResult {
         configMtime = fileMtime(KEEL_TOML) ?: 0L,
         sourcesNewestMtime = newestMtime(config.sources),
         classesDirMtime = if (fileExists(CLASSES_DIR)) newestMtimeAll(CLASSES_DIR) else null,
-        lockfileMtime = if (fileExists(LOCK_FILE)) fileMtime(LOCK_FILE) else null
+        lockfileMtime = if (fileExists(LOCK_FILE)) fileMtime(LOCK_FILE) else null,
+        resourcesNewestMtime = if (config.resources.isEmpty()) null
+            else config.resources.maxOf { newestMtimeAll(it) }
     )
     val cachedState = readFileAsString(BUILD_STATE_FILE).getOrElse { null }
         ?.let { parseBuildState(it) }
@@ -106,6 +108,14 @@ internal fun doBuild(): BuildResult {
     executeCommand(buildCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "compilation"))
         exitProcess(EXIT_BUILD_ERROR)
+    }
+
+    for (resourceDir in config.resources) {
+        if (!fileExists(resourceDir)) continue
+        copyDirectoryContents(resourceDir, CLASSES_DIR).getOrElse { error ->
+            eprintln("error: could not copy resources from ${error.path}")
+            exitProcess(EXIT_BUILD_ERROR)
+        }
     }
 
     val jarCmd = jarCommand(config)
@@ -165,7 +175,15 @@ internal fun doTest(testArgs: List<String> = emptyList()) {
         exitProcess(EXIT_BUILD_ERROR)
     }
 
-    val runCmd = testRunCommand(CLASSES_DIR, testCmd.outputPath, consoleLauncherPath, classpath, testArgs)
+    val existingTestResourceDirs = config.testResources.filter { fileExists(it) }
+    val runCmd = testRunCommand(
+        classesDir = CLASSES_DIR,
+        testClassesDir = testCmd.outputPath,
+        consoleLauncherPath = consoleLauncherPath,
+        testResourceDirs = existingTestResourceDirs,
+        classpath = classpath,
+        testArgs = testArgs
+    )
     println("running tests...")
     executeCommand(runCmd.args).getOrElse { error ->
         when (error) {

--- a/src/nativeMain/kotlin/keel/config/Config.kt
+++ b/src/nativeMain/kotlin/keel/config/Config.kt
@@ -25,6 +25,8 @@ data class KeelConfig(
     val main: String,
     val sources: List<String>,
     @SerialName("test_sources") val testSources: List<String> = listOf("test"),
+    val resources: List<String> = emptyList(),
+    @SerialName("test_resources") val testResources: List<String> = emptyList(),
     val dependencies: Map<String, String> = emptyMap(),
     @SerialName("test-dependencies") val testDependencies: Map<String, String> = emptyMap(),
     @SerialName("fmt_style") val fmtStyle: String = "google",

--- a/src/nativeMain/kotlin/keel/infra/FileSystem.kt
+++ b/src/nativeMain/kotlin/keel/infra/FileSystem.kt
@@ -153,7 +153,6 @@ private fun collectNewestMtime(directory: String, onFile: (Long) -> Unit) {
     }
 }
 
-/** Return the newest mtime among all files (any extension) in the given directory tree. 0 if no files found. */
 @OptIn(ExperimentalForeignApi::class)
 fun newestMtimeAll(directory: String): Long {
     var newest = 0L
@@ -216,6 +215,60 @@ private fun collectKotlinFiles(directory: String, result: MutableList<String>): 
         closedir(dir)
     }
     return null
+}
+
+data class CopyFailed(val path: String)
+
+fun copyDirectoryContents(src: String, dest: String): Result<Unit, CopyFailed> {
+    if (!fileExists(src)) return Err(CopyFailed(src))
+    return copyDirRecursive(src, dest)
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun copyDirRecursive(src: String, dest: String): Result<Unit, CopyFailed> {
+    val dir = opendir(src) ?: return Err(CopyFailed(src))
+    try {
+        while (true) {
+            val entry = readdir(dir) ?: break
+            val name = entry.pointed.d_name.toKString()
+            if (name == "." || name == "..") continue
+            val srcChild = "$src/$name"
+            val destChild = "$dest/$name"
+            if (isDirectory(srcChild)) {
+                ensureDirectory(destChild).getOrElse { return Err(CopyFailed(destChild)) }
+                copyDirRecursive(srcChild, destChild).getOrElse { return Err(it) }
+            } else {
+                copyFile(srcChild, destChild).getOrElse { return Err(it) }
+            }
+        }
+    } finally {
+        closedir(dir)
+    }
+    return Ok(Unit)
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun copyFile(src: String, dest: String): Result<Unit, CopyFailed> {
+    val srcFp = fopen(src, "rb") ?: return Err(CopyFailed(src))
+    try {
+        val destFp = fopen(dest, "wb") ?: return Err(CopyFailed(dest))
+        try {
+            memScoped {
+                val buffer = allocArray<ByteVar>(4096)
+                while (true) {
+                    val bytesRead = fread(buffer, 1u, 4096u, srcFp)
+                    if (bytesRead == 0uL) break
+                    val written = fwrite(buffer, 1u, bytesRead, destFp)
+                    if (written != bytesRead) return Err(CopyFailed(dest))
+                }
+            }
+        } finally {
+            fclose(destFp)
+        }
+    } finally {
+        fclose(srcFp)
+    }
+    return Ok(Unit)
 }
 
 data class HomeNotFound(val message: String = "HOME environment variable is not set")

--- a/src/nativeTest/kotlin/keel/build/BuildCacheTest.kt
+++ b/src/nativeTest/kotlin/keel/build/BuildCacheTest.kt
@@ -3,6 +3,7 @@ package keel.build
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -171,5 +172,95 @@ class BuildCacheTest {
     @Test
     fun parseEmptyStringReturnsNull() {
         assertNull(parseBuildState(""))
+    }
+
+    @Test
+    fun upToDateWhenResourcesMtimesMatch() {
+        // Given: both current and cached have the same resourcesNewestMtime
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            resourcesNewestMtime = 4000L
+        )
+        assertTrue(isBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun notUpToDateWhenResourcesMtimeChanged() {
+        // Given: cached has older resourcesNewestMtime
+        val cached = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            resourcesNewestMtime = 4000L
+        )
+        val current = cached.copy(resourcesNewestMtime = 5000L)
+        assertFalse(isBuildUpToDate(current = current, cached = cached))
+    }
+
+    @Test
+    fun notUpToDateWhenResourcesMtimeChangedFromNullToValue() {
+        // Given: cached has null (no resources), current has resources
+        val cached = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            resourcesNewestMtime = null
+        )
+        val current = cached.copy(resourcesNewestMtime = 4000L)
+        assertFalse(isBuildUpToDate(current = current, cached = cached))
+    }
+
+    @Test
+    fun upToDateWhenBothResourcesMtimesNull() {
+        // Given: neither current nor cached have resources
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            resourcesNewestMtime = null
+        )
+        assertTrue(isBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun serializeAndDeserializeRoundTripWithResourcesMtime() {
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = 500L,
+            resourcesNewestMtime = 4000L
+        )
+        val json = serializeBuildState(state)
+        val parsed = parseBuildState(json)
+        assertEquals(state, parsed)
+    }
+
+    @Test
+    fun serializationUsesResourcesNewestMtimeKey() {
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            resourcesNewestMtime = 4000L
+        )
+        val json = serializeBuildState(state)
+        assertTrue(json.contains("resources_newest_mtime"), "Expected JSON key 'resources_newest_mtime' in: $json")
+    }
+
+    @Test
+    fun resourcesNewestMtimeDefaultsToNullForOlderStateJson() {
+        // Given: older JSON without resources_newest_mtime
+        val oldJson = """{"config_mtime":1000,"sources_newest_mtime":2000,"classes_dir_mtime":3000,"lockfile_mtime":null}"""
+        val parsed = parseBuildState(oldJson)
+        assertNotNull(parsed)
+        assertNull(parsed.resourcesNewestMtime)
     }
 }

--- a/src/nativeTest/kotlin/keel/build/TestRunnerTest.kt
+++ b/src/nativeTest/kotlin/keel/build/TestRunnerTest.kt
@@ -81,4 +81,87 @@ class TestRunnerTest {
             cmd.args
         )
     }
+
+    @Test
+    fun testRunCommandWithTestResourceDirs() {
+        // Given: a single test resource directory
+        val cmd = testRunCommand(
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
+            consoleLauncherPath = "/tools/launcher.jar",
+            testResourceDirs = listOf("test-resources")
+        )
+
+        // Then: test resource dir is inserted between test-classes and deps
+        assertEquals(
+            listOf(
+                "java", "-jar", "/tools/launcher.jar",
+                "--class-path", "build/classes:build/test-classes:test-resources",
+                "--scan-class-path"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun testRunCommandWithMultipleTestResourceDirs() {
+        // Given: multiple test resource directories
+        val cmd = testRunCommand(
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
+            consoleLauncherPath = "/tools/launcher.jar",
+            testResourceDirs = listOf("test-resources", "fixtures")
+        )
+
+        assertEquals(
+            listOf(
+                "java", "-jar", "/tools/launcher.jar",
+                "--class-path", "build/classes:build/test-classes:test-resources:fixtures",
+                "--scan-class-path"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun testRunCommandWithTestResourceDirsAndClasspath() {
+        // Given: both test resource dirs and dependency classpath
+        val cmd = testRunCommand(
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
+            consoleLauncherPath = "/tools/launcher.jar",
+            testResourceDirs = listOf("test-resources"),
+            classpath = "/cache/dep.jar"
+        )
+
+        // Then: order is classes:test-classes:test-resources:deps
+        assertEquals(
+            listOf(
+                "java", "-jar", "/tools/launcher.jar",
+                "--class-path", "build/classes:build/test-classes:test-resources:/cache/dep.jar",
+                "--scan-class-path"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun testRunCommandWithEmptyTestResourceDirs() {
+        // Given: empty testResourceDirs (same as not providing it)
+        val cmd = testRunCommand(
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
+            consoleLauncherPath = "/tools/launcher.jar",
+            testResourceDirs = emptyList()
+        )
+
+        assertEquals(
+            listOf(
+                "java", "-jar", "/tools/launcher.jar",
+                "--class-path", "build/classes:build/test-classes",
+                "--scan-class-path"
+            ),
+            cmd.args
+        )
+    }
 }

--- a/src/nativeTest/kotlin/keel/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/keel/config/ConfigTest.kt
@@ -436,6 +436,99 @@ class ConfigTest {
     }
 
     @Test
+    fun parseMinimalConfigHasDefaultResources() {
+        // Given: no resources or test_resources fields in TOML
+        // When: config is parsed
+        val config = assertNotNull(parseConfig(minimalToml).get())
+
+        // Then: both default to empty list
+        assertEquals(emptyList(), config.resources)
+        assertEquals(emptyList(), config.testResources)
+    }
+
+    @Test
+    fun parseConfigWithResources() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+            resources = ["resources"]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals(listOf("resources"), config.resources)
+    }
+
+    @Test
+    fun parseConfigWithMultipleResources() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+            resources = ["resources", "assets"]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals(listOf("resources", "assets"), config.resources)
+    }
+
+    @Test
+    fun parseConfigWithTestResources() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+            test_resources = ["test-resources"]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals(listOf("test-resources"), config.testResources)
+    }
+
+    @Test
+    fun parseConfigWithBothResourceFields() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+            resources = ["resources"]
+            test_resources = ["test-resources"]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals(listOf("resources"), config.resources)
+        assertEquals(listOf("test-resources"), config.testResources)
+    }
+
+    @Test
+    fun parseConfigWithEmptyResources() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+            resources = []
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals(emptyList(), config.resources)
+    }
+
+    @Test
     fun commentsAreIgnored() {
         val toml = """
             # Project configuration

--- a/src/nativeTest/kotlin/keel/infra/FileSystemTest.kt
+++ b/src/nativeTest/kotlin/keel/infra/FileSystemTest.kt
@@ -279,6 +279,142 @@ class FileSystemTest {
         }
     }
 
+    @Test
+    fun copyDirectoryContentsCopiesFilesToDest() {
+        // Given: source dir with one file
+        val src = "/tmp/keel_copy_src_basic"
+        val dest = "/tmp/keel_copy_dest_basic"
+        platform.posix.mkdir(src, 0b111111101u)
+        platform.posix.mkdir(dest, 0b111111101u)
+        writeTestFile("$src/hello.txt", "hello")
+        try {
+            // When: copyDirectoryContents is called
+            val result = copyDirectoryContents(src, dest)
+
+            // Then: file exists in dest
+            assertNotNull(result.get())
+            assertTrue(fileExists("$dest/hello.txt"))
+            assertEquals("hello", assertNotNull(readFileAsString("$dest/hello.txt").get()))
+        } finally {
+            remove("$src/hello.txt")
+            remove("$dest/hello.txt")
+            platform.posix.rmdir(src)
+            platform.posix.rmdir(dest)
+        }
+    }
+
+    @Test
+    fun copyDirectoryContentsPreservesRelativePaths() {
+        // Given: source dir with a nested file
+        val src = "/tmp/keel_copy_src_nested"
+        val sub = "$src/config"
+        val dest = "/tmp/keel_copy_dest_nested"
+        platform.posix.mkdir(src, 0b111111101u)
+        platform.posix.mkdir(sub, 0b111111101u)
+        platform.posix.mkdir(dest, 0b111111101u)
+        writeTestFile("$sub/app.properties", "key=value")
+        try {
+            // When: copyDirectoryContents is called
+            val result = copyDirectoryContents(src, dest)
+
+            // Then: nested file exists at same relative path in dest
+            assertNotNull(result.get())
+            assertTrue(fileExists("$dest/config/app.properties"))
+            assertEquals("key=value", assertNotNull(readFileAsString("$dest/config/app.properties").get()))
+        } finally {
+            remove("$sub/app.properties")
+            remove("$dest/config/app.properties")
+            platform.posix.rmdir(sub)
+            platform.posix.rmdir("$dest/config")
+            platform.posix.rmdir(src)
+            platform.posix.rmdir(dest)
+        }
+    }
+
+    @Test
+    fun copyDirectoryContentsCopiesMultipleFiles() {
+        // Given: source dir with multiple files
+        val src = "/tmp/keel_copy_src_multi"
+        val dest = "/tmp/keel_copy_dest_multi"
+        platform.posix.mkdir(src, 0b111111101u)
+        platform.posix.mkdir(dest, 0b111111101u)
+        writeTestFile("$src/a.txt", "aaa")
+        writeTestFile("$src/b.conf", "bbb")
+        try {
+            // When: copyDirectoryContents is called
+            val result = copyDirectoryContents(src, dest)
+
+            // Then: all files exist in dest
+            assertNotNull(result.get())
+            assertTrue(fileExists("$dest/a.txt"))
+            assertTrue(fileExists("$dest/b.conf"))
+            assertEquals("aaa", assertNotNull(readFileAsString("$dest/a.txt").get()))
+            assertEquals("bbb", assertNotNull(readFileAsString("$dest/b.conf").get()))
+        } finally {
+            remove("$src/a.txt")
+            remove("$src/b.conf")
+            remove("$dest/a.txt")
+            remove("$dest/b.conf")
+            platform.posix.rmdir(src)
+            platform.posix.rmdir(dest)
+        }
+    }
+
+    @Test
+    fun copyDirectoryContentsOverwritesExistingFile() {
+        // Given: dest already has a file with old content
+        val src = "/tmp/keel_copy_src_overwrite"
+        val dest = "/tmp/keel_copy_dest_overwrite"
+        platform.posix.mkdir(src, 0b111111101u)
+        platform.posix.mkdir(dest, 0b111111101u)
+        writeTestFile("$src/data.txt", "new content")
+        writeTestFile("$dest/data.txt", "old content")
+        try {
+            // When: copyDirectoryContents is called
+            copyDirectoryContents(src, dest)
+
+            // Then: dest file has new content
+            assertEquals("new content", assertNotNull(readFileAsString("$dest/data.txt").get()))
+        } finally {
+            remove("$src/data.txt")
+            remove("$dest/data.txt")
+            platform.posix.rmdir(src)
+            platform.posix.rmdir(dest)
+        }
+    }
+
+    @Test
+    fun copyDirectoryContentsForNonExistentSrcReturnsErr() {
+        // Given: source dir does not exist
+        val result = copyDirectoryContents(
+            src = "/tmp/keel_copy_nonexistent_src",
+            dest = "/tmp/keel_copy_dest_err"
+        )
+
+        // Then: returns Err
+        assertNull(result.get())
+        assertIs<CopyFailed>(result.getError())
+    }
+
+    @Test
+    fun copyDirectoryContentsForEmptySrcSucceeds() {
+        // Given: source dir exists but is empty
+        val src = "/tmp/keel_copy_src_empty"
+        val dest = "/tmp/keel_copy_dest_empty"
+        platform.posix.mkdir(src, 0b111111101u)
+        platform.posix.mkdir(dest, 0b111111101u)
+        try {
+            // When: copyDirectoryContents is called
+            val result = copyDirectoryContents(src, dest)
+
+            // Then: succeeds with no files copied
+            assertNotNull(result.get())
+        } finally {
+            platform.posix.rmdir(src)
+            platform.posix.rmdir(dest)
+        }
+    }
+
     private fun writeTestFile(path: String, content: String) {
         val fp = platform.posix.fopen(path, "w") ?: error("could not create test file: $path")
         if (content.isNotEmpty()) {


### PR DESCRIPTION
## Summary

## Summary

Add support for including resource files (config files, templates, static assets, etc.) in the build output and on the test classpath.

## Proposed Config

```toml
resources = ["resources"]
test_resources = ["test-resources"]
```

When omitted, no resources are bundled (current behavior). Both fields default to empty list.

## Current State (after #35)

```
keel build → kotlinc -d build/classes/ → jar cf build/{name}.jar -C build/classes/ .
keel run   → doBuild() then java -cp build/classes/:deps MainKt
keel test  → doBuild() then kotlinc -d build/test-classes/ then java ... --class-path build/classes/:build/test-classes/:deps
```

Resources are not handled at all.

## Target State

```
keel build → kotlinc -d build/classes/ → copy resources into build/classes/ → jar cf build/{name}.jar -C build/classes/ .
keel run   → doBuild() (resources already in build/classes/) then java -cp build/classes/:deps MainKt
keel test  → doBuild() then kotlinc -d build/test-classes/ then java ... --class-path build/classes/:build/test-classes/:test-resources/:deps
```

## Implementation Details

### 1. Config.kt

Add two optional fields to `KeelConfig`:

```kotlin
val resources: List<String> = emptyList(),
@SerialName("test_resources") val testResources: List<String> = emptyList(),
```

### 2. BuildCommands.kt — doBuild()

After `kotlinc` compilation and before `jar cf`, copy resource files into `build/classes/`:

```
ensureDirectory(CLASSES_DIR)
kotlinc -d build/classes/ ...
// NEW: copy resources
for each dir in config.resources (that exists):
    recursively copy dir contents into build/classes/
jar cf build/{name}.jar -C build/classes/ .
```

Resource files are merged into the classes directory, so they end up in the JAR and are accessible at runtime via `ClassLoader.getResource()`.

Non-existent resource directories are silently skipped (same pattern as `existingTestSources` in `doTest()`).

### 3. Runner.kt — No change

`keel run` calls `doBuild()` first, which copies resources into `build/classes/`. Since `runCommand()` already uses `build/classes/` on the classpath, resources are accessible without any change.

### 4. TestRunner.kt — testRunCommand()

Add `test_resources` directories to the classpath:

```
Before: java -jar consoleLauncher --class-path build/classes/:build/test-classes/:deps
After:  java -jar consoleLauncher --class-path build/classes/:build/test-classes/:test-resources/:deps
```

Test resources are added as directories on the classpath (not copied into test-classes). This avoids unnecessary file copying and matches how Gradle/Maven handle test resources.

Note: main `resources` are already available via `build/classes/` (copied during build). `test_resources` are additive.

### 5. BuildCache.kt

Add resource directory mtime tracking to `BuildState`:

```kotlin
@SerialName("resources_newest_mtime") val resourcesNewestMtime: Long? = null,
```

If resources change but sources don't, the build must still re-copy resources and re-package the JAR.

### 6. Infra — File copy utility

A recursive file copy function is needed for copying resource directories into `build/classes/`. Add to `FileSystem.kt`:

```
copyDirectoryContents(src: String, dest: String) → Result<Unit, CopyFailed>
```

Copies all files from `src` into `dest`, preserving relative paths.

## Non-existent Directory Handling

- If a directory listed in `resources` or `test_resources` does not exist, skip it silently
- Same pattern as `existingTestSources` filtering in `doTest()`
- No error, no warning — the directory may be created later or only relevant for certain targets

## Out of Scope

- Glob patterns in resource paths (e.g. `resources = ["*.properties"]`)
- Resource filtering/variable substitution
- Resource exclusion patterns

## Execution Report

Workflow `keel` completed successfully.

Closes #20