### PR TITLE
Support Kotlin/Native build target (Phase A)

### DIFF
--- a/src/nativeMain/kotlin/keel/build/Builder.kt
+++ b/src/nativeMain/kotlin/keel/build/Builder.kt
@@ -7,6 +7,37 @@ internal const val CLASSES_DIR = "$BUILD_DIR/classes"
 
 internal fun outputJarPath(config: KeelConfig): String = "$BUILD_DIR/${config.name}.jar"
 
+internal fun outputKexePath(config: KeelConfig): String = "$BUILD_DIR/${config.name}.kexe"
+
+// Derives the Kotlin/Native entry point FQN from config.main.
+//
+// config.main is a JVM-style class name (e.g. "com.example.MainKt"). For
+// Kotlin/Native, konanc needs the fully-qualified function name instead. We
+// take the package portion (everything before the last dot) and append
+// ".main". The class-name suffix itself is discarded.
+//
+// Limitations (Phase A): we assume the entry function is a top-level `fun main`
+// in the same package as the JVM facade class. Non-standard entry points
+// (custom function name, `@JvmStatic` on a companion, etc.) are not supported
+// and will produce a konanc "entry point not found" error. Callers should
+// prefer top-level `fun main()` and a `*Kt` facade class name. See
+// needsNativeEntryPointWarning for the heuristic used to flag likely issues.
+internal fun nativeEntryPoint(config: KeelConfig): String {
+    val lastDot = config.main.lastIndexOf('.')
+    val pkg = if (lastDot >= 0) config.main.substring(0, lastDot) else ""
+    return if (pkg.isEmpty()) "main" else "$pkg.main"
+}
+
+// Returns true when config.main's class-name segment does not end with "Kt",
+// which is the conventional suffix kotlinc generates for top-level functions
+// in file Foo.kt. A non-Kt class name suggests the user may have pointed main
+// at a non-top-level entry, and nativeEntryPoint's derivation will likely not
+// match their intent.
+internal fun needsNativeEntryPointWarning(config: KeelConfig): Boolean {
+    val lastSegment = config.main.substringAfterLast('.')
+    return lastSegment.isNotEmpty() && !lastSegment.endsWith("Kt")
+}
+
 data class BuildCommand(
     val args: List<String>,
     val outputPath: String
@@ -49,6 +80,28 @@ fun buildCommand(
         add(CLASSES_DIR)
     }
     return BuildCommand(args = args, outputPath = CLASSES_DIR)
+}
+
+fun nativeBuildCommand(
+    config: KeelConfig,
+    pluginArgs: List<String> = emptyList(),
+    konancPath: String? = null
+): BuildCommand {
+    val outputPath = outputKexePath(config)
+    // konanc -o takes the path without the .kexe extension
+    val outputBase = "$BUILD_DIR/${config.name}"
+    val args = buildList {
+        add(konancPath ?: "konanc")
+        addAll(config.sources)
+        add("-p")
+        add("program")
+        add("-e")
+        add(nativeEntryPoint(config))
+        add("-o")
+        add(outputBase)
+        addAll(pluginArgs)
+    }
+    return BuildCommand(args = args, outputPath = outputPath)
 }
 
 fun jarCommand(config: KeelConfig, jarPath: String? = null): BuildCommand {

--- a/src/nativeMain/kotlin/keel/build/Runner.kt
+++ b/src/nativeMain/kotlin/keel/build/Runner.kt
@@ -17,3 +17,8 @@ fun runCommand(
         args = listOf(javaPath ?: "java", "-cp", cp, config.main) + appArgs
     )
 }
+
+fun nativeRunCommand(
+    config: KeelConfig,
+    appArgs: List<String> = emptyList()
+): RunCommand = RunCommand(args = listOf(outputKexePath(config)) + appArgs)

--- a/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
@@ -37,6 +37,13 @@ internal fun loadProjectConfig(): KeelConfig {
 internal fun doCheck() {
     val startMark = TimeSource.Monotonic.markNow()
     val config = loadProjectConfig()
+    // For native target, check is equivalent to a full build (konanc has no
+    // syntax-only mode). Delegate to doBuild and discard its BuildResult —
+    // check has no further use for it.
+    if (config.target == "native") {
+        doBuild()
+        return
+    }
     val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
     val managedKotlincBin = ensureKotlincBin(config.kotlin, paths, EXIT_BUILD_ERROR)
 
@@ -68,6 +75,10 @@ internal fun doClean() {
 internal fun doBuild(): BuildResult {
     val startMark = TimeSource.Monotonic.markNow()
     val config = loadProjectConfig()
+
+    if (config.target == "native") {
+        return doNativeBuild(config)
+    }
 
     val currentState = BuildState(
         configMtime = fileMtime(KEEL_TOML) ?: 0L,
@@ -131,7 +142,82 @@ internal fun doBuild(): BuildResult {
     return BuildResult(config, classpath, pArgs, managedJavaBin)
 }
 
+private fun doNativeBuild(config: KeelConfig): BuildResult {
+    val startMark = TimeSource.Monotonic.markNow()
+
+    if (needsNativeEntryPointWarning(config)) {
+        eprintln(
+            "warning: main = \"${config.main}\" does not end with 'Kt'; " +
+                "native build assumes a top-level 'fun main' in package " +
+                "'${nativeEntryPoint(config).substringBeforeLast('.', "")}' " +
+                "(derived entry point: ${nativeEntryPoint(config)})"
+        )
+    }
+
+    val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
+    val managedKonancBin = ensureKonancBin(config.kotlin, paths, EXIT_BUILD_ERROR)
+
+    val kexePath = outputKexePath(config)
+    val currentState = BuildState(
+        configMtime = fileMtime(KEEL_TOML) ?: 0L,
+        sourcesNewestMtime = newestMtime(config.sources),
+        classesDirMtime = if (fileExists(kexePath)) fileMtime(kexePath) else null,
+        lockfileMtime = null,
+        resourcesNewestMtime = null
+    )
+    val cachedState = readFileAsString(BUILD_STATE_FILE).getOrElse { null }
+        ?.let { parseBuildState(it) }
+
+    if (isBuildUpToDate(current = currentState, cached = cachedState)) {
+        val elapsed = startMark.elapsedNow()
+        println("${config.name} is up to date (${formatDuration(elapsed)})")
+        return BuildResult(config, classpath = null, pluginArgs = emptyList(), javaPath = null)
+    }
+
+    ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
+        eprintln("error: could not create directory ${error.path}")
+        exitProcess(EXIT_BUILD_ERROR)
+    }
+
+    val buildCmd = nativeBuildCommand(config, konancPath = managedKonancBin)
+    println("compiling ${config.name} (native)...")
+    executeCommand(buildCmd.args).getOrElse { error ->
+        eprintln(formatProcessError(error, "compilation"))
+        exitProcess(EXIT_BUILD_ERROR)
+    }
+
+    if (!fileExists(kexePath)) {
+        eprintln("error: $kexePath not produced by konanc")
+        exitProcess(EXIT_BUILD_ERROR)
+    }
+
+    val newState = currentState.copy(classesDirMtime = fileMtime(kexePath))
+    writeFileAsString(BUILD_STATE_FILE, serializeBuildState(newState)).getOrElse {
+        eprintln("warning: could not write build state file")
+    }
+
+    val elapsed = startMark.elapsedNow()
+    println("built $kexePath in ${formatDuration(elapsed)}")
+    return BuildResult(config, classpath = null, pluginArgs = emptyList(), javaPath = null)
+}
+
 internal fun doRun(config: KeelConfig, classpath: String?, appArgs: List<String> = emptyList(), javaPath: String? = null) {
+    if (config.target == "native") {
+        val kexePath = outputKexePath(config)
+        if (!fileExists(kexePath)) {
+            eprintln("error: $kexePath not found. Run 'keel build' first.")
+            exitProcess(EXIT_BUILD_ERROR)
+        }
+        val cmd = nativeRunCommand(config, appArgs)
+        executeCommand(cmd.args).getOrElse { error ->
+            when (error) {
+                is ProcessError.NonZeroExit -> exitProcess(error.exitCode)
+                else -> exitProcess(EXIT_BUILD_ERROR)
+            }
+        }
+        return
+    }
+
     if (!fileExists(CLASSES_DIR)) {
         eprintln("error: $CLASSES_DIR not found. Run 'keel build' first.")
         exitProcess(EXIT_BUILD_ERROR)
@@ -147,7 +233,15 @@ internal fun doRun(config: KeelConfig, classpath: String?, appArgs: List<String>
 }
 
 internal fun doTest(testArgs: List<String> = emptyList()) {
-    val (config, classpath, pArgs, javaPath) = doBuild()
+    // Load the config once up front to fail fast on unsupported targets
+    // before entering doBuild. doBuild will load it again for the jvm path;
+    // this is the cost of keeping the native guard here.
+    val config = loadProjectConfig()
+    if (config.target == "native") {
+        eprintln("error: 'keel test' is not yet supported for target = \"native\" (tracked in #16)")
+        exitProcess(EXIT_TEST_ERROR)
+    }
+    val (_, classpath, pArgs, javaPath) = doBuild()
 
     val existingTestSources = config.testSources.filter { fileExists(it) }
     if (existingTestSources.isEmpty()) {

--- a/src/nativeMain/kotlin/keel/config/Config.kt
+++ b/src/nativeMain/kotlin/keel/config/Config.kt
@@ -11,6 +11,8 @@ import kotlinx.serialization.SerializationException
 
 const val MAVEN_CENTRAL_BASE = "https://repo1.maven.org/maven2"
 
+val VALID_TARGETS = setOf("jvm", "native")
+
 sealed class ConfigError {
     data class ParseFailed(val message: String) : ConfigError()
 }
@@ -42,6 +44,11 @@ private val toml = Toml(
 fun parseConfig(tomlString: String): Result<KeelConfig, ConfigError> {
     return try {
         val config = toml.decodeFromString(KeelConfig.serializer(), tomlString)
+        if (config.target !in VALID_TARGETS) {
+            return Err(ConfigError.ParseFailed(
+                "invalid target '${config.target}' (valid targets: ${VALID_TARGETS.joinToString(", ")})"
+            ))
+        }
         // ktoml preserves quotes in map keys; strip them
         val cleanedDeps = config.dependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }
         val cleanedTestDeps = config.testDependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }

--- a/src/nativeTest/kotlin/keel/TestFixtures.kt
+++ b/src/nativeTest/kotlin/keel/TestFixtures.kt
@@ -12,12 +12,13 @@ fun testConfig(
     testDependencies: Map<String, String> = emptyMap(),
     plugins: Map<String, Boolean> = emptyMap(),
     repositories: Map<String, String> = mapOf("central" to MAVEN_CENTRAL_BASE),
-    jdk: String? = null
+    jdk: String? = null,
+    target: String = "jvm"
 ) = KeelConfig(
     name = name,
     version = "0.1.0",
     kotlin = "2.1.0",
-    target = "jvm",
+    target = target,
     jvmTarget = jvmTarget,
     main = "com.example.MainKt",
     sources = sources,

--- a/src/nativeTest/kotlin/keel/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/keel/build/BuilderTest.kt
@@ -4,6 +4,7 @@ import keel.testConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class BuilderTest {
 
@@ -329,6 +330,100 @@ class BuilderTest {
 
         // Then: falls back to system "jar"
         assertEquals("jar", cmd.args.first())
+    }
+
+    // --- nativeBuildCommand ---
+
+    @Test
+    fun nativeBuildCommandProducesProgramKexe() {
+        val cmd = nativeBuildCommand(testConfig(target = "native"))
+
+        assertEquals(
+            listOf("konanc", "src", "-p", "program", "-e", "com.example.main", "-o", "build/my-app"),
+            cmd.args
+        )
+        assertEquals("build/my-app.kexe", cmd.outputPath)
+    }
+
+    @Test
+    fun nativeBuildCommandMultipleSources() {
+        val cmd = nativeBuildCommand(testConfig(sources = listOf("src", "generated"), target = "native"))
+
+        assertEquals(
+            listOf("konanc", "src", "generated", "-p", "program", "-e", "com.example.main", "-o", "build/my-app"),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeBuildCommandWithProjectName() {
+        val cmd = nativeBuildCommand(testConfig(name = "hello", target = "native"))
+
+        assertEquals("build/hello.kexe", cmd.outputPath)
+        assertEquals(
+            listOf("konanc", "src", "-p", "program", "-e", "com.example.main", "-o", "build/hello"),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeBuildCommandWithManagedKonancPath() {
+        val managedKonanc = "/home/user/.keel/toolchains/konanc/2.1.0/bin/konanc"
+        val cmd = nativeBuildCommand(testConfig(target = "native"), konancPath = managedKonanc)
+
+        assertEquals(managedKonanc, cmd.args.first())
+    }
+
+    @Test
+    fun nativeBuildCommandWithPluginArgs() {
+        val cmd = nativeBuildCommand(
+            testConfig(target = "native"),
+            pluginArgs = listOf("-Xplugin=foo.jar")
+        )
+
+        assertEquals(
+            listOf("konanc", "src", "-p", "program", "-e", "com.example.main", "-o", "build/my-app", "-Xplugin=foo.jar"),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeEntryPointStripsClassNameAndAppendsMain() {
+        assertEquals("com.example.main", nativeEntryPoint(testConfig()))
+    }
+
+    @Test
+    fun nativeEntryPointRootPackage() {
+        val config = testConfig().copy(main = "MainKt")
+        assertEquals("main", nativeEntryPoint(config))
+    }
+
+    @Test
+    fun nativeEntryPointDeepPackage() {
+        val config = testConfig().copy(main = "foo.bar.baz.AppKt")
+        assertEquals("foo.bar.baz.main", nativeEntryPoint(config))
+    }
+
+    // --- needsNativeEntryPointWarning ---
+
+    @Test
+    fun needsNativeEntryPointWarningFalseForKtSuffix() {
+        assertFalse(needsNativeEntryPointWarning(testConfig()))
+    }
+
+    @Test
+    fun needsNativeEntryPointWarningFalseForRootKtSuffix() {
+        assertFalse(needsNativeEntryPointWarning(testConfig().copy(main = "MainKt")))
+    }
+
+    @Test
+    fun needsNativeEntryPointWarningTrueForNonKtClass() {
+        assertTrue(needsNativeEntryPointWarning(testConfig().copy(main = "com.example.App")))
+    }
+
+    @Test
+    fun needsNativeEntryPointWarningTrueForRootNonKt() {
+        assertTrue(needsNativeEntryPointWarning(testConfig().copy(main = "Main")))
     }
 
     @Test

--- a/src/nativeTest/kotlin/keel/build/RunnerTest.kt
+++ b/src/nativeTest/kotlin/keel/build/RunnerTest.kt
@@ -82,6 +82,26 @@ class RunnerTest {
         )
     }
 
+    // --- nativeRunCommand ---
+
+    @Test
+    fun nativeRunCommandExecutesKexeBinary() {
+        val cmd = nativeRunCommand(testConfig(target = "native"))
+        assertEquals(listOf("build/my-app.kexe"), cmd.args)
+    }
+
+    @Test
+    fun nativeRunCommandAppendsAppArgs() {
+        val cmd = nativeRunCommand(testConfig(target = "native"), listOf("--port", "8080"))
+        assertEquals(listOf("build/my-app.kexe", "--port", "8080"), cmd.args)
+    }
+
+    @Test
+    fun nativeRunCommandUsesProjectName() {
+        val cmd = nativeRunCommand(testConfig(name = "hello", target = "native"))
+        assertEquals(listOf("build/hello.kexe"), cmd.args)
+    }
+
     @Test
     fun runCommandWithManagedJavaAndAppArgs() {
         // Given: managed java + app arguments

--- a/src/nativeTest/kotlin/keel/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/keel/config/ConfigTest.kt
@@ -163,6 +163,42 @@ class ConfigTest {
     }
 
     @Test
+    fun parseConfigWithNativeTarget() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "native"
+            main = "com.example.MainKt"
+            sources = ["src"]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals("native", config.target)
+    }
+
+    @Test
+    fun unknownTargetReturnsErr() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "wasm"
+            main = "com.example.MainKt"
+            sources = ["src"]
+        """.trimIndent()
+
+        val result = parseConfig(toml)
+
+        assertNull(result.get())
+        val error = assertIs<ConfigError.ParseFailed>(result.getError())
+        // message should mention valid targets
+        kotlin.test.assertTrue(error.message.contains("target"))
+        kotlin.test.assertTrue(error.message.contains("jvm"))
+        kotlin.test.assertTrue(error.message.contains("native"))
+    }
+
+    @Test
     fun unknownFieldsAreIgnored() {
         val toml = """
             name = "my-app"


### PR DESCRIPTION
## Summary
First phase of #16 (Kotlin/Native build target support). Scope is deliberately minimal: a dependency-free Hello World can be built and run with `target = "native"`.

- `Config`: validate `target` is `jvm` or `native`; unknown targets now produce a clear error
- `Builder`: `nativeBuildCommand` uses `konanc -p program -e <entry> -o <base>` to produce `build/<name>.kexe`
- `Builder`: `nativeEntryPoint` derives the entry FQN from `config.main` (class-name segment is discarded, `.main` appended to the package). `needsNativeEntryPointWarning` flags non-`*Kt` class names so the user gets a hint when their main will likely not be found.
- `Runner`: `nativeRunCommand` executes the `.kexe` directly
- `BuildCommands`: target branching in `doCheck` / `doBuild` / `doRun` / `doTest`
  - `check` for native delegates to a full build (konanc has no syntax-only mode)
  - `test` for native errors out with a pointer to #16

## Out of scope (follow-up phases of #16)
- Phase B: single native dependency resolution (`kotlin-stdlib` via Gradle metadata / variant selection)
- Phase C: transitive native dependency resolution (`.klib`)
- Phase D: native test execution

## Related
- #16 (parent, stays open)
- #50 (hardening the build cache up-to-date check — to be addressed together with the cache field rename in Phase B/C)

## Test plan
- [x] `./gradlew linuxX64Test` passes
- [x] Unit tests for `nativeBuildCommand` / `nativeRunCommand` / `nativeEntryPoint` / `needsNativeEntryPointWarning` / `parseConfig` target validation
- [x] End-to-end verification with a local `test_project`:
  - `keel build` on `target = "native"` installs konanc on demand and produces `build/hello-native.kexe`
  - `keel run` executes the binary and prints "Hello from Kotlin/Native!"
  - `keel check` completes via the build path
  - `keel test` errors with the tracking pointer
  - `target = "wasm"` errors with `invalid target 'wasm' (valid targets: jvm, native)`