### PR TITLE
Parse Kotlin/Native variants from Gradle Module Metadata

### DIFF
--- a/src/nativeMain/kotlin/keel/resolve/Dependency.kt
+++ b/src/nativeMain/kotlin/keel/resolve/Dependency.kt
@@ -46,8 +46,6 @@ fun buildModuleDownloadUrl(coord: Coordinate, baseUrl: String): String = buildMa
 
 fun buildModuleCachePath(coord: Coordinate): String = buildRelativePath(coord, "module")
 
-fun buildKlibDownloadUrl(coord: Coordinate, baseUrl: String): String = buildMavenUrl(coord, baseUrl, "klib")
-
 fun buildKlibCachePath(coord: Coordinate): String = buildRelativePath(coord, "klib")
 
 fun buildClasspath(paths: List<String>): String = paths.joinToString(":")

--- a/src/nativeMain/kotlin/keel/resolve/Dependency.kt
+++ b/src/nativeMain/kotlin/keel/resolve/Dependency.kt
@@ -46,4 +46,8 @@ fun buildModuleDownloadUrl(coord: Coordinate, baseUrl: String): String = buildMa
 
 fun buildModuleCachePath(coord: Coordinate): String = buildRelativePath(coord, "module")
 
+fun buildKlibDownloadUrl(coord: Coordinate, baseUrl: String): String = buildMavenUrl(coord, baseUrl, "klib")
+
+fun buildKlibCachePath(coord: Coordinate): String = buildRelativePath(coord, "klib")
+
 fun buildClasspath(paths: List<String>): String = paths.joinToString(":")

--- a/src/nativeMain/kotlin/keel/resolve/GradleMetadata.kt
+++ b/src/nativeMain/kotlin/keel/resolve/GradleMetadata.kt
@@ -81,14 +81,19 @@ data class NativeDependency(
 /**
  * Parses a Gradle Module Metadata JSON and extracts the available-at redirect
  * for the given Kotlin/Native target (e.g. "linux_x64"). Returns null when the
- * JSON is invalid, no matching variant exists, or the matching variant has no
- * available-at redirect.
+ * JSON is invalid, no matching variant exists, or matching variants exist but
+ * none have an available-at redirect.
  *
  * A variant matches when ALL of these attributes are present:
  * - `org.jetbrains.kotlin.platform.type` == "native"
  * - `org.jetbrains.kotlin.native.target` == <nativeTarget>
  * - `org.gradle.usage` == "kotlin-api"
  * - `org.gradle.category` == "library"
+ *
+ * Unlike [parseJvmRedirect], a matching variant without `available-at` is
+ * skipped rather than aborting: native modules list many targets in parallel,
+ * and an earlier target with no redirect does not imply the requested target
+ * is missing.
  */
 fun parseNativeRedirect(moduleJson: String, nativeTarget: String): NativeRedirect? {
     val metadata = try {

--- a/src/nativeMain/kotlin/keel/resolve/GradleMetadata.kt
+++ b/src/nativeMain/kotlin/keel/resolve/GradleMetadata.kt
@@ -50,6 +50,99 @@ fun parseJvmRedirect(moduleJson: String): JvmRedirect? {
     return redirect
 }
 
+/**
+ * Redirect target for a Kotlin/Native platform variant. A multiplatform root
+ * module redirects each native target to a separate module, e.g.
+ * `kotlinx-coroutines-core` → `kotlinx-coroutines-core-linuxx64` for linux_x64.
+ */
+data class NativeRedirect(
+    val group: String,
+    val module: String,
+    val version: String
+)
+
+/**
+ * A resolved native variant from a platform-specific module file. Carries the
+ * `.klib` file reference (relative URL and sha256) and the transitive dependencies
+ * declared in the Gradle module metadata.
+ */
+data class NativeArtifact(
+    val klibFileUrl: String,
+    val klibSha256: String,
+    val dependencies: List<NativeDependency>
+)
+
+data class NativeDependency(
+    val group: String,
+    val module: String,
+    val version: String
+)
+
+/**
+ * Parses a Gradle Module Metadata JSON and extracts the available-at redirect
+ * for the given Kotlin/Native target (e.g. "linux_x64"). Returns null when the
+ * JSON is invalid, no matching variant exists, or the matching variant has no
+ * available-at redirect.
+ *
+ * A variant matches when ALL of these attributes are present:
+ * - `org.jetbrains.kotlin.platform.type` == "native"
+ * - `org.jetbrains.kotlin.native.target` == <nativeTarget>
+ * - `org.gradle.usage` == "kotlin-api"
+ * - `org.gradle.category` == "library"
+ */
+fun parseNativeRedirect(moduleJson: String, nativeTarget: String): NativeRedirect? {
+    val metadata = try {
+        lenientJson.decodeFromString<GradleModuleMetadata>(moduleJson)
+    } catch (_: Exception) {
+        return null
+    }
+
+    for (variant in metadata.variants) {
+        if (!matchesNativeVariant(variant.attributes, nativeTarget)) continue
+        val availableAt = variant.availableAt ?: continue
+        return NativeRedirect(
+            group = availableAt.group,
+            module = availableAt.module,
+            version = availableAt.version
+        )
+    }
+    return null
+}
+
+/**
+ * Parses a Gradle Module Metadata JSON (a platform-specific redirect target)
+ * and extracts the `.klib` file and dependencies for the given Kotlin/Native
+ * target. Returns null when the JSON is invalid, no matching variant exists,
+ * or the matching variant has no `.klib` file entry.
+ */
+fun parseNativeArtifact(moduleJson: String, nativeTarget: String): NativeArtifact? {
+    val metadata = try {
+        lenientJson.decodeFromString<GradleModuleMetadata>(moduleJson)
+    } catch (_: Exception) {
+        return null
+    }
+
+    for (variant in metadata.variants) {
+        if (!matchesNativeVariant(variant.attributes, nativeTarget)) continue
+        val klibFile = variant.files.firstOrNull { it.url.endsWith(".klib") } ?: continue
+        val deps = variant.dependencies.map { d ->
+            NativeDependency(group = d.group, module = d.module, version = d.version.requires)
+        }
+        return NativeArtifact(
+            klibFileUrl = klibFile.url,
+            klibSha256 = klibFile.sha256,
+            dependencies = deps
+        )
+    }
+    return null
+}
+
+private fun matchesNativeVariant(attrs: Map<String, String>, nativeTarget: String): Boolean =
+    attrs["org.jetbrains.kotlin.platform.type"] == "native" &&
+        attrs["org.jetbrains.kotlin.native.target"] == nativeTarget &&
+        attrs["org.gradle.usage"] == "kotlin-api" &&
+        attrs["org.gradle.category"] == "library"
+
 private val lenientJson = Json { ignoreUnknownKeys = true }
 
 @Serializable
@@ -61,7 +154,9 @@ private data class GradleModuleMetadata(
 private data class GradleVariant(
     val attributes: Map<String, String> = emptyMap(),
     @SerialName("available-at")
-    val availableAt: AvailableAt? = null
+    val availableAt: AvailableAt? = null,
+    val files: List<GradleFile> = emptyList(),
+    val dependencies: List<GradleDependency> = emptyList()
 )
 
 @Serializable
@@ -69,4 +164,23 @@ private data class AvailableAt(
     val group: String,
     val module: String,
     val version: String
+)
+
+@Serializable
+private data class GradleFile(
+    val name: String = "",
+    val url: String,
+    val sha256: String = ""
+)
+
+@Serializable
+private data class GradleDependency(
+    val group: String,
+    val module: String,
+    val version: GradleVersionSpec
+)
+
+@Serializable
+private data class GradleVersionSpec(
+    val requires: String = ""
 )

--- a/src/nativeTest/kotlin/keel/resolve/DependencyTest.kt
+++ b/src/nativeTest/kotlin/keel/resolve/DependencyTest.kt
@@ -162,26 +162,6 @@ class DependencyTest {
     // --- klib helpers ---
 
     @Test
-    fun buildKlibDownloadUrlProducesCorrectMavenCentralUrl() {
-        val coord = Coordinate("org.jetbrains.kotlinx", "kotlinx-coroutines-core-linuxx64", "1.9.0")
-        val url = buildKlibDownloadUrl(coord, MAVEN_CENTRAL_BASE)
-        assertEquals(
-            "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-linuxx64/1.9.0/kotlinx-coroutines-core-linuxx64-1.9.0.klib",
-            url
-        )
-    }
-
-    @Test
-    fun buildKlibDownloadUrlWithCustomBaseUrl() {
-        val coord = Coordinate("com.example", "lib-linuxx64", "1.0.0")
-        val url = buildKlibDownloadUrl(coord, "https://nexus.example.com/repository/maven-public")
-        assertEquals(
-            "https://nexus.example.com/repository/maven-public/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib",
-            url
-        )
-    }
-
-    @Test
     fun buildKlibCachePathProducesRelativePath() {
         val coord = Coordinate("org.jetbrains.kotlinx", "atomicfu-linuxx64", "0.25.0")
         val path = buildKlibCachePath(coord)

--- a/src/nativeTest/kotlin/keel/resolve/DependencyTest.kt
+++ b/src/nativeTest/kotlin/keel/resolve/DependencyTest.kt
@@ -158,4 +158,36 @@ class DependencyTest {
             path
         )
     }
+
+    // --- klib helpers ---
+
+    @Test
+    fun buildKlibDownloadUrlProducesCorrectMavenCentralUrl() {
+        val coord = Coordinate("org.jetbrains.kotlinx", "kotlinx-coroutines-core-linuxx64", "1.9.0")
+        val url = buildKlibDownloadUrl(coord, MAVEN_CENTRAL_BASE)
+        assertEquals(
+            "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-linuxx64/1.9.0/kotlinx-coroutines-core-linuxx64-1.9.0.klib",
+            url
+        )
+    }
+
+    @Test
+    fun buildKlibDownloadUrlWithCustomBaseUrl() {
+        val coord = Coordinate("com.example", "lib-linuxx64", "1.0.0")
+        val url = buildKlibDownloadUrl(coord, "https://nexus.example.com/repository/maven-public")
+        assertEquals(
+            "https://nexus.example.com/repository/maven-public/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib",
+            url
+        )
+    }
+
+    @Test
+    fun buildKlibCachePathProducesRelativePath() {
+        val coord = Coordinate("org.jetbrains.kotlinx", "atomicfu-linuxx64", "0.25.0")
+        val path = buildKlibCachePath(coord)
+        assertEquals(
+            "org/jetbrains/kotlinx/atomicfu-linuxx64/0.25.0/atomicfu-linuxx64-0.25.0.klib",
+            path
+        )
+    }
 }

--- a/src/nativeTest/kotlin/keel/resolve/GradleMetadataTest.kt
+++ b/src/nativeTest/kotlin/keel/resolve/GradleMetadataTest.kt
@@ -361,8 +361,8 @@ class GradleMetadataTest {
 
     @Test
     fun parseNativeRedirectRequiresKotlinApiUsage() {
-        // RuntimeElements should also be acceptable per research findings;
-        // but metadata-only usage should not match.
+        // Non-api usages (e.g. kotlin-metadata, kotlin-runtime) must be
+        // skipped so we only resolve compile-time klibs.
         val json = """
         {
           "formatVersion": "1.1",

--- a/src/nativeTest/kotlin/keel/resolve/GradleMetadataTest.kt
+++ b/src/nativeTest/kotlin/keel/resolve/GradleMetadataTest.kt
@@ -211,6 +211,390 @@ class GradleMetadataTest {
         assertNull(redirect)
     }
 
+    // --- parseNativeRedirect ---
+
+    @Test
+    fun parseNativeRedirectExtractsLinuxX64AvailableAt() {
+        // Based on kotlinx-coroutines-core:1.9.0 actual .module structure.
+        val json = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "metadataApiElements",
+              "attributes": {
+                "org.jetbrains.kotlin.platform.type": "common"
+              }
+            },
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "artifactType": "org.jetbrains.kotlin.klib",
+                "org.gradle.category": "library",
+                "org.gradle.jvm.environment": "non-jvm",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../kotlinx-coroutines-core-linuxx64/1.9.0/kotlinx-coroutines-core-linuxx64-1.9.0.module",
+                "group": "org.jetbrains.kotlinx",
+                "module": "kotlinx-coroutines-core-linuxx64",
+                "version": "1.9.0"
+              }
+            },
+            {
+              "name": "macosArm64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "macos_arm64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../kotlinx-coroutines-core-macosarm64/1.9.0/kotlinx-coroutines-core-macosarm64-1.9.0.module",
+                "group": "org.jetbrains.kotlinx",
+                "module": "kotlinx-coroutines-core-macosarm64",
+                "version": "1.9.0"
+              }
+            }
+          ]
+        }
+        """.trimIndent()
+
+        val redirect = parseNativeRedirect(json, "linux_x64")
+
+        assertEquals("org.jetbrains.kotlinx", redirect?.group)
+        assertEquals("kotlinx-coroutines-core-linuxx64", redirect?.module)
+        assertEquals("1.9.0", redirect?.version)
+    }
+
+    @Test
+    fun parseNativeRedirectReturnsNullForDifferentTarget() {
+        // Only linuxX64 variant present; asked for macos_arm64 → null
+        val json = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../lib-linuxx64/1.0/lib-linuxx64-1.0.module",
+                "group": "com.example",
+                "module": "lib-linuxx64",
+                "version": "1.0"
+              }
+            }
+          ]
+        }
+        """.trimIndent()
+
+        val redirect = parseNativeRedirect(json, "macos_arm64")
+
+        assertNull(redirect)
+    }
+
+    @Test
+    fun parseNativeRedirectSkipsNonNativePlatformTypes() {
+        // jvm variants with native.target attribute should not match
+        val json = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "jvmApiElements-published",
+              "attributes": {
+                "org.jetbrains.kotlin.platform.type": "jvm"
+              },
+              "available-at": {
+                "url": "../../lib-jvm/1.0/lib-jvm-1.0.module",
+                "group": "com.example",
+                "module": "lib-jvm",
+                "version": "1.0"
+              }
+            }
+          ]
+        }
+        """.trimIndent()
+
+        val redirect = parseNativeRedirect(json, "linux_x64")
+
+        assertNull(redirect)
+    }
+
+    @Test
+    fun parseNativeRedirectRequiresLibraryCategory() {
+        // A native variant in the documentation category should be skipped
+        val json = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64SourcesElements-published",
+              "attributes": {
+                "org.gradle.category": "documentation",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../lib-sources/1.0/lib-sources-1.0.module",
+                "group": "com.example",
+                "module": "lib-sources",
+                "version": "1.0"
+              }
+            }
+          ]
+        }
+        """.trimIndent()
+
+        val redirect = parseNativeRedirect(json, "linux_x64")
+
+        assertNull(redirect)
+    }
+
+    @Test
+    fun parseNativeRedirectRequiresKotlinApiUsage() {
+        // RuntimeElements should also be acceptable per research findings;
+        // but metadata-only usage should not match.
+        val json = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64MetadataElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-metadata",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../lib-meta/1.0/lib-meta-1.0.module",
+                "group": "com.example",
+                "module": "lib-meta",
+                "version": "1.0"
+              }
+            }
+          ]
+        }
+        """.trimIndent()
+
+        val redirect = parseNativeRedirect(json, "linux_x64")
+
+        assertNull(redirect)
+    }
+
+    @Test
+    fun parseNativeRedirectReturnsNullForInvalidJson() {
+        assertNull(parseNativeRedirect("not json", "linux_x64"))
+    }
+
+    @Test
+    fun parseNativeRedirectReturnsNullForEmptyVariants() {
+        val json = """{"formatVersion": "1.1", "variants": []}"""
+
+        assertNull(parseNativeRedirect(json, "linux_x64"))
+    }
+
+    // --- parseNativeArtifact ---
+
+    @Test
+    fun parseNativeArtifactExtractsKlibFileAndDependencies() {
+        // Based on kotlinx-coroutines-core-linuxx64:1.9.0 actual .module structure.
+        val json = """
+        {
+          "formatVersion": "1.1",
+          "component": {
+            "url": "../../kotlinx-coroutines-core/1.9.0/kotlinx-coroutines-core-1.9.0.module",
+            "group": "org.jetbrains.kotlinx",
+            "module": "kotlinx-coroutines-core",
+            "version": "1.9.0"
+          },
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "artifactType": "org.jetbrains.kotlin.klib",
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "dependencies": [
+                {
+                  "group": "org.jetbrains.kotlinx",
+                  "module": "atomicfu",
+                  "version": { "requires": "0.25.0" }
+                },
+                {
+                  "group": "org.jetbrains.kotlin",
+                  "module": "kotlin-stdlib",
+                  "version": { "requires": "2.0.0" }
+                }
+              ],
+              "files": [
+                {
+                  "name": "kotlinx-coroutines-core.klib",
+                  "url": "kotlinx-coroutines-core-linuxx64-1.9.0.klib",
+                  "size": 884378,
+                  "sha256": "651d39f4ebfdd8218c30cc4c9239194dc23483a2ed8feae161749226f02f76fe"
+                }
+              ]
+            }
+          ]
+        }
+        """.trimIndent()
+
+        val artifact = parseNativeArtifact(json, "linux_x64")
+
+        assertEquals("kotlinx-coroutines-core-linuxx64-1.9.0.klib", artifact?.klibFileUrl)
+        assertEquals("651d39f4ebfdd8218c30cc4c9239194dc23483a2ed8feae161749226f02f76fe", artifact?.klibSha256)
+        val deps = artifact?.dependencies.orEmpty()
+        assertEquals(2, deps.size)
+        assertEquals("org.jetbrains.kotlinx", deps[0].group)
+        assertEquals("atomicfu", deps[0].module)
+        assertEquals("0.25.0", deps[0].version)
+        assertEquals("kotlin-stdlib", deps[1].module)
+        assertEquals("2.0.0", deps[1].version)
+    }
+
+    @Test
+    fun parseNativeArtifactReturnsNullForDifferentTarget() {
+        val json = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "files": [
+                {
+                  "name": "foo.klib",
+                  "url": "foo-linuxx64-1.0.klib",
+                  "sha256": "abc"
+                }
+              ]
+            }
+          ]
+        }
+        """.trimIndent()
+
+        assertNull(parseNativeArtifact(json, "macos_arm64"))
+    }
+
+    @Test
+    fun parseNativeArtifactHandlesEmptyDependencies() {
+        val json = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "files": [
+                {
+                  "name": "lib.klib",
+                  "url": "lib-linuxx64-1.0.klib",
+                  "sha256": "def"
+                }
+              ]
+            }
+          ]
+        }
+        """.trimIndent()
+
+        val artifact = parseNativeArtifact(json, "linux_x64")
+
+        assertEquals("lib-linuxx64-1.0.klib", artifact?.klibFileUrl)
+        assertEquals("def", artifact?.klibSha256)
+        assertEquals(0, artifact?.dependencies?.size)
+    }
+
+    @Test
+    fun parseNativeArtifactReturnsNullWhenNoKlibFile() {
+        // Variant matches but files[] has no .klib entry (edge case)
+        val json = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "files": []
+            }
+          ]
+        }
+        """.trimIndent()
+
+        assertNull(parseNativeArtifact(json, "linux_x64"))
+    }
+
+    @Test
+    fun parseNativeArtifactReturnsNullForInvalidJson() {
+        assertNull(parseNativeArtifact("not json", "linux_x64"))
+    }
+
+    @Test
+    fun parseNativeArtifactPicksKlibFileAmongMultiple() {
+        // In practice .module files list only .klib; but if some future
+        // variant lists multiple, we should pick the one ending in .klib.
+        val json = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "files": [
+                {
+                  "name": "README.txt",
+                  "url": "README.txt",
+                  "sha256": "ignored"
+                },
+                {
+                  "name": "lib.klib",
+                  "url": "lib-linuxx64-2.0.klib",
+                  "sha256": "good"
+                }
+              ]
+            }
+          ]
+        }
+        """.trimIndent()
+
+        val artifact = parseNativeArtifact(json, "linux_x64")
+
+        assertEquals("lib-linuxx64-2.0.klib", artifact?.klibFileUrl)
+        assertEquals("good", artifact?.klibSha256)
+    }
+
     @Test
     fun parseJvmRedirectPicksJvmRuntimeVariantToo() {
         val json = """


### PR DESCRIPTION
## Summary
First of two PRs for #16 Phase B (single-target native dependency resolution). This one is **parser + URL helpers only**, no resolver or build-pipeline wiring — those follow in PR B-2.

### What changes
- \`Dependency.kt\`: \`buildKlibDownloadUrl\` / \`buildKlibCachePath\` for \`.klib\` artifacts, mirroring the existing jar/pom/module helpers
- \`GradleMetadata.kt\`:
  - \`parseNativeRedirect(moduleJson, nativeTarget)\` — given a root multiplatform \`.module\`, returns the \`available-at\` redirect (group/module/version) for a Kotlin/Native target like \`linux_x64\`
  - \`parseNativeArtifact(moduleJson, nativeTarget)\` — given a platform-specific redirect-target \`.module\`, returns the \`.klib\` file URL + sha256 + Gradle-declared \`dependencies[]\`
  - Variant matching requires all four attributes: \`platform.type = native\`, \`native.target = <target>\`, \`usage = kotlin-api\`, \`category = library\` (to avoid sources / metadata / documentation variants)
  - \`.klib\` file is chosen by filtering \`files[].url\` for the \`.klib\` suffix (the \`files[].name\` field is an internal klib logical name and must not be used for the download URL)

### Why parser-only
The resolver branch for native targets (recursion, stdlib skip, cache integration) and the \`konanc -library\` wiring in \`Builder\` / \`BuildCommands\` are sizable; keeping this PR pure-function-only makes it fully unit-testable without I/O and gives reviewers a tight focus on the metadata format understanding before the larger wiring PR lands.

### Spike verification (prior to this PR)
Before writing any code, a manual spike confirmed end-to-end that:
- \`konanc <src> -p program -e <entry> -l <coroutines.klib> -l <atomicfu.klib> -o <out>\` builds and runs a \`runBlocking { delay(10); println(...) }\` program
- stdlib is auto-linked by konanc (no \`-library\` needed)
- Dropping \`atomicfu\` breaks the link, so transitive resolution is required (coroutines' native variant declares \`atomicfu\` in its \`dependencies[]\`)
- atomicfu's klib carries an internal manifest dep on a \`atomicfu-cinterop-interop\` klib that does not exist on Maven Central but produces only a non-fatal warning (not a blocker for Phase B)

These findings back the design choices in this PR: follow \`dependencies[]\` for transitive, skip \`kotlin-stdlib\` explicitly, accept the cinterop-interop warning as non-fatal.

## Out of scope (PR B-2)
- \`TransitiveResolver\` native branch (metadata → redirect → klib, recursion, stdlib skip)
- \`Builder.nativeBuildCommand\` \`-library\` wiring
- \`BuildCommands.doNativeBuild\` plumbing of klib paths into konanc
- End-to-end verification with a real \`test_project\` using \`kotlinx-coroutines-core\`

## Test plan
- [x] \`./gradlew linuxX64Test\` passes
- [x] 14 new unit tests:
  - 3 for klib URL / cache path helpers
  - 11 for \`parseNativeRedirect\` / \`parseNativeArtifact\` covering happy path, target mismatch, non-native platform, non-library category, non-api usage, missing \`.klib\` file, invalid JSON, empty variants, empty dependencies, and \`.klib\` filtering among multiple files
- Fixtures are trimmed copies of real \`kotlinx-coroutines-core:1.9.0\` \`.module\` JSON (root and linuxx64 redirect target) captured during the spike

Refs #16