### PR TITLE
[#38] add-kotlinc-toolchain-mgmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,18 @@ target = "jvm"
 jvm_target = "17"
 main = "MainKt"
 sources = ["src"]
+resources = ["resources"]
+test_resources = ["test-resources"]
+
+[plugins]
+serialization = true
 
 [dependencies]
 "org.jetbrains.kotlinx:kotlinx-coroutines-core" = "1.9.0"
+
+[repositories]
+central = "https://repo1.maven.org/maven2"
+jitpack = "https://jitpack.io"
 ```
 
 ### Fields
@@ -92,7 +101,11 @@ sources = ["src"]
 | `main` | Entry point class | (required) |
 | `sources` | Source directories | (required) |
 | `test_sources` | Test source directories | `["test"]` |
+| `resources` | Resource directories to include in build output | `[]` |
+| `test_resources` | Test resource directories added to test classpath | `[]` |
 | `fmt_style` | ktfmt style: `"google"`, `"kotlinlang"`, `"meta"` | `"google"` |
+| `[plugins]` | Compiler plugins (`serialization`, `allopen`, `noarg`) | `{}` |
+| `[repositories]` | Maven repositories (name = URL) | Maven Central only |
 
 ### Dependencies
 
@@ -114,7 +127,41 @@ Or declare Maven coordinates directly in `[dependencies]`:
 
 Run `keel install` to resolve and download all dependencies without building.
 
-Transitive dependencies are resolved automatically via POM metadata from Maven Central. A `keel.lock` file records versions and SHA-256 hashes for reproducible builds.
+Transitive dependencies are resolved automatically via POM metadata. A `keel.lock` file records versions and SHA-256 hashes for reproducible builds.
+
+### Custom Repositories
+
+By default, keel resolves dependencies from Maven Central. To add custom repositories (e.g., JitPack), declare them in `[repositories]`:
+
+```toml
+[repositories]
+central = "https://repo1.maven.org/maven2"
+jitpack = "https://jitpack.io"
+```
+
+Repositories are tried in declaration order. When omitted, Maven Central is used.
+
+### Compiler Plugins
+
+Enable Kotlin compiler plugins in `[plugins]`:
+
+```toml
+[plugins]
+serialization = true
+```
+
+Supported plugins: `serialization`, `allopen`, `noarg`. Plugin JARs are resolved from the Kotlin compiler distribution.
+
+### Resource Files
+
+Include resource files (config files, templates, static assets) in the build output:
+
+```toml
+resources = ["resources"]
+test_resources = ["test-resources"]
+```
+
+Files in `resources` directories are copied into the build output and included in the JAR. Files in `test_resources` directories are added to the classpath during test execution. Non-existent directories are silently skipped.
 
 ### Test Dependencies
 

--- a/src/nativeMain/kotlin/keel/build/Builder.kt
+++ b/src/nativeMain/kotlin/keel/build/Builder.kt
@@ -15,9 +15,10 @@ data class BuildCommand(
 fun checkCommand(
     config: KeelConfig,
     classpath: String? = null,
-    pluginArgs: List<String> = emptyList()
+    pluginArgs: List<String> = emptyList(),
+    kotlincPath: String? = null
 ): List<String> = buildList {
-    add("kotlinc")
+    add(kotlincPath ?: "kotlinc")
     if (!classpath.isNullOrEmpty()) {
         add("-cp")
         add(classpath)
@@ -31,10 +32,11 @@ fun checkCommand(
 fun buildCommand(
     config: KeelConfig,
     classpath: String? = null,
-    pluginArgs: List<String> = emptyList()
+    pluginArgs: List<String> = emptyList(),
+    kotlincPath: String? = null
 ): BuildCommand {
     val args = buildList {
-        add("kotlinc")
+        add(kotlincPath ?: "kotlinc")
         if (!classpath.isNullOrEmpty()) {
             add("-cp")
             add(classpath)

--- a/src/nativeMain/kotlin/keel/build/TestBuilder.kt
+++ b/src/nativeMain/kotlin/keel/build/TestBuilder.kt
@@ -13,14 +13,15 @@ fun testBuildCommand(
     config: KeelConfig,
     classesDir: String,
     classpath: String? = null,
-    pluginArgs: List<String> = emptyList()
+    pluginArgs: List<String> = emptyList(),
+    kotlincPath: String? = null
 ): TestBuildCommand {
     val cp = buildList {
         add(classesDir)
         if (!classpath.isNullOrEmpty()) add(classpath)
     }.joinToString(":")
     val args = buildList {
-        add("kotlinc")
+        add(kotlincPath ?: "kotlinc")
         add("-cp")
         add(cp)
         addAll(config.testSources)

--- a/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
@@ -29,7 +29,9 @@ internal fun loadProjectConfig(): KeelConfig {
     }
 }
 
-private fun checkVersion(config: KeelConfig) {
+// managedKotlincBin: non-null means managed toolchain (version is known, skip check)
+private fun checkVersion(config: KeelConfig, managedKotlincBin: String?) {
+    if (managedKotlincBin != null) return
     val output = executeAndCapture("kotlinc -version 2>&1").getOrElse {
         eprintln("warning: could not determine kotlinc version")
         return
@@ -47,11 +49,13 @@ private fun checkVersion(config: KeelConfig) {
 internal fun doCheck() {
     val startMark = TimeSource.Monotonic.markNow()
     val config = loadProjectConfig()
-    checkVersion(config)
+    val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
+    val managedKotlincBin = resolveKotlincPath(config.kotlin, paths)
+    checkVersion(config, managedKotlincBin)
 
     val classpath = resolveDependencies(config)
-    val pArgs = resolvePluginArgs(config)
-    val cmd = checkCommand(config, classpath, pArgs)
+    val pArgs = resolvePluginArgs(config, managedKotlincBin)
+    val cmd = checkCommand(config, classpath, pArgs, kotlincPath = managedKotlincBin)
 
     println("checking ${config.name}...")
     executeCommand(cmd).getOrElse { error ->
@@ -89,16 +93,19 @@ internal fun doBuild(): BuildResult {
     val cachedState = readFileAsString(BUILD_STATE_FILE).getOrElse { null }
         ?.let { parseBuildState(it) }
 
+    val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
+    val managedKotlincBin = resolveKotlincPath(config.kotlin, paths)
+
     if (isBuildUpToDate(current = currentState, cached = cachedState)) {
         val elapsed = startMark.elapsedNow()
         println("${config.name} is up to date (${formatDuration(elapsed)})")
-        return BuildResult(config, cachedState!!.classpath, resolvePluginArgs(config))
+        return BuildResult(config, cachedState!!.classpath, resolvePluginArgs(config, managedKotlincBin))
     }
 
-    checkVersion(config)
+    checkVersion(config, managedKotlincBin)
     val classpath = resolveDependencies(config)
-    val pArgs = resolvePluginArgs(config)
-    val buildCmd = buildCommand(config, classpath, pArgs)
+    val pArgs = resolvePluginArgs(config, managedKotlincBin)
+    val buildCmd = buildCommand(config, classpath, pArgs, kotlincPath = managedKotlincBin)
     ensureDirectoryRecursive(CLASSES_DIR).getOrElse { error ->
         eprintln("error: could not create directory ${error.path}")
         exitProcess(EXIT_BUILD_ERROR)
@@ -166,9 +173,10 @@ internal fun doTest(testArgs: List<String> = emptyList()) {
 
     val paths = resolveKeelPaths(EXIT_TEST_ERROR)
     val consoleLauncherPath = ensureTool(paths, CONSOLE_LAUNCHER_SPEC, EXIT_TEST_ERROR)
+    val managedKotlincBin = resolveKotlincPath(config.kotlin, paths)
 
     val testConfig = config.copy(testSources = existingTestSources)
-    val testCmd = testBuildCommand(testConfig, CLASSES_DIR, classpath, pArgs)
+    val testCmd = testBuildCommand(testConfig, CLASSES_DIR, classpath, pArgs, kotlincPath = managedKotlincBin)
     println("compiling tests...")
     executeCommand(testCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "test compilation"))

--- a/src/nativeMain/kotlin/keel/cli/Main.kt
+++ b/src/nativeMain/kotlin/keel/cli/Main.kt
@@ -36,6 +36,7 @@ fun main(args: Array<String>) {
         "add" -> doAdd(args.drop(1))
         "install" -> doInstall()
         "update" -> doUpdate()
+        "toolchain" -> doToolchain(args.drop(1))
         "--version", "version" -> println(versionString())
         else -> {
             eprintln("error: unknown command '${args[0]}'")
@@ -60,5 +61,6 @@ private fun printUsage() {
     eprintln("  tree       Show dependency tree")
     eprintln("  install    Resolve dependencies and download JARs")
     eprintln("  update     Re-resolve dependencies and update lockfile")
+    eprintln("  toolchain  Manage kotlinc toolchain (e.g. keel toolchain install)")
     eprintln("  version    Show version information")
 }

--- a/src/nativeMain/kotlin/keel/cli/PluginSupport.kt
+++ b/src/nativeMain/kotlin/keel/cli/PluginSupport.kt
@@ -23,11 +23,15 @@ internal fun resolveKotlinHome(): String {
     return parseKotlinHome(kotlincPath)
 }
 
-internal fun resolvePluginArgs(config: KeelConfig): List<String> {
+internal fun resolvePluginArgs(config: KeelConfig, managedKotlincBin: String? = null): List<String> {
     val enabled = config.plugins.filterValues { it }
     if (enabled.isEmpty()) return emptyList()
 
-    val kotlinHome = resolveKotlinHome()
+    val kotlinHome = if (managedKotlincBin != null) {
+        parseKotlinHome(managedKotlincBin)
+    } else {
+        resolveKotlinHome()
+    }
     return pluginArgs(config.plugins, kotlinHome).getOrElse { error ->
         eprintln("error: unknown plugin '${error.name}'")
         exitProcess(EXIT_CONFIG_ERROR)

--- a/src/nativeMain/kotlin/keel/cli/ToolchainCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/ToolchainCommands.kt
@@ -1,0 +1,20 @@
+package keel.cli
+
+import keel.config.resolveKeelPaths
+import keel.infra.eprintln
+import keel.tool.installKotlincToolchain
+import kotlin.system.exitProcess
+
+internal fun doToolchain(args: List<String>) {
+    if (args.isEmpty() || args[0] != "install") {
+        eprintln("usage: keel toolchain install")
+        exitProcess(EXIT_BUILD_ERROR)
+    }
+    doToolchainInstall()
+}
+
+private fun doToolchainInstall() {
+    val config = loadProjectConfig()
+    val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
+    installKotlincToolchain(config.kotlin, paths, EXIT_BUILD_ERROR)
+}

--- a/src/nativeMain/kotlin/keel/cli/ToolchainCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/ToolchainCommands.kt
@@ -8,7 +8,7 @@ import kotlin.system.exitProcess
 internal fun doToolchain(args: List<String>) {
     if (args.isEmpty() || args[0] != "install") {
         eprintln("usage: keel toolchain install")
-        exitProcess(EXIT_BUILD_ERROR)
+        exitProcess(EXIT_CONFIG_ERROR)
     }
     doToolchainInstall()
 }

--- a/src/nativeMain/kotlin/keel/config/KeelPaths.kt
+++ b/src/nativeMain/kotlin/keel/config/KeelPaths.kt
@@ -8,6 +8,10 @@ import kotlin.system.exitProcess
 internal data class KeelPaths(val home: String) {
     val cacheBase: String = "$home/.keel/cache"
     val toolsDir: String = "$home/.keel/tools"
+    val toolchainsDir: String = "$home/.keel/toolchains"
+
+    fun kotlincPath(version: String): String = "$toolchainsDir/kotlinc/$version"
+    fun kotlincBin(version: String): String = "${kotlincPath(version)}/bin/kotlinc"
 }
 
 internal fun resolveKeelPaths(exitCode: Int): KeelPaths {

--- a/src/nativeMain/kotlin/keel/tool/ToolchainManager.kt
+++ b/src/nativeMain/kotlin/keel/tool/ToolchainManager.kt
@@ -1,0 +1,114 @@
+package keel.tool
+
+import com.github.michaelbull.result.getOrElse
+import keel.config.KeelPaths
+import keel.infra.*
+import kotlin.system.exitProcess
+
+internal fun kotlincDownloadUrl(version: String): String =
+    "https://github.com/JetBrains/kotlin/releases/download/v$version/kotlin-compiler-$version.zip"
+
+internal fun kotlincSha256Url(version: String): String =
+    "${kotlincDownloadUrl(version)}.sha256"
+
+internal fun resolveKotlincPath(version: String, paths: KeelPaths): String? {
+    val binPath = paths.kotlincBin(version)
+    return if (fileExists(binPath)) binPath else null
+}
+
+internal fun installKotlincToolchain(version: String, paths: KeelPaths, exitCode: Int) {
+    val finalPath = paths.kotlincPath(version)
+    val binPath = paths.kotlincBin(version)
+
+    if (fileExists(binPath)) {
+        println("kotlinc $version is already installed at $finalPath")
+        return
+    }
+
+    val kotlincBaseDir = "${paths.toolchainsDir}/kotlinc"
+    ensureDirectoryRecursive(kotlincBaseDir).getOrElse { error ->
+        eprintln("error: could not create directory ${error.path}")
+        exitProcess(exitCode)
+    }
+
+    val zipPath = "$kotlincBaseDir/$version.zip"
+    val sha256Path = "$kotlincBaseDir/$version.zip.sha256"
+    val extractTempDir = "$kotlincBaseDir/${version}_extract"
+
+    println("downloading kotlin-compiler-$version.zip...")
+    downloadFile(kotlincDownloadUrl(version), zipPath).getOrElse { error ->
+        when (error) {
+            is DownloadError.HttpFailed -> eprintln("error: failed to download kotlinc $version (HTTP ${error.statusCode})")
+            is DownloadError.WriteFailed -> eprintln("error: could not write $zipPath")
+            is DownloadError.NetworkError -> eprintln("error: network error downloading kotlinc $version: ${error.message}")
+        }
+        exitProcess(exitCode)
+    }
+
+    downloadFile(kotlincSha256Url(version), sha256Path).getOrElse { error ->
+        deleteFile(zipPath)
+        when (error) {
+            is DownloadError.HttpFailed -> eprintln("error: failed to download sha256 for kotlinc $version (HTTP ${error.statusCode})")
+            is DownloadError.WriteFailed -> eprintln("error: could not write $sha256Path")
+            is DownloadError.NetworkError -> eprintln("error: network error downloading sha256: ${error.message}")
+        }
+        exitProcess(exitCode)
+    }
+
+    val sha256Content = readFileAsString(sha256Path).getOrElse { error ->
+        deleteFile(zipPath)
+        deleteFile(sha256Path)
+        eprintln("error: could not read ${error.path}")
+        exitProcess(exitCode)
+    }
+    // SHA256 files can be "<hash>  <filename>" or just "<hash>"
+    val expectedHash = sha256Content.trim().split(Regex("\\s+")).first()
+    deleteFile(sha256Path)
+
+    val actualHash = computeSha256(zipPath).getOrElse { _ ->
+        deleteFile(zipPath)
+        eprintln("error: could not compute sha256 for $zipPath")
+        exitProcess(exitCode)
+    }
+
+    if (actualHash != expectedHash) {
+        deleteFile(zipPath)
+        eprintln("error: sha256 mismatch for kotlinc $version (expected $expectedHash, got $actualHash)")
+        exitProcess(exitCode)
+    }
+
+    ensureDirectoryRecursive(extractTempDir).getOrElse { error ->
+        deleteFile(zipPath)
+        eprintln("error: could not create directory ${error.path}")
+        exitProcess(exitCode)
+    }
+
+    println("extracting kotlinc $version...")
+    executeCommand(listOf("unzip", "-q", zipPath, "-d", extractTempDir)).getOrElse { error ->
+        deleteFile(zipPath)
+        removeDirectoryRecursive(extractTempDir).getOrElse { e ->
+            eprintln("warning: could not remove temp directory ${e.path}")
+        }
+        eprintln(formatProcessError(error, "unzip"))
+        exitProcess(exitCode)
+    }
+    deleteFile(zipPath)
+
+    executeCommand(listOf("mv", "$extractTempDir/kotlinc", finalPath)).getOrElse { error ->
+        removeDirectoryRecursive(extractTempDir).getOrElse { e ->
+            eprintln("warning: could not remove temp directory ${e.path}")
+        }
+        eprintln(formatProcessError(error, "mv"))
+        exitProcess(exitCode)
+    }
+    removeDirectoryRecursive(extractTempDir).getOrElse { e ->
+        eprintln("warning: could not remove temp directory ${e.path}")
+    }
+
+    if (!fileExists(binPath)) {
+        eprintln("error: kotlinc binary not found at $binPath after installation")
+        exitProcess(exitCode)
+    }
+
+    println("installed kotlinc $version at $finalPath")
+}

--- a/src/nativeTest/kotlin/keel/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/keel/build/BuilderTest.kt
@@ -193,6 +193,85 @@ class BuilderTest {
         )
     }
 
+    @Test
+    fun buildCommandWithManagedKotlincPathUsesItAsCompiler() {
+        // Given: a managed kotlinc binary path
+        val managedKotlincBin = "/home/user/.keel/toolchains/kotlinc/2.1.0/bin/kotlinc"
+
+        // When: buildCommand is called with that path
+        val cmd = buildCommand(testConfig(), kotlincPath = managedKotlincBin)
+
+        // Then: the managed path is used as the first arg, not the system "kotlinc"
+        assertEquals(
+            listOf(managedKotlincBin, "src", "-jvm-target", "17", "-d", "build/classes"),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun buildCommandWithNullKotlincPathDefaultsToSystemKotlinc() {
+        // Given: no managed toolchain (null)
+        // When: buildCommand is called with explicit null kotlincPath
+        val cmd = buildCommand(testConfig(), kotlincPath = null)
+
+        // Then: falls back to system "kotlinc"
+        assertEquals("kotlinc", cmd.args.first())
+    }
+
+    @Test
+    fun buildCommandWithManagedKotlincAndClasspath() {
+        // Given: managed kotlinc + classpath
+        val managedKotlincBin = "/home/user/.keel/toolchains/kotlinc/2.1.0/bin/kotlinc"
+
+        // When: buildCommand is called with both
+        val cmd = buildCommand(testConfig(), classpath = "/cache/a.jar", kotlincPath = managedKotlincBin)
+
+        // Then: managed path is first, classpath follows
+        assertEquals(
+            listOf(managedKotlincBin, "-cp", "/cache/a.jar", "src", "-jvm-target", "17", "-d", "build/classes"),
+            cmd.args
+        )
+    }
+
+    // --- checkCommand (kotlincPath) ---
+
+    @Test
+    fun checkCommandWithManagedKotlincPathUsesItAsCompiler() {
+        // Given: a managed kotlinc binary path
+        val managedKotlincBin = "/home/user/.keel/toolchains/kotlinc/2.1.0/bin/kotlinc"
+
+        // When: checkCommand is called with that path
+        val cmd = checkCommand(testConfig(), kotlincPath = managedKotlincBin)
+
+        // Then: the managed path is first in args
+        assertEquals(
+            listOf(managedKotlincBin, "src", "-jvm-target", "17"),
+            cmd
+        )
+    }
+
+    @Test
+    fun checkCommandWithNullKotlincPathDefaultsToSystemKotlinc() {
+        // Given: no managed toolchain (null)
+        val cmd = checkCommand(testConfig(), kotlincPath = null)
+
+        // Then: falls back to system "kotlinc"
+        assertEquals("kotlinc", cmd.first())
+    }
+
+    @Test
+    fun checkCommandWithManagedKotlincAndClasspath() {
+        // Given: managed kotlinc + classpath
+        val managedKotlincBin = "/home/user/.keel/toolchains/kotlinc/2.1.0/bin/kotlinc"
+
+        val cmd = checkCommand(testConfig(), classpath = "/cache/a.jar", kotlincPath = managedKotlincBin)
+
+        assertEquals(
+            listOf(managedKotlincBin, "-cp", "/cache/a.jar", "src", "-jvm-target", "17"),
+            cmd
+        )
+    }
+
     // --- jarCommand ---
 
     @Test

--- a/src/nativeTest/kotlin/keel/build/TestBuilderTest.kt
+++ b/src/nativeTest/kotlin/keel/build/TestBuilderTest.kt
@@ -140,6 +140,58 @@ class TestBuilderTest {
         )
     }
 
+    // --- kotlincPath parameter ---
+
+    @Test
+    fun testBuildCommandWithManagedKotlincPathUsesItAsCompiler() {
+        // Given: a managed kotlinc binary path
+        val managedKotlincBin = "/home/user/.keel/toolchains/kotlinc/2.1.0/bin/kotlinc"
+
+        // When: testBuildCommand is called with that path
+        val cmd = testBuildCommand(
+            config = testConfig(),
+            classesDir = "build/classes",
+            kotlincPath = managedKotlincBin
+        )
+
+        // Then: the managed path is used as the first arg, not system "kotlinc"
+        assertEquals(
+            listOf(managedKotlincBin, "-cp", "build/classes", "test", "-jvm-target", "17", "-d", "build/test-classes"),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun testBuildCommandWithNullKotlincPathDefaultsToSystemKotlinc() {
+        // Given: no managed toolchain (null)
+        val cmd = testBuildCommand(
+            config = testConfig(),
+            classesDir = "build/classes",
+            kotlincPath = null
+        )
+
+        // Then: falls back to system "kotlinc"
+        assertEquals("kotlinc", cmd.args.first())
+    }
+
+    @Test
+    fun testBuildCommandWithManagedKotlincAndClasspath() {
+        // Given: managed kotlinc + extra classpath
+        val managedKotlincBin = "/home/user/.keel/toolchains/kotlinc/2.1.0/bin/kotlinc"
+
+        val cmd = testBuildCommand(
+            config = testConfig(),
+            classesDir = "build/classes",
+            classpath = "/cache/dep.jar",
+            kotlincPath = managedKotlincBin
+        )
+
+        assertEquals(
+            listOf(managedKotlincBin, "-cp", "build/classes:/cache/dep.jar", "test", "-jvm-target", "17", "-d", "build/test-classes"),
+            cmd.args
+        )
+    }
+
     @Test
     fun testBuildCommandWithClasspathAndPluginArgs() {
         val pluginArgs = listOf("-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar")

--- a/src/nativeTest/kotlin/keel/cli/PluginSupportTest.kt
+++ b/src/nativeTest/kotlin/keel/cli/PluginSupportTest.kt
@@ -1,0 +1,68 @@
+package keel.cli
+
+import keel.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PluginSupportTest {
+
+    // --- resolvePluginArgs with managedKotlincBin ---
+
+    @Test
+    fun resolvePluginArgsNoPluginsReturnsEmpty() {
+        val config = testConfig(plugins = emptyMap())
+
+        val result = resolvePluginArgs(config, managedKotlincBin = "/home/user/.keel/toolchains/kotlinc/2.1.0/bin/kotlinc")
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun resolvePluginArgsWithManagedBinUsesToolchainHome() {
+        val config = testConfig(plugins = mapOf("serialization" to true))
+        val managedBin = "/home/user/.keel/toolchains/kotlinc/2.1.0/bin/kotlinc"
+
+        val result = resolvePluginArgs(config, managedKotlincBin = managedBin)
+
+        assertEquals(
+            listOf("-Xplugin=/home/user/.keel/toolchains/kotlinc/2.1.0/lib/kotlinx-serialization-compiler-plugin.jar"),
+            result
+        )
+    }
+
+    @Test
+    fun resolvePluginArgsWithManagedBinDoesNotUseSystemKotlinc() {
+        // When managedKotlincBin is provided, plugin JARs must come from the managed toolchain,
+        // not from system kotlinc. This ensures compiler and plugin versions are consistent.
+        val config = testConfig(plugins = mapOf("allopen" to true))
+        val managedBin = "/home/user/.keel/toolchains/kotlinc/2.1.0/bin/kotlinc"
+
+        val result = resolvePluginArgs(config, managedKotlincBin = managedBin)
+
+        assertEquals(1, result.size)
+        assertTrue(
+            result[0].startsWith("-Xplugin=/home/user/.keel/toolchains/kotlinc/2.1.0/"),
+            "Plugin arg should reference managed toolchain path, got: ${result[0]}"
+        )
+    }
+
+    @Test
+    fun resolvePluginArgsWithNullManagedBinAndNoPluginsReturnsEmpty() {
+        val config = testConfig(plugins = emptyMap())
+
+        val result = resolvePluginArgs(config, managedKotlincBin = null)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun resolvePluginArgsDisabledPluginIsExcluded() {
+        val config = testConfig(plugins = mapOf("serialization" to false))
+        val managedBin = "/home/user/.keel/toolchains/kotlinc/2.1.0/bin/kotlinc"
+
+        val result = resolvePluginArgs(config, managedKotlincBin = managedBin)
+
+        assertTrue(result.isEmpty())
+    }
+}

--- a/src/nativeTest/kotlin/keel/config/KeelPathsTest.kt
+++ b/src/nativeTest/kotlin/keel/config/KeelPathsTest.kt
@@ -16,4 +16,51 @@ class KeelPathsTest {
         val paths = KeelPaths("/home/user")
         assertEquals("/home/user/.keel/tools", paths.toolsDir)
     }
+
+    @Test
+    fun toolchainsDirConstructedFromHome() {
+        // Given: KeelPaths with a known home
+        val paths = KeelPaths("/home/user")
+
+        // Then: toolchainsDir is under ~/.keel/toolchains
+        assertEquals("/home/user/.keel/toolchains", paths.toolchainsDir)
+    }
+
+    @Test
+    fun kotlincPathBuildsVersionedDirectory() {
+        // Given: KeelPaths with a known home
+        val paths = KeelPaths("/home/user")
+
+        // When: kotlincPath is called for a specific version
+        val path = paths.kotlincPath("2.1.0")
+
+        // Then: path points to the versioned directory under toolchains
+        assertEquals("/home/user/.keel/toolchains/kotlinc/2.1.0", path)
+    }
+
+    @Test
+    fun kotlincBinBuildsVersionedBinPath() {
+        // Given: KeelPaths with a known home
+        val paths = KeelPaths("/home/user")
+
+        // When: kotlincBin is called for a specific version
+        val bin = paths.kotlincBin("2.1.0")
+
+        // Then: bin path points to bin/kotlinc inside the versioned directory
+        assertEquals("/home/user/.keel/toolchains/kotlinc/2.1.0/bin/kotlinc", bin)
+    }
+
+    @Test
+    fun kotlincPathDifferentVersion() {
+        val paths = KeelPaths("/home/alice")
+
+        assertEquals("/home/alice/.keel/toolchains/kotlinc/2.3.20", paths.kotlincPath("2.3.20"))
+    }
+
+    @Test
+    fun kotlincBinDifferentHome() {
+        val paths = KeelPaths("/root")
+
+        assertEquals("/root/.keel/toolchains/kotlinc/2.3.20/bin/kotlinc", paths.kotlincBin("2.3.20"))
+    }
 }

--- a/src/nativeTest/kotlin/keel/tool/ToolchainManagerTest.kt
+++ b/src/nativeTest/kotlin/keel/tool/ToolchainManagerTest.kt
@@ -1,0 +1,175 @@
+package keel.tool
+
+import keel.config.KeelPaths
+import keel.infra.ensureDirectoryRecursive
+import keel.infra.removeDirectoryRecursive
+import keel.infra.writeFileAsString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ToolchainManagerTest {
+
+    // --- kotlincDownloadUrl ---
+
+    @Test
+    fun kotlincDownloadUrlHasVersionInTagAndFilename() {
+        // Given: version 2.1.0
+        // When: building download URL
+        val url = kotlincDownloadUrl("2.1.0")
+
+        // Then: URL uses v-prefixed tag and includes version in filename
+        assertEquals(
+            "https://github.com/JetBrains/kotlin/releases/download/v2.1.0/kotlin-compiler-2.1.0.zip",
+            url
+        )
+    }
+
+    @Test
+    fun kotlincDownloadUrlDifferentVersion() {
+        // Given: version 2.3.20
+        // When: building download URL
+        val url = kotlincDownloadUrl("2.3.20")
+
+        // Then: URL has correct version in both tag and filename
+        assertEquals(
+            "https://github.com/JetBrains/kotlin/releases/download/v2.3.20/kotlin-compiler-2.3.20.zip",
+            url
+        )
+    }
+
+    // --- kotlincSha256Url ---
+
+    @Test
+    fun kotlincSha256UrlIsZipUrlWithSha256Suffix() {
+        // Given: version 2.1.0
+        // When: building SHA256 URL
+        val url = kotlincSha256Url("2.1.0")
+
+        // Then: URL points to the .sha256 sidecar file alongside the zip
+        assertEquals(
+            "https://github.com/JetBrains/kotlin/releases/download/v2.1.0/kotlin-compiler-2.1.0.zip.sha256",
+            url
+        )
+    }
+
+    @Test
+    fun kotlincSha256UrlDifferentVersion() {
+        // Given: version 2.3.20
+        val url = kotlincSha256Url("2.3.20")
+
+        assertEquals(
+            "https://github.com/JetBrains/kotlin/releases/download/v2.3.20/kotlin-compiler-2.3.20.zip.sha256",
+            url
+        )
+    }
+
+    // --- resolveKotlincPath ---
+
+    @Test
+    fun resolveKotlincPathReturnsBinPathWhenManagedVersionInstalled() {
+        // Given: managed kotlinc bin exists at paths.kotlincBin(version)
+        val paths = KeelPaths("/tmp/keel_tc_resolve_installed")
+        val binDir = "${paths.toolchainsDir}/kotlinc/2.1.0/bin"
+        val binPath = "$binDir/kotlinc"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString(binPath, "#!/bin/sh")
+        try {
+            // When: resolveKotlincPath is called with matching version
+            val result = resolveKotlincPath("2.1.0", paths)
+
+            // Then: returns exactly paths.kotlincBin(version)
+            assertEquals(paths.kotlincBin("2.1.0"), result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun resolveKotlincPathDelegatesPathConstructionToKeelPaths() {
+        // Given: a paths object and a file at the expected location
+        val paths = KeelPaths("/tmp/keel_tc_resolve_delegation")
+        val expectedBin = paths.kotlincBin("2.3.20")
+        val binDir = expectedBin.substringBeforeLast("/")
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString(expectedBin, "#!/bin/sh")
+        try {
+            // When: resolveKotlincPath is called
+            val result = resolveKotlincPath("2.3.20", paths)
+
+            // Then: returned path equals paths.kotlincBin() — no independent path construction
+            assertEquals(expectedBin, result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun resolveKotlincPathReturnsNullWhenToolchainsDirAbsent() {
+        // Given: toolchains directory does not exist at all
+        val paths = KeelPaths("/tmp/keel_tc_resolve_no_dir")
+
+        // When: resolveKotlincPath is called
+        val result = resolveKotlincPath("2.1.0", paths)
+
+        // Then: returns null (system kotlinc fallback)
+        assertNull(result)
+    }
+
+    @Test
+    fun resolveKotlincPathReturnsNullWhenVersionDirExistsButBinMissing() {
+        // Given: version directory exists but bin/kotlinc is absent
+        val paths = KeelPaths("/tmp/keel_tc_resolve_no_bin")
+        val versionDir = "${paths.toolchainsDir}/kotlinc/2.1.0"
+        ensureDirectoryRecursive(versionDir)
+        try {
+            // When: resolveKotlincPath is called
+            val result = resolveKotlincPath("2.1.0", paths)
+
+            // Then: returns null — partial installation is not usable
+            assertNull(result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun resolveKotlincPathReturnsNullForDifferentInstalledVersion() {
+        // Given: only version 2.3.0 is installed, not 2.1.0
+        val paths = KeelPaths("/tmp/keel_tc_resolve_version_isolation")
+        val binDir = "${paths.toolchainsDir}/kotlinc/2.3.0/bin"
+        val binPath = "$binDir/kotlinc"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString(binPath, "#!/bin/sh")
+        try {
+            // When: resolveKotlincPath is called for 2.1.0
+            val result = resolveKotlincPath("2.1.0", paths)
+
+            // Then: returns null — version isolation must be exact
+            assertNull(result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun resolveKotlincPathReturnsBinPathForCorrectVersionAmongMultiple() {
+        // Given: both 2.1.0 and 2.3.0 are installed
+        val paths = KeelPaths("/tmp/keel_tc_resolve_multi_version")
+        val bin210 = "${paths.toolchainsDir}/kotlinc/2.1.0/bin"
+        val bin230 = "${paths.toolchainsDir}/kotlinc/2.3.0/bin"
+        ensureDirectoryRecursive(bin210)
+        ensureDirectoryRecursive(bin230)
+        writeFileAsString("$bin210/kotlinc", "#!/bin/sh")
+        writeFileAsString("$bin230/kotlinc", "#!/bin/sh")
+        try {
+            // When: resolveKotlincPath is called for 2.1.0
+            val result = resolveKotlincPath("2.1.0", paths)
+
+            // Then: returns paths.kotlincBin("2.1.0"), not 2.3.0
+            assertEquals(paths.kotlincBin("2.1.0"), result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

## Summary

Add kotlinc toolchain management as the foundation for all toolchain support. keel can download, extract, and use a specific kotlinc version defined in `keel.toml`, falling back to system `kotlinc` if not managed.

This is the first of 4 issues split from #17:
- **A (this): kotlinc toolchain management**
- B: JDK toolchain management (#39)
- C: Auto-install on build/run/test (#40)
- D: `keel toolchain list/remove` commands (#41)

## Toolchain Resolution Strategy (applies to all toolchain issues)

**Managed-first, system-fallback:**
1. If managed toolchain exists at `~/.keel/toolchains/kotlinc/{version}/` → use it
2. If not → fall back to system `kotlinc` on PATH (current behavior)
3. In both cases, version mismatch warning (existing `checkVersion()`) still applies

This preserves backward compatibility — existing users without managed toolchains see no behavior change.

## Storage Layout

```
~/.keel/
  toolchains/
    kotlinc/
      2.1.0/
        bin/kotlinc
        lib/...
      2.3.0/
        bin/kotlinc
        lib/...
```

## Download Source

kotlinc is distributed as a zip from GitHub Releases:

```
https://github.com/JetBrains/kotlin/releases/download/v{version}/kotlin-compiler-{version}.zip
```

The zip contains a top-level `kotlinc/` directory with `bin/` and `lib/` inside.

### SHA256 Verification

After downloading, verify the zip checksum against the `.sha256` file published alongside the release:

```
https://github.com/JetBrains/kotlin/releases/download/v{version}/kotlin-compiler-{version}.zip.sha256
```

This is consistent with the existing SHA256 verification policy for dependency JARs (`Sha256.kt`, `TransitiveResolver.kt`).

## Implementation Details

### 1. KeelPaths — Add toolchains directory

Add `toolchainsDir` to `KeelPaths`:

```kotlin
val toolchainsDir: String = "$home/.keel/toolchains"
```

Add a helper to resolve a specific kotlinc path:

```kotlin
fun kotlincPath(version: String): String = "$toolchainsDir/kotlinc/$version"
fun kotlincBin(version: String): String = "${kotlincPath(version)}/bin/kotlinc"
```

### 2. New file: tool/ToolchainManager.kt

Responsible for:
- Checking if a managed kotlinc version is installed (directory exists + bin/kotlinc exists)
- Downloading kotlinc zip from GitHub Releases
- Verifying SHA256 checksum against the published `.sha256` file
- Extracting zip to `~/.keel/toolchains/kotlinc/{version}/`
- Extraction: use `unzip` shell command (`unzip -q archive.zip -d target/`). The zip contains a `kotlinc/` top-level dir, so extract to a temp location and move contents.

> **Note on `unzip` dependency:** This implementation relies on the system `unzip` command. This is a pragmatic choice for the initial implementation — a native solution (e.g. libarchive cinterop) can replace it later if the shell dependency becomes problematic.

Pure resolution function:

```kotlin
fun resolveKotlincPath(version: String, toolchainsDir: String): String?
// Returns full path to bin/kotlinc if managed version exists, null otherwise
```

### 3. Builder.kt — Accept kotlinc path

Change `buildCommand()`, `checkCommand()` to accept an optional `kotlincPath` parameter:

```
Before: args = ["kotlinc", ...]
After:  args = [kotlincPath ?: "kotlinc", ...]
```

Default `null` means system `kotlinc` (backward compatible). Same for `TestBuilder.kt`.

### 4. BuildCommands.kt — Wire up resolution

In `doBuild()`, `doCheck()`, `doTest()`:

```kotlin
val kotlincBin = resolveKotlincPath(config.kotlin, paths.toolchainsDir) ?: "kotlinc"
```

Pass `kotlincBin` to `buildCommand()`, `checkCommand()`, `testBuildCommand()`.

### 5. CLI command: `keel toolchain install`

```bash
keel toolchain install          # Install kotlinc version from keel.toml
```

Steps:
1. Read `keel.toml` to get kotlin version
2. Check if already installed → skip with message
3. Download zip to temp file
4. Download `.sha256` file and verify checksum
5. Extract with `unzip -q`
6. Move extracted `kotlinc/` to `~/.keel/toolchains/kotlinc/{version}/`
7. Verify `bin/kotlinc` exists

### 6. checkVersion() update

When using a managed toolchain, skip the `kotlinc -version` check (the version is known from the directory path). Only run version check when falling back to system kotlinc.

## Out of Scope

- JDK management (#39)
- Auto-install on build/run/test (#40)
- `keel toolchain list/remove` (#41)
- kotlinc-native (#16)
- Windows/macOS support

## Dependencies

- Depends on: nothing (foundation issue)
- Blocks: #39, #40, #41

## Execution Report

Workflow `keel` completed successfully.

Closes #38