### PR TITLE
Resolve Kotlin/Native dependencies and link klibs via konanc

### DIFF
--- a/src/nativeMain/kotlin/keel/build/Builder.kt
+++ b/src/nativeMain/kotlin/keel/build/Builder.kt
@@ -85,7 +85,8 @@ fun buildCommand(
 fun nativeBuildCommand(
     config: KeelConfig,
     pluginArgs: List<String> = emptyList(),
-    konancPath: String? = null
+    konancPath: String? = null,
+    klibs: List<String> = emptyList()
 ): BuildCommand {
     val outputPath = outputKexePath(config)
     // konanc -o takes the path without the .kexe extension
@@ -97,6 +98,11 @@ fun nativeBuildCommand(
         add("program")
         add("-e")
         add(nativeEntryPoint(config))
+        // -library / -l takes one library per flag; do not join with colons.
+        for (klib in klibs) {
+            add("-l")
+            add(klib)
+        }
         add("-o")
         add(outputBase)
         addAll(pluginArgs)

--- a/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
@@ -157,6 +157,8 @@ private fun doNativeBuild(config: KeelConfig): BuildResult {
     val paths = resolveKeelPaths(EXIT_BUILD_ERROR)
     val managedKonancBin = ensureKonancBin(config.kotlin, paths, EXIT_BUILD_ERROR)
 
+    val klibs = resolveNativeDependencies(config, paths)
+
     val kexePath = outputKexePath(config)
     val currentState = BuildState(
         configMtime = fileMtime(KEEL_TOML) ?: 0L,
@@ -179,7 +181,7 @@ private fun doNativeBuild(config: KeelConfig): BuildResult {
         exitProcess(EXIT_BUILD_ERROR)
     }
 
-    val buildCmd = nativeBuildCommand(config, konancPath = managedKonancBin)
+    val buildCmd = nativeBuildCommand(config, konancPath = managedKonancBin, klibs = klibs)
     println("compiling ${config.name} (native)...")
     executeCommand(buildCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "compilation"))
@@ -199,6 +201,22 @@ private fun doNativeBuild(config: KeelConfig): BuildResult {
     val elapsed = startMark.elapsedNow()
     println("built $kexePath in ${formatDuration(elapsed)}")
     return BuildResult(config, classpath = null, pluginArgs = emptyList(), javaPath = null)
+}
+
+/**
+ * Resolves direct + transitive Kotlin/Native dependencies and returns their
+ * on-disk `.klib` paths. Unlike [resolveDependencies] for jvm, this does not
+ * read or write `keel.lock` (lockfile support for native lands later).
+ */
+internal fun resolveNativeDependencies(config: KeelConfig, paths: KeelPaths): List<String> {
+    if (config.dependencies.isEmpty()) return emptyList()
+
+    println("resolving native dependencies...")
+    val result = resolve(config, existingLock = null, paths.cacheBase, createResolverDeps()).getOrElse { error ->
+        eprintln(formatResolveError(error))
+        exitProcess(EXIT_DEPENDENCY_ERROR)
+    }
+    return result.deps.map { it.cachePath }
 }
 
 internal fun doRun(config: KeelConfig, classpath: String?, appArgs: List<String> = emptyList(), javaPath: String? = null) {

--- a/src/nativeMain/kotlin/keel/resolve/Dependency.kt
+++ b/src/nativeMain/kotlin/keel/resolve/Dependency.kt
@@ -46,6 +46,8 @@ fun buildModuleDownloadUrl(coord: Coordinate, baseUrl: String): String = buildMa
 
 fun buildModuleCachePath(coord: Coordinate): String = buildRelativePath(coord, "module")
 
+fun buildKlibDownloadUrl(coord: Coordinate, baseUrl: String): String = buildMavenUrl(coord, baseUrl, "klib")
+
 fun buildKlibCachePath(coord: Coordinate): String = buildRelativePath(coord, "klib")
 
 fun buildClasspath(paths: List<String>): String = paths.joinToString(":")

--- a/src/nativeMain/kotlin/keel/resolve/GradleMetadata.kt
+++ b/src/nativeMain/kotlin/keel/resolve/GradleMetadata.kt
@@ -142,6 +142,21 @@ fun parseNativeArtifact(moduleJson: String, nativeTarget: String): NativeArtifac
     return null
 }
 
+/**
+ * Returns true when the JSON decodes as a well-formed Gradle Module Metadata
+ * document (v1.1 schema, the subset keel cares about). Use this to distinguish
+ * "JSON is broken" from "JSON is valid but no variant matches our target",
+ * since [parseNativeRedirect] and [parseNativeArtifact] both return null in
+ * both cases.
+ */
+internal fun isValidGradleModuleJson(moduleJson: String): Boolean =
+    try {
+        lenientJson.decodeFromString<GradleModuleMetadata>(moduleJson)
+        true
+    } catch (_: Exception) {
+        false
+    }
+
 private fun matchesNativeVariant(attrs: Map<String, String>, nativeTarget: String): Boolean =
     attrs["org.jetbrains.kotlin.platform.type"] == "native" &&
         attrs["org.jetbrains.kotlin.native.target"] == nativeTarget &&

--- a/src/nativeMain/kotlin/keel/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/keel/resolve/NativeResolver.kt
@@ -1,0 +1,231 @@
+package keel.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import keel.config.KeelConfig
+
+// Phase B is linuxX64-only. Cross-platform support lands in a later phase.
+internal const val NATIVE_TARGET_LINUX_X64 = "linux_x64"
+
+// Kotlin/Native bundles the stdlib in the konanc distribution — it must be
+// skipped during dependency resolution even though Gradle module metadata
+// declares it as a dependency on every native variant.
+private fun isKotlinStdlib(groupArtifact: String): Boolean =
+    groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib"
+
+private data class NativeResolved(val redirect: NativeRedirect, val artifact: NativeArtifact)
+
+/**
+ * Resolves Kotlin/Native dependencies by walking Gradle Module Metadata.
+ *
+ * For each dependency in the BFS queue:
+ * 1. Fetch the root `.module` file and find the available-at redirect for
+ *    the current native target (linux_x64 in Phase B).
+ * 2. Fetch the redirect target's `.module` file and extract the `.klib`
+ *    file reference (url + sha256) and the variant's `dependencies[]`.
+ * 3. Enqueue each transitive dependency (except `kotlin-stdlib`, which
+ *    konanc bundles).
+ *
+ * After BFS, each resolved `(groupArtifact, version)` has its `.klib`
+ * downloaded and hashed; the sha256 is verified against the metadata.
+ *
+ * Version conflict resolution mirrors the JVM resolver:
+ * - Direct deps always win over transitive.
+ * - Among transitive deps, the highest version wins.
+ *
+ * The lockfile is not consulted or written for native targets in Phase B;
+ * `lockChanged` is always false. Lockfile support for native comes later.
+ */
+fun resolveNative(
+    config: KeelConfig,
+    cacheBase: String,
+    deps: ResolverDeps
+): Result<ResolveResult, ResolveError> {
+    val nativeTarget = NATIVE_TARGET_LINUX_X64
+    val repos = config.repositories.values.toList()
+
+    // Validate direct coords up front (mirrors jvm resolver)
+    for ((groupArtifact, _) in config.dependencies) {
+        if (isKotlinStdlib(groupArtifact)) continue
+        parseCoordinate(groupArtifact, "0").getOrElse {
+            return Err(ResolveError.InvalidDependency(groupArtifact))
+        }
+    }
+
+    val directKeys = config.dependencies.keys
+        .filterNot { isKotlinStdlib(it) }
+        .toSet()
+
+    // resolvedVersions: groupArtifact -> (version, isDirect)
+    val resolvedVersions = mutableMapOf<String, Pair<String, Boolean>>()
+    val queue = ArrayDeque<Pair<String, String>>()
+    val visited = mutableSetOf<String>()
+    // processed[ga:version] = (redirect, artifact) populated during BFS
+    val processed = mutableMapOf<String, NativeResolved>()
+
+    // Seed direct deps (skipping stdlib)
+    for ((groupArtifact, version) in config.dependencies) {
+        if (isKotlinStdlib(groupArtifact)) continue
+        resolvedVersions[groupArtifact] = Pair(version, true)
+        queue.addLast(groupArtifact to version)
+    }
+
+    while (queue.isNotEmpty()) {
+        val (groupArtifact, version) = queue.removeFirst()
+        val visitKey = "$groupArtifact:$version"
+        if (visitKey in visited) continue
+        visited.add(visitKey)
+
+        // A higher version may have superseded this entry while it waited in
+        // the queue. Skip fetching metadata for versions that no longer match
+        // the current resolution — we only need to materialize the final one.
+        if (resolvedVersions[groupArtifact]?.first != version) continue
+
+        val resolved = fetchNativeMetadata(
+            groupArtifact, version, nativeTarget, cacheBase, repos, deps
+        ).getOrElse { return Err(it) }
+        processed[visitKey] = resolved
+
+        // Enqueue transitive deps
+        for (dep in resolved.artifact.dependencies) {
+            val depGA = "${dep.group}:${dep.module}"
+            if (isKotlinStdlib(depGA)) continue
+
+            val existing = resolvedVersions[depGA]
+            if (existing != null) {
+                val (existingVersion, isDirect) = existing
+                if (isDirect) continue
+                if (compareVersions(dep.version, existingVersion) <= 0) continue
+            }
+            resolvedVersions[depGA] = Pair(dep.version, false)
+            queue.addLast(depGA to dep.version)
+        }
+    }
+
+    // Materialize: for each resolved (ga, version), download the .klib and
+    // verify its sha256. processed[ga:version] is guaranteed to exist because
+    // BFS visits every version that ends up in resolvedVersions.
+    val resolvedDeps = mutableListOf<ResolvedDep>()
+    for ((groupArtifact, versionAndDirect) in resolvedVersions) {
+        val (version, _) = versionAndDirect
+        val isDirect = groupArtifact in directKeys
+        val resolved = processed["$groupArtifact:$version"]
+            ?: return Err(ResolveError.MetadataFetchFailed(groupArtifact))
+
+        val targetCoord = Coordinate(
+            resolved.redirect.group,
+            resolved.redirect.module,
+            resolved.redirect.version
+        )
+        val klibCachePath = "$cacheBase/${buildKlibCachePath(targetCoord)}"
+
+        if (!deps.fileExists(klibCachePath)) {
+            val parentDir = klibCachePath.substringBeforeLast('/')
+            deps.ensureDirectoryRecursive(parentDir).getOrElse {
+                return Err(ResolveError.DirectoryCreateFailed(parentDir))
+            }
+            downloadFromRepositories(
+                repos,
+                klibCachePath,
+                { buildKlibDownloadUrl(targetCoord, it) },
+                deps::downloadFile
+            ).getOrElse { return Err(ResolveError.DownloadFailed(groupArtifact, it)) }
+        }
+
+        val actualHash = deps.computeSha256(klibCachePath).getOrElse {
+            return Err(ResolveError.HashComputeFailed(groupArtifact, it))
+        }
+        if (actualHash != resolved.artifact.klibSha256) {
+            return Err(ResolveError.Sha256Mismatch(groupArtifact, resolved.artifact.klibSha256, actualHash))
+        }
+
+        resolvedDeps.add(
+            ResolvedDep(
+                groupArtifact = groupArtifact,
+                version = version,
+                sha256 = actualHash,
+                cachePath = klibCachePath,
+                transitive = !isDirect
+            )
+        )
+    }
+
+    return Ok(ResolveResult(deps = resolvedDeps, lockChanged = false))
+}
+
+/**
+ * Fetches and parses both the root `.module` (for the available-at redirect)
+ * and the platform-specific `.module` (for the klib file + dependencies) for
+ * a single coordinate.
+ */
+private fun fetchNativeMetadata(
+    groupArtifact: String,
+    version: String,
+    nativeTarget: String,
+    cacheBase: String,
+    repos: List<String>,
+    deps: ResolverDeps
+): Result<NativeResolved, ResolveError> {
+    val rootCoord = parseCoordinate(groupArtifact, version).getOrElse {
+        return Err(ResolveError.InvalidDependency(groupArtifact))
+    }
+
+    val rootJson = fetchAndRead(
+        coord = rootCoord,
+        relativePath = buildModuleCachePath(rootCoord),
+        urlBuilder = { buildModuleDownloadUrl(rootCoord, it) },
+        cacheBase = cacheBase,
+        repos = repos,
+        deps = deps
+    ).getOrElse { return Err(it) }
+
+    val redirect = parseNativeRedirect(rootJson, nativeTarget)
+        ?: return Err(ResolveError.NoNativeVariant(groupArtifact, nativeTarget))
+
+    val targetCoord = Coordinate(redirect.group, redirect.module, redirect.version)
+    val targetJson = fetchAndRead(
+        coord = targetCoord,
+        relativePath = buildModuleCachePath(targetCoord),
+        urlBuilder = { buildModuleDownloadUrl(targetCoord, it) },
+        cacheBase = cacheBase,
+        repos = repos,
+        deps = deps
+    ).getOrElse { return Err(it) }
+
+    val artifact = parseNativeArtifact(targetJson, nativeTarget)
+        ?: return Err(ResolveError.MetadataFetchFailed(groupArtifact))
+
+    return Ok(NativeResolved(redirect, artifact))
+}
+
+/**
+ * Downloads a file from the first available repository if it is not yet on
+ * disk, then reads and returns its contents. Used for `.module` fetches.
+ */
+private fun fetchAndRead(
+    coord: Coordinate,
+    relativePath: String,
+    urlBuilder: (String) -> String,
+    cacheBase: String,
+    repos: List<String>,
+    deps: ResolverDeps
+): Result<String, ResolveError> {
+    val groupArtifact = "${coord.group}:${coord.artifact}"
+    val cachePath = "$cacheBase/$relativePath"
+
+    if (!deps.fileExists(cachePath)) {
+        val parentDir = cachePath.substringBeforeLast('/')
+        deps.ensureDirectoryRecursive(parentDir).getOrElse {
+            return Err(ResolveError.DirectoryCreateFailed(parentDir))
+        }
+        downloadFromRepositories(repos, cachePath, urlBuilder, deps::downloadFile).getOrElse {
+            return Err(ResolveError.DownloadFailed(groupArtifact, it))
+        }
+    }
+    val content = deps.readFileContent(cachePath).getOrElse {
+        return Err(ResolveError.MetadataFetchFailed(groupArtifact))
+    }
+    return Ok(content)
+}

--- a/src/nativeMain/kotlin/keel/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/keel/resolve/NativeResolver.kt
@@ -54,10 +54,6 @@ fun resolveNative(
         }
     }
 
-    val directKeys = config.dependencies.keys
-        .filterNot { isKotlinStdlib(it) }
-        .toSet()
-
     // resolvedVersions: groupArtifact -> (version, isDirect)
     val resolvedVersions = mutableMapOf<String, Pair<String, Boolean>>()
     val queue = ArrayDeque<Pair<String, String>>()
@@ -109,10 +105,9 @@ fun resolveNative(
     // BFS visits every version that ends up in resolvedVersions.
     val resolvedDeps = mutableListOf<ResolvedDep>()
     for ((groupArtifact, versionAndDirect) in resolvedVersions) {
-        val (version, _) = versionAndDirect
-        val isDirect = groupArtifact in directKeys
+        val (version, isDirect) = versionAndDirect
         val resolved = processed["$groupArtifact:$version"]
-            ?: return Err(ResolveError.MetadataFetchFailed(groupArtifact))
+            ?: return Err(ResolveError.MetadataParseFailed(groupArtifact))
 
         val targetCoord = Coordinate(
             resolved.redirect.group,
@@ -181,6 +176,9 @@ private fun fetchNativeMetadata(
         deps = deps
     ).getOrElse { return Err(it) }
 
+    if (!isValidGradleModuleJson(rootJson)) {
+        return Err(ResolveError.MetadataParseFailed(groupArtifact))
+    }
     val redirect = parseNativeRedirect(rootJson, nativeTarget)
         ?: return Err(ResolveError.NoNativeVariant(groupArtifact, nativeTarget))
 
@@ -194,8 +192,11 @@ private fun fetchNativeMetadata(
         deps = deps
     ).getOrElse { return Err(it) }
 
+    if (!isValidGradleModuleJson(targetJson)) {
+        return Err(ResolveError.MetadataParseFailed(groupArtifact))
+    }
     val artifact = parseNativeArtifact(targetJson, nativeTarget)
-        ?: return Err(ResolveError.MetadataFetchFailed(groupArtifact))
+        ?: return Err(ResolveError.MetadataParseFailed(groupArtifact))
 
     return Ok(NativeResolved(redirect, artifact))
 }

--- a/src/nativeMain/kotlin/keel/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/keel/resolve/Resolver.kt
@@ -18,6 +18,7 @@ sealed class ResolveError {
     data class HashComputeFailed(val groupArtifact: String, val error: Sha256Error) : ResolveError()
     data class DirectoryCreateFailed(val path: String) : ResolveError()
     data class NoNativeVariant(val groupArtifact: String, val nativeTarget: String) : ResolveError()
+    data class MetadataParseFailed(val groupArtifact: String) : ResolveError()
     data class MetadataFetchFailed(val groupArtifact: String) : ResolveError()
 }
 
@@ -33,8 +34,10 @@ fun formatResolveError(error: ResolveError): String = when (error) {
     is ResolveError.DirectoryCreateFailed -> "error: could not create directory ${error.path}"
     is ResolveError.NoNativeVariant ->
         "error: ${error.groupArtifact} has no Kotlin/Native variant for target '${error.nativeTarget}'"
+    is ResolveError.MetadataParseFailed ->
+        "error: failed to parse Gradle module metadata for ${error.groupArtifact}"
     is ResolveError.MetadataFetchFailed ->
-        "error: failed to fetch or parse Gradle module metadata for ${error.groupArtifact}"
+        "error: failed to read Gradle module metadata for ${error.groupArtifact}"
 }
 
 data class ResolvedDep(

--- a/src/nativeMain/kotlin/keel/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/keel/resolve/Resolver.kt
@@ -17,6 +17,8 @@ sealed class ResolveError {
     data class DownloadFailed(val groupArtifact: String, val error: DownloadError) : ResolveError()
     data class HashComputeFailed(val groupArtifact: String, val error: Sha256Error) : ResolveError()
     data class DirectoryCreateFailed(val path: String) : ResolveError()
+    data class NoNativeVariant(val groupArtifact: String, val nativeTarget: String) : ResolveError()
+    data class MetadataFetchFailed(val groupArtifact: String) : ResolveError()
 }
 
 fun formatResolveError(error: ResolveError): String = when (error) {
@@ -29,6 +31,10 @@ fun formatResolveError(error: ResolveError): String = when (error) {
     is ResolveError.DownloadFailed -> "error: failed to download ${error.groupArtifact}"
     is ResolveError.HashComputeFailed -> "error: failed to compute hash for ${error.groupArtifact}"
     is ResolveError.DirectoryCreateFailed -> "error: could not create directory ${error.path}"
+    is ResolveError.NoNativeVariant ->
+        "error: ${error.groupArtifact} has no Kotlin/Native variant for target '${error.nativeTarget}'"
+    is ResolveError.MetadataFetchFailed ->
+        "error: failed to fetch or parse Gradle module metadata for ${error.groupArtifact}"
 }
 
 data class ResolvedDep(
@@ -57,7 +63,9 @@ fun resolve(
     existingLock: Lockfile?,
     cacheBase: String,
     deps: ResolverDeps
-): Result<ResolveResult, ResolveError> = resolveTransitive(config, existingLock, cacheBase, deps)
+): Result<ResolveResult, ResolveError> =
+    if (config.target == "native") resolveNative(config, cacheBase, deps)
+    else resolveTransitive(config, existingLock, cacheBase, deps)
 
 fun buildLockfileFromResolved(config: KeelConfig, deps: List<ResolvedDep>): Lockfile {
     return Lockfile(

--- a/src/nativeTest/kotlin/keel/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/keel/build/BuilderTest.kt
@@ -388,6 +388,48 @@ class BuilderTest {
     }
 
     @Test
+    fun nativeBuildCommandWithSingleKlib() {
+        val cmd = nativeBuildCommand(
+            testConfig(target = "native"),
+            klibs = listOf("/cache/lib.klib")
+        )
+
+        assertEquals(
+            listOf("konanc", "src", "-p", "program", "-e", "com.example.main", "-l", "/cache/lib.klib", "-o", "build/my-app"),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeBuildCommandWithMultipleKlibsRepeatsLFlag() {
+        // -library is single-argument per library: NOT colon/comma-joined.
+        val cmd = nativeBuildCommand(
+            testConfig(target = "native"),
+            klibs = listOf("/cache/a.klib", "/cache/b.klib", "/cache/c.klib")
+        )
+
+        assertEquals(
+            listOf(
+                "konanc", "src",
+                "-p", "program",
+                "-e", "com.example.main",
+                "-l", "/cache/a.klib",
+                "-l", "/cache/b.klib",
+                "-l", "/cache/c.klib",
+                "-o", "build/my-app"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeBuildCommandEmptyKlibsOmitsLibraryFlag() {
+        val cmd = nativeBuildCommand(testConfig(target = "native"), klibs = emptyList())
+
+        assertFalse(cmd.args.contains("-l"))
+    }
+
+    @Test
     fun nativeEntryPointStripsClassNameAndAppendsMain() {
         assertEquals("com.example.main", nativeEntryPoint(testConfig()))
     }

--- a/src/nativeTest/kotlin/keel/resolve/DependencyTest.kt
+++ b/src/nativeTest/kotlin/keel/resolve/DependencyTest.kt
@@ -162,6 +162,26 @@ class DependencyTest {
     // --- klib helpers ---
 
     @Test
+    fun buildKlibDownloadUrlProducesCorrectMavenCentralUrl() {
+        val coord = Coordinate("org.jetbrains.kotlinx", "kotlinx-coroutines-core-linuxx64", "1.9.0")
+        val url = buildKlibDownloadUrl(coord, MAVEN_CENTRAL_BASE)
+        assertEquals(
+            "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-linuxx64/1.9.0/kotlinx-coroutines-core-linuxx64-1.9.0.klib",
+            url
+        )
+    }
+
+    @Test
+    fun buildKlibDownloadUrlWithCustomBaseUrl() {
+        val coord = Coordinate("com.example", "lib-linuxx64", "1.0.0")
+        val url = buildKlibDownloadUrl(coord, "https://nexus.example.com/repository/maven-public")
+        assertEquals(
+            "https://nexus.example.com/repository/maven-public/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib",
+            url
+        )
+    }
+
+    @Test
     fun buildKlibCachePathProducesRelativePath() {
         val coord = Coordinate("org.jetbrains.kotlinx", "atomicfu-linuxx64", "0.25.0")
         val path = buildKlibCachePath(coord)

--- a/src/nativeTest/kotlin/keel/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/keel/resolve/NativeResolverTest.kt
@@ -341,7 +341,9 @@ class NativeResolverTest {
     }
 
     @Test
-    fun failsOnMetadataParseError() {
+    fun failsOnInvalidJsonWithMetadataParseFailed() {
+        // Broken JSON must not surface as NoNativeVariant — the user would
+        // mistake it for "this library has no linux_x64 build".
         val config = testConfig(target = "native").copy(
             dependencies = mapOf("com.example:lib" to "1.0.0")
         )
@@ -353,8 +355,7 @@ class NativeResolverTest {
         )
 
         val result = resolveNative(config, "/cache", deps)
-        val error = assertIs<ResolveError.NoNativeVariant>(result.getError())
-        // Invalid JSON surfaces as NoNativeVariant because parseNativeRedirect returns null
+        val error = assertIs<ResolveError.MetadataParseFailed>(result.getError())
         assertEquals("com.example:lib", error.groupArtifact)
     }
 

--- a/src/nativeTest/kotlin/keel/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/keel/resolve/NativeResolverTest.kt
@@ -1,0 +1,458 @@
+package keel.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import keel.infra.DownloadError
+import keel.infra.MkdirFailed
+import keel.infra.OpenFailed
+import keel.infra.Sha256Error
+import keel.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class NativeResolverTest {
+
+    @Test
+    fun resolvesDirectDepWithNoTransitives() {
+        val config = testConfig(target = "native").copy(
+            dependencies = mapOf("com.example:lib" to "1.0.0")
+        )
+
+        val rootModule = rootModuleJson(
+            redirectGroup = "com.example",
+            redirectModule = "lib-linuxx64",
+            redirectVersion = "1.0.0"
+        )
+        val platformModule = platformModuleJson(
+            klibFileName = "lib-linuxx64-1.0.0.klib",
+            klibSha256 = "hash1",
+            dependencies = emptyList()
+        )
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to rootModule,
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to platformModule
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "hash1"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+
+        val resolved = assertNotNull(result.get())
+        assertEquals(1, resolved.deps.size)
+        assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
+        assertEquals("1.0.0", resolved.deps[0].version)
+        assertEquals("hash1", resolved.deps[0].sha256)
+        assertEquals(
+            "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib",
+            resolved.deps[0].cachePath
+        )
+        assertFalse(resolved.deps[0].transitive)
+    }
+
+    @Test
+    fun resolvesSingleTransitiveDep() {
+        val config = testConfig(target = "native").copy(
+            dependencies = mapOf("com.example:lib" to "1.0.0")
+        )
+
+        val libRoot = rootModuleJson("com.example", "lib-linuxx64", "1.0.0")
+        val libPlatform = platformModuleJson(
+            klibFileName = "lib-linuxx64-1.0.0.klib",
+            klibSha256 = "h-lib",
+            dependencies = listOf(
+                NativeDependency("com.example", "trans", "2.0.0")
+            )
+        )
+        val transRoot = rootModuleJson("com.example", "trans-linuxx64", "2.0.0")
+        val transPlatform = platformModuleJson(
+            klibFileName = "trans-linuxx64-2.0.0.klib",
+            klibSha256 = "h-trans",
+            dependencies = emptyList()
+        )
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to libRoot,
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to libPlatform,
+                "/cache/com/example/trans/2.0.0/trans-2.0.0.module" to transRoot,
+                "/cache/com/example/trans-linuxx64/2.0.0/trans-linuxx64-2.0.0.module" to transPlatform
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "h-lib",
+                "/cache/com/example/trans-linuxx64/2.0.0/trans-linuxx64-2.0.0.klib" to "h-trans"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        assertEquals(2, resolved.deps.size)
+
+        val direct = resolved.deps.first { it.groupArtifact == "com.example:lib" }
+        assertFalse(direct.transitive)
+
+        val transitive = resolved.deps.first { it.groupArtifact == "com.example:trans" }
+        assertTrue(transitive.transitive)
+        assertEquals("2.0.0", transitive.version)
+    }
+
+    @Test
+    fun skipsKotlinStdlibFromTransitives() {
+        val config = testConfig(target = "native").copy(
+            dependencies = mapOf("com.example:lib" to "1.0.0")
+        )
+
+        val libRoot = rootModuleJson("com.example", "lib-linuxx64", "1.0.0")
+        val libPlatform = platformModuleJson(
+            klibFileName = "lib-linuxx64-1.0.0.klib",
+            klibSha256 = "h",
+            dependencies = listOf(
+                NativeDependency("org.jetbrains.kotlin", "kotlin-stdlib", "2.0.0")
+            )
+        )
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to libRoot,
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to libPlatform
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "h"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        // kotlin-stdlib should NOT appear in resolved deps
+        assertEquals(1, resolved.deps.size)
+        assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
+    }
+
+    @Test
+    fun skipsKotlinStdlibAsDirectDependencyToo() {
+        val config = testConfig(target = "native").copy(
+            dependencies = mapOf(
+                "com.example:lib" to "1.0.0",
+                "org.jetbrains.kotlin:kotlin-stdlib" to "2.0.0"
+            )
+        )
+
+        val libRoot = rootModuleJson("com.example", "lib-linuxx64", "1.0.0")
+        val libPlatform = platformModuleJson("lib-linuxx64-1.0.0.klib", "h", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to libRoot,
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to libPlatform
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "h"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        assertEquals(1, resolved.deps.size)
+        assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
+    }
+
+    @Test
+    fun returnsEmptyWhenNoDependencies() {
+        val config = testConfig(target = "native").copy(dependencies = emptyMap())
+        val deps = fakeDeps()
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        assertEquals(0, resolved.deps.size)
+        assertFalse(resolved.lockChanged)
+    }
+
+    @Test
+    fun failsWhenNoNativeVariantAvailable() {
+        val config = testConfig(target = "native").copy(
+            dependencies = mapOf("com.example:jvmonly" to "1.0.0")
+        )
+
+        // Module only has a jvm variant
+        val jvmOnlyModule = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "jvmApiElements-published",
+              "attributes": {
+                "org.jetbrains.kotlin.platform.type": "jvm"
+              },
+              "available-at": {
+                "url": "../../jvmonly-jvm/1.0.0/jvmonly-jvm-1.0.0.module",
+                "group": "com.example",
+                "module": "jvmonly-jvm",
+                "version": "1.0.0"
+              }
+            }
+          ]
+        }
+        """.trimIndent()
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/jvmonly/1.0.0/jvmonly-1.0.0.module" to jvmOnlyModule
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val error = assertIs<ResolveError.NoNativeVariant>(result.getError())
+        assertEquals("com.example:jvmonly", error.groupArtifact)
+        assertEquals("linux_x64", error.nativeTarget)
+    }
+
+    @Test
+    fun failsOnSha256Mismatch() {
+        val config = testConfig(target = "native").copy(
+            dependencies = mapOf("com.example:lib" to "1.0.0")
+        )
+
+        val root = rootModuleJson("com.example", "lib-linuxx64", "1.0.0")
+        val platform = platformModuleJson("lib-linuxx64-1.0.0.klib", "expected-hash", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to root,
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to platform
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "actual-hash"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val error = assertIs<ResolveError.Sha256Mismatch>(result.getError())
+        assertEquals("com.example:lib", error.groupArtifact)
+        assertEquals("expected-hash", error.expected)
+        assertEquals("actual-hash", error.actual)
+    }
+
+    @Test
+    fun diamondDependencyHighestVersionWins() {
+        // a -> shared:1.0, b -> shared:2.0 => shared:2.0 should win
+        val config = testConfig(target = "native").copy(
+            dependencies = mapOf(
+                "com.example:a" to "1.0.0",
+                "com.example:b" to "1.0.0"
+            )
+        )
+
+        val aRoot = rootModuleJson("com.example", "a-linuxx64", "1.0.0")
+        val aPlatform = platformModuleJson(
+            "a-linuxx64-1.0.0.klib", "h-a",
+            listOf(NativeDependency("com.example", "shared", "1.0.0"))
+        )
+        val bRoot = rootModuleJson("com.example", "b-linuxx64", "1.0.0")
+        val bPlatform = platformModuleJson(
+            "b-linuxx64-1.0.0.klib", "h-b",
+            listOf(NativeDependency("com.example", "shared", "2.0.0"))
+        )
+        val sharedRoot20 = rootModuleJson("com.example", "shared-linuxx64", "2.0.0")
+        val sharedPlatform20 = platformModuleJson("shared-linuxx64-2.0.0.klib", "h-s20", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/a/1.0.0/a-1.0.0.module" to aRoot,
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.module" to aPlatform,
+                "/cache/com/example/b/1.0.0/b-1.0.0.module" to bRoot,
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.module" to bPlatform,
+                "/cache/com/example/shared/2.0.0/shared-2.0.0.module" to sharedRoot20,
+                "/cache/com/example/shared-linuxx64/2.0.0/shared-linuxx64-2.0.0.module" to sharedPlatform20
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.klib" to "h-a",
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.klib" to "h-b",
+                "/cache/com/example/shared-linuxx64/2.0.0/shared-linuxx64-2.0.0.klib" to "h-s20"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        assertEquals(3, resolved.deps.size)
+
+        val shared = resolved.deps.first { it.groupArtifact == "com.example:shared" }
+        assertEquals("2.0.0", shared.version)
+        assertTrue(shared.transitive)
+    }
+
+    @Test
+    fun directDepVersionWinsOverTransitive() {
+        // direct: shared:1.0, transitive from a: shared:2.0 => direct wins
+        val config = testConfig(target = "native").copy(
+            dependencies = mapOf(
+                "com.example:a" to "1.0.0",
+                "com.example:shared" to "1.0.0"
+            )
+        )
+
+        val aRoot = rootModuleJson("com.example", "a-linuxx64", "1.0.0")
+        val aPlatform = platformModuleJson(
+            "a-linuxx64-1.0.0.klib", "h-a",
+            listOf(NativeDependency("com.example", "shared", "2.0.0"))
+        )
+        val sharedRoot10 = rootModuleJson("com.example", "shared-linuxx64", "1.0.0")
+        val sharedPlatform10 = platformModuleJson("shared-linuxx64-1.0.0.klib", "h-s10", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/a/1.0.0/a-1.0.0.module" to aRoot,
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.module" to aPlatform,
+                "/cache/com/example/shared/1.0.0/shared-1.0.0.module" to sharedRoot10,
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.module" to sharedPlatform10
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.klib" to "h-a",
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.klib" to "h-s10"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        val shared = resolved.deps.first { it.groupArtifact == "com.example:shared" }
+        assertEquals("1.0.0", shared.version)
+        assertFalse(shared.transitive)
+    }
+
+    @Test
+    fun failsOnInvalidCoordinate() {
+        val config = testConfig(target = "native").copy(
+            dependencies = mapOf("invalid-no-colon" to "1.0.0")
+        )
+        val deps = fakeDeps()
+
+        val result = resolveNative(config, "/cache", deps)
+        val error = assertIs<ResolveError.InvalidDependency>(result.getError())
+        assertEquals("invalid-no-colon", error.input)
+    }
+
+    @Test
+    fun failsOnMetadataParseError() {
+        val config = testConfig(target = "native").copy(
+            dependencies = mapOf("com.example:lib" to "1.0.0")
+        )
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to "not json"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val error = assertIs<ResolveError.NoNativeVariant>(result.getError())
+        // Invalid JSON surfaces as NoNativeVariant because parseNativeRedirect returns null
+        assertEquals("com.example:lib", error.groupArtifact)
+    }
+
+    // --- fixtures ---
+
+    private fun rootModuleJson(
+        redirectGroup: String,
+        redirectModule: String,
+        redirectVersion: String
+    ): String = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../$redirectModule/$redirectVersion/$redirectModule-$redirectVersion.module",
+                "group": "$redirectGroup",
+                "module": "$redirectModule",
+                "version": "$redirectVersion"
+              }
+            }
+          ]
+        }
+    """.trimIndent()
+
+    private fun platformModuleJson(
+        klibFileName: String,
+        klibSha256: String,
+        dependencies: List<NativeDependency>
+    ): String {
+        val depsJson = dependencies.joinToString(",\n") { d ->
+            """
+              {
+                "group": "${d.group}",
+                "module": "${d.module}",
+                "version": { "requires": "${d.version}" }
+              }
+            """.trimIndent()
+        }
+        return """
+            {
+              "formatVersion": "1.1",
+              "variants": [
+                {
+                  "name": "linuxX64ApiElements-published",
+                  "attributes": {
+                    "org.gradle.category": "library",
+                    "org.gradle.usage": "kotlin-api",
+                    "org.jetbrains.kotlin.native.target": "linux_x64",
+                    "org.jetbrains.kotlin.platform.type": "native"
+                  },
+                  "dependencies": [$depsJson],
+                  "files": [
+                    {
+                      "name": "inner.klib",
+                      "url": "$klibFileName",
+                      "sha256": "$klibSha256"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+    }
+
+    private fun fakeDeps(
+        cachedFiles: MutableSet<String> = mutableSetOf(),
+        contents: Map<String, String> = emptyMap(),
+        sha256: Map<String, String> = emptyMap()
+    ): ResolverDeps {
+        // Files whose content is provided are considered already cached on disk.
+        cachedFiles.addAll(contents.keys)
+        return object : ResolverDeps {
+            override fun fileExists(path: String): Boolean = path in cachedFiles
+
+            override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+            override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+                cachedFiles.add(destPath)
+                return Ok(Unit)
+            }
+
+            override fun computeSha256(filePath: String): Result<String, Sha256Error> {
+                val hash = sha256[filePath] ?: return Err(Sha256Error(filePath))
+                return Ok(hash)
+            }
+
+            override fun readFileContent(path: String): Result<String, OpenFailed> {
+                val content = contents[path] ?: return Err(OpenFailed(path))
+                return Ok(content)
+            }
+        }
+    }
+}

--- a/src/nativeTest/kotlin/keel/resolve/ResolveErrorFormatTest.kt
+++ b/src/nativeTest/kotlin/keel/resolve/ResolveErrorFormatTest.kt
@@ -50,4 +50,22 @@ class ResolveErrorFormatTest {
         val error = ResolveError.DirectoryCreateFailed("/cache/dir")
         assertEquals("error: could not create directory /cache/dir", formatResolveError(error))
     }
+
+    @Test
+    fun noNativeVariantFormat() {
+        val error = ResolveError.NoNativeVariant("com.example:lib", "linux_x64")
+        assertEquals(
+            "error: com.example:lib has no Kotlin/Native variant for target 'linux_x64'",
+            formatResolveError(error)
+        )
+    }
+
+    @Test
+    fun metadataFetchFailedFormat() {
+        val error = ResolveError.MetadataFetchFailed("com.example:lib")
+        assertEquals(
+            "error: failed to fetch or parse Gradle module metadata for com.example:lib",
+            formatResolveError(error)
+        )
+    }
 }

--- a/src/nativeTest/kotlin/keel/resolve/ResolveErrorFormatTest.kt
+++ b/src/nativeTest/kotlin/keel/resolve/ResolveErrorFormatTest.kt
@@ -61,10 +61,19 @@ class ResolveErrorFormatTest {
     }
 
     @Test
+    fun metadataParseFailedFormat() {
+        val error = ResolveError.MetadataParseFailed("com.example:lib")
+        assertEquals(
+            "error: failed to parse Gradle module metadata for com.example:lib",
+            formatResolveError(error)
+        )
+    }
+
+    @Test
     fun metadataFetchFailedFormat() {
         val error = ResolveError.MetadataFetchFailed("com.example:lib")
         assertEquals(
-            "error: failed to fetch or parse Gradle module metadata for com.example:lib",
+            "error: failed to read Gradle module metadata for com.example:lib",
             formatResolveError(error)
         )
     }


### PR DESCRIPTION
## Summary
Second of two PRs for #16 Phase B. Builds on the pure parser from #53 to wire Gradle Module Metadata → \`.klib\` resolution into the build pipeline, then feeds the resolved klibs into \`konanc -library\`. After this merges, a \`target = \"native\"\` project can depend on multiplatform libraries like \`kotlinx-coroutines-core\` and build an executable that links them correctly.

## What changes

- **\`NativeResolver.kt\` (new, 231 LoC)** — BFS over root \`.module\` → \`available-at\` redirect → platform \`.module\` → \`.klib\`, with transitive dependency recursion and version conflict resolution. Rules mirror the JVM resolver: direct deps always win, among transitives highest version wins. \`kotlin-stdlib\` is explicitly skipped at every level because konanc bundles its own stdlib.
- **\`Resolver.kt\`** — \`resolve()\` now routes on \`config.target\`: \`native\` → \`resolveNative\`, otherwise the existing POM-based \`resolveTransitive\`. Two new \`ResolveError\` variants (\`NoNativeVariant\`, \`MetadataFetchFailed\`) with \`formatResolveError\` output.
- **\`Dependency.kt\`** — brings back \`buildKlibDownloadUrl\` (it was YAGNI-deleted in #53, but the native resolver needs it now).
- **\`Builder.kt\`** — \`nativeBuildCommand\` accepts \`klibs: List<String>\` and expands one \`-l\` flag per library. konanc \`-library\` / \`-l\` is one-argument-per-library and must not be colon-joined like \`-cp\`.
- **\`BuildCommands.kt\`** — \`doNativeBuild\` calls a new \`resolveNativeDependencies\` helper and threads the \`.klib\` paths into \`nativeBuildCommand\`. Lockfile is not consulted or written for native in Phase B (native lockfile is a follow-up).

### Resolver BFS design notes

- A \`(groupArtifact, version)\` pair is metadata-fetched lazily inside the loop, but entries whose version has been superseded while waiting in the queue are skipped before the fetch — this keeps us from downloading \`.module\` files for versions we will never use, and (helpfully) means tests only need to supply fixtures for the winning version.
- Each direct dep is validated up front via \`parseCoordinate\` so invalid \`group:artifact\` inputs fail fast.
- Sha256 is verified against the value in the platform module's \`files[].sha256\`, not a sidecar fetch — Gradle metadata already carries the hash.

## Out of scope
- Lockfile v3 with native target awareness — the native path ignores \`keel.lock\` entirely in Phase B
- Cross-platform targets (macOS, Windows, iOS) — hardcoded to \`linux_x64\`
- Source JARs / \`-sources\` variants
- Gradle metadata \`strictly\` / \`prefers\` / \`rejects\` (tracked in #54)

## Test plan

- [x] \`./gradlew linuxX64Test\` passes
- [x] Unit tests:
  - \`NativeResolverTest\`: 11 cases — direct dep no transitives, single transitive, stdlib skip (transitive + direct), empty deps, \`NoNativeVariant\`, sha256 mismatch, diamond highest-wins, direct-wins-over-transitive, invalid coordinate, metadata parse error
  - \`BuilderTest\`: 4 new cases for \`nativeBuildCommand\` klibs (single, multiple repeating \`-l\`, empty, combined with entry point)
  - \`DependencyTest\`: 2 cases for \`buildKlibDownloadUrl\`
  - \`ResolveErrorFormatTest\`: 2 cases for the new error variants
- [x] End-to-end with a local \`test_project\`:
  - \`keel.toml\` with \`target = \"native\"\` and \`\"org.jetbrains.kotlinx:kotlinx-coroutines-core\" = \"1.9.0\"\`
  - \`keel build\` downloads and caches the coroutines + atomicfu \`.module\` and \`.klib\` files under \`~/.keel/cache/\`, resolves atomicfu transitively, compiles with \`konanc -l\` per klib, produces \`build/coroutines-native.kexe\`
  - \`keel run\` executes the binary and prints \`before delay\` / \`after delay\` from a \`runBlocking { delay(10); println(...) }\` program
  - Expected non-fatal warning \`Could not find \"org.jetbrains.kotlinx:atomicfu-cinterop-interop\"\` is still emitted by konanc (per the Phase B spike findings) and does not block the build

## Related
- #16 (parent, stays open)
- #53 (#16 Phase B-1, parser PR — merged)
- #54 (follow-up: \`strictly\` / \`prefers\` / \`rejects\` version constraints)