### PR TITLE
[#40] Auto-install toolchains on build/run/test

### DIFF
--- a/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
@@ -34,29 +34,12 @@ internal fun loadProjectConfig(): KeelConfig {
     }
 }
 
-// managedKotlincBin: non-null means managed toolchain (version is known, skip check)
-private fun checkVersion(config: KeelConfig, managedKotlincBin: String?) {
-    if (managedKotlincBin != null) return
-    val output = executeAndCapture("kotlinc -version 2>&1").getOrElse {
-        eprintln("warning: could not determine kotlinc version")
-        return
-    }
-    val installedVersion = parseKotlincVersion(output)
-    if (installedVersion == null) {
-        eprintln("warning: could not parse kotlinc version from: $output")
-        return
-    }
-    if (installedVersion != config.kotlin) {
-        eprintln("warning: $KEEL_TOML specifies kotlin ${config.kotlin}, but kotlinc $installedVersion is installed")
-    }
-}
 
 internal fun doCheck() {
     val startMark = TimeSource.Monotonic.markNow()
     val config = loadProjectConfig()
     val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
-    val managedKotlincBin = resolveKotlincPath(config.kotlin, paths)
-    checkVersion(config, managedKotlincBin)
+    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths, EXIT_BUILD_ERROR)
 
     val classpath = resolveDependencies(config)
     val pArgs = resolvePluginArgs(config, managedKotlincBin)
@@ -99,16 +82,14 @@ internal fun doBuild(): BuildResult {
         ?.let { parseBuildState(it) }
 
     val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
-    val managedKotlincBin = resolveKotlincPath(config.kotlin, paths)
-    val (managedJavaBin, managedJarBin) = resolveJdkBins(config, paths)
+    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths, EXIT_BUILD_ERROR)
+    val (managedJavaBin, managedJarBin) = ensureJdkBinsFromConfig(config, paths)
 
     if (isBuildUpToDate(current = currentState, cached = cachedState)) {
         val elapsed = startMark.elapsedNow()
         println("${config.name} is up to date (${formatDuration(elapsed)})")
         return BuildResult(config, cachedState!!.classpath, resolvePluginArgs(config, managedKotlincBin), managedJavaBin)
     }
-
-    checkVersion(config, managedKotlincBin)
     val classpath = resolveDependencies(config)
     val pArgs = resolvePluginArgs(config, managedKotlincBin)
     val buildCmd = buildCommand(config, classpath, pArgs, kotlincPath = managedKotlincBin)
@@ -179,7 +160,7 @@ internal fun doTest(testArgs: List<String> = emptyList()) {
 
     val paths = resolveKeelPaths(EXIT_TEST_ERROR)
     val consoleLauncherPath = ensureTool(paths, CONSOLE_LAUNCHER_SPEC, EXIT_TEST_ERROR)
-    val managedKotlincBin = resolveKotlincPath(config.kotlin, paths)
+    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths, EXIT_TEST_ERROR)
 
     val testConfig = config.copy(testSources = existingTestSources)
     val testCmd = testBuildCommand(testConfig, CLASSES_DIR, classpath, pArgs, kotlincPath = managedKotlincBin)
@@ -214,16 +195,9 @@ internal fun doTest(testArgs: List<String> = emptyList()) {
     println("tests passed in ${formatDuration(elapsed)}")
 }
 
-internal data class JdkBins(val java: String?, val jar: String?)
-
-internal fun resolveJdkBins(config: KeelConfig, paths: KeelPaths): JdkBins {
+internal fun ensureJdkBinsFromConfig(config: KeelConfig, paths: KeelPaths): JdkBins {
     val version = config.jdk ?: return JdkBins(null, null)
-    val javaBin = resolveJavaBinPath(version, paths)
-    val jarBin = resolveJarBinPath(version, paths)
-    if (javaBin == null) {
-        eprintln("warning: jdk $version not installed (run 'keel toolchain install'). falling back to system java/jar")
-    }
-    return JdkBins(javaBin, jarBin)
+    return ensureJdkBins(version, paths, EXIT_BUILD_ERROR)
 }
 
 internal fun createResolverDeps() = object : ResolverDeps {

--- a/src/nativeMain/kotlin/keel/tool/ToolchainManager.kt
+++ b/src/nativeMain/kotlin/keel/tool/ToolchainManager.kt
@@ -170,6 +170,34 @@ internal fun resolveKotlincPath(version: String, paths: KeelPaths): String? {
     return if (fileExists(binPath)) binPath else null
 }
 
+internal fun ensureKotlincBin(version: String, paths: KeelPaths, exitCode: Int): String {
+    resolveKotlincPath(version, paths)?.let { return it }
+    installKotlincToolchain(version, paths, exitCode)
+    return resolveKotlincPath(version, paths)
+        ?: run {
+            eprintln("error: kotlinc $version not found after installation")
+            exitProcess(exitCode)
+        }
+}
+
+data class JdkBins(val java: String?, val jar: String?)
+
+internal fun ensureJdkBins(version: String, paths: KeelPaths, exitCode: Int): JdkBins {
+    val javaBin = resolveJavaBinPath(version, paths)
+    if (javaBin != null) {
+        val jarBin = resolveJarBinPath(version, paths)
+        return JdkBins(javaBin, jarBin)
+    }
+    installJdkToolchain(version, paths, exitCode)
+    return JdkBins(
+        resolveJavaBinPath(version, paths) ?: run {
+            eprintln("error: java binary not found after installation")
+            exitProcess(exitCode)
+        },
+        resolveJarBinPath(version, paths)
+    )
+}
+
 internal fun installKotlincToolchain(version: String, paths: KeelPaths, exitCode: Int) {
     val finalPath = paths.kotlincPath(version)
     val binPath = paths.kotlincBin(version)

--- a/src/nativeTest/kotlin/keel/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/keel/cli/BuildCommandsTest.kt
@@ -5,37 +5,24 @@ import keel.config.KeelPaths
 import keel.infra.ensureDirectoryRecursive
 import keel.infra.removeDirectoryRecursive
 import keel.infra.writeFileAsString
+import keel.tool.JdkBins
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-class ResolveJdkBinsTest {
+class EnsureJdkBinsFromConfigTest {
 
     @Test
     fun jdkNullInConfigReturnsNullBins() {
         // Given: config has no jdk field
         val config = testConfig(jdk = null)
-        val paths = KeelPaths("/tmp/keel_resolve_jdk_bins_null")
+        val paths = KeelPaths("/tmp/keel_ensure_jdk_bins_null")
 
-        // When: resolveJdkBins is called
-        val result = resolveJdkBins(config, paths)
+        // When: ensureJdkBinsFromConfig is called
+        val result = ensureJdkBinsFromConfig(config, paths)
 
         // Then: both java and jar are null — no managed JDK
-        assertNull(result.java)
-        assertNull(result.jar)
-    }
-
-    @Test
-    fun jdkSpecifiedButNotInstalledReturnsNullBins() {
-        // Given: config specifies jdk 21, but the toolchain dir is absent
-        val config = testConfig(jdk = "21")
-        val paths = KeelPaths("/tmp/keel_resolve_jdk_bins_not_installed")
-
-        // When: resolveJdkBins is called
-        val result = resolveJdkBins(config, paths)
-
-        // Then: both java and jar are null — managed JDK not found, falls back to system
         assertNull(result.java)
         assertNull(result.jar)
     }
@@ -44,14 +31,14 @@ class ResolveJdkBinsTest {
     fun jdkSpecifiedAndInstalledReturnsBinPaths() {
         // Given: config specifies jdk 21 and binaries exist at the managed location
         val config = testConfig(jdk = "21")
-        val paths = KeelPaths("/tmp/keel_resolve_jdk_bins_installed")
+        val paths = KeelPaths("/tmp/keel_ensure_jdk_bins_installed")
         val binDir = "${paths.toolchainsDir}/jdk/21/bin"
         ensureDirectoryRecursive(binDir)
         writeFileAsString("$binDir/java", "#!/bin/sh")
         writeFileAsString("$binDir/jar", "#!/bin/sh")
         try {
-            // When: resolveJdkBins is called
-            val result = resolveJdkBins(config, paths)
+            // When: ensureJdkBinsFromConfig is called
+            val result = ensureJdkBinsFromConfig(config, paths)
 
             // Then: returns managed java and jar paths
             assertEquals(paths.javaBin("21"), result.java)

--- a/src/nativeTest/kotlin/keel/tool/ToolchainManagerTest.kt
+++ b/src/nativeTest/kotlin/keel/tool/ToolchainManagerTest.kt
@@ -452,4 +452,46 @@ class ToolchainManagerTest {
             removeDirectoryRecursive(paths.home + "/.keel")
         }
     }
+
+    // --- ensureKotlincBin ---
+
+    @Test
+    fun ensureKotlincBinReturnsPathWhenAlreadyInstalled() {
+        // Given: managed kotlinc 2.1.0 is already installed
+        val paths = KeelPaths("/tmp/keel_tc_ensure_kotlinc_installed")
+        val binDir = "${paths.toolchainsDir}/kotlinc/2.1.0/bin"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString("$binDir/kotlinc", "#!/bin/sh")
+        try {
+            // When: ensureKotlincBin is called
+            val result = ensureKotlincBin("2.1.0", paths, 1)
+
+            // Then: returns the managed bin path without triggering download
+            assertEquals(paths.kotlincBin("2.1.0"), result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    // --- ensureJdkBins ---
+
+    @Test
+    fun ensureJdkBinsReturnsPathsWhenAlreadyInstalled() {
+        // Given: managed jdk 21 is already installed
+        val paths = KeelPaths("/tmp/keel_tc_ensure_jdk_installed")
+        val binDir = "${paths.toolchainsDir}/jdk/21/bin"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString("$binDir/java", "#!/bin/sh")
+        writeFileAsString("$binDir/jar", "#!/bin/sh")
+        try {
+            // When: ensureJdkBins is called
+            val result = ensureJdkBins("21", paths, 1)
+
+            // Then: returns managed java and jar paths
+            assertEquals(paths.javaBin("21"), result.java)
+            assertEquals(paths.jarBin("21"), result.jar)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Auto-install kotlinc and JDK toolchains when running `keel build`, `keel run`, `keel check`, or `keel test` if not already installed
- Eliminates the need for a separate `keel toolchain install` step
- Follows the existing `ensureTool()` pattern (resolve → install → resolve)

## Behavior Change

**Before:** Managed toolchain not found → warning message, fall back to system `kotlinc`/`java`  
**After:** Managed toolchain not found → auto-download and install, then use it

```
$ keel build
downloading kotlin-compiler-2.1.0.zip...
extracting kotlinc 2.1.0...
installed kotlinc 2.1.0 at ~/.keel/toolchains/kotlinc/2.1.0
downloading jdk 21...
extracting jdk 21...
installed jdk 21 at ~/.keel/toolchains/jdk/21
compiling myapp...
built build/myapp.jar in 12.3s
```

On subsequent runs, toolchains are already installed — no download needed.

## Changed Files

| File | Change |
|------|--------|
| `ToolchainManager.kt` | Add `ensureKotlincBin()`, `ensureJdkBins()`, move `JdkBins` here |
| `BuildCommands.kt` | Replace `resolveKotlincPath`/`resolveJdkBins` with `ensure*` functions; remove `checkVersion()` and system-fallback warning |
| `ToolchainManagerTest.kt` | 2 tests for ensure functions (already-installed path) |
| `BuildCommandsTest.kt` | Update tests for `ensureJdkBinsFromConfig` |

## Design Decisions

- **No confirmation prompt**: Consistent with `keel install` (dependencies) and `ensureTool()` (ktfmt/JUnit launcher) which already auto-download silently
- **`checkVersion()` removed**: With auto-install, the managed toolchain version always matches `keel.toml` — no need to verify system kotlinc version
- **No `!!` operator**: `ensure*` functions handle the post-install null case with explicit error + exitProcess, avoiding exception throwing per project rules
- **Download timeout**: Kept at 300s (current default). JDK ~200MB requires ~5Mbps which is reasonable for broadband. Can be increased later if needed.

## Test plan

- [x] `ensureKotlincBin` returns path when already installed (no download)
- [x] `ensureJdkBins` returns paths when already installed (no download)
- [x] `ensureJdkBinsFromConfig` returns null bins when jdk not in config
- [x] `ensureJdkBinsFromConfig` returns paths when installed
- [x] All existing tests pass

Closes #40