### PR TITLE
Add konanc toolchain management

### DIFF
--- a/src/nativeMain/kotlin/keel/cli/ToolchainCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/ToolchainCommands.kt
@@ -8,10 +8,11 @@ import keel.config.KeelPaths
 import keel.config.resolveKeelPaths
 import keel.infra.*
 import keel.tool.installJdkToolchain
+import keel.tool.installKonancToolchain
 import keel.tool.installKotlincToolchain
 import kotlin.system.exitProcess
 
-private val KNOWN_TOOLCHAINS = listOf("kotlinc", "jdk")
+private val KNOWN_TOOLCHAINS = listOf("kotlinc", "jdk", "konanc")
 
 internal fun doToolchain(args: List<String>) {
     if (args.isEmpty()) {
@@ -45,13 +46,17 @@ private fun doToolchainInstall() {
     if (config.jdk != null) {
         installJdkToolchain(config.jdk, paths, EXIT_BUILD_ERROR)
     }
+    if (config.target == "native") {
+        installKonancToolchain(config.kotlin, paths, EXIT_BUILD_ERROR)
+    }
 }
 
 private fun doToolchainList() {
     val paths = resolveKeelPaths(EXIT_CONFIG_ERROR)
     val kotlincVersions = listInstalledVersions("${paths.toolchainsDir}/kotlinc")
     val jdkVersions = listInstalledVersions("${paths.toolchainsDir}/jdk")
-    println(formatToolchainList(kotlincVersions, jdkVersions))
+    val konancVersions = listInstalledVersions("${paths.toolchainsDir}/konanc")
+    println(formatToolchainList(kotlincVersions, jdkVersions, konancVersions))
 }
 
 private fun listInstalledVersions(dir: String): List<String> {
@@ -59,16 +64,23 @@ private fun listInstalledVersions(dir: String): List<String> {
     return listSubdirectories(dir).getOrElse { emptyList() }
 }
 
-internal fun formatToolchainList(kotlincVersions: List<String>, jdkVersions: List<String>): String {
-    if (kotlincVersions.isEmpty() && jdkVersions.isEmpty()) {
+internal fun formatToolchainList(
+    kotlincVersions: List<String>,
+    jdkVersions: List<String>,
+    konancVersions: List<String>
+): String {
+    if (kotlincVersions.isEmpty() && jdkVersions.isEmpty() && konancVersions.isEmpty()) {
         return "no toolchains installed"
     }
     val sections = mutableListOf<String>()
     if (kotlincVersions.isNotEmpty()) {
-        sections.add("kotlinc:\n" + kotlincVersions.joinToString("\n") { "  $it" })
+        sections.add("kotlinc (Kotlin compiler):\n" + kotlincVersions.joinToString("\n") { "  $it" })
     }
     if (jdkVersions.isNotEmpty()) {
-        sections.add("jdk:\n" + jdkVersions.joinToString("\n") { "  $it" })
+        sections.add("jdk (Java Development Kit):\n" + jdkVersions.joinToString("\n") { "  $it" })
+    }
+    if (konancVersions.isNotEmpty()) {
+        sections.add("konanc (Kotlin/Native compiler):\n" + konancVersions.joinToString("\n") { "  $it" })
     }
     return sections.joinToString("\n\n")
 }
@@ -90,6 +102,7 @@ internal fun resolveToolchainPathForRemove(name: String, version: String, paths:
     val dir = when (name) {
         "kotlinc" -> paths.kotlincPath(version)
         "jdk" -> paths.jdkPath(version)
+        "konanc" -> paths.konancPath(version)
         else -> return null
     }
     return if (fileExists(dir)) dir else null

--- a/src/nativeMain/kotlin/keel/config/KeelPaths.kt
+++ b/src/nativeMain/kotlin/keel/config/KeelPaths.kt
@@ -16,6 +16,9 @@ internal data class KeelPaths(val home: String) {
     fun jdkPath(version: String): String = "$toolchainsDir/jdk/$version"
     fun javaBin(version: String): String = "${jdkPath(version)}/bin/java"
     fun jarBin(version: String): String = "${jdkPath(version)}/bin/jar"
+
+    fun konancPath(version: String): String = "$toolchainsDir/konanc/$version"
+    fun konancBin(version: String): String = "${konancPath(version)}/bin/konanc"
 }
 
 internal fun resolveKeelPaths(exitCode: Int): KeelPaths {

--- a/src/nativeMain/kotlin/keel/tool/ToolchainManager.kt
+++ b/src/nativeMain/kotlin/keel/tool/ToolchainManager.kt
@@ -294,3 +294,121 @@ internal fun installKotlincToolchain(version: String, paths: KeelPaths, exitCode
 
     println("installed kotlinc $version at $finalPath")
 }
+
+internal fun konancDownloadUrl(version: String): String =
+    "https://github.com/JetBrains/kotlin/releases/download/v$version/kotlin-native-prebuilt-linux-x86_64-$version.tar.gz"
+
+internal fun konancSha256Url(version: String): String =
+    "${konancDownloadUrl(version)}.sha256"
+
+internal fun resolveKonancPath(version: String, paths: KeelPaths): String? {
+    val binPath = paths.konancBin(version)
+    return if (fileExists(binPath)) binPath else null
+}
+
+internal fun ensureKonancBin(version: String, paths: KeelPaths, exitCode: Int): String {
+    resolveKonancPath(version, paths)?.let { return it }
+    installKonancToolchain(version, paths, exitCode)
+    return resolveKonancPath(version, paths)
+        ?: run {
+            eprintln("error: konanc $version not found after installation")
+            exitProcess(exitCode)
+        }
+}
+
+internal fun installKonancToolchain(version: String, paths: KeelPaths, exitCode: Int) {
+    val finalPath = paths.konancPath(version)
+    val binPath = paths.konancBin(version)
+
+    if (fileExists(binPath)) {
+        println("konanc $version is already installed at $finalPath")
+        return
+    }
+
+    val konancBaseDir = "${paths.toolchainsDir}/konanc"
+    ensureDirectoryRecursive(konancBaseDir).getOrElse { error ->
+        eprintln("error: could not create directory ${error.path}")
+        exitProcess(exitCode)
+    }
+
+    val tarPath = "$konancBaseDir/$version.tar.gz"
+    val sha256Path = "$konancBaseDir/$version.tar.gz.sha256"
+    val extractTempDir = "$konancBaseDir/${version}_extract"
+    val archiveTopLevelDir = "kotlin-native-prebuilt-linux-x86_64-$version"
+
+    println("downloading konanc $version...")
+    downloadFile(konancDownloadUrl(version), tarPath).getOrElse { error ->
+        when (error) {
+            is DownloadError.HttpFailed -> eprintln("error: failed to download konanc $version (HTTP ${error.statusCode})")
+            is DownloadError.WriteFailed -> eprintln("error: could not write $tarPath")
+            is DownloadError.NetworkError -> eprintln("error: network error downloading konanc $version: ${error.message}")
+        }
+        exitProcess(exitCode)
+    }
+
+    downloadFile(konancSha256Url(version), sha256Path).getOrElse { error ->
+        deleteFile(tarPath)
+        when (error) {
+            is DownloadError.HttpFailed -> eprintln("error: failed to download sha256 for konanc $version (HTTP ${error.statusCode})")
+            is DownloadError.WriteFailed -> eprintln("error: could not write $sha256Path")
+            is DownloadError.NetworkError -> eprintln("error: network error downloading sha256: ${error.message}")
+        }
+        exitProcess(exitCode)
+    }
+
+    val sha256Content = readFileAsString(sha256Path).getOrElse { error ->
+        deleteFile(tarPath)
+        deleteFile(sha256Path)
+        eprintln("error: could not read ${error.path}")
+        exitProcess(exitCode)
+    }
+    val expectedHash = sha256Content.trim().split(Regex("\\s+")).first()
+    deleteFile(sha256Path)
+
+    val actualHash = computeSha256(tarPath).getOrElse { _ ->
+        deleteFile(tarPath)
+        eprintln("error: could not compute sha256 for $tarPath")
+        exitProcess(exitCode)
+    }
+
+    if (actualHash != expectedHash) {
+        deleteFile(tarPath)
+        eprintln("error: sha256 mismatch for konanc $version (expected $expectedHash, got $actualHash)")
+        exitProcess(exitCode)
+    }
+
+    ensureDirectoryRecursive(extractTempDir).getOrElse { error ->
+        deleteFile(tarPath)
+        eprintln("error: could not create directory ${error.path}")
+        exitProcess(exitCode)
+    }
+
+    println("extracting konanc $version...")
+    executeCommand(listOf("tar", "xzf", tarPath, "-C", extractTempDir)).getOrElse { error ->
+        deleteFile(tarPath)
+        removeDirectoryRecursive(extractTempDir).getOrElse { e ->
+            eprintln("warning: could not remove temp directory ${e.path}")
+        }
+        eprintln(formatProcessError(error, "tar"))
+        exitProcess(exitCode)
+    }
+    deleteFile(tarPath)
+
+    executeCommand(listOf("mv", "$extractTempDir/$archiveTopLevelDir", finalPath)).getOrElse { error ->
+        removeDirectoryRecursive(extractTempDir).getOrElse { e ->
+            eprintln("warning: could not remove temp directory ${e.path}")
+        }
+        eprintln(formatProcessError(error, "mv"))
+        exitProcess(exitCode)
+    }
+    removeDirectoryRecursive(extractTempDir).getOrElse { e ->
+        eprintln("warning: could not remove temp directory ${e.path}")
+    }
+
+    if (!fileExists(binPath)) {
+        eprintln("error: konanc binary not found at $binPath after installation")
+        exitProcess(exitCode)
+    }
+
+    println("installed konanc $version at $finalPath")
+}

--- a/src/nativeTest/kotlin/keel/cli/ToolchainCommandsTest.kt
+++ b/src/nativeTest/kotlin/keel/cli/ToolchainCommandsTest.kt
@@ -20,7 +20,7 @@ class FormatToolchainListTest {
         val jdkVersions = emptyList<String>()
 
         // When: formatting the list
-        val result = formatToolchainList(kotlincVersions, jdkVersions)
+        val result = formatToolchainList(kotlincVersions, jdkVersions, emptyList())
 
         // Then: returns "no toolchains installed" message
         assertEquals("no toolchains installed", result)
@@ -33,11 +33,11 @@ class FormatToolchainListTest {
         val jdkVersions = emptyList<String>()
 
         // When: formatting the list
-        val result = formatToolchainList(kotlincVersions, jdkVersions)
+        val result = formatToolchainList(kotlincVersions, jdkVersions, emptyList())
 
-        // Then: shows kotlinc section only
+        // Then: shows kotlinc section only with description
         val expected = """
-            kotlinc:
+            kotlinc (Kotlin compiler):
               2.1.0
               2.3.0
         """.trimIndent()
@@ -51,11 +51,11 @@ class FormatToolchainListTest {
         val jdkVersions = listOf("21")
 
         // When: formatting the list
-        val result = formatToolchainList(kotlincVersions, jdkVersions)
+        val result = formatToolchainList(kotlincVersions, jdkVersions, emptyList())
 
-        // Then: shows jdk section only
+        // Then: shows jdk section only with description
         val expected = """
-            jdk:
+            jdk (Java Development Kit):
               21
         """.trimIndent()
         assertEquals(expected, result)
@@ -68,16 +68,50 @@ class FormatToolchainListTest {
         val jdkVersions = listOf("17", "21")
 
         // When: formatting the list
-        val result = formatToolchainList(kotlincVersions, jdkVersions)
+        val result = formatToolchainList(kotlincVersions, jdkVersions, emptyList())
 
-        // Then: shows both sections separated by blank line
+        // Then: shows both sections separated by blank line, with descriptions
         val expected = """
-            kotlinc:
+            kotlinc (Kotlin compiler):
               2.1.0
 
-            jdk:
+            jdk (Java Development Kit):
               17
               21
+        """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun onlyKonancInstalled() {
+        // Given: konanc versions installed
+        val result = formatToolchainList(emptyList(), emptyList(), listOf("2.3.20"))
+
+        val expected = """
+            konanc (Kotlin/Native compiler):
+              2.3.20
+        """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun allThreeToolchainsInstalled() {
+        // Given: kotlinc, jdk, konanc all installed
+        val result = formatToolchainList(
+            listOf("2.1.0"),
+            listOf("21"),
+            listOf("2.1.0")
+        )
+
+        val expected = """
+            kotlinc (Kotlin compiler):
+              2.1.0
+
+            jdk (Java Development Kit):
+              21
+
+            konanc (Kotlin/Native compiler):
+              2.1.0
         """.trimIndent()
         assertEquals(expected, result)
     }
@@ -108,13 +142,24 @@ class ValidateToolchainRemoveArgsTest {
     }
 
     @Test
+    fun validKonancArgs() {
+        // Given: valid konanc remove args
+        val result = validateToolchainRemoveArgs(listOf("konanc", "2.3.20"))
+
+        // Then: returns Ok with parsed args
+        val args = assertNotNull(result.get())
+        assertEquals("konanc", args.name)
+        assertEquals("2.3.20", args.version)
+    }
+
+    @Test
     fun unknownToolchainNameReturnsError() {
         // Given: unknown toolchain name
         val result = validateToolchainRemoveArgs(listOf("foo", "1.0"))
 
         // Then: returns Err with message
         assertNull(result.get())
-        assertEquals("error: unknown toolchain 'foo' (available: kotlinc, jdk)", result.getError())
+        assertEquals("error: unknown toolchain 'foo' (available: kotlinc, jdk, konanc)", result.getError())
     }
 
     @Test
@@ -171,6 +216,22 @@ class ResolveToolchainPathForRemoveTest {
 
             // Then: returns the path from KeelPaths.jdkPath()
             assertEquals(paths.jdkPath("21"), result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun konancInstalledReturnsKeelPathsPath() {
+        // Given: konanc 2.3.20 is installed
+        val paths = KeelPaths("/tmp/keel_tc_remove_konanc")
+        val binDir = "${paths.toolchainsDir}/konanc/2.3.20/bin"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString("$binDir/konanc", "#!/bin/sh")
+        try {
+            val result = resolveToolchainPathForRemove("konanc", "2.3.20", paths)
+
+            assertEquals(paths.konancPath("2.3.20"), result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.keel")
         }

--- a/src/nativeTest/kotlin/keel/config/KeelPathsTest.kt
+++ b/src/nativeTest/kotlin/keel/config/KeelPathsTest.kt
@@ -127,6 +127,42 @@ class KeelPathsTest {
         assertEquals("/root/.keel/toolchains/jdk/17/bin/jar", paths.jarBin("17"))
     }
 
+    // --- konancPath ---
+
+    @Test
+    fun konancPathBuildsVersionedDirectory() {
+        val paths = KeelPaths("/home/user")
+
+        val path = paths.konancPath("2.3.20")
+
+        assertEquals("/home/user/.keel/toolchains/konanc/2.3.20", path)
+    }
+
+    @Test
+    fun konancPathDifferentVersion() {
+        val paths = KeelPaths("/home/alice")
+
+        assertEquals("/home/alice/.keel/toolchains/konanc/2.1.0", paths.konancPath("2.1.0"))
+    }
+
+    // --- konancBin ---
+
+    @Test
+    fun konancBinBuildsVersionedBinPath() {
+        val paths = KeelPaths("/home/user")
+
+        val bin = paths.konancBin("2.3.20")
+
+        assertEquals("/home/user/.keel/toolchains/konanc/2.3.20/bin/konanc", bin)
+    }
+
+    @Test
+    fun konancBinDifferentHome() {
+        val paths = KeelPaths("/root")
+
+        assertEquals("/root/.keel/toolchains/konanc/2.3.20/bin/konanc", paths.konancBin("2.3.20"))
+    }
+
     @Test
     fun jdkJavaBinAndJarBinShareSameVersionedDirectory() {
         // Given: jdkPath, javaBin, and jarBin for the same version

--- a/src/nativeTest/kotlin/keel/tool/ToolchainManagerTest.kt
+++ b/src/nativeTest/kotlin/keel/tool/ToolchainManagerTest.kt
@@ -473,6 +473,113 @@ class ToolchainManagerTest {
         }
     }
 
+    // --- konancDownloadUrl ---
+
+    @Test
+    fun konancDownloadUrlHasVersionInTagAndFilename() {
+        val url = konancDownloadUrl("2.1.0")
+
+        assertEquals(
+            "https://github.com/JetBrains/kotlin/releases/download/v2.1.0/kotlin-native-prebuilt-linux-x86_64-2.1.0.tar.gz",
+            url
+        )
+    }
+
+    @Test
+    fun konancDownloadUrlDifferentVersion() {
+        val url = konancDownloadUrl("2.3.20")
+
+        assertEquals(
+            "https://github.com/JetBrains/kotlin/releases/download/v2.3.20/kotlin-native-prebuilt-linux-x86_64-2.3.20.tar.gz",
+            url
+        )
+    }
+
+    // --- konancSha256Url ---
+
+    @Test
+    fun konancSha256UrlIsTarGzUrlWithSha256Suffix() {
+        val url = konancSha256Url("2.1.0")
+
+        assertEquals(
+            "https://github.com/JetBrains/kotlin/releases/download/v2.1.0/kotlin-native-prebuilt-linux-x86_64-2.1.0.tar.gz.sha256",
+            url
+        )
+    }
+
+    // --- resolveKonancPath ---
+
+    @Test
+    fun resolveKonancPathReturnsBinPathWhenManagedVersionInstalled() {
+        val paths = KeelPaths("/tmp/keel_tc_konanc_resolve_installed")
+        val binDir = "${paths.toolchainsDir}/konanc/2.1.0/bin"
+        val binPath = "$binDir/konanc"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString(binPath, "#!/bin/sh")
+        try {
+            val result = resolveKonancPath("2.1.0", paths)
+
+            assertEquals(paths.konancBin("2.1.0"), result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun resolveKonancPathReturnsNullWhenToolchainsDirAbsent() {
+        val paths = KeelPaths("/tmp/keel_tc_konanc_resolve_no_dir")
+
+        val result = resolveKonancPath("2.1.0", paths)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun resolveKonancPathReturnsNullWhenVersionDirExistsButBinMissing() {
+        val paths = KeelPaths("/tmp/keel_tc_konanc_resolve_no_bin")
+        val versionDir = "${paths.toolchainsDir}/konanc/2.1.0"
+        ensureDirectoryRecursive(versionDir)
+        try {
+            val result = resolveKonancPath("2.1.0", paths)
+
+            assertNull(result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    @Test
+    fun resolveKonancPathReturnsNullForDifferentInstalledVersion() {
+        val paths = KeelPaths("/tmp/keel_tc_konanc_resolve_version_isolation")
+        val binDir = "${paths.toolchainsDir}/konanc/2.3.0/bin"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString("$binDir/konanc", "#!/bin/sh")
+        try {
+            val result = resolveKonancPath("2.1.0", paths)
+
+            assertNull(result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
+    // --- ensureKonancBin ---
+
+    @Test
+    fun ensureKonancBinReturnsPathWhenAlreadyInstalled() {
+        val paths = KeelPaths("/tmp/keel_tc_ensure_konanc_installed")
+        val binDir = "${paths.toolchainsDir}/konanc/2.1.0/bin"
+        ensureDirectoryRecursive(binDir)
+        writeFileAsString("$binDir/konanc", "#!/bin/sh")
+        try {
+            val result = ensureKonancBin("2.1.0", paths, 1)
+
+            assertEquals(paths.konancBin("2.1.0"), result)
+        } finally {
+            removeDirectoryRecursive(paths.home + "/.keel")
+        }
+    }
+
     // --- ensureJdkBins ---
 
     @Test


### PR DESCRIPTION
## Summary
- Add `konanc` (Kotlin/Native compiler) to toolchain management alongside `kotlinc` / `jdk`
- `keel toolchain install` installs konanc when `target = "native"` in `keel.toml`
- `keel toolchain list` now shows konanc and includes short descriptions for each section
- `keel toolchain remove konanc <version>` supported
- SHA256 verification follows the existing kotlinc flow
- Build/run integration is out of scope and deferred to #16

## Test plan
- [x] `./gradlew linuxX64Test` passes
- [x] New unit tests for `konancDownloadUrl` / `konancSha256Url` / `resolveKonancPath` / `ensureKonancBin`
- [x] Updated `formatToolchainList` tests cover konanc section and new descriptions
- [x] `validateToolchainRemoveArgs` / `resolveToolchainPathForRemove` cover konanc

Closes #48