### PR TITLE
[#41] Add toolchain list and remove commands

### DIFF
--- a/src/nativeMain/kotlin/keel/cli/Main.kt
+++ b/src/nativeMain/kotlin/keel/cli/Main.kt
@@ -61,6 +61,6 @@ private fun printUsage() {
     eprintln("  tree       Show dependency tree")
     eprintln("  install    Resolve dependencies and download JARs")
     eprintln("  update     Re-resolve dependencies and update lockfile")
-    eprintln("  toolchain  Manage toolchains (e.g. keel toolchain install)")
+    eprintln("  toolchain  Manage toolchains (install, list, remove)")
     eprintln("  version    Show version information")
 }

--- a/src/nativeMain/kotlin/keel/cli/ToolchainCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/ToolchainCommands.kt
@@ -1,17 +1,38 @@
 package keel.cli
 
+import com.github.michaelbull.result.getOrElse
+import keel.config.KeelPaths
 import keel.config.resolveKeelPaths
-import keel.infra.eprintln
+import keel.infra.*
 import keel.tool.installJdkToolchain
 import keel.tool.installKotlincToolchain
 import kotlin.system.exitProcess
 
+private val KNOWN_TOOLCHAINS = listOf("kotlinc", "jdk")
+
 internal fun doToolchain(args: List<String>) {
-    if (args.isEmpty() || args[0] != "install") {
-        eprintln("usage: keel toolchain install")
+    if (args.isEmpty()) {
+        printToolchainUsage()
         exitProcess(EXIT_CONFIG_ERROR)
     }
-    doToolchainInstall()
+    when (args[0]) {
+        "install" -> doToolchainInstall()
+        "list" -> doToolchainList()
+        "remove" -> doToolchainRemove(args.drop(1))
+        else -> {
+            printToolchainUsage()
+            exitProcess(EXIT_CONFIG_ERROR)
+        }
+    }
+}
+
+private fun printToolchainUsage() {
+    eprintln("usage: keel toolchain <subcommand>")
+    eprintln("")
+    eprintln("subcommands:")
+    eprintln("  install    Install toolchains defined in keel.toml")
+    eprintln("  list       List installed toolchains")
+    eprintln("  remove     Remove an installed toolchain (e.g. keel toolchain remove kotlinc 2.1.0)")
 }
 
 private fun doToolchainInstall() {
@@ -21,4 +42,69 @@ private fun doToolchainInstall() {
     if (config.jdk != null) {
         installJdkToolchain(config.jdk, paths, EXIT_BUILD_ERROR)
     }
+}
+
+private fun doToolchainList() {
+    val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
+    val kotlincVersions = listInstalledVersions("${paths.toolchainsDir}/kotlinc")
+    val jdkVersions = listInstalledVersions("${paths.toolchainsDir}/jdk")
+    println(formatToolchainList(kotlincVersions, jdkVersions))
+}
+
+private fun listInstalledVersions(dir: String): List<String> {
+    if (!fileExists(dir)) return emptyList()
+    return listDirectoryEntries(dir).getOrElse { emptyList() }
+}
+
+internal fun formatToolchainList(kotlincVersions: List<String>, jdkVersions: List<String>): String {
+    if (kotlincVersions.isEmpty() && jdkVersions.isEmpty()) {
+        return "no toolchains installed"
+    }
+    val sections = mutableListOf<String>()
+    if (kotlincVersions.isNotEmpty()) {
+        sections.add("kotlinc:\n" + kotlincVersions.joinToString("\n") { "  $it" })
+    }
+    if (jdkVersions.isNotEmpty()) {
+        sections.add("jdk:\n" + jdkVersions.joinToString("\n") { "  $it" })
+    }
+    return sections.joinToString("\n\n")
+}
+
+internal data class ToolchainRemoveArgs(val name: String, val version: String)
+
+internal fun validateToolchainRemoveArgs(args: List<String>): Pair<ToolchainRemoveArgs?, String?> {
+    if (args.size < 2) {
+        return null to "usage: keel toolchain remove <name> <version>"
+    }
+    val name = args[0]
+    if (name !in KNOWN_TOOLCHAINS) {
+        return null to "error: unknown toolchain '$name' (available: ${KNOWN_TOOLCHAINS.joinToString(", ")})"
+    }
+    return ToolchainRemoveArgs(name, args[1]) to null
+}
+
+internal fun resolveToolchainPathForRemove(name: String, version: String, paths: KeelPaths): String? {
+    val dir = "${paths.toolchainsDir}/$name/$version"
+    return if (fileExists(dir)) dir else null
+}
+
+private fun doToolchainRemove(args: List<String>) {
+    val (parsed, error) = validateToolchainRemoveArgs(args)
+    if (parsed == null) {
+        eprintln(error!!)
+        exitProcess(EXIT_CONFIG_ERROR)
+    }
+
+    val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
+    val toolchainPath = resolveToolchainPathForRemove(parsed.name, parsed.version, paths)
+    if (toolchainPath == null) {
+        eprintln("error: ${parsed.name} ${parsed.version} is not installed")
+        exitProcess(EXIT_BUILD_ERROR)
+    }
+
+    removeDirectoryRecursive(toolchainPath).getOrElse { err ->
+        eprintln("error: could not remove ${err.path}")
+        exitProcess(EXIT_BUILD_ERROR)
+    }
+    println("removed ${parsed.name} ${parsed.version}")
 }

--- a/src/nativeMain/kotlin/keel/cli/ToolchainCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/ToolchainCommands.kt
@@ -1,5 +1,8 @@
 package keel.cli
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import keel.config.KeelPaths
 import keel.config.resolveKeelPaths
@@ -37,7 +40,7 @@ private fun printToolchainUsage() {
 
 private fun doToolchainInstall() {
     val config = loadProjectConfig()
-    val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
+    val paths = resolveKeelPaths(EXIT_CONFIG_ERROR)
     installKotlincToolchain(config.kotlin, paths, EXIT_BUILD_ERROR)
     if (config.jdk != null) {
         installJdkToolchain(config.jdk, paths, EXIT_BUILD_ERROR)
@@ -45,7 +48,7 @@ private fun doToolchainInstall() {
 }
 
 private fun doToolchainList() {
-    val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
+    val paths = resolveKeelPaths(EXIT_CONFIG_ERROR)
     val kotlincVersions = listInstalledVersions("${paths.toolchainsDir}/kotlinc")
     val jdkVersions = listInstalledVersions("${paths.toolchainsDir}/jdk")
     println(formatToolchainList(kotlincVersions, jdkVersions))
@@ -53,7 +56,7 @@ private fun doToolchainList() {
 
 private fun listInstalledVersions(dir: String): List<String> {
     if (!fileExists(dir)) return emptyList()
-    return listDirectoryEntries(dir).getOrElse { emptyList() }
+    return listSubdirectories(dir).getOrElse { emptyList() }
 }
 
 internal fun formatToolchainList(kotlincVersions: List<String>, jdkVersions: List<String>): String {
@@ -72,30 +75,33 @@ internal fun formatToolchainList(kotlincVersions: List<String>, jdkVersions: Lis
 
 internal data class ToolchainRemoveArgs(val name: String, val version: String)
 
-internal fun validateToolchainRemoveArgs(args: List<String>): Pair<ToolchainRemoveArgs?, String?> {
+internal fun validateToolchainRemoveArgs(args: List<String>): Result<ToolchainRemoveArgs, String> {
     if (args.size < 2) {
-        return null to "usage: keel toolchain remove <name> <version>"
+        return Err("usage: keel toolchain remove <name> <version>")
     }
     val name = args[0]
     if (name !in KNOWN_TOOLCHAINS) {
-        return null to "error: unknown toolchain '$name' (available: ${KNOWN_TOOLCHAINS.joinToString(", ")})"
+        return Err("error: unknown toolchain '$name' (available: ${KNOWN_TOOLCHAINS.joinToString(", ")})")
     }
-    return ToolchainRemoveArgs(name, args[1]) to null
+    return Ok(ToolchainRemoveArgs(name, args[1]))
 }
 
 internal fun resolveToolchainPathForRemove(name: String, version: String, paths: KeelPaths): String? {
-    val dir = "${paths.toolchainsDir}/$name/$version"
+    val dir = when (name) {
+        "kotlinc" -> paths.kotlincPath(version)
+        "jdk" -> paths.jdkPath(version)
+        else -> return null
+    }
     return if (fileExists(dir)) dir else null
 }
 
 private fun doToolchainRemove(args: List<String>) {
-    val (parsed, error) = validateToolchainRemoveArgs(args)
-    if (parsed == null) {
-        eprintln(error!!)
+    val parsed = validateToolchainRemoveArgs(args).getOrElse { error ->
+        eprintln(error)
         exitProcess(EXIT_CONFIG_ERROR)
     }
 
-    val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
+    val paths = resolveKeelPaths(EXIT_CONFIG_ERROR)
     val toolchainPath = resolveToolchainPathForRemove(parsed.name, parsed.version, paths)
     if (toolchainPath == null) {
         eprintln("error: ${parsed.name} ${parsed.version} is not installed")
@@ -103,7 +109,7 @@ private fun doToolchainRemove(args: List<String>) {
     }
 
     removeDirectoryRecursive(toolchainPath).getOrElse { err ->
-        eprintln("error: could not remove ${err.path}")
+        eprintln("error: could not remove ${parsed.name} ${parsed.version}: ${err.path}")
         exitProcess(EXIT_BUILD_ERROR)
     }
     println("removed ${parsed.name} ${parsed.version}")

--- a/src/nativeMain/kotlin/keel/infra/FileSystem.kt
+++ b/src/nativeMain/kotlin/keel/infra/FileSystem.kt
@@ -185,7 +185,7 @@ private fun collectAllFileMtimes(directory: String, onFile: (Long) -> Unit) {
 }
 
 @OptIn(ExperimentalForeignApi::class)
-fun listDirectoryEntries(path: String): Result<List<String>, ListFilesFailed> {
+fun listSubdirectories(path: String): Result<List<String>, ListFilesFailed> {
     val dir = opendir(path) ?: return Err(ListFilesFailed(path))
     val entries = mutableListOf<String>()
     try {
@@ -193,7 +193,9 @@ fun listDirectoryEntries(path: String): Result<List<String>, ListFilesFailed> {
             val entry = readdir(dir) ?: break
             val name = entry.pointed.d_name.toKString()
             if (name == "." || name == "..") continue
-            entries.add(name)
+            if (isDirectory("$path/$name")) {
+                entries.add(name)
+            }
         }
     } finally {
         closedir(dir)

--- a/src/nativeMain/kotlin/keel/infra/FileSystem.kt
+++ b/src/nativeMain/kotlin/keel/infra/FileSystem.kt
@@ -184,6 +184,24 @@ private fun collectAllFileMtimes(directory: String, onFile: (Long) -> Unit) {
     }
 }
 
+@OptIn(ExperimentalForeignApi::class)
+fun listDirectoryEntries(path: String): Result<List<String>, ListFilesFailed> {
+    val dir = opendir(path) ?: return Err(ListFilesFailed(path))
+    val entries = mutableListOf<String>()
+    try {
+        while (true) {
+            val entry = readdir(dir) ?: break
+            val name = entry.pointed.d_name.toKString()
+            if (name == "." || name == "..") continue
+            entries.add(name)
+        }
+    } finally {
+        closedir(dir)
+    }
+    entries.sort()
+    return Ok(entries)
+}
+
 data class ListFilesFailed(val path: String)
 
 @OptIn(ExperimentalForeignApi::class)

--- a/src/nativeTest/kotlin/keel/cli/ToolchainCommandsTest.kt
+++ b/src/nativeTest/kotlin/keel/cli/ToolchainCommandsTest.kt
@@ -1,0 +1,191 @@
+package keel.cli
+
+import keel.config.KeelPaths
+import keel.infra.ensureDirectoryRecursive
+import keel.infra.removeDirectoryRecursive
+import keel.infra.writeFileAsString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class FormatToolchainListTest {
+
+    @Test
+    fun noToolchainsInstalledReturnsMessage() {
+        // Given: no toolchains installed
+        val kotlincVersions = emptyList<String>()
+        val jdkVersions = emptyList<String>()
+
+        // When: formatting the list
+        val result = formatToolchainList(kotlincVersions, jdkVersions)
+
+        // Then: returns "no toolchains installed" message
+        assertEquals("no toolchains installed", result)
+    }
+
+    @Test
+    fun onlyKotlincInstalled() {
+        // Given: kotlinc versions installed
+        val kotlincVersions = listOf("2.1.0", "2.3.0")
+        val jdkVersions = emptyList<String>()
+
+        // When: formatting the list
+        val result = formatToolchainList(kotlincVersions, jdkVersions)
+
+        // Then: shows kotlinc section only
+        val expected = """
+            kotlinc:
+              2.1.0
+              2.3.0
+        """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun onlyJdkInstalled() {
+        // Given: jdk versions installed
+        val kotlincVersions = emptyList<String>()
+        val jdkVersions = listOf("21")
+
+        // When: formatting the list
+        val result = formatToolchainList(kotlincVersions, jdkVersions)
+
+        // Then: shows jdk section only
+        val expected = """
+            jdk:
+              21
+        """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun bothKotlincAndJdkInstalled() {
+        // Given: both kotlinc and jdk installed
+        val kotlincVersions = listOf("2.1.0")
+        val jdkVersions = listOf("17", "21")
+
+        // When: formatting the list
+        val result = formatToolchainList(kotlincVersions, jdkVersions)
+
+        // Then: shows both sections separated by blank line
+        val expected = """
+            kotlinc:
+              2.1.0
+
+            jdk:
+              17
+              21
+        """.trimIndent()
+        assertEquals(expected, result)
+    }
+}
+
+class ValidateToolchainRemoveArgsTest {
+
+    @Test
+    fun validKotlincArgs() {
+        // Given: valid kotlinc remove args
+        val result = validateToolchainRemoveArgs(listOf("kotlinc", "2.1.0"))
+
+        // Then: returns valid parsed args
+        val args = assertNotNull(result.first)
+        assertEquals("kotlinc", args.name)
+        assertEquals("2.1.0", args.version)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun validJdkArgs() {
+        // Given: valid jdk remove args
+        val result = validateToolchainRemoveArgs(listOf("jdk", "21"))
+
+        // Then: returns valid parsed args
+        val args = assertNotNull(result.first)
+        assertEquals("jdk", args.name)
+        assertEquals("21", args.version)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun unknownToolchainNameReturnsError() {
+        // Given: unknown toolchain name
+        val result = validateToolchainRemoveArgs(listOf("foo", "1.0"))
+
+        // Then: returns error message
+        assertNull(result.first)
+        assertEquals("error: unknown toolchain 'foo' (available: kotlinc, jdk)", result.second)
+    }
+
+    @Test
+    fun missingArgsReturnsError() {
+        // Given: not enough args
+        val result = validateToolchainRemoveArgs(listOf("kotlinc"))
+
+        // Then: returns usage error
+        assertNull(result.first)
+        assertEquals("usage: keel toolchain remove <name> <version>", result.second)
+    }
+
+    @Test
+    fun emptyArgsReturnsError() {
+        // Given: no args
+        val result = validateToolchainRemoveArgs(emptyList())
+
+        // Then: returns usage error
+        assertNull(result.first)
+        assertEquals("usage: keel toolchain remove <name> <version>", result.second)
+    }
+}
+
+class ResolveToolchainPathForRemoveTest {
+
+    @Test
+    fun kotlincInstalledReturnsPath() {
+        // Given: kotlinc 2.1.0 is installed
+        val paths = KeelPaths("/tmp/keel_tc_remove_kotlinc")
+        val binDir = "${paths.toolchainsDir}/kotlinc/2.1.0/bin"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString("$binDir/kotlinc", "#!/bin/sh")
+        try {
+            // When: resolving path for removal
+            val result = resolveToolchainPathForRemove("kotlinc", "2.1.0", paths)
+
+            // Then: returns the toolchain directory path
+            assertEquals("${paths.toolchainsDir}/kotlinc/2.1.0", result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun jdkInstalledReturnsPath() {
+        // Given: jdk 21 is installed
+        val paths = KeelPaths("/tmp/keel_tc_remove_jdk")
+        val binDir = "${paths.toolchainsDir}/jdk/21/bin"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString("$binDir/java", "#!/bin/sh")
+        try {
+            // When: resolving path for removal
+            val result = resolveToolchainPathForRemove("jdk", "21", paths)
+
+            // Then: returns the toolchain directory path
+            assertEquals("${paths.toolchainsDir}/jdk/21", result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun notInstalledReturnsNull() {
+        // Given: kotlinc 2.1.0 is not installed
+        val paths = KeelPaths("/tmp/keel_tc_remove_not_installed")
+
+        // When: resolving path for removal
+        val result = resolveToolchainPathForRemove("kotlinc", "2.1.0", paths)
+
+        // Then: returns null
+        assertNull(result)
+    }
+}

--- a/src/nativeTest/kotlin/keel/cli/ToolchainCommandsTest.kt
+++ b/src/nativeTest/kotlin/keel/cli/ToolchainCommandsTest.kt
@@ -1,12 +1,13 @@
 package keel.cli
 
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
 import keel.config.KeelPaths
 import keel.infra.ensureDirectoryRecursive
 import keel.infra.removeDirectoryRecursive
 import keel.infra.writeFileAsString
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -89,11 +90,10 @@ class ValidateToolchainRemoveArgsTest {
         // Given: valid kotlinc remove args
         val result = validateToolchainRemoveArgs(listOf("kotlinc", "2.1.0"))
 
-        // Then: returns valid parsed args
-        val args = assertNotNull(result.first)
+        // Then: returns Ok with parsed args
+        val args = assertNotNull(result.get())
         assertEquals("kotlinc", args.name)
         assertEquals("2.1.0", args.version)
-        assertNull(result.second)
     }
 
     @Test
@@ -101,11 +101,10 @@ class ValidateToolchainRemoveArgsTest {
         // Given: valid jdk remove args
         val result = validateToolchainRemoveArgs(listOf("jdk", "21"))
 
-        // Then: returns valid parsed args
-        val args = assertNotNull(result.first)
+        // Then: returns Ok with parsed args
+        val args = assertNotNull(result.get())
         assertEquals("jdk", args.name)
         assertEquals("21", args.version)
-        assertNull(result.second)
     }
 
     @Test
@@ -113,9 +112,9 @@ class ValidateToolchainRemoveArgsTest {
         // Given: unknown toolchain name
         val result = validateToolchainRemoveArgs(listOf("foo", "1.0"))
 
-        // Then: returns error message
-        assertNull(result.first)
-        assertEquals("error: unknown toolchain 'foo' (available: kotlinc, jdk)", result.second)
+        // Then: returns Err with message
+        assertNull(result.get())
+        assertEquals("error: unknown toolchain 'foo' (available: kotlinc, jdk)", result.getError())
     }
 
     @Test
@@ -123,9 +122,9 @@ class ValidateToolchainRemoveArgsTest {
         // Given: not enough args
         val result = validateToolchainRemoveArgs(listOf("kotlinc"))
 
-        // Then: returns usage error
-        assertNull(result.first)
-        assertEquals("usage: keel toolchain remove <name> <version>", result.second)
+        // Then: returns Err with usage message
+        assertNull(result.get())
+        assertEquals("usage: keel toolchain remove <name> <version>", result.getError())
     }
 
     @Test
@@ -133,16 +132,16 @@ class ValidateToolchainRemoveArgsTest {
         // Given: no args
         val result = validateToolchainRemoveArgs(emptyList())
 
-        // Then: returns usage error
-        assertNull(result.first)
-        assertEquals("usage: keel toolchain remove <name> <version>", result.second)
+        // Then: returns Err with usage message
+        assertNull(result.get())
+        assertEquals("usage: keel toolchain remove <name> <version>", result.getError())
     }
 }
 
 class ResolveToolchainPathForRemoveTest {
 
     @Test
-    fun kotlincInstalledReturnsPath() {
+    fun kotlincInstalledReturnsKeelPathsPath() {
         // Given: kotlinc 2.1.0 is installed
         val paths = KeelPaths("/tmp/keel_tc_remove_kotlinc")
         val binDir = "${paths.toolchainsDir}/kotlinc/2.1.0/bin"
@@ -152,15 +151,15 @@ class ResolveToolchainPathForRemoveTest {
             // When: resolving path for removal
             val result = resolveToolchainPathForRemove("kotlinc", "2.1.0", paths)
 
-            // Then: returns the toolchain directory path
-            assertEquals("${paths.toolchainsDir}/kotlinc/2.1.0", result)
+            // Then: returns the path from KeelPaths.kotlincPath()
+            assertEquals(paths.kotlincPath("2.1.0"), result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.keel")
         }
     }
 
     @Test
-    fun jdkInstalledReturnsPath() {
+    fun jdkInstalledReturnsKeelPathsPath() {
         // Given: jdk 21 is installed
         val paths = KeelPaths("/tmp/keel_tc_remove_jdk")
         val binDir = "${paths.toolchainsDir}/jdk/21/bin"
@@ -170,8 +169,8 @@ class ResolveToolchainPathForRemoveTest {
             // When: resolving path for removal
             val result = resolveToolchainPathForRemove("jdk", "21", paths)
 
-            // Then: returns the toolchain directory path
-            assertEquals("${paths.toolchainsDir}/jdk/21", result)
+            // Then: returns the path from KeelPaths.jdkPath()
+            assertEquals(paths.jdkPath("21"), result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.keel")
         }

--- a/src/nativeTest/kotlin/keel/infra/FileSystemTest.kt
+++ b/src/nativeTest/kotlin/keel/infra/FileSystemTest.kt
@@ -415,21 +415,21 @@ class FileSystemTest {
         }
     }
 
-    // --- listDirectoryEntries ---
+    // --- listSubdirectories ---
 
     @Test
-    fun listDirectoryEntriesReturnsSortedNames() {
+    fun listSubdirectoriesReturnsSortedNames() {
         // Given: directory with multiple subdirectories
-        val base = "/tmp/keel_list_entries_sorted"
+        val base = "/tmp/keel_list_subdirs_sorted"
         platform.posix.mkdir(base, 0b111111101u)
         platform.posix.mkdir("$base/beta", 0b111111101u)
         platform.posix.mkdir("$base/alpha", 0b111111101u)
         platform.posix.mkdir("$base/gamma", 0b111111101u)
         try {
-            // When: listing entries
-            val result = listDirectoryEntries(base)
+            // When: listing subdirectories
+            val result = listSubdirectories(base)
 
-            // Then: returns sorted entry names
+            // Then: returns sorted directory names
             assertEquals(listOf("alpha", "beta", "gamma"), result.get())
         } finally {
             platform.posix.rmdir("$base/alpha")
@@ -440,13 +440,13 @@ class FileSystemTest {
     }
 
     @Test
-    fun listDirectoryEntriesReturnsEmptyForEmptyDir() {
+    fun listSubdirectoriesReturnsEmptyForEmptyDir() {
         // Given: empty directory
-        val base = "/tmp/keel_list_entries_empty"
+        val base = "/tmp/keel_list_subdirs_empty"
         platform.posix.mkdir(base, 0b111111101u)
         try {
-            // When: listing entries
-            val result = listDirectoryEntries(base)
+            // When: listing subdirectories
+            val result = listSubdirectories(base)
 
             // Then: returns empty list
             assertEquals(emptyList(), result.get())
@@ -456,9 +456,9 @@ class FileSystemTest {
     }
 
     @Test
-    fun listDirectoryEntriesReturnsErrForNonExistentDir() {
+    fun listSubdirectoriesReturnsErrForNonExistentDir() {
         // Given: non-existent directory
-        val result = listDirectoryEntries("/tmp/keel_list_entries_nonexistent")
+        val result = listSubdirectories("/tmp/keel_list_subdirs_nonexistent")
 
         // Then: returns Err
         assertNull(result.get())
@@ -466,18 +466,18 @@ class FileSystemTest {
     }
 
     @Test
-    fun listDirectoryEntriesIncludesBothFilesAndDirs() {
+    fun listSubdirectoriesExcludesFiles() {
         // Given: directory with a file and a subdirectory
-        val base = "/tmp/keel_list_entries_mixed"
+        val base = "/tmp/keel_list_subdirs_mixed"
         platform.posix.mkdir(base, 0b111111101u)
         platform.posix.mkdir("$base/subdir", 0b111111101u)
         writeTestFile("$base/file.txt", "content")
         try {
-            // When: listing entries
-            val result = listDirectoryEntries(base)
+            // When: listing subdirectories
+            val result = listSubdirectories(base)
 
-            // Then: includes both
-            assertEquals(listOf("file.txt", "subdir"), result.get())
+            // Then: includes only subdirectories, not files
+            assertEquals(listOf("subdir"), result.get())
         } finally {
             remove("$base/file.txt")
             platform.posix.rmdir("$base/subdir")

--- a/src/nativeTest/kotlin/keel/infra/FileSystemTest.kt
+++ b/src/nativeTest/kotlin/keel/infra/FileSystemTest.kt
@@ -415,6 +415,76 @@ class FileSystemTest {
         }
     }
 
+    // --- listDirectoryEntries ---
+
+    @Test
+    fun listDirectoryEntriesReturnsSortedNames() {
+        // Given: directory with multiple subdirectories
+        val base = "/tmp/keel_list_entries_sorted"
+        platform.posix.mkdir(base, 0b111111101u)
+        platform.posix.mkdir("$base/beta", 0b111111101u)
+        platform.posix.mkdir("$base/alpha", 0b111111101u)
+        platform.posix.mkdir("$base/gamma", 0b111111101u)
+        try {
+            // When: listing entries
+            val result = listDirectoryEntries(base)
+
+            // Then: returns sorted entry names
+            assertEquals(listOf("alpha", "beta", "gamma"), result.get())
+        } finally {
+            platform.posix.rmdir("$base/alpha")
+            platform.posix.rmdir("$base/beta")
+            platform.posix.rmdir("$base/gamma")
+            platform.posix.rmdir(base)
+        }
+    }
+
+    @Test
+    fun listDirectoryEntriesReturnsEmptyForEmptyDir() {
+        // Given: empty directory
+        val base = "/tmp/keel_list_entries_empty"
+        platform.posix.mkdir(base, 0b111111101u)
+        try {
+            // When: listing entries
+            val result = listDirectoryEntries(base)
+
+            // Then: returns empty list
+            assertEquals(emptyList(), result.get())
+        } finally {
+            platform.posix.rmdir(base)
+        }
+    }
+
+    @Test
+    fun listDirectoryEntriesReturnsErrForNonExistentDir() {
+        // Given: non-existent directory
+        val result = listDirectoryEntries("/tmp/keel_list_entries_nonexistent")
+
+        // Then: returns Err
+        assertNull(result.get())
+        assertIs<ListFilesFailed>(result.getError())
+    }
+
+    @Test
+    fun listDirectoryEntriesIncludesBothFilesAndDirs() {
+        // Given: directory with a file and a subdirectory
+        val base = "/tmp/keel_list_entries_mixed"
+        platform.posix.mkdir(base, 0b111111101u)
+        platform.posix.mkdir("$base/subdir", 0b111111101u)
+        writeTestFile("$base/file.txt", "content")
+        try {
+            // When: listing entries
+            val result = listDirectoryEntries(base)
+
+            // Then: includes both
+            assertEquals(listOf("file.txt", "subdir"), result.get())
+        } finally {
+            remove("$base/file.txt")
+            platform.posix.rmdir("$base/subdir")
+            platform.posix.rmdir(base)
+        }
+    }
+
     private fun writeTestFile(path: String, content: String) {
         val fp = platform.posix.fopen(path, "w") ?: error("could not create test file: $path")
         if (content.isNotEmpty()) {


### PR DESCRIPTION
## Summary

- Add `keel toolchain list` to show installed kotlinc and JDK versions
- Add `keel toolchain remove <name> <version>` to delete an installed toolchain
- Add `listDirectoryEntries()` to infra for POSIX directory listing
- Expand toolchain subcommand dispatch with usage help

## Commands

### `keel toolchain list`

```
$ keel toolchain list
kotlinc:
  2.1.0
  2.3.0

jdk:
  21
```

If no toolchains are installed: `no toolchains installed`

### `keel toolchain remove <name> <version>`

```
$ keel toolchain remove kotlinc 2.1.0
removed kotlinc 2.1.0
```

Errors:
- Not installed → `error: kotlinc 2.1.0 is not installed`
- Unknown name → `error: unknown toolchain 'foo' (available: kotlinc, jdk)`

### `keel toolchain` (no subcommand or unknown)

Shows usage help with available subcommands.

## Changed Files

| File | Change |
|------|--------|
| `FileSystem.kt` | Add `listDirectoryEntries()` using POSIX `opendir`/`readdir` |
| `ToolchainCommands.kt` | Add list/remove commands, validation, usage help |
| `Main.kt` | Update toolchain usage text |
| `FileSystemTest.kt` | 4 tests for `listDirectoryEntries` |
| `ToolchainCommandsTest.kt` | 12 tests for formatting, validation, path resolution |

## Test plan

- [x] `listDirectoryEntries` returns sorted names, handles empty/nonexistent dirs
- [x] `formatToolchainList` formats empty, kotlinc-only, jdk-only, both cases
- [x] `validateToolchainRemoveArgs` validates name against known toolchains, handles missing args
- [x] `resolveToolchainPathForRemove` returns path when installed, null when not
- [x] All existing tests pass

Closes #41