### PR TITLE
[#39] add-jdk-toolchain

### DIFF
--- a/src/nativeMain/kotlin/keel/build/Builder.kt
+++ b/src/nativeMain/kotlin/keel/build/Builder.kt
@@ -5,7 +5,7 @@ import keel.config.KeelConfig
 internal const val BUILD_DIR = "build"
 internal const val CLASSES_DIR = "$BUILD_DIR/classes"
 
-internal fun jarPath(config: KeelConfig): String = "$BUILD_DIR/${config.name}.jar"
+internal fun outputJarPath(config: KeelConfig): String = "$BUILD_DIR/${config.name}.jar"
 
 data class BuildCommand(
     val args: List<String>,
@@ -51,10 +51,10 @@ fun buildCommand(
     return BuildCommand(args = args, outputPath = CLASSES_DIR)
 }
 
-fun jarCommand(config: KeelConfig): BuildCommand {
-    val outputPath = jarPath(config)
+fun jarCommand(config: KeelConfig, jarPath: String? = null): BuildCommand {
+    val outputPath = outputJarPath(config)
     return BuildCommand(
-        args = listOf("jar", "cf", outputPath, "-C", CLASSES_DIR, "."),
+        args = listOf(jarPath ?: "jar", "cf", outputPath, "-C", CLASSES_DIR, "."),
         outputPath = outputPath
     )
 }

--- a/src/nativeMain/kotlin/keel/build/Runner.kt
+++ b/src/nativeMain/kotlin/keel/build/Runner.kt
@@ -6,9 +6,14 @@ data class RunCommand(
     val args: List<String>
 )
 
-fun runCommand(config: KeelConfig, classpath: String? = null, appArgs: List<String> = emptyList()): RunCommand {
+fun runCommand(
+    config: KeelConfig,
+    classpath: String? = null,
+    appArgs: List<String> = emptyList(),
+    javaPath: String? = null
+): RunCommand {
     val cp = if (!classpath.isNullOrEmpty()) "$CLASSES_DIR:$classpath" else CLASSES_DIR
     return RunCommand(
-        args = listOf("java", "-cp", cp, config.main) + appArgs
+        args = listOf(javaPath ?: "java", "-cp", cp, config.main) + appArgs
     )
 }

--- a/src/nativeMain/kotlin/keel/build/TestRunner.kt
+++ b/src/nativeMain/kotlin/keel/build/TestRunner.kt
@@ -10,7 +10,8 @@ fun testRunCommand(
     consoleLauncherPath: String,
     testResourceDirs: List<String> = emptyList(),
     classpath: String? = null,
-    testArgs: List<String> = emptyList()
+    testArgs: List<String> = emptyList(),
+    javaPath: String? = null
 ): TestRunCommand {
     val cp = buildList {
         add(classesDir)
@@ -19,7 +20,7 @@ fun testRunCommand(
         if (!classpath.isNullOrEmpty()) add(classpath)
     }.joinToString(":")
     val args = buildList {
-        add("java")
+        add(javaPath ?: "java")
         add("-jar")
         add(consoleLauncherPath)
         add("--class-path")

--- a/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
@@ -14,7 +14,12 @@ internal const val LOCK_FILE = "keel.lock"
 private const val WORKSPACE_JSON = "workspace.json"
 private const val KLS_CLASSPATH = "kls-classpath"
 
-internal data class BuildResult(val config: KeelConfig, val classpath: String?, val pluginArgs: List<String> = emptyList())
+internal data class BuildResult(
+    val config: KeelConfig,
+    val classpath: String?,
+    val pluginArgs: List<String> = emptyList(),
+    val javaPath: String? = null
+)
 
 internal fun loadProjectConfig(): KeelConfig {
     val tomlString = readFileAsString(KEEL_TOML).getOrElse { error ->
@@ -95,11 +100,12 @@ internal fun doBuild(): BuildResult {
 
     val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
     val managedKotlincBin = resolveKotlincPath(config.kotlin, paths)
+    val (managedJavaBin, managedJarBin) = resolveJdkBins(config, paths)
 
     if (isBuildUpToDate(current = currentState, cached = cachedState)) {
         val elapsed = startMark.elapsedNow()
         println("${config.name} is up to date (${formatDuration(elapsed)})")
-        return BuildResult(config, cachedState!!.classpath, resolvePluginArgs(config, managedKotlincBin))
+        return BuildResult(config, cachedState!!.classpath, resolvePluginArgs(config, managedKotlincBin), managedJavaBin)
     }
 
     checkVersion(config, managedKotlincBin)
@@ -125,7 +131,7 @@ internal fun doBuild(): BuildResult {
         }
     }
 
-    val jarCmd = jarCommand(config)
+    val jarCmd = jarCommand(config, jarPath = managedJarBin)
     executeCommand(jarCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "jar packaging"))
         exitProcess(EXIT_BUILD_ERROR)
@@ -142,16 +148,16 @@ internal fun doBuild(): BuildResult {
 
     val elapsed = startMark.elapsedNow()
     println("built ${jarCmd.outputPath} in ${formatDuration(elapsed)}")
-    return BuildResult(config, classpath, pArgs)
+    return BuildResult(config, classpath, pArgs, managedJavaBin)
 }
 
-internal fun doRun(config: KeelConfig, classpath: String?, appArgs: List<String> = emptyList()) {
+internal fun doRun(config: KeelConfig, classpath: String?, appArgs: List<String> = emptyList(), javaPath: String? = null) {
     if (!fileExists(CLASSES_DIR)) {
         eprintln("error: $CLASSES_DIR not found. Run 'keel build' first.")
         exitProcess(EXIT_BUILD_ERROR)
     }
 
-    val cmd = runCommand(config, classpath, appArgs)
+    val cmd = runCommand(config, classpath, appArgs, javaPath = javaPath)
     executeCommand(cmd.args).getOrElse { error ->
         when (error) {
             is ProcessError.NonZeroExit -> exitProcess(error.exitCode)
@@ -161,7 +167,7 @@ internal fun doRun(config: KeelConfig, classpath: String?, appArgs: List<String>
 }
 
 internal fun doTest(testArgs: List<String> = emptyList()) {
-    val (config, classpath, pArgs) = doBuild()
+    val (config, classpath, pArgs, javaPath) = doBuild()
 
     val existingTestSources = config.testSources.filter { fileExists(it) }
     if (existingTestSources.isEmpty()) {
@@ -190,7 +196,8 @@ internal fun doTest(testArgs: List<String> = emptyList()) {
         consoleLauncherPath = consoleLauncherPath,
         testResourceDirs = existingTestResourceDirs,
         classpath = classpath,
-        testArgs = testArgs
+        testArgs = testArgs,
+        javaPath = javaPath
     )
     println("running tests...")
     executeCommand(runCmd.args).getOrElse { error ->
@@ -205,6 +212,18 @@ internal fun doTest(testArgs: List<String> = emptyList()) {
     }
     val elapsed = testStartMark.elapsedNow()
     println("tests passed in ${formatDuration(elapsed)}")
+}
+
+internal data class JdkBins(val java: String?, val jar: String?)
+
+internal fun resolveJdkBins(config: KeelConfig, paths: KeelPaths): JdkBins {
+    val version = config.jdk ?: return JdkBins(null, null)
+    val javaBin = resolveJavaBinPath(version, paths)
+    val jarBin = resolveJarBinPath(version, paths)
+    if (javaBin == null) {
+        eprintln("warning: jdk $version not installed (run 'keel toolchain install'). falling back to system java/jar")
+    }
+    return JdkBins(javaBin, jarBin)
 }
 
 internal fun createResolverDeps() = object : ResolverDeps {

--- a/src/nativeMain/kotlin/keel/cli/Main.kt
+++ b/src/nativeMain/kotlin/keel/cli/Main.kt
@@ -19,8 +19,8 @@ fun main(args: Array<String>) {
                 val sep = all.indexOf("--")
                 if (sep >= 0) all.subList(sep + 1, all.size) else emptyList()
             }
-            val (config, classpath) = doBuild()
-            doRun(config, classpath, appArgs)
+            val (config, classpath, _, javaPath) = doBuild()
+            doRun(config, classpath, appArgs, javaPath)
         }
         "test" -> {
             val testArgs = args.toList().let { all ->
@@ -61,6 +61,6 @@ private fun printUsage() {
     eprintln("  tree       Show dependency tree")
     eprintln("  install    Resolve dependencies and download JARs")
     eprintln("  update     Re-resolve dependencies and update lockfile")
-    eprintln("  toolchain  Manage kotlinc toolchain (e.g. keel toolchain install)")
+    eprintln("  toolchain  Manage toolchains (e.g. keel toolchain install)")
     eprintln("  version    Show version information")
 }

--- a/src/nativeMain/kotlin/keel/cli/ToolchainCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/ToolchainCommands.kt
@@ -2,6 +2,7 @@ package keel.cli
 
 import keel.config.resolveKeelPaths
 import keel.infra.eprintln
+import keel.tool.installJdkToolchain
 import keel.tool.installKotlincToolchain
 import kotlin.system.exitProcess
 
@@ -17,4 +18,7 @@ private fun doToolchainInstall() {
     val config = loadProjectConfig()
     val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
     installKotlincToolchain(config.kotlin, paths, EXIT_BUILD_ERROR)
+    if (config.jdk != null) {
+        installJdkToolchain(config.jdk, paths, EXIT_BUILD_ERROR)
+    }
 }

--- a/src/nativeMain/kotlin/keel/config/Config.kt
+++ b/src/nativeMain/kotlin/keel/config/Config.kt
@@ -31,7 +31,8 @@ data class KeelConfig(
     @SerialName("test-dependencies") val testDependencies: Map<String, String> = emptyMap(),
     @SerialName("fmt_style") val fmtStyle: String = "google",
     val plugins: Map<String, Boolean> = emptyMap(),
-    val repositories: Map<String, String> = mapOf("central" to MAVEN_CENTRAL_BASE)
+    val repositories: Map<String, String> = mapOf("central" to MAVEN_CENTRAL_BASE),
+    val jdk: String? = null
 )
 
 private val toml = Toml(

--- a/src/nativeMain/kotlin/keel/config/KeelPaths.kt
+++ b/src/nativeMain/kotlin/keel/config/KeelPaths.kt
@@ -12,6 +12,10 @@ internal data class KeelPaths(val home: String) {
 
     fun kotlincPath(version: String): String = "$toolchainsDir/kotlinc/$version"
     fun kotlincBin(version: String): String = "${kotlincPath(version)}/bin/kotlinc"
+
+    fun jdkPath(version: String): String = "$toolchainsDir/jdk/$version"
+    fun javaBin(version: String): String = "${jdkPath(version)}/bin/java"
+    fun jarBin(version: String): String = "${jdkPath(version)}/bin/jar"
 }
 
 internal fun resolveKeelPaths(exitCode: Int): KeelPaths {

--- a/src/nativeMain/kotlin/keel/tool/ToolchainManager.kt
+++ b/src/nativeMain/kotlin/keel/tool/ToolchainManager.kt
@@ -5,6 +5,92 @@ import keel.config.KeelPaths
 import keel.infra.*
 import kotlin.system.exitProcess
 
+internal fun jdkDownloadUrl(version: String): String =
+    "https://api.adoptium.net/v3/binary/latest/$version/ga/linux/x64/jdk/hotspot/normal/eclipse"
+
+internal fun resolveJavaBinPath(version: String, paths: KeelPaths): String? {
+    val binPath = paths.javaBin(version)
+    return if (fileExists(binPath)) binPath else null
+}
+
+internal fun resolveJarBinPath(version: String, paths: KeelPaths): String? {
+    val binPath = paths.jarBin(version)
+    return if (fileExists(binPath)) binPath else null
+}
+
+internal fun installJdkToolchain(version: String, paths: KeelPaths, exitCode: Int) {
+    val finalPath = paths.jdkPath(version)
+    val javaBinPath = paths.javaBin(version)
+
+    if (fileExists(javaBinPath)) {
+        println("jdk $version is already installed at $finalPath")
+        return
+    }
+
+    val jdkBaseDir = "${paths.toolchainsDir}/jdk"
+    ensureDirectoryRecursive(jdkBaseDir).getOrElse { error ->
+        eprintln("error: could not create directory ${error.path}")
+        exitProcess(exitCode)
+    }
+
+    val tarPath = "$jdkBaseDir/$version.tar.gz"
+    val extractTempDir = "$jdkBaseDir/${version}_extract"
+
+    println("downloading jdk $version...")
+    downloadFile(jdkDownloadUrl(version), tarPath).getOrElse { error ->
+        when (error) {
+            is DownloadError.HttpFailed -> eprintln("error: failed to download jdk $version (HTTP ${error.statusCode})")
+            is DownloadError.WriteFailed -> eprintln("error: could not write $tarPath")
+            is DownloadError.NetworkError -> eprintln("error: network error downloading jdk $version: ${error.message}")
+        }
+        exitProcess(exitCode)
+    }
+
+    ensureDirectoryRecursive(extractTempDir).getOrElse { error ->
+        deleteFile(tarPath)
+        eprintln("error: could not create directory ${error.path}")
+        exitProcess(exitCode)
+    }
+
+    println("extracting jdk $version...")
+    executeCommand(listOf("tar", "xzf", tarPath, "-C", extractTempDir)).getOrElse { error ->
+        deleteFile(tarPath)
+        removeDirectoryRecursive(extractTempDir).getOrElse { e ->
+            eprintln("warning: could not remove temp directory ${e.path}")
+        }
+        eprintln(formatProcessError(error, "tar"))
+        exitProcess(exitCode)
+    }
+    deleteFile(tarPath)
+
+    // Adoptium tar.gz contains a top-level dir like "jdk-21.0.2+13/" — find and move its contents
+    val topLevelDir = executeAndCapture("ls '$extractTempDir'").getOrElse { _ ->
+        removeDirectoryRecursive(extractTempDir).getOrElse { e ->
+            eprintln("warning: could not remove temp directory ${e.path}")
+        }
+        eprintln("error: could not list extracted jdk directory")
+        exitProcess(exitCode)
+    }.trim()
+
+    executeCommand(listOf("mv", "$extractTempDir/$topLevelDir", finalPath)).getOrElse { error ->
+        removeDirectoryRecursive(extractTempDir).getOrElse { e ->
+            eprintln("warning: could not remove temp directory ${e.path}")
+        }
+        eprintln(formatProcessError(error, "mv"))
+        exitProcess(exitCode)
+    }
+    removeDirectoryRecursive(extractTempDir).getOrElse { e ->
+        eprintln("warning: could not remove temp directory ${e.path}")
+    }
+
+    if (!fileExists(javaBinPath)) {
+        eprintln("error: java binary not found at $javaBinPath after installation")
+        exitProcess(exitCode)
+    }
+
+    println("installed jdk $version at $finalPath")
+}
+
 internal fun kotlincDownloadUrl(version: String): String =
     "https://github.com/JetBrains/kotlin/releases/download/v$version/kotlin-compiler-$version.zip"
 

--- a/src/nativeMain/kotlin/keel/tool/ToolchainManager.kt
+++ b/src/nativeMain/kotlin/keel/tool/ToolchainManager.kt
@@ -3,10 +3,31 @@ package keel.tool
 import com.github.michaelbull.result.getOrElse
 import keel.config.KeelPaths
 import keel.infra.*
+import kotlinx.serialization.json.*
 import kotlin.system.exitProcess
 
 internal fun jdkDownloadUrl(version: String): String =
     "https://api.adoptium.net/v3/binary/latest/$version/ga/linux/x64/jdk/hotspot/normal/eclipse"
+
+internal fun jdkMetadataUrl(version: String): String =
+    "https://api.adoptium.net/v3/assets/latest/$version/hotspot?architecture=x64&image_type=jdk&os=linux&vendor=eclipse"
+
+internal fun parseJdkChecksum(json: String): String? =
+    try {
+        Json.parseToJsonElement(json)
+            .jsonArray.firstOrNull()
+            ?.jsonObject?.get("binary")
+            ?.jsonObject?.get("package")
+            ?.jsonObject?.get("checksum")
+            ?.jsonPrimitive?.content
+    } catch (_: Exception) {
+        null
+    }
+
+internal fun findSingleEntry(lsOutput: String): String? {
+    val entries = lsOutput.trim().lines().filter { it.isNotBlank() }
+    return if (entries.size == 1) entries.first().trim() else null
+}
 
 internal fun resolveJavaBinPath(version: String, paths: KeelPaths): String? {
     val binPath = paths.javaBin(version)
@@ -34,6 +55,7 @@ internal fun installJdkToolchain(version: String, paths: KeelPaths, exitCode: In
     }
 
     val tarPath = "$jdkBaseDir/$version.tar.gz"
+    val metadataPath = "$jdkBaseDir/$version.metadata.json"
     val extractTempDir = "$jdkBaseDir/${version}_extract"
 
     println("downloading jdk $version...")
@@ -43,6 +65,44 @@ internal fun installJdkToolchain(version: String, paths: KeelPaths, exitCode: In
             is DownloadError.WriteFailed -> eprintln("error: could not write $tarPath")
             is DownloadError.NetworkError -> eprintln("error: network error downloading jdk $version: ${error.message}")
         }
+        exitProcess(exitCode)
+    }
+
+    // SHA256 verification via Adoptium metadata API
+    downloadFile(jdkMetadataUrl(version), metadataPath).getOrElse { error ->
+        deleteFile(tarPath)
+        when (error) {
+            is DownloadError.HttpFailed -> eprintln("error: failed to download metadata for jdk $version (HTTP ${error.statusCode})")
+            is DownloadError.WriteFailed -> eprintln("error: could not write $metadataPath")
+            is DownloadError.NetworkError -> eprintln("error: network error downloading metadata: ${error.message}")
+        }
+        exitProcess(exitCode)
+    }
+
+    val metadataContent = readFileAsString(metadataPath).getOrElse { error ->
+        deleteFile(tarPath)
+        deleteFile(metadataPath)
+        eprintln("error: could not read ${error.path}")
+        exitProcess(exitCode)
+    }
+    val expectedHash = parseJdkChecksum(metadataContent)
+    deleteFile(metadataPath)
+
+    if (expectedHash == null) {
+        deleteFile(tarPath)
+        eprintln("error: could not parse checksum from jdk $version metadata")
+        exitProcess(exitCode)
+    }
+
+    val actualHash = computeSha256(tarPath).getOrElse { _ ->
+        deleteFile(tarPath)
+        eprintln("error: could not compute sha256 for $tarPath")
+        exitProcess(exitCode)
+    }
+
+    if (actualHash != expectedHash) {
+        deleteFile(tarPath)
+        eprintln("error: sha256 mismatch for jdk $version (expected $expectedHash, got $actualHash)")
         exitProcess(exitCode)
     }
 
@@ -63,14 +123,22 @@ internal fun installJdkToolchain(version: String, paths: KeelPaths, exitCode: In
     }
     deleteFile(tarPath)
 
-    // Adoptium tar.gz contains a top-level dir like "jdk-21.0.2+13/" — find and move its contents
-    val topLevelDir = executeAndCapture("ls '$extractTempDir'").getOrElse { _ ->
+    // Adoptium tar.gz contains a single top-level dir like "jdk-21.0.2+13/" — find and move it
+    val lsOutput = executeAndCapture("ls '$extractTempDir'").getOrElse { _ ->
         removeDirectoryRecursive(extractTempDir).getOrElse { e ->
             eprintln("warning: could not remove temp directory ${e.path}")
         }
         eprintln("error: could not list extracted jdk directory")
         exitProcess(exitCode)
-    }.trim()
+    }
+    val topLevelDir = findSingleEntry(lsOutput)
+    if (topLevelDir == null) {
+        removeDirectoryRecursive(extractTempDir).getOrElse { e ->
+            eprintln("warning: could not remove temp directory ${e.path}")
+        }
+        eprintln("error: expected exactly one top-level directory in jdk archive, got: ${lsOutput.trim()}")
+        exitProcess(exitCode)
+    }
 
     executeCommand(listOf("mv", "$extractTempDir/$topLevelDir", finalPath)).getOrElse { error ->
         removeDirectoryRecursive(extractTempDir).getOrElse { e ->

--- a/src/nativeTest/kotlin/keel/TestFixtures.kt
+++ b/src/nativeTest/kotlin/keel/TestFixtures.kt
@@ -11,7 +11,8 @@ fun testConfig(
     testSources: List<String> = listOf("test"),
     testDependencies: Map<String, String> = emptyMap(),
     plugins: Map<String, Boolean> = emptyMap(),
-    repositories: Map<String, String> = mapOf("central" to MAVEN_CENTRAL_BASE)
+    repositories: Map<String, String> = mapOf("central" to MAVEN_CENTRAL_BASE),
+    jdk: String? = null
 ) = KeelConfig(
     name = name,
     version = "0.1.0",
@@ -24,5 +25,6 @@ fun testConfig(
     testSources = testSources,
     testDependencies = testDependencies,
     plugins = plugins,
-    repositories = repositories
+    repositories = repositories,
+    jdk = jdk
 )

--- a/src/nativeTest/kotlin/keel/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/keel/build/BuilderTest.kt
@@ -305,4 +305,45 @@ class BuilderTest {
         assertEquals("build/classes", cmd1.args[4])
         assertEquals("build/classes", cmd2.args[4])
     }
+
+    @Test
+    fun jarCommandWithManagedJarPathUsesItAsJar() {
+        // Given: a managed jar binary path
+        val managedJarBin = "/home/user/.keel/toolchains/jdk/21/bin/jar"
+
+        // When: jarCommand is called with that path
+        val cmd = jarCommand(testConfig(), jarPath = managedJarBin)
+
+        // Then: managed path is used as the first arg, not system "jar"
+        assertEquals(
+            listOf(managedJarBin, "cf", "build/my-app.jar", "-C", "build/classes", "."),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun jarCommandWithNullJarPathDefaultsToSystemJar() {
+        // Given: no managed JDK (null)
+        // When: jarCommand is called with explicit null jarPath
+        val cmd = jarCommand(testConfig(), jarPath = null)
+
+        // Then: falls back to system "jar"
+        assertEquals("jar", cmd.args.first())
+    }
+
+    @Test
+    fun jarCommandWithManagedJarPathPreservesOutputPath() {
+        // Given: a managed jar binary path
+        val managedJarBin = "/home/user/.keel/toolchains/jdk/21/bin/jar"
+
+        // When: jarCommand is called with jarPath
+        val cmd = jarCommand(testConfig(name = "hello-world"), jarPath = managedJarBin)
+
+        // Then: outputPath is still derived from project name, not affected by jarPath
+        assertEquals("build/hello-world.jar", cmd.outputPath)
+        assertEquals(
+            listOf(managedJarBin, "cf", "build/hello-world.jar", "-C", "build/classes", "."),
+            cmd.args
+        )
+    }
 }

--- a/src/nativeTest/kotlin/keel/build/RunnerTest.kt
+++ b/src/nativeTest/kotlin/keel/build/RunnerTest.kt
@@ -41,4 +41,59 @@ class RunnerTest {
         val cmd = runCommand(testConfig(), "")
         assertEquals(listOf("java", "-cp", "build/classes", "com.example.MainKt"), cmd.args)
     }
+
+    @Test
+    fun runCommandWithManagedJavaPathUsesItAsJava() {
+        // Given: a managed java binary path
+        val managedJavaBin = "/home/user/.keel/toolchains/jdk/21/bin/java"
+
+        // When: runCommand is called with that path
+        val cmd = runCommand(testConfig(), null, javaPath = managedJavaBin)
+
+        // Then: the managed path is used as the first arg, not system "java"
+        assertEquals(
+            listOf(managedJavaBin, "-cp", "build/classes", "com.example.MainKt"),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun runCommandWithNullJavaPathDefaultsToSystemJava() {
+        // Given: no managed JDK (null)
+        // When: runCommand is called with explicit null javaPath
+        val cmd = runCommand(testConfig(), null, javaPath = null)
+
+        // Then: falls back to system "java"
+        assertEquals("java", cmd.args.first())
+    }
+
+    @Test
+    fun runCommandWithManagedJavaAndClasspath() {
+        // Given: managed java + dependency classpath
+        val managedJavaBin = "/home/user/.keel/toolchains/jdk/21/bin/java"
+
+        // When: runCommand is called with both
+        val cmd = runCommand(testConfig(), "/cache/lib.jar", javaPath = managedJavaBin)
+
+        // Then: managed path is first, classpath is appended after build/classes
+        assertEquals(
+            listOf(managedJavaBin, "-cp", "build/classes:/cache/lib.jar", "com.example.MainKt"),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun runCommandWithManagedJavaAndAppArgs() {
+        // Given: managed java + app arguments
+        val managedJavaBin = "/home/user/.keel/toolchains/jdk/21/bin/java"
+
+        // When: runCommand is called with javaPath and appArgs
+        val cmd = runCommand(testConfig(), null, listOf("--port", "8080"), javaPath = managedJavaBin)
+
+        // Then: managed java path is first, appArgs are appended at the end
+        assertEquals(
+            listOf(managedJavaBin, "-cp", "build/classes", "com.example.MainKt", "--port", "8080"),
+            cmd.args
+        )
+    }
 }

--- a/src/nativeTest/kotlin/keel/build/TestRunnerTest.kt
+++ b/src/nativeTest/kotlin/keel/build/TestRunnerTest.kt
@@ -164,4 +164,68 @@ class TestRunnerTest {
             cmd.args
         )
     }
+
+    @Test
+    fun testRunCommandWithManagedJavaPathUsesItAsJava() {
+        // Given: a managed java binary path
+        val managedJavaBin = "/home/user/.keel/toolchains/jdk/21/bin/java"
+
+        // When: testRunCommand is called with javaPath
+        val cmd = testRunCommand(
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
+            consoleLauncherPath = "/tools/launcher.jar",
+            javaPath = managedJavaBin
+        )
+
+        // Then: managed path is used as the first arg, not system "java"
+        assertEquals(
+            listOf(
+                managedJavaBin, "-jar", "/tools/launcher.jar",
+                "--class-path", "build/classes:build/test-classes",
+                "--scan-class-path"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun testRunCommandWithNullJavaPathDefaultsToSystemJava() {
+        // Given: no managed JDK (null)
+        // When: testRunCommand is called with explicit null javaPath
+        val cmd = testRunCommand(
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
+            consoleLauncherPath = "/tools/launcher.jar",
+            javaPath = null
+        )
+
+        // Then: falls back to system "java"
+        assertEquals("java", cmd.args.first())
+    }
+
+    @Test
+    fun testRunCommandWithManagedJavaAndClasspath() {
+        // Given: managed java + classpath
+        val managedJavaBin = "/home/user/.keel/toolchains/jdk/21/bin/java"
+
+        // When: testRunCommand is called with both javaPath and classpath
+        val cmd = testRunCommand(
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
+            consoleLauncherPath = "/tools/launcher.jar",
+            classpath = "/cache/dep.jar",
+            javaPath = managedJavaBin
+        )
+
+        // Then: managed java is first, classpath includes dependency
+        assertEquals(
+            listOf(
+                managedJavaBin, "-jar", "/tools/launcher.jar",
+                "--class-path", "build/classes:build/test-classes:/cache/dep.jar",
+                "--scan-class-path"
+            ),
+            cmd.args
+        )
+    }
 }

--- a/src/nativeTest/kotlin/keel/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/keel/cli/BuildCommandsTest.kt
@@ -1,8 +1,66 @@
 package keel.cli
 
+import keel.testConfig
+import keel.config.KeelPaths
+import keel.infra.ensureDirectoryRecursive
+import keel.infra.removeDirectoryRecursive
+import keel.infra.writeFileAsString
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
+
+class ResolveJdkBinsTest {
+
+    @Test
+    fun jdkNullInConfigReturnsNullBins() {
+        // Given: config has no jdk field
+        val config = testConfig(jdk = null)
+        val paths = KeelPaths("/tmp/keel_resolve_jdk_bins_null")
+
+        // When: resolveJdkBins is called
+        val result = resolveJdkBins(config, paths)
+
+        // Then: both java and jar are null — no managed JDK
+        assertNull(result.java)
+        assertNull(result.jar)
+    }
+
+    @Test
+    fun jdkSpecifiedButNotInstalledReturnsNullBins() {
+        // Given: config specifies jdk 21, but the toolchain dir is absent
+        val config = testConfig(jdk = "21")
+        val paths = KeelPaths("/tmp/keel_resolve_jdk_bins_not_installed")
+
+        // When: resolveJdkBins is called
+        val result = resolveJdkBins(config, paths)
+
+        // Then: both java and jar are null — managed JDK not found, falls back to system
+        assertNull(result.java)
+        assertNull(result.jar)
+    }
+
+    @Test
+    fun jdkSpecifiedAndInstalledReturnsBinPaths() {
+        // Given: config specifies jdk 21 and binaries exist at the managed location
+        val config = testConfig(jdk = "21")
+        val paths = KeelPaths("/tmp/keel_resolve_jdk_bins_installed")
+        val binDir = "${paths.toolchainsDir}/jdk/21/bin"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString("$binDir/java", "#!/bin/sh")
+        writeFileAsString("$binDir/jar", "#!/bin/sh")
+        try {
+            // When: resolveJdkBins is called
+            val result = resolveJdkBins(config, paths)
+
+            // Then: returns managed java and jar paths
+            assertEquals(paths.javaBin("21"), result.java)
+            assertEquals(paths.jarBin("21"), result.jar)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+}
 
 class FindOverlappingDependenciesTest {
 

--- a/src/nativeTest/kotlin/keel/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/keel/config/ConfigTest.kt
@@ -552,4 +552,58 @@ class ConfigTest {
         val config = assertNotNull(parseConfig(minimalToml).get())
         assertEquals(MAVEN_CENTRAL_BASE, config.repositories["central"])
     }
+
+    // --- jdk field ---
+
+    @Test
+    fun parseMinimalConfigHasNullJdk() {
+        // Given: minimal config with no jdk field
+        // When: parsing
+        val config = assertNotNull(parseConfig(minimalToml).get())
+
+        // Then: jdk defaults to null (use system java)
+        assertNull(config.jdk)
+    }
+
+    @Test
+    fun parseConfigWithJdkVersion() {
+        // Given: config with jdk = "21"
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            jdk = "21"
+            main = "com.example.MainKt"
+            sources = ["src"]
+        """.trimIndent()
+
+        // When: parsing
+        val config = assertNotNull(parseConfig(toml).get())
+
+        // Then: jdk field contains the specified version
+        assertEquals("21", config.jdk)
+    }
+
+    @Test
+    fun parseConfigWithJdkAndJvmTargetAreIndependent() {
+        // Given: config with both jdk and jvm_target set to different values
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "jvm"
+            jdk = "21"
+            jvm_target = "17"
+            main = "com.example.MainKt"
+            sources = ["src"]
+        """.trimIndent()
+
+        // When: parsing
+        val config = assertNotNull(parseConfig(toml).get())
+
+        // Then: jdk and jvm_target are independent fields
+        assertEquals("21", config.jdk)
+        assertEquals("17", config.jvmTarget)
+    }
 }

--- a/src/nativeTest/kotlin/keel/config/KeelPathsTest.kt
+++ b/src/nativeTest/kotlin/keel/config/KeelPathsTest.kt
@@ -63,4 +63,78 @@ class KeelPathsTest {
 
         assertEquals("/root/.keel/toolchains/kotlinc/2.3.20/bin/kotlinc", paths.kotlincBin("2.3.20"))
     }
+
+    // --- jdkPath ---
+
+    @Test
+    fun jdkPathBuildsVersionedDirectory() {
+        // Given: KeelPaths with a known home
+        val paths = KeelPaths("/home/user")
+
+        // When: jdkPath is called for a specific major version
+        val path = paths.jdkPath("21")
+
+        // Then: path points to the versioned directory under toolchains/jdk
+        assertEquals("/home/user/.keel/toolchains/jdk/21", path)
+    }
+
+    @Test
+    fun jdkPathDifferentVersion() {
+        val paths = KeelPaths("/home/alice")
+
+        assertEquals("/home/alice/.keel/toolchains/jdk/17", paths.jdkPath("17"))
+    }
+
+    // --- javaBin ---
+
+    @Test
+    fun javaBinBuildsVersionedBinPath() {
+        // Given: KeelPaths with a known home
+        val paths = KeelPaths("/home/user")
+
+        // When: javaBin is called for a specific major version
+        val bin = paths.javaBin("21")
+
+        // Then: bin path points to bin/java inside the versioned directory
+        assertEquals("/home/user/.keel/toolchains/jdk/21/bin/java", bin)
+    }
+
+    @Test
+    fun javaBinDifferentHome() {
+        val paths = KeelPaths("/root")
+
+        assertEquals("/root/.keel/toolchains/jdk/17/bin/java", paths.javaBin("17"))
+    }
+
+    // --- jarBin ---
+
+    @Test
+    fun jarBinBuildsVersionedBinPath() {
+        // Given: KeelPaths with a known home
+        val paths = KeelPaths("/home/user")
+
+        // When: jarBin is called for a specific major version
+        val bin = paths.jarBin("21")
+
+        // Then: bin path points to bin/jar inside the versioned directory
+        assertEquals("/home/user/.keel/toolchains/jdk/21/bin/jar", bin)
+    }
+
+    @Test
+    fun jarBinDifferentHome() {
+        val paths = KeelPaths("/root")
+
+        assertEquals("/root/.keel/toolchains/jdk/17/bin/jar", paths.jarBin("17"))
+    }
+
+    @Test
+    fun jdkJavaBinAndJarBinShareSameVersionedDirectory() {
+        // Given: jdkPath, javaBin, and jarBin for the same version
+        val paths = KeelPaths("/home/user")
+
+        // Then: javaBin and jarBin are both under jdkPath
+        val base = paths.jdkPath("21")
+        assertEquals("$base/bin/java", paths.javaBin("21"))
+        assertEquals("$base/bin/jar", paths.jarBin("21"))
+    }
 }

--- a/src/nativeTest/kotlin/keel/tool/ToolchainManagerTest.kt
+++ b/src/nativeTest/kotlin/keel/tool/ToolchainManagerTest.kt
@@ -172,4 +172,168 @@ class ToolchainManagerTest {
             removeDirectoryRecursive(paths.home + "/.keel")
         }
     }
+
+    // --- jdkDownloadUrl ---
+
+    @Test
+    fun jdkDownloadUrlContainsMajorVersion() {
+        // Given: major version 21
+        // When: building JDK download URL
+        val url = jdkDownloadUrl("21")
+
+        // Then: URL contains the major version
+        assertEquals(
+            "https://api.adoptium.net/v3/binary/latest/21/ga/linux/x64/jdk/hotspot/normal/eclipse",
+            url
+        )
+    }
+
+    @Test
+    fun jdkDownloadUrlDifferentVersion() {
+        // Given: major version 17
+        val url = jdkDownloadUrl("17")
+
+        assertEquals(
+            "https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jdk/hotspot/normal/eclipse",
+            url
+        )
+    }
+
+    // --- resolveJavaBinPath ---
+
+    @Test
+    fun resolveJavaBinPathReturnsBinPathWhenManagedVersionInstalled() {
+        // Given: managed java bin exists at paths.javaBin(version)
+        val paths = KeelPaths("/tmp/keel_tc_jdk_resolve_installed")
+        val binDir = "${paths.toolchainsDir}/jdk/21/bin"
+        val binPath = "$binDir/java"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString(binPath, "#!/bin/sh")
+        try {
+            // When: resolveJavaBinPath is called with matching version
+            val result = resolveJavaBinPath("21", paths)
+
+            // Then: returns exactly paths.javaBin(version)
+            assertEquals(paths.javaBin("21"), result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun resolveJavaBinPathReturnsNullWhenToolchainsDirAbsent() {
+        // Given: toolchains directory does not exist at all
+        val paths = KeelPaths("/tmp/keel_tc_jdk_resolve_no_dir")
+
+        // When: resolveJavaBinPath is called
+        val result = resolveJavaBinPath("21", paths)
+
+        // Then: returns null (system java fallback)
+        assertNull(result)
+    }
+
+    @Test
+    fun resolveJavaBinPathReturnsNullWhenVersionDirExistsButBinMissing() {
+        // Given: version directory exists but bin/java is absent
+        val paths = KeelPaths("/tmp/keel_tc_jdk_resolve_no_bin")
+        val versionDir = "${paths.toolchainsDir}/jdk/21"
+        ensureDirectoryRecursive(versionDir)
+        try {
+            // When: resolveJavaBinPath is called
+            val result = resolveJavaBinPath("21", paths)
+
+            // Then: returns null — partial installation is not usable
+            assertNull(result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun resolveJavaBinPathReturnsNullForDifferentInstalledVersion() {
+        // Given: only version 17 is installed, not 21
+        val paths = KeelPaths("/tmp/keel_tc_jdk_resolve_version_isolation")
+        val binDir = "${paths.toolchainsDir}/jdk/17/bin"
+        val binPath = "$binDir/java"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString(binPath, "#!/bin/sh")
+        try {
+            // When: resolveJavaBinPath is called for 21
+            val result = resolveJavaBinPath("21", paths)
+
+            // Then: returns null — version isolation must be exact
+            assertNull(result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun resolveJavaBinPathDelegatesPathConstructionToKeelPaths() {
+        // Given: a paths object and a file at the expected location
+        val paths = KeelPaths("/tmp/keel_tc_jdk_resolve_delegation")
+        val expectedBin = paths.javaBin("21")
+        val binDir = expectedBin.substringBeforeLast("/")
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString(expectedBin, "#!/bin/sh")
+        try {
+            // When: resolveJavaBinPath is called
+            val result = resolveJavaBinPath("21", paths)
+
+            // Then: returned path equals paths.javaBin() — no independent path construction
+            assertEquals(expectedBin, result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    // --- resolveJarBinPath ---
+
+    @Test
+    fun resolveJarBinPathReturnsBinPathWhenManagedVersionInstalled() {
+        // Given: managed jar bin exists at paths.jarBin(version)
+        val paths = KeelPaths("/tmp/keel_tc_jar_resolve_installed")
+        val binDir = "${paths.toolchainsDir}/jdk/21/bin"
+        val binPath = "$binDir/jar"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString(binPath, "#!/bin/sh")
+        try {
+            // When: resolveJarBinPath is called with matching version
+            val result = resolveJarBinPath("21", paths)
+
+            // Then: returns exactly paths.jarBin(version)
+            assertEquals(paths.jarBin("21"), result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun resolveJarBinPathReturnsNullWhenToolchainsDirAbsent() {
+        // Given: toolchains directory does not exist at all
+        val paths = KeelPaths("/tmp/keel_tc_jar_resolve_no_dir")
+
+        // When: resolveJarBinPath is called
+        val result = resolveJarBinPath("21", paths)
+
+        // Then: returns null (system jar fallback)
+        assertNull(result)
+    }
+
+    @Test
+    fun resolveJarBinPathReturnsNullWhenVersionDirExistsButBinMissing() {
+        // Given: version directory exists but bin/jar is absent
+        val paths = KeelPaths("/tmp/keel_tc_jar_resolve_no_bin")
+        val versionDir = "${paths.toolchainsDir}/jdk/21"
+        ensureDirectoryRecursive(versionDir)
+        try {
+            // When: resolveJarBinPath is called
+            val result = resolveJarBinPath("21", paths)
+
+            // Then: returns null — partial installation is not usable
+            assertNull(result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
 }

--- a/src/nativeTest/kotlin/keel/tool/ToolchainManagerTest.kt
+++ b/src/nativeTest/kotlin/keel/tool/ToolchainManagerTest.kt
@@ -199,6 +199,122 @@ class ToolchainManagerTest {
         )
     }
 
+    // --- jdkMetadataUrl ---
+
+    @Test
+    fun jdkMetadataUrlContainsMajorVersion() {
+        // Given: major version 21
+        // When: building JDK metadata URL
+        val url = jdkMetadataUrl("21")
+
+        // Then: URL points to Adoptium assets API with correct filters
+        assertEquals(
+            "https://api.adoptium.net/v3/assets/latest/21/hotspot?architecture=x64&image_type=jdk&os=linux&vendor=eclipse",
+            url
+        )
+    }
+
+    @Test
+    fun jdkMetadataUrlDifferentVersion() {
+        // Given: major version 17
+        val url = jdkMetadataUrl("17")
+
+        assertEquals(
+            "https://api.adoptium.net/v3/assets/latest/17/hotspot?architecture=x64&image_type=jdk&os=linux&vendor=eclipse",
+            url
+        )
+    }
+
+    // --- parseJdkChecksum ---
+
+    @Test
+    fun parseJdkChecksumExtractsHashFromMetadataJson() {
+        // Given: Adoptium metadata API JSON response
+        val json = """
+            [{"binary":{"package":{"checksum":"ea3b9bd464d6dd253e9a7accf59f7ccd2a36e4aa69640b7251e3370caef896a4","name":"OpenJDK21U-jdk_x64_linux_hotspot_21.0.10_7.tar.gz","link":"https://example.com/jdk.tar.gz"}}}]
+        """.trimIndent()
+
+        // When: parsing the checksum
+        val result = parseJdkChecksum(json)
+
+        // Then: returns the checksum string
+        assertEquals("ea3b9bd464d6dd253e9a7accf59f7ccd2a36e4aa69640b7251e3370caef896a4", result)
+    }
+
+    @Test
+    fun parseJdkChecksumReturnsNullOnInvalidJson() {
+        // Given: invalid JSON
+        val json = "not json"
+
+        // When: parsing the checksum
+        val result = parseJdkChecksum(json)
+
+        // Then: returns null
+        assertNull(result)
+    }
+
+    @Test
+    fun parseJdkChecksumReturnsNullOnEmptyArray() {
+        // Given: empty JSON array
+        val json = "[]"
+
+        // When: parsing the checksum
+        val result = parseJdkChecksum(json)
+
+        // Then: returns null
+        assertNull(result)
+    }
+
+    // --- findSingleEntry ---
+
+    @Test
+    fun findSingleEntryReturnsTrimmedNameWhenOneEntry() {
+        // Given: ls output with a single directory name
+        val lsOutput = "jdk-21.0.2+13\n"
+
+        // When: finding the single entry
+        val result = findSingleEntry(lsOutput)
+
+        // Then: returns the trimmed directory name
+        assertEquals("jdk-21.0.2+13", result)
+    }
+
+    @Test
+    fun findSingleEntryReturnsNullWhenMultipleEntries() {
+        // Given: ls output with multiple entries
+        val lsOutput = "jdk-21.0.2+13\nextra-dir\n"
+
+        // When: finding the single entry
+        val result = findSingleEntry(lsOutput)
+
+        // Then: returns null — ambiguous
+        assertNull(result)
+    }
+
+    @Test
+    fun findSingleEntryReturnsNullWhenEmpty() {
+        // Given: empty ls output
+        val lsOutput = ""
+
+        // When: finding the single entry
+        val result = findSingleEntry(lsOutput)
+
+        // Then: returns null
+        assertNull(result)
+    }
+
+    @Test
+    fun findSingleEntryReturnsNullWhenBlank() {
+        // Given: whitespace-only ls output
+        val lsOutput = "   \n  \n"
+
+        // When: finding the single entry
+        val result = findSingleEntry(lsOutput)
+
+        // Then: returns null
+        assertNull(result)
+    }
+
     // --- resolveJavaBinPath ---
 
     @Test


### PR DESCRIPTION
## Summary

## Summary

Add JDK toolchain management. keel can download, extract, and use a specific JDK version defined in `keel.toml`, falling back to system `java` if not managed.

Second of 4 issues split from #17. Builds on the infrastructure established in #38 (kotlinc toolchain).

## Config Change

Add `jdk` field to `keel.toml`:

```toml
kotlin = "2.1.0"
jdk = "21"            # NEW — JDK major version
jvm_target = "17"     # Existing — bytecode target version (unchanged)
```

- `jdk`: the actual JDK installation to use for `java` command
- `jvm_target`: the bytecode compatibility level passed to `kotlinc -jvm-target`
- When `jdk` is omitted, fall back to system `java` on PATH (backward compatible)

## Toolchain Resolution

Same strategy as kotlinc (#38): managed-first, system-fallback.

1. If `jdk` is specified in `keel.toml` and managed JDK exists → use `~/.keel/toolchains/jdk/{version}/bin/java`
2. If `jdk` is specified but not installed → fall back to system `java` with warning
3. If `jdk` is not specified → use system `java` (current behavior)

## Storage Layout

```
~/.keel/
  toolchains/
    jdk/
      21/
        bin/java
        bin/jar
        lib/...
```

## Download Source

Adoptium (Eclipse Temurin) API:

```
https://api.adoptium.net/v3/binary/latest/{major_version}/ga/linux/x64/jdk/hotspot/normal/eclipse
```

This returns a redirect to the actual tar.gz file. libcurl with `CURLOPT_FOLLOWLOCATION` (already configured) handles this.

Distribution is fixed to Adoptium (Eclipse Temurin) for the initial implementation.

## Implementation Details

### 1. Config.kt — Add jdk field

```kotlin
val jdk: String? = null,  // Optional — null means use system java
```

### 2. KeelPaths — Add JDK path helpers

```kotlin
fun jdkPath(version: String): String = "$toolchainsDir/jdk/$version"
fun javaBin(version: String): String = "${jdkPath(version)}/bin/java"
fun jarBin(version: String): String = "${jdkPath(version)}/bin/jar"
```

### 3. ToolchainManager — Add JDK support

- Download tar.gz from Adoptium
- Extract with `tar xzf archive.tar.gz -C target/`
- Adoptium tar.gz contains a top-level dir like `jdk-21.0.2+13/` — extract and move contents
- Detect the actual top-level directory name after extraction

### 4. Runner.kt — Accept java path

```
Before: args = ["java", "-cp", ...]
After:  args = [javaPath ?: "java", "-cp", ...]
```

Same for TestRunner.kt.

### 5. Builder.kt — jarCommand() accepts jar path

```
Before: args = ["jar", "cf", ...]
After:  args = [jarPath ?: "jar", "cf", ...]
```

### 6. BuildCommands.kt — Wire up JDK resolution

```kotlin
val javaBin = config.jdk?.let { resolveJavaBin(it, paths.toolchainsDir) } ?: "java"
val jarBin = config.jdk?.let { resolveJarBin(it, paths.toolchainsDir) } ?: "jar"
```

### 7. `keel toolchain install` — Add JDK

```bash
keel toolchain install          # Install both kotlinc and JDK from keel.toml
```

If `jdk` is not specified in `keel.toml`, skip JDK installation.

## Known Limitations

### JDK version reproducibility

`jdk = "21"` specifies a major version only. The actual version downloaded from Adoptium (e.g. `21.0.2+13`) may change over time as new patch releases are published. This means builds are not fully reproducible across time with the same `keel.toml`.

For the initial implementation, major version specification is sufficient. Future improvements may include:
- Recording the full JDK version (e.g. `21.0.2+13`) in `keel.lock` to pin exact versions
- Supporting full version specification in `keel.toml` (e.g. `jdk = "21.0.2+13"`)

## Out of Scope

- Auto-install on build/run/test (#40)
- `keel toolchain list/remove` (#41)
- macOS/Windows/aarch64 support
- Alternative JDK vendors (Corretto, Zulu, etc.) — can be added later via a `jdk_vendor` field if needed

## Dependencies

- Depends on: #38 (storage layout, extraction infrastructure)
- Blocks: #40

## Execution Report

Workflow `keel` completed successfully.

Closes #39