### PR TITLE
Support keel test for Kotlin/Native target (Phase D)

### DIFF
--- a/.claude/skills/keel-usage/SKILL.md
+++ b/.claude/skills/keel-usage/SKILL.md
@@ -147,3 +147,5 @@ Stored at `~/.keel/toolchains/kotlinc/{version}/`. Used automatically when avail
 | 4 | Test error |
 | 5 | Format error |
 | 127 | Command not found |
+
+Note: `keel test` can exit with codes other than 0 or 4. Dependency resolution failures (e.g. a klib that cannot be fetched during native test) exit with `3`, test source compilation failures exit with `1`. Only actual test-runner failures (non-zero exit from the test binary) produce `4`. CI pipelines that branch on "tests failed vs other error" should check `== 4` rather than `!= 0`.

--- a/.claude/skills/keel-usage/SKILL.md
+++ b/.claude/skills/keel-usage/SKILL.md
@@ -100,7 +100,7 @@ keel add --test io.kotest:kotest-runner-junit5:5.8.0      # test dependency
 
 ## Testing
 
-keel auto-injects `kotlin-test-junit5` matching the Kotlin version. Just use `kotlin.test`:
+Just use `kotlin.test`:
 
 ```kotlin
 import kotlin.test.Test
@@ -114,12 +114,14 @@ class MyTest {
 }
 ```
 
-Runs via JUnit Platform Console Standalone. Supports kotlin.test, JUnit 5, and Kotest.
-
 ```sh
 keel test
-keel test -- --include-classname ".*IntegrationTest"
+keel test -- <extra runner args>
 ```
+
+**JVM target (`target = "jvm"`):** keel auto-injects `kotlin-test-junit5` matching the Kotlin version and runs via JUnit Platform Console Standalone. Supports kotlin.test, JUnit 5, and Kotest. Extra args are forwarded to the console launcher, e.g. `keel test -- --include-classname ".*IntegrationTest"`.
+
+**Native target (`target = "native"`):** keel compiles main + test sources in a single `konanc -generate-test-runner` invocation and executes the resulting `build/<name>-test.kexe`. `kotlin.test` is provided by the bundled Kotlin/Native stdlib — no test dependency needs to be declared. Extra args are forwarded to the native test runner, e.g. `keel test -- --ktest_filter=MyTest.*` or `--ktest_logger=SIMPLE`. The test executable exits non-zero on any failed test.
 
 ## Toolchain Management
 

--- a/src/nativeMain/kotlin/keel/build/Builder.kt
+++ b/src/nativeMain/kotlin/keel/build/Builder.kt
@@ -9,6 +9,8 @@ internal fun outputJarPath(config: KeelConfig): String = "$BUILD_DIR/${config.na
 
 internal fun outputKexePath(config: KeelConfig): String = "$BUILD_DIR/${config.name}.kexe"
 
+internal fun outputNativeTestKexePath(config: KeelConfig): String = "$BUILD_DIR/${config.name}-test.kexe"
+
 // Derives the Kotlin/Native entry point FQN from config.main.
 //
 // config.main is a JVM-style class name (e.g. "com.example.MainKt"). For
@@ -106,6 +108,35 @@ fun nativeBuildCommand(
         add("-o")
         add(outputBase)
         addAll(pluginArgs)
+    }
+    return BuildCommand(args = args, outputPath = outputPath)
+}
+
+// Builds a konanc command that compiles main + test sources together and
+// asks the compiler to synthesize a test runner main() via -generate-test-runner.
+// The resulting kexe exits non-zero on any test failure. Unlike nativeBuildCommand
+// we intentionally omit -e: the synthesized runner provides the entry point, and
+// passing -e in addition would conflict with it.
+fun nativeTestBuildCommand(
+    config: KeelConfig,
+    konancPath: String? = null,
+    klibs: List<String> = emptyList()
+): BuildCommand {
+    val outputPath = outputNativeTestKexePath(config)
+    val outputBase = "$BUILD_DIR/${config.name}-test"
+    val args = buildList {
+        add(konancPath ?: "konanc")
+        addAll(config.sources)
+        addAll(config.testSources)
+        add("-p")
+        add("program")
+        add("-generate-test-runner")
+        for (klib in klibs) {
+            add("-l")
+            add(klib)
+        }
+        add("-o")
+        add(outputBase)
     }
     return BuildCommand(args = args, outputPath = outputPath)
 }

--- a/src/nativeMain/kotlin/keel/build/Runner.kt
+++ b/src/nativeMain/kotlin/keel/build/Runner.kt
@@ -22,3 +22,11 @@ fun nativeRunCommand(
     config: KeelConfig,
     appArgs: List<String> = emptyList()
 ): RunCommand = RunCommand(args = listOf(outputKexePath(config)) + appArgs)
+
+// Invokes the test kexe produced by nativeTestBuildCommand. testArgs are passed
+// through verbatim so users can supply kotlin.native test flags such as
+// --ktest_filter, --ktest_logger, --ktest_negative_filter.
+fun nativeTestRunCommand(
+    config: KeelConfig,
+    testArgs: List<String> = emptyList()
+): RunCommand = RunCommand(args = listOf(outputNativeTestKexePath(config)) + testArgs)

--- a/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/keel/cli/BuildCommands.kt
@@ -251,13 +251,14 @@ internal fun doRun(config: KeelConfig, classpath: String?, appArgs: List<String>
 }
 
 internal fun doTest(testArgs: List<String> = emptyList()) {
-    // Load the config once up front to fail fast on unsupported targets
-    // before entering doBuild. doBuild will load it again for the jvm path;
-    // this is the cost of keeping the native guard here.
+    // Load the config once up front so we can dispatch on target before doing
+    // any compilation work. The native path compiles main + test in a single
+    // konanc invocation and therefore bypasses doBuild() entirely, unlike the
+    // jvm path which reuses the build artifacts from doBuild().
     val config = loadProjectConfig()
     if (config.target == "native") {
-        eprintln("error: 'keel test' is not yet supported for target = \"native\" (tracked in #16)")
-        exitProcess(EXIT_TEST_ERROR)
+        doNativeTest(config, testArgs)
+        return
     }
     val (_, classpath, pArgs, javaPath) = doBuild()
 
@@ -291,6 +292,54 @@ internal fun doTest(testArgs: List<String> = emptyList()) {
         testArgs = testArgs,
         javaPath = javaPath
     )
+    println("running tests...")
+    executeCommand(runCmd.args).getOrElse { error ->
+        when (error) {
+            is ProcessError.NonZeroExit -> {
+                val elapsed = testStartMark.elapsedNow()
+                eprintln("tests failed in ${formatDuration(elapsed)}")
+            }
+            else -> eprintln("error: failed to run tests")
+        }
+        exitProcess(EXIT_TEST_ERROR)
+    }
+    val elapsed = testStartMark.elapsedNow()
+    println("tests passed in ${formatDuration(elapsed)}")
+}
+
+private fun doNativeTest(config: KeelConfig, testArgs: List<String>) {
+    val existingTestSources = config.testSources.filter { fileExists(it) }
+    if (existingTestSources.isEmpty()) {
+        eprintln("error: no test sources found in ${config.testSources}")
+        exitProcess(EXIT_TEST_ERROR)
+    }
+
+    val testStartMark = TimeSource.Monotonic.markNow()
+
+    val paths = resolveKeelPaths(EXIT_TEST_ERROR)
+    val managedKonancBin = ensureKonancBin(config.kotlin, paths, EXIT_TEST_ERROR)
+
+    val klibs = resolveNativeDependencies(config, paths)
+
+    ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
+        eprintln("error: could not create directory ${error.path}")
+        exitProcess(EXIT_BUILD_ERROR)
+    }
+
+    val testConfig = config.copy(testSources = existingTestSources)
+    val buildCmd = nativeTestBuildCommand(testConfig, konancPath = managedKonancBin, klibs = klibs)
+    println("compiling tests (native)...")
+    executeCommand(buildCmd.args).getOrElse { error ->
+        eprintln(formatProcessError(error, "test compilation"))
+        exitProcess(EXIT_BUILD_ERROR)
+    }
+
+    if (!fileExists(buildCmd.outputPath)) {
+        eprintln("error: ${buildCmd.outputPath} not produced by konanc")
+        exitProcess(EXIT_BUILD_ERROR)
+    }
+
+    val runCmd = nativeTestRunCommand(testConfig, testArgs)
     println("running tests...")
     executeCommand(runCmd.args).getOrElse { error ->
         when (error) {

--- a/src/nativeTest/kotlin/keel/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/keel/build/BuilderTest.kt
@@ -468,6 +468,129 @@ class BuilderTest {
         assertTrue(needsNativeEntryPointWarning(testConfig().copy(main = "Main")))
     }
 
+    // --- nativeTestBuildCommand ---
+
+    @Test
+    fun nativeTestBuildCommandCompilesMainAndTestSourcesWithGeneratedRunner() {
+        val cmd = nativeTestBuildCommand(testConfig(target = "native"))
+
+        assertEquals(
+            listOf(
+                "konanc",
+                "src", "test",
+                "-p", "program",
+                "-generate-test-runner",
+                "-o", "build/my-app-test"
+            ),
+            cmd.args
+        )
+        assertEquals("build/my-app-test.kexe", cmd.outputPath)
+    }
+
+    @Test
+    fun nativeTestBuildCommandDoesNotEmitEntryPointFlag() {
+        // -generate-test-runner makes the compiler synthesize main(); -e would conflict.
+        val cmd = nativeTestBuildCommand(testConfig(target = "native"))
+
+        assertFalse(cmd.args.contains("-e"))
+    }
+
+    @Test
+    fun nativeTestBuildCommandMultipleSourcesAndTestSources() {
+        val cmd = nativeTestBuildCommand(
+            testConfig(
+                sources = listOf("src", "generated"),
+                testSources = listOf("test", "integration-test"),
+                target = "native"
+            )
+        )
+
+        assertEquals(
+            listOf(
+                "konanc",
+                "src", "generated", "test", "integration-test",
+                "-p", "program",
+                "-generate-test-runner",
+                "-o", "build/my-app-test"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeTestBuildCommandWithProjectName() {
+        val cmd = nativeTestBuildCommand(testConfig(name = "hello", target = "native"))
+
+        assertEquals("build/hello-test.kexe", cmd.outputPath)
+        assertEquals(
+            listOf(
+                "konanc",
+                "src", "test",
+                "-p", "program",
+                "-generate-test-runner",
+                "-o", "build/hello-test"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeTestBuildCommandWithManagedKonancPath() {
+        val managedKonanc = "/home/user/.keel/toolchains/konanc/2.1.0/bin/konanc"
+        val cmd = nativeTestBuildCommand(testConfig(target = "native"), konancPath = managedKonanc)
+
+        assertEquals(managedKonanc, cmd.args.first())
+    }
+
+    @Test
+    fun nativeTestBuildCommandWithSingleKlib() {
+        val cmd = nativeTestBuildCommand(
+            testConfig(target = "native"),
+            klibs = listOf("/cache/lib.klib")
+        )
+
+        assertEquals(
+            listOf(
+                "konanc",
+                "src", "test",
+                "-p", "program",
+                "-generate-test-runner",
+                "-l", "/cache/lib.klib",
+                "-o", "build/my-app-test"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeTestBuildCommandWithMultipleKlibsRepeatsLFlag() {
+        val cmd = nativeTestBuildCommand(
+            testConfig(target = "native"),
+            klibs = listOf("/cache/a.klib", "/cache/b.klib", "/cache/c.klib")
+        )
+
+        assertEquals(
+            listOf(
+                "konanc",
+                "src", "test",
+                "-p", "program",
+                "-generate-test-runner",
+                "-l", "/cache/a.klib",
+                "-l", "/cache/b.klib",
+                "-l", "/cache/c.klib",
+                "-o", "build/my-app-test"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeTestBuildCommandEmptyKlibsOmitsLibraryFlag() {
+        val cmd = nativeTestBuildCommand(testConfig(target = "native"), klibs = emptyList())
+
+        assertFalse(cmd.args.contains("-l"))
+    }
+
     @Test
     fun jarCommandWithManagedJarPathPreservesOutputPath() {
         // Given: a managed jar binary path

--- a/src/nativeTest/kotlin/keel/build/RunnerTest.kt
+++ b/src/nativeTest/kotlin/keel/build/RunnerTest.kt
@@ -102,6 +102,32 @@ class RunnerTest {
         assertEquals(listOf("build/hello.kexe"), cmd.args)
     }
 
+    // --- nativeTestRunCommand ---
+
+    @Test
+    fun nativeTestRunCommandExecutesTestKexeBinary() {
+        val cmd = nativeTestRunCommand(testConfig(target = "native"))
+        assertEquals(listOf("build/my-app-test.kexe"), cmd.args)
+    }
+
+    @Test
+    fun nativeTestRunCommandUsesProjectName() {
+        val cmd = nativeTestRunCommand(testConfig(name = "hello", target = "native"))
+        assertEquals(listOf("build/hello-test.kexe"), cmd.args)
+    }
+
+    @Test
+    fun nativeTestRunCommandAppendsTestArgs() {
+        val cmd = nativeTestRunCommand(
+            testConfig(target = "native"),
+            testArgs = listOf("--ktest_filter=MyTest.*", "--ktest_logger=SIMPLE")
+        )
+        assertEquals(
+            listOf("build/my-app-test.kexe", "--ktest_filter=MyTest.*", "--ktest_logger=SIMPLE"),
+            cmd.args
+        )
+    }
+
     @Test
     fun runCommandWithManagedJavaAndAppArgs() {
         // Given: managed java + app arguments


### PR DESCRIPTION
## Summary

- Add native test support via `konanc -generate-test-runner`, closing Phase D of #16.
- `doTest` now dispatches on `target`: the native path compiles main + test sources in a single konanc invocation and executes the resulting `build/<name>-test.kexe` — the kernel exits non-zero on any failed test, which maps onto the existing `ProcessError.NonZeroExit` → `EXIT_TEST_ERROR` flow.
- `kotlin.test` is provided by the konanc-bundled stdlib, so no additional test dependency resolution is needed.

## Approach

Adopted the **single-step** (α) strategy: main and test sources are compiled together with `-generate-test-runner -p program` and no `-e` (the compiler-synthesized runner provides `main()`). `internal` visibility works naturally because both sources live in the same compilation unit. klib deps are passed with repeated `-l` flags, reusing the existing `resolveNativeDependencies` pipeline from Phase B.

The alternative — compile main into a `.klib`, then compile tests against it with `-library` + `-friend-modules` — was considered but deferred. Its only real benefit is incremental recompilation in the "edit tests only" hot loop, and it would require changes to `doNativeBuild` and build-state tracking. If native TDD loops turn out to be painful, that can be a targeted follow-up.

## Changes

- `Builder.kt` — new `nativeTestBuildCommand` and `outputNativeTestKexePath`.
- `Runner.kt` — new `nativeTestRunCommand` that invokes the test kexe and forwards extra args to the native test runner (`--ktest_filter`, `--ktest_logger`, etc.).
- `BuildCommands.kt` — `doTest` dispatches on target; new `doNativeTest` handles the native flow end-to-end.
- `BuilderTest.kt` / `RunnerTest.kt` — 11 new pure-function tests covering flag order, klib expansion, project name suffix, and the explicit non-emission of `-e`.
- `.claude/skills/keel-usage/SKILL.md` — documents the native testing flow and runner args.

## Intentionally out of scope

- Incremental test build (test kexe mtime caching).
- `.klib` friend-modules two-step compile (approach β).
- `keel.toml` surface for test filters / loggers — already usable via `keel test -- --ktest_filter=...`.
- Cross-platform native targets (`linux_x64` only).

## Test plan

- [x] `./gradlew build` passes (includes `linuxX64Test` with 11 new unit tests).
- [x] Manual E2E on a fresh `target = "native"` project:
  - [x] All tests passing → `keel test` exits 0, "tests passed in ..." output.
  - [x] One test failing → `keel test` exits 4 (`EXIT_TEST_ERROR`), failing test names listed, "tests failed in ..." output.
  - [x] No test sources directory → exits 4 with "error: no test sources found in [test]".
  - [x] Test code accesses `internal` declaration from main — compiles and passes.
- [ ] Reviewer spot-check: `keel test -- --ktest_filter=...` forwarding (not exercised in E2E but wired through `testArgs`).

Closes #16.