### PR TITLE
Support Kotlin compiler plugins for Kotlin/Native target

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -11,6 +11,12 @@ internal fun outputKexePath(config: KoltConfig): String = "$BUILD_DIR/${config.n
 
 internal fun outputNativeTestKexePath(config: KoltConfig): String = "$BUILD_DIR/${config.name}-test.kexe"
 
+// Stage 1 output: the unpacked klib directory produced by `konanc -p library -nopack`.
+// Using a `-klib` suffix keeps it distinct from the sibling `<name>.kexe` file.
+internal fun outputNativeKlibPath(config: KoltConfig): String = "$BUILD_DIR/${config.name}-klib"
+
+internal fun outputNativeTestKlibPath(config: KoltConfig): String = "$BUILD_DIR/${config.name}-test-klib"
+
 // Derives the Kotlin/Native entry point FQN from config.main.
 //
 // config.main is a JVM-style class name (e.g. "com.example.MainKt"). For
@@ -84,23 +90,26 @@ fun buildCommand(
     return BuildCommand(args = args, outputPath = CLASSES_DIR)
 }
 
-fun nativeBuildCommand(
+// Native builds run in two stages because konanc silently no-ops compiler
+// plugins (e.g. kotlinx.serialization) on a single-step `-p program` invocation.
+// Stage 1 compiles sources into an unpacked klib with the plugin applied; Stage
+// 2 links that klib into a program binary. This matches what the Kotlin Gradle
+// plugin does: compileKotlinLinuxX64 produces a klib, linkDebugExecutableLinuxX64
+// produces the executable.
+
+fun nativeLibraryCommand(
     config: KoltConfig,
     pluginArgs: List<String> = emptyList(),
     konancPath: String? = null,
     klibs: List<String> = emptyList()
 ): BuildCommand {
-    val outputPath = outputKexePath(config)
-    // konanc -o takes the path without the .kexe extension
-    val outputBase = "$BUILD_DIR/${config.name}"
+    val outputBase = outputNativeKlibPath(config)
     val args = buildList {
         add(konancPath ?: "konanc")
         addAll(config.sources)
         add("-p")
-        add("program")
-        add("-e")
-        add(nativeEntryPoint(config))
-        // -library / -l takes one library per flag; do not join with colons.
+        add("library")
+        add("-nopack")
         for (klib in klibs) {
             add("-l")
             add(klib)
@@ -109,29 +118,54 @@ fun nativeBuildCommand(
         add(outputBase)
         addAll(pluginArgs)
     }
+    return BuildCommand(args = args, outputPath = outputBase)
+}
+
+// Stage 2 consumes the klib produced by nativeLibraryCommand via -Xinclude,
+// which pulls the klib's IR (including the main() function) into the final
+// program. The plugin flag is not needed here — the IR is already transformed.
+// We intentionally omit -e: -Xinclude brings the compiled entry point with it,
+// and passing -e risks conflicting with the linked-in main().
+fun nativeLinkCommand(
+    config: KoltConfig,
+    konancPath: String? = null,
+    klibs: List<String> = emptyList()
+): BuildCommand {
+    val outputPath = outputKexePath(config)
+    val outputBase = "$BUILD_DIR/${config.name}"
+    val klibPath = outputNativeKlibPath(config)
+    val args = buildList {
+        add(konancPath ?: "konanc")
+        add("-p")
+        add("program")
+        for (klib in klibs) {
+            add("-l")
+            add(klib)
+        }
+        add("-Xinclude=$klibPath")
+        add("-o")
+        add(outputBase)
+    }
     return BuildCommand(args = args, outputPath = outputPath)
 }
 
-// Builds a konanc command that compiles main + test sources together and
-// asks the compiler to synthesize a test runner main() via -generate-test-runner.
-// The resulting kexe exits non-zero on any test failure. Unlike nativeBuildCommand
-// we intentionally omit -e: the synthesized runner provides the entry point, and
-// passing -e in addition would conflict with it.
-fun nativeTestBuildCommand(
+// Test Stage 1: compile main + test sources together into a klib. Kotlin/Native
+// test discovery needs the @Test classes to live in a klib so the runner can
+// synthesize a main() that iterates them in Stage 2.
+fun nativeTestLibraryCommand(
     config: KoltConfig,
     pluginArgs: List<String> = emptyList(),
     konancPath: String? = null,
     klibs: List<String> = emptyList()
 ): BuildCommand {
-    val outputPath = outputNativeTestKexePath(config)
-    val outputBase = "$BUILD_DIR/${config.name}-test"
+    val outputBase = outputNativeTestKlibPath(config)
     val args = buildList {
         add(konancPath ?: "konanc")
         addAll(config.sources)
         addAll(config.testSources)
         add("-p")
-        add("program")
-        add("-generate-test-runner")
+        add("library")
+        add("-nopack")
         for (klib in klibs) {
             add("-l")
             add(klib)
@@ -139,6 +173,32 @@ fun nativeTestBuildCommand(
         add("-o")
         add(outputBase)
         addAll(pluginArgs)
+    }
+    return BuildCommand(args = args, outputPath = outputBase)
+}
+
+// Test Stage 2: -generate-test-runner asks the compiler to synthesize a main()
+// that discovers and runs @Test functions pulled in via -Xinclude from the klib.
+fun nativeTestLinkCommand(
+    config: KoltConfig,
+    konancPath: String? = null,
+    klibs: List<String> = emptyList()
+): BuildCommand {
+    val outputPath = outputNativeTestKexePath(config)
+    val outputBase = "$BUILD_DIR/${config.name}-test"
+    val klibPath = outputNativeTestKlibPath(config)
+    val args = buildList {
+        add(konancPath ?: "konanc")
+        add("-p")
+        add("program")
+        add("-generate-test-runner")
+        for (klib in klibs) {
+            add("-l")
+            add(klib)
+        }
+        add("-Xinclude=$klibPath")
+        add("-o")
+        add(outputBase)
     }
     return BuildCommand(args = args, outputPath = outputPath)
 }

--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -119,6 +119,7 @@ fun nativeBuildCommand(
 // passing -e in addition would conflict with it.
 fun nativeTestBuildCommand(
     config: KoltConfig,
+    pluginArgs: List<String> = emptyList(),
     konancPath: String? = null,
     klibs: List<String> = emptyList()
 ): BuildCommand {
@@ -137,6 +138,7 @@ fun nativeTestBuildCommand(
         }
         add("-o")
         add(outputBase)
+        addAll(pluginArgs)
     }
     return BuildCommand(args = args, outputPath = outputPath)
 }

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -182,10 +182,17 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
         exitProcess(EXIT_BUILD_ERROR)
     }
 
-    val buildCmd = nativeBuildCommand(config, pluginArgs = pArgs, konancPath = managedKonancBin, klibs = klibs)
+    val libraryCmd = nativeLibraryCommand(config, pluginArgs = pArgs, konancPath = managedKonancBin, klibs = klibs)
     println("compiling ${config.name} (native)...")
-    executeCommand(buildCmd.args).getOrElse { error ->
+    executeCommand(libraryCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "compilation"))
+        exitProcess(EXIT_BUILD_ERROR)
+    }
+
+    val linkCmd = nativeLinkCommand(config, konancPath = managedKonancBin, klibs = klibs)
+    println("linking ${config.name} (native)...")
+    executeCommand(linkCmd.args).getOrElse { error ->
+        eprintln(formatProcessError(error, "linking"))
         exitProcess(EXIT_BUILD_ERROR)
     }
 
@@ -329,15 +336,22 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>) {
     }
 
     val testConfig = config.copy(testSources = existingTestSources)
-    val buildCmd = nativeTestBuildCommand(testConfig, pluginArgs = pArgs, konancPath = managedKonancBin, klibs = klibs)
+    val libraryCmd = nativeTestLibraryCommand(testConfig, pluginArgs = pArgs, konancPath = managedKonancBin, klibs = klibs)
     println("compiling tests (native)...")
-    executeCommand(buildCmd.args).getOrElse { error ->
+    executeCommand(libraryCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "test compilation"))
         exitProcess(EXIT_BUILD_ERROR)
     }
 
-    if (!fileExists(buildCmd.outputPath)) {
-        eprintln("error: ${buildCmd.outputPath} not produced by konanc")
+    val linkCmd = nativeTestLinkCommand(testConfig, konancPath = managedKonancBin, klibs = klibs)
+    println("linking tests (native)...")
+    executeCommand(linkCmd.args).getOrElse { error ->
+        eprintln(formatProcessError(error, "test linking"))
+        exitProcess(EXIT_BUILD_ERROR)
+    }
+
+    if (!fileExists(linkCmd.outputPath)) {
+        eprintln("error: ${linkCmd.outputPath} not produced by konanc")
         exitProcess(EXIT_BUILD_ERROR)
     }
 

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -156,6 +156,7 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
 
     val paths = resolveKoltPaths(EXIT_BUILD_ERROR)
     val managedKonancBin = ensureKonancBin(config.kotlin, paths, EXIT_BUILD_ERROR)
+    val pArgs = resolveNativePluginArgs(config, paths, EXIT_BUILD_ERROR)
 
     val klibs = resolveNativeDependencies(config, paths)
 
@@ -173,7 +174,7 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
     if (isBuildUpToDate(current = currentState, cached = cachedState)) {
         val elapsed = startMark.elapsedNow()
         println("${config.name} is up to date (${formatDuration(elapsed)})")
-        return BuildResult(config, classpath = null, pluginArgs = emptyList(), javaPath = null)
+        return BuildResult(config, classpath = null, pluginArgs = pArgs, javaPath = null)
     }
 
     ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
@@ -181,7 +182,7 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
         exitProcess(EXIT_BUILD_ERROR)
     }
 
-    val buildCmd = nativeBuildCommand(config, konancPath = managedKonancBin, klibs = klibs)
+    val buildCmd = nativeBuildCommand(config, pluginArgs = pArgs, konancPath = managedKonancBin, klibs = klibs)
     println("compiling ${config.name} (native)...")
     executeCommand(buildCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "compilation"))
@@ -200,7 +201,7 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
 
     val elapsed = startMark.elapsedNow()
     println("built $kexePath in ${formatDuration(elapsed)}")
-    return BuildResult(config, classpath = null, pluginArgs = emptyList(), javaPath = null)
+    return BuildResult(config, classpath = null, pluginArgs = pArgs, javaPath = null)
 }
 
 /**
@@ -318,6 +319,7 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>) {
 
     val paths = resolveKoltPaths(EXIT_TEST_ERROR)
     val managedKonancBin = ensureKonancBin(config.kotlin, paths, EXIT_TEST_ERROR)
+    val pArgs = resolveNativePluginArgs(config, paths, EXIT_TEST_ERROR)
 
     val klibs = resolveNativeDependencies(config, paths)
 
@@ -327,7 +329,7 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>) {
     }
 
     val testConfig = config.copy(testSources = existingTestSources)
-    val buildCmd = nativeTestBuildCommand(testConfig, konancPath = managedKonancBin, klibs = klibs)
+    val buildCmd = nativeTestBuildCommand(testConfig, pluginArgs = pArgs, konancPath = managedKonancBin, klibs = klibs)
     println("compiling tests (native)...")
     executeCommand(buildCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "test compilation"))

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -156,7 +156,6 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
 
     val paths = resolveKoltPaths(EXIT_BUILD_ERROR)
     val managedKonancBin = ensureKonancBin(config.kotlin, paths, EXIT_BUILD_ERROR)
-    val pArgs = resolveNativePluginArgs(config, paths, EXIT_BUILD_ERROR)
 
     val klibs = resolveNativeDependencies(config, paths)
 
@@ -174,15 +173,18 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
     if (isBuildUpToDate(current = currentState, cached = cachedState)) {
         val elapsed = startMark.elapsedNow()
         println("${config.name} is up to date (${formatDuration(elapsed)})")
-        return BuildResult(config, classpath = null, pluginArgs = pArgs, javaPath = null)
+        return BuildResult(config, classpath = null, pluginArgs = emptyList(), javaPath = null)
     }
+
+    // Resolved only on a real rebuild so cached builds don't provision kotlinc.
+    val nativePluginArgs = resolveNativePluginArgs(config, paths, EXIT_BUILD_ERROR)
 
     ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
         eprintln("error: could not create directory ${error.path}")
         exitProcess(EXIT_BUILD_ERROR)
     }
 
-    val libraryCmd = nativeLibraryCommand(config, pluginArgs = pArgs, konancPath = managedKonancBin, klibs = klibs)
+    val libraryCmd = nativeLibraryCommand(config, pluginArgs = nativePluginArgs, konancPath = managedKonancBin, klibs = klibs)
     println("compiling ${config.name} (native)...")
     executeCommand(libraryCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "compilation"))
@@ -208,7 +210,7 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
 
     val elapsed = startMark.elapsedNow()
     println("built $kexePath in ${formatDuration(elapsed)}")
-    return BuildResult(config, classpath = null, pluginArgs = pArgs, javaPath = null)
+    return BuildResult(config, classpath = null, pluginArgs = nativePluginArgs, javaPath = null)
 }
 
 /**
@@ -326,7 +328,7 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>) {
 
     val paths = resolveKoltPaths(EXIT_TEST_ERROR)
     val managedKonancBin = ensureKonancBin(config.kotlin, paths, EXIT_TEST_ERROR)
-    val pArgs = resolveNativePluginArgs(config, paths, EXIT_TEST_ERROR)
+    val nativePluginArgs = resolveNativePluginArgs(config, paths, EXIT_TEST_ERROR)
 
     val klibs = resolveNativeDependencies(config, paths)
 
@@ -336,7 +338,7 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>) {
     }
 
     val testConfig = config.copy(testSources = existingTestSources)
-    val libraryCmd = nativeTestLibraryCommand(testConfig, pluginArgs = pArgs, konancPath = managedKonancBin, klibs = klibs)
+    val libraryCmd = nativeTestLibraryCommand(testConfig, pluginArgs = nativePluginArgs, konancPath = managedKonancBin, klibs = klibs)
     println("compiling tests (native)...")
     executeCommand(libraryCmd.args).getOrElse { error ->
         eprintln(formatProcessError(error, "test compilation"))

--- a/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
+++ b/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
@@ -6,6 +6,8 @@ import kolt.build.pluginArgs
 import kolt.config.KoltConfig
 import kolt.infra.eprintln
 import kolt.infra.executeAndCapture
+import kolt.config.KoltPaths
+import kolt.tool.ensureKotlincBin
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
 import platform.posix.getenv
@@ -36,4 +38,15 @@ internal fun resolvePluginArgs(config: KoltConfig, managedKotlincBin: String? = 
         eprintln("error: unknown plugin '${error.name}'")
         exitProcess(EXIT_CONFIG_ERROR)
     }
+}
+
+// Kotlin/Native path: konanc ships no compiler-plugin jars, so when a native
+// build needs plugins we provision the kotlinc distribution purely to borrow
+// them. Callers that have no enabled plugins should not call this at all
+// (short-circuit on the caller side) to avoid the kotlinc download entirely.
+internal fun resolveNativePluginArgs(config: KoltConfig, paths: KoltPaths, exitCode: Int): List<String> {
+    val hasEnabledPlugin = config.plugins.any { (_, enabled) -> enabled }
+    if (!hasEnabledPlugin) return emptyList()
+    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths, exitCode)
+    return resolvePluginArgs(config, managedKotlincBin)
 }

--- a/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
@@ -332,78 +332,71 @@ class BuilderTest {
         assertEquals("jar", cmd.args.first())
     }
 
-    // --- nativeBuildCommand ---
+    // --- nativeLibraryCommand (Stage 1: sources -> klib) ---
 
     @Test
-    fun nativeBuildCommandProducesProgramKexe() {
-        val cmd = nativeBuildCommand(testConfig(target = "native"))
+    fun nativeLibraryCommandProducesKlibDirectory() {
+        val cmd = nativeLibraryCommand(testConfig(target = "native"))
 
         assertEquals(
-            listOf("konanc", "src", "-p", "program", "-e", "com.example.main", "-o", "build/my-app"),
+            listOf("konanc", "src", "-p", "library", "-nopack", "-o", "build/my-app-klib"),
             cmd.args
         )
-        assertEquals("build/my-app.kexe", cmd.outputPath)
+        assertEquals("build/my-app-klib", cmd.outputPath)
     }
 
     @Test
-    fun nativeBuildCommandMultipleSources() {
-        val cmd = nativeBuildCommand(testConfig(sources = listOf("src", "generated"), target = "native"))
-
-        assertEquals(
-            listOf("konanc", "src", "generated", "-p", "program", "-e", "com.example.main", "-o", "build/my-app"),
-            cmd.args
+    fun nativeLibraryCommandMultipleSources() {
+        val cmd = nativeLibraryCommand(
+            testConfig(sources = listOf("src", "generated"), target = "native")
         )
-    }
 
-    @Test
-    fun nativeBuildCommandWithProjectName() {
-        val cmd = nativeBuildCommand(testConfig(name = "hello", target = "native"))
-
-        assertEquals("build/hello.kexe", cmd.outputPath)
         assertEquals(
-            listOf("konanc", "src", "-p", "program", "-e", "com.example.main", "-o", "build/hello"),
+            listOf("konanc", "src", "generated", "-p", "library", "-nopack", "-o", "build/my-app-klib"),
             cmd.args
         )
     }
 
     @Test
-    fun nativeBuildCommandWithManagedKonancPath() {
+    fun nativeLibraryCommandWithProjectName() {
+        val cmd = nativeLibraryCommand(testConfig(name = "hello", target = "native"))
+
+        assertEquals("build/hello-klib", cmd.outputPath)
+        assertEquals(
+            listOf("konanc", "src", "-p", "library", "-nopack", "-o", "build/hello-klib"),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeLibraryCommandWithManagedKonancPath() {
         val managedKonanc = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/konanc"
-        val cmd = nativeBuildCommand(testConfig(target = "native"), konancPath = managedKonanc)
+        val cmd = nativeLibraryCommand(testConfig(target = "native"), konancPath = managedKonanc)
 
         assertEquals(managedKonanc, cmd.args.first())
     }
 
     @Test
-    fun nativeBuildCommandWithPluginArgs() {
-        val cmd = nativeBuildCommand(
+    fun nativeLibraryCommandWithPluginArgs() {
+        val cmd = nativeLibraryCommand(
             testConfig(target = "native"),
             pluginArgs = listOf("-Xplugin=foo.jar")
         )
 
         assertEquals(
-            listOf("konanc", "src", "-p", "program", "-e", "com.example.main", "-o", "build/my-app", "-Xplugin=foo.jar"),
+            listOf(
+                "konanc", "src",
+                "-p", "library", "-nopack",
+                "-o", "build/my-app-klib",
+                "-Xplugin=foo.jar"
+            ),
             cmd.args
         )
     }
 
     @Test
-    fun nativeBuildCommandWithSingleKlib() {
-        val cmd = nativeBuildCommand(
-            testConfig(target = "native"),
-            klibs = listOf("/cache/lib.klib")
-        )
-
-        assertEquals(
-            listOf("konanc", "src", "-p", "program", "-e", "com.example.main", "-l", "/cache/lib.klib", "-o", "build/my-app"),
-            cmd.args
-        )
-    }
-
-    @Test
-    fun nativeBuildCommandWithMultipleKlibsRepeatsLFlag() {
-        // -library is single-argument per library: NOT colon/comma-joined.
-        val cmd = nativeBuildCommand(
+    fun nativeLibraryCommandWithMultipleKlibsRepeatsLFlag() {
+        val cmd = nativeLibraryCommand(
             testConfig(target = "native"),
             klibs = listOf("/cache/a.klib", "/cache/b.klib", "/cache/c.klib")
         )
@@ -411,11 +404,82 @@ class BuilderTest {
         assertEquals(
             listOf(
                 "konanc", "src",
-                "-p", "program",
-                "-e", "com.example.main",
+                "-p", "library", "-nopack",
                 "-l", "/cache/a.klib",
                 "-l", "/cache/b.klib",
                 "-l", "/cache/c.klib",
+                "-o", "build/my-app-klib"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeLibraryCommandEmptyKlibsOmitsLibraryFlag() {
+        val cmd = nativeLibraryCommand(testConfig(target = "native"), klibs = emptyList())
+
+        assertFalse(cmd.args.contains("-l"))
+    }
+
+    // --- nativeLinkCommand (Stage 2: klib -> kexe) ---
+
+    @Test
+    fun nativeLinkCommandLinksKlibToProgramKexe() {
+        val cmd = nativeLinkCommand(testConfig(target = "native"))
+
+        assertEquals(
+            listOf(
+                "konanc",
+                "-p", "program",
+                "-Xinclude=build/my-app-klib",
+                "-o", "build/my-app"
+            ),
+            cmd.args
+        )
+        assertEquals("build/my-app.kexe", cmd.outputPath)
+    }
+
+    @Test
+    fun nativeLinkCommandWithProjectName() {
+        val cmd = nativeLinkCommand(testConfig(name = "hello", target = "native"))
+
+        assertEquals("build/hello.kexe", cmd.outputPath)
+        assertEquals(
+            listOf(
+                "konanc",
+                "-p", "program",
+                "-Xinclude=build/hello-klib",
+                "-o", "build/hello"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeLinkCommandWithManagedKonancPath() {
+        val managedKonanc = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/konanc"
+        val cmd = nativeLinkCommand(testConfig(target = "native"), konancPath = managedKonanc)
+
+        assertEquals(managedKonanc, cmd.args.first())
+    }
+
+    @Test
+    fun nativeLinkCommandWithMultipleKlibsRepeatsLFlag() {
+        // Even though the project klib already linked against these deps, the
+        // final link stage still needs them on its classpath to resolve symbols
+        // referenced from the generated serializer code etc.
+        val cmd = nativeLinkCommand(
+            testConfig(target = "native"),
+            klibs = listOf("/cache/a.klib", "/cache/b.klib")
+        )
+
+        assertEquals(
+            listOf(
+                "konanc",
+                "-p", "program",
+                "-l", "/cache/a.klib",
+                "-l", "/cache/b.klib",
+                "-Xinclude=build/my-app-klib",
                 "-o", "build/my-app"
             ),
             cmd.args
@@ -423,10 +487,19 @@ class BuilderTest {
     }
 
     @Test
-    fun nativeBuildCommandEmptyKlibsOmitsLibraryFlag() {
-        val cmd = nativeBuildCommand(testConfig(target = "native"), klibs = emptyList())
+    fun nativeLinkCommandEmptyKlibsOmitsLibraryFlag() {
+        val cmd = nativeLinkCommand(testConfig(target = "native"), klibs = emptyList())
 
         assertFalse(cmd.args.contains("-l"))
+    }
+
+    @Test
+    fun nativeLinkCommandDoesNotEmitEntryPointFlag() {
+        // -Xinclude pulls in the compiled main() from the klib. -e would be
+        // redundant and risks conflicting with what the klib already declares.
+        val cmd = nativeLinkCommand(testConfig(target = "native"))
+
+        assertFalse(cmd.args.contains("-e"))
     }
 
     @Test
@@ -468,36 +541,27 @@ class BuilderTest {
         assertTrue(needsNativeEntryPointWarning(testConfig().copy(main = "Main")))
     }
 
-    // --- nativeTestBuildCommand ---
+    // --- nativeTestLibraryCommand (Stage 1: main+test sources -> klib) ---
 
     @Test
-    fun nativeTestBuildCommandCompilesMainAndTestSourcesWithGeneratedRunner() {
-        val cmd = nativeTestBuildCommand(testConfig(target = "native"))
+    fun nativeTestLibraryCommandIncludesMainAndTestSources() {
+        val cmd = nativeTestLibraryCommand(testConfig(target = "native"))
 
         assertEquals(
             listOf(
                 "konanc",
                 "src", "test",
-                "-p", "program",
-                "-generate-test-runner",
-                "-o", "build/my-app-test"
+                "-p", "library", "-nopack",
+                "-o", "build/my-app-test-klib"
             ),
             cmd.args
         )
-        assertEquals("build/my-app-test.kexe", cmd.outputPath)
+        assertEquals("build/my-app-test-klib", cmd.outputPath)
     }
 
     @Test
-    fun nativeTestBuildCommandDoesNotEmitEntryPointFlag() {
-        // -generate-test-runner makes the compiler synthesize main(); -e would conflict.
-        val cmd = nativeTestBuildCommand(testConfig(target = "native"))
-
-        assertFalse(cmd.args.contains("-e"))
-    }
-
-    @Test
-    fun nativeTestBuildCommandMultipleSourcesAndTestSources() {
-        val cmd = nativeTestBuildCommand(
+    fun nativeTestLibraryCommandMultipleSources() {
+        val cmd = nativeTestLibraryCommand(
             testConfig(
                 sources = listOf("src", "generated"),
                 testSources = listOf("test", "integration-test"),
@@ -509,25 +573,97 @@ class BuilderTest {
             listOf(
                 "konanc",
                 "src", "generated", "test", "integration-test",
-                "-p", "program",
-                "-generate-test-runner",
-                "-o", "build/my-app-test"
+                "-p", "library", "-nopack",
+                "-o", "build/my-app-test-klib"
             ),
             cmd.args
         )
     }
 
     @Test
-    fun nativeTestBuildCommandWithProjectName() {
-        val cmd = nativeTestBuildCommand(testConfig(name = "hello", target = "native"))
+    fun nativeTestLibraryCommandWithPluginArgs() {
+        val cmd = nativeTestLibraryCommand(
+            testConfig(target = "native"),
+            pluginArgs = listOf("-Xplugin=foo.jar", "-Xplugin=bar.jar")
+        )
+
+        assertEquals(
+            listOf(
+                "konanc",
+                "src", "test",
+                "-p", "library", "-nopack",
+                "-o", "build/my-app-test-klib",
+                "-Xplugin=foo.jar", "-Xplugin=bar.jar"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeTestLibraryCommandWithMultipleKlibsRepeatsLFlag() {
+        val cmd = nativeTestLibraryCommand(
+            testConfig(target = "native"),
+            klibs = listOf("/cache/a.klib", "/cache/b.klib")
+        )
+
+        assertEquals(
+            listOf(
+                "konanc",
+                "src", "test",
+                "-p", "library", "-nopack",
+                "-l", "/cache/a.klib",
+                "-l", "/cache/b.klib",
+                "-o", "build/my-app-test-klib"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun nativeTestLibraryCommandWithManagedKonancPath() {
+        val managedKonanc = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/konanc"
+        val cmd = nativeTestLibraryCommand(testConfig(target = "native"), konancPath = managedKonanc)
+
+        assertEquals(managedKonanc, cmd.args.first())
+    }
+
+    // --- nativeTestLinkCommand (Stage 2: klib -> test kexe) ---
+
+    @Test
+    fun nativeTestLinkCommandLinksWithGeneratedRunner() {
+        val cmd = nativeTestLinkCommand(testConfig(target = "native"))
+
+        assertEquals(
+            listOf(
+                "konanc",
+                "-p", "program",
+                "-generate-test-runner",
+                "-Xinclude=build/my-app-test-klib",
+                "-o", "build/my-app-test"
+            ),
+            cmd.args
+        )
+        assertEquals("build/my-app-test.kexe", cmd.outputPath)
+    }
+
+    @Test
+    fun nativeTestLinkCommandDoesNotEmitEntryPointFlag() {
+        val cmd = nativeTestLinkCommand(testConfig(target = "native"))
+
+        assertFalse(cmd.args.contains("-e"))
+    }
+
+    @Test
+    fun nativeTestLinkCommandWithProjectName() {
+        val cmd = nativeTestLinkCommand(testConfig(name = "hello", target = "native"))
 
         assertEquals("build/hello-test.kexe", cmd.outputPath)
         assertEquals(
             listOf(
                 "konanc",
-                "src", "test",
                 "-p", "program",
                 "-generate-test-runner",
+                "-Xinclude=build/hello-test-klib",
                 "-o", "build/hello-test"
             ),
             cmd.args
@@ -535,49 +671,20 @@ class BuilderTest {
     }
 
     @Test
-    fun nativeTestBuildCommandWithManagedKonancPath() {
-        val managedKonanc = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/konanc"
-        val cmd = nativeTestBuildCommand(testConfig(target = "native"), konancPath = managedKonanc)
-
-        assertEquals(managedKonanc, cmd.args.first())
-    }
-
-    @Test
-    fun nativeTestBuildCommandWithSingleKlib() {
-        val cmd = nativeTestBuildCommand(
+    fun nativeTestLinkCommandWithMultipleKlibsRepeatsLFlag() {
+        val cmd = nativeTestLinkCommand(
             testConfig(target = "native"),
-            klibs = listOf("/cache/lib.klib")
+            klibs = listOf("/cache/a.klib", "/cache/b.klib")
         )
 
         assertEquals(
             listOf(
                 "konanc",
-                "src", "test",
-                "-p", "program",
-                "-generate-test-runner",
-                "-l", "/cache/lib.klib",
-                "-o", "build/my-app-test"
-            ),
-            cmd.args
-        )
-    }
-
-    @Test
-    fun nativeTestBuildCommandWithMultipleKlibsRepeatsLFlag() {
-        val cmd = nativeTestBuildCommand(
-            testConfig(target = "native"),
-            klibs = listOf("/cache/a.klib", "/cache/b.klib", "/cache/c.klib")
-        )
-
-        assertEquals(
-            listOf(
-                "konanc",
-                "src", "test",
                 "-p", "program",
                 "-generate-test-runner",
                 "-l", "/cache/a.klib",
                 "-l", "/cache/b.klib",
-                "-l", "/cache/c.klib",
+                "-Xinclude=build/my-app-test-klib",
                 "-o", "build/my-app-test"
             ),
             cmd.args
@@ -585,29 +692,11 @@ class BuilderTest {
     }
 
     @Test
-    fun nativeTestBuildCommandEmptyKlibsOmitsLibraryFlag() {
-        val cmd = nativeTestBuildCommand(testConfig(target = "native"), klibs = emptyList())
+    fun nativeTestLinkCommandWithManagedKonancPath() {
+        val managedKonanc = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/konanc"
+        val cmd = nativeTestLinkCommand(testConfig(target = "native"), konancPath = managedKonanc)
 
-        assertFalse(cmd.args.contains("-l"))
-    }
-
-    @Test
-    fun nativeTestBuildCommandWithPluginArgs() {
-        val cmd = nativeTestBuildCommand(
-            testConfig(target = "native"),
-            pluginArgs = listOf("-Xplugin=foo.jar", "-Xplugin=bar.jar")
-        )
-
-        assertEquals(
-            listOf(
-                "konanc", "src", "test",
-                "-p", "program",
-                "-generate-test-runner",
-                "-o", "build/my-app-test",
-                "-Xplugin=foo.jar", "-Xplugin=bar.jar"
-            ),
-            cmd.args
-        )
+        assertEquals(managedKonanc, cmd.args.first())
     }
 
     @Test

--- a/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
@@ -592,6 +592,25 @@ class BuilderTest {
     }
 
     @Test
+    fun nativeTestBuildCommandWithPluginArgs() {
+        val cmd = nativeTestBuildCommand(
+            testConfig(target = "native"),
+            pluginArgs = listOf("-Xplugin=foo.jar", "-Xplugin=bar.jar")
+        )
+
+        assertEquals(
+            listOf(
+                "konanc", "src", "test",
+                "-p", "program",
+                "-generate-test-runner",
+                "-o", "build/my-app-test",
+                "-Xplugin=foo.jar", "-Xplugin=bar.jar"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
     fun jarCommandWithManagedJarPathPreservesOutputPath() {
         // Given: a managed jar binary path
         val managedJarBin = "/home/user/.kolt/toolchains/jdk/21/bin/jar"

--- a/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
@@ -465,9 +465,10 @@ class BuilderTest {
 
     @Test
     fun nativeLinkCommandWithMultipleKlibsRepeatsLFlag() {
-        // Even though the project klib already linked against these deps, the
-        // final link stage still needs them on its classpath to resolve symbols
-        // referenced from the generated serializer code etc.
+        // -Xinclude only pulls the project klib's IR into the link unit; any
+        // external references (e.g. kotlinx-serialization-core symbols touched
+        // by plugin-generated code) are still unresolved and need the
+        // transitive klibs on the library path at link time.
         val cmd = nativeLinkCommand(
             testConfig(target = "native"),
             klibs = listOf("/cache/a.klib", "/cache/b.klib")

--- a/src/nativeTest/kotlin/kolt/cli/PluginSupportTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/PluginSupportTest.kt
@@ -1,5 +1,6 @@
 package kolt.cli
 
+import kolt.config.KoltPaths
 import kolt.testConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -62,6 +63,36 @@ class PluginSupportTest {
         val managedBin = "/home/user/.kolt/toolchains/kotlinc/2.1.0/bin/kotlinc"
 
         val result = resolvePluginArgs(config, managedKotlincBin = managedBin)
+
+        assertTrue(result.isEmpty())
+    }
+
+    // --- resolveNativePluginArgs short-circuit ---
+    //
+    // These tests use a bogus KoltPaths home. If the short-circuit regresses
+    // and resolveNativePluginArgs starts provisioning kotlinc unconditionally,
+    // ensureKotlincBin will try to download under the bogus path and exit the
+    // test process, failing the test.
+
+    @Test
+    fun resolveNativePluginArgsNoPluginsSkipsKotlincProvisioning() {
+        val config = testConfig(plugins = emptyMap(), target = "native")
+        val bogusPaths = KoltPaths("/nonexistent-home-for-test")
+
+        val result = resolveNativePluginArgs(config, bogusPaths, exitCode = 999)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun resolveNativePluginArgsAllPluginsDisabledSkipsKotlincProvisioning() {
+        val config = testConfig(
+            plugins = mapOf("serialization" to false, "allopen" to false),
+            target = "native"
+        )
+        val bogusPaths = KoltPaths("/nonexistent-home-for-test")
+
+        val result = resolveNativePluginArgs(config, bogusPaths, exitCode = 999)
 
         assertTrue(result.isEmpty())
     }


### PR DESCRIPTION
## Summary
- Wire compiler plugin args (e.g. `kotlinx.serialization`) into the native build path by provisioning the kotlinc distribution as a sidecar purely for plugin jar lookup.
- Split native build into a two-stage library → link flow because konanc silently no-ops compiler plugins when invoked with `-p program` in one shot.
- Verified end-to-end with a `target = "native"` project that round-trips a `@Serializable` data class through JSON.

Fixes #62. Unblocks #61.

## Why two stages
konanc accepts `-Xplugin=<jar>` on a single-step `-p program` invocation without error, but the plugin registrars never actually run — `@Serializable` stays as a plain annotation and `Foo.serializer()` is never generated. The Kotlin Gradle plugin works around this by always compiling sources into a klib first and then linking the klib into an executable as a separate step, and that is the only invocation shape where the plugin registrars fire.

This PR restructures the native build to match:

- `nativeLibraryCommand` — `konanc -p library -nopack`, runs with `pluginArgs`, outputs `build/<name>-klib/`
- `nativeLinkCommand` — `konanc -p program -Xinclude=<klib>`, pulls the already-plugin-transformed IR (including `main`) out of the klib
- Same split on the test path via `nativeTestLibraryCommand` / `nativeTestLinkCommand`; `-generate-test-runner` lives on the link step so the synthesized runner sees `@Test` classes pulled in via `-Xinclude`

`doNativeBuild` / `doNativeTest` run the two konanc invocations back to back.

## Design note: kotlinc as a sidecar
konanc ships no compiler-plugin jars in its distribution, so to get `-Xplugin=...serialization-compiler-plugin.jar` we provision the kotlinc distribution and reuse `<kotlincHome>/lib/<plugin>.jar`. This does mean a native-only project that enables a plugin will also download kotlinc. A follow-up (#65) will switch to resolving plugin jars from Maven Central by fixed coordinate so the kotlinc sidecar can be dropped.

## Test plan
- [x] `./gradlew build` green (existing + new two-stage `BuilderTest` cases)
- [x] Manual E2E: `kolt-examples/native-serialization` (new example) with `target = "native"` + `plugins.serialization = true` round-trips `@Serializable` data through JSON. Output:
      ```
      encoded: {"name":"world","count":3}
      decoded: Greeting(name=world, count=3)
      round-trip ok
      ```
- [ ] Reviewer sanity-check the two-stage split against `doNativeBuild` / `doNativeTest` orchestration