### PR TITLE
Support cinterop for Kotlin/Native target (libcurl .def → klib)

### DIFF
--- a/.claude/skills/kolt-usage/SKILL.md
+++ b/.claude/skills/kolt-usage/SKILL.md
@@ -56,6 +56,13 @@ fmt_style = "google"
 [plugins]
 serialization = true
 
+[[cinterop]]
+name = "libcurl"
+def = "src/nativeInterop/cinterop/libcurl.def"
+package = "libcurl"
+compiler_options = ["-I/usr/include", "-I/usr/include/x86_64-linux-gnu"]
+linker_options = ["-L/usr/lib/x86_64-linux-gnu", "-lcurl"]
+
 [dependencies]
 "org.jetbrains.kotlinx:kotlinx-coroutines-core" = "1.9.0"
 
@@ -83,7 +90,12 @@ jitpack = "https://jitpack.io"
 | `test_resources` | Test resource directories added to test classpath | `[]` |
 | `fmt_style` | ktfmt style: `"google"`, `"kotlinlang"`, `"meta"` | `"google"` |
 | `[plugins]` | Compiler plugins (`serialization`, `allopen`, `noarg`) | `{}` |
+| `[[cinterop]]` | C interop bindings for `target = "native"` (array of `.def` entries) | `[]` |
 | `[repositories]` | Maven repositories (name = URL, tried in order) | Maven Central only |
+
+### C Interop
+
+For `target = "native"` projects, declare one `[[cinterop]]` entry per `.def` file. kolt invokes the konan `cinterop` tool, caches `build/<name>.klib`, and links it via `konanc -l`. Fields: `name` (klib base), `def` (.def path), `package` (optional Kotlin package), `compiler_options` (list — emitted as repeated `-compiler-option`), `linker_options` (list — emitted as repeated `-linker-option`). Klibs are regenerated when the `.def` file's mtime changes.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ jitpack = "https://jitpack.io"
 | `test_resources` | Test resource directories added to test classpath | `[]` |
 | `fmt_style` | ktfmt style: `"google"`, `"kotlinlang"`, `"meta"` | `"google"` |
 | `[plugins]` | Compiler plugins (`serialization`, `allopen`, `noarg`) | `{}` |
+| `[[cinterop]]` | C interop bindings for `target = "native"` (one array entry per `.def`) | `[]` |
 | `[repositories]` | Maven repositories (name = URL) | Maven Central only |
 
 ### Dependencies
@@ -154,6 +155,29 @@ serialization = true
 Supported plugins: `serialization`, `allopen`, `noarg`. Plugin JARs are resolved from the Kotlin compiler distribution.
 
 Plugins work for both `target = "jvm"` and `target = "native"`. On native, kolt compiles the project in two konanc stages (`-p library` then `-p program -Xinclude=...`) so the plugin registrars run on the library stage; this is a workaround for a konanc quirk where single-step `-p program` invocations silently skip compiler plugins. See ADR 0014 for details. Enabling a plugin on a native project currently provisions the kotlinc distribution as a sidecar purely to borrow plugin jars from `<kotlincHome>/lib/`; a follow-up will switch to resolving them from Maven Central directly.
+
+### C Interop (native target)
+
+For `target = "native"` projects that need to call C libraries, declare one `[[cinterop]]` entry per `.def` file. kolt invokes the konan `cinterop` tool for each entry, caches the generated `.klib` under `build/`, and passes it to `konanc` via `-l` on both the library and link stages.
+
+```toml
+[[cinterop]]
+name = "libcurl"
+def = "src/nativeInterop/cinterop/libcurl.def"
+package = "libcurl"
+compiler_options = ["-I/usr/include", "-I/usr/include/x86_64-linux-gnu"]
+linker_options = ["-L/usr/lib/x86_64-linux-gnu", "-lcurl"]
+```
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `name` | Output klib base name (`build/<name>.klib`) | (required) |
+| `def` | Path to the `.def` file describing the binding | (required) |
+| `package` | Kotlin package for generated bindings | (derived from `.def`) |
+| `compiler_options` | Extra flags forwarded to clang as repeated `-compiler-option` | `[]` |
+| `linker_options` | Extra flags forwarded to the linker as repeated `-linker-option` | `[]` |
+
+The `cinterop` klib is regenerated when the `.def` file's mtime changes; source-only edits reuse the cached klib. Multiple `[[cinterop]]` entries are allowed and are linked in declaration order.
 
 ### Resource Files
 

--- a/src/nativeMain/kotlin/kolt/build/BuildCache.kt
+++ b/src/nativeMain/kotlin/kolt/build/BuildCache.kt
@@ -14,7 +14,8 @@ data class BuildState(
     @SerialName("classes_dir_mtime") val classesDirMtime: Long?,
     @SerialName("lockfile_mtime") val lockfileMtime: Long?,
     val classpath: String? = null,
-    @SerialName("resources_newest_mtime") val resourcesNewestMtime: Long? = null
+    @SerialName("resources_newest_mtime") val resourcesNewestMtime: Long? = null,
+    @SerialName("def_newest_mtime") val defNewestMtime: Long? = null
 )
 
 fun isBuildUpToDate(current: BuildState, cached: BuildState?): Boolean {
@@ -23,7 +24,8 @@ fun isBuildUpToDate(current: BuildState, cached: BuildState?): Boolean {
         current.sourcesNewestMtime == cached.sourcesNewestMtime &&
         current.classesDirMtime == cached.classesDirMtime &&
         current.lockfileMtime == cached.lockfileMtime &&
-        current.resourcesNewestMtime == cached.resourcesNewestMtime
+        current.resourcesNewestMtime == cached.resourcesNewestMtime &&
+        current.defNewestMtime == cached.defNewestMtime
 }
 
 private val json = Json { prettyPrint = true }

--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -221,13 +221,13 @@ fun cinteropCommand(
             add("-pkg")
             add(entry.packageName)
         }
-        if (entry.compilerOptions != null) {
-            add("-compiler-options")
-            add(entry.compilerOptions)
+        for (opt in entry.compilerOptions) {
+            add("-compiler-option")
+            add(opt)
         }
-        if (entry.linkerOptions != null) {
-            add("-linker-options")
-            add(entry.linkerOptions)
+        for (opt in entry.linkerOptions) {
+            add("-linker-option")
+            add(opt)
         }
     }
     return BuildCommand(args = args, outputPath = outputBase)

--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -1,5 +1,6 @@
 package kolt.build
 
+import kolt.config.CinteropConfig
 import kolt.config.KoltConfig
 
 internal const val BUILD_DIR = "build"
@@ -202,6 +203,38 @@ fun nativeTestLinkCommand(
     }
     return BuildCommand(args = args, outputPath = outputPath)
 }
+
+// cinterop appends .klib to the -o path, so outputPath is without the extension.
+fun cinteropCommand(
+    entry: CinteropConfig,
+    cinteropPath: String? = null,
+    outputDir: String = BUILD_DIR
+): BuildCommand {
+    val outputBase = "$outputDir/${entry.name}"
+    val args = buildList {
+        add(cinteropPath ?: "cinterop")
+        add("-def")
+        add(entry.def)
+        add("-o")
+        add(outputBase)
+        if (entry.packageName != null) {
+            add("-pkg")
+            add(entry.packageName)
+        }
+        if (entry.compilerOptions != null) {
+            add("-compiler-options")
+            add(entry.compilerOptions)
+        }
+        if (entry.linkerOptions != null) {
+            add("-linker-options")
+            add(entry.linkerOptions)
+        }
+    }
+    return BuildCommand(args = args, outputPath = outputBase)
+}
+
+fun cinteropOutputKlibPath(entry: CinteropConfig, outputDir: String = BUILD_DIR): String =
+    "$outputDir/${entry.name}.klib"
 
 fun jarCommand(config: KoltConfig, jarPath: String? = null): BuildCommand {
     val outputPath = outputJarPath(config)

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -157,15 +157,17 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
     val paths = resolveKoltPaths(EXIT_BUILD_ERROR)
     val managedKonancBin = ensureKonancBin(config.kotlin, paths, EXIT_BUILD_ERROR)
 
-    val klibs = resolveNativeDependencies(config, paths)
+    val depKlibs = resolveNativeDependencies(config, paths)
 
     val kexePath = outputKexePath(config)
+    val defNewestMtime = newestDefMtime(config)
     val currentState = BuildState(
         configMtime = fileMtime(KOLT_TOML) ?: 0L,
         sourcesNewestMtime = newestMtime(config.sources),
         classesDirMtime = if (fileExists(kexePath)) fileMtime(kexePath) else null,
         lockfileMtime = null,
-        resourcesNewestMtime = null
+        resourcesNewestMtime = null,
+        defNewestMtime = defNewestMtime
     )
     val cachedState = readFileAsString(BUILD_STATE_FILE).getOrElse { null }
         ?.let { parseBuildState(it) }
@@ -183,6 +185,9 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
         eprintln("error: could not create directory ${error.path}")
         exitProcess(EXIT_BUILD_ERROR)
     }
+
+    val cinteropKlibs = runCinterop(config, paths)
+    val klibs = depKlibs + cinteropKlibs
 
     val libraryCmd = nativeLibraryCommand(config, pluginArgs = nativePluginArgs, konancPath = managedKonancBin, klibs = klibs)
     println("compiling ${config.name} (native)...")
@@ -211,6 +216,31 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
     val elapsed = startMark.elapsedNow()
     println("built $kexePath in ${formatDuration(elapsed)}")
     return BuildResult(config, classpath = null, pluginArgs = nativePluginArgs, javaPath = null)
+}
+
+/** Returns the newest mtime among all .def files declared in cinterop entries, or null if none. */
+private fun newestDefMtime(config: KoltConfig): Long? {
+    if (config.cinterop.isEmpty()) return null
+    val mtimes = config.cinterop.mapNotNull { fileMtime(it.def) }
+    return if (mtimes.isEmpty()) null else mtimes.max()
+}
+
+/**
+ * Runs `cinterop` for each [[cinterop]] entry in the config.
+ * Returns the list of generated .klib paths to pass to konanc via -l.
+ */
+private fun runCinterop(config: KoltConfig, paths: KoltPaths): List<String> {
+    if (config.cinterop.isEmpty()) return emptyList()
+    val managedCinteropBin = paths.cinteropBin(config.kotlin)
+    return config.cinterop.map { entry ->
+        val cmd = cinteropCommand(entry, cinteropPath = managedCinteropBin)
+        println("generating cinterop klib for ${entry.name}...")
+        executeCommand(cmd.args).getOrElse { error ->
+            eprintln(formatProcessError(error, "cinterop (${entry.name})"))
+            exitProcess(EXIT_BUILD_ERROR)
+        }
+        cinteropOutputKlibPath(entry)
+    }
 }
 
 /**
@@ -330,12 +360,15 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>) {
     val managedKonancBin = ensureKonancBin(config.kotlin, paths, EXIT_TEST_ERROR)
     val nativePluginArgs = resolveNativePluginArgs(config, paths, EXIT_TEST_ERROR)
 
-    val klibs = resolveNativeDependencies(config, paths)
+    val depKlibs = resolveNativeDependencies(config, paths)
 
     ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
         eprintln("error: could not create directory ${error.path}")
         exitProcess(EXIT_BUILD_ERROR)
     }
+
+    val cinteropKlibs = runCinterop(config, paths)
+    val klibs = depKlibs + cinteropKlibs
 
     val testConfig = config.copy(testSources = existingTestSources)
     val libraryCmd = nativeTestLibraryCommand(testConfig, pluginArgs = nativePluginArgs, konancPath = managedKonancBin, klibs = klibs)

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -18,6 +18,15 @@ sealed class ConfigError {
 }
 
 @Serializable
+data class CinteropConfig(
+    val name: String,
+    val def: String,
+    @SerialName("package") val packageName: String? = null,
+    @SerialName("compiler_options") val compilerOptions: String? = null,
+    @SerialName("linker_options") val linkerOptions: String? = null
+)
+
+@Serializable
 data class KoltConfig(
     val name: String,
     val version: String,
@@ -34,7 +43,8 @@ data class KoltConfig(
     @SerialName("fmt_style") val fmtStyle: String = "google",
     val plugins: Map<String, Boolean> = emptyMap(),
     val repositories: Map<String, String> = mapOf("central" to MAVEN_CENTRAL_BASE),
-    val jdk: String? = null
+    val jdk: String? = null,
+    val cinterop: List<CinteropConfig> = emptyList()
 )
 
 private val toml = Toml(

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -22,8 +22,8 @@ data class CinteropConfig(
     val name: String,
     val def: String,
     @SerialName("package") val packageName: String? = null,
-    @SerialName("compiler_options") val compilerOptions: String? = null,
-    @SerialName("linker_options") val linkerOptions: String? = null
+    @SerialName("compiler_options") val compilerOptions: List<String> = emptyList(),
+    @SerialName("linker_options") val linkerOptions: List<String> = emptyList()
 )
 
 @Serializable

--- a/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
+++ b/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
@@ -19,6 +19,7 @@ internal data class KoltPaths(val home: String) {
 
     fun konancPath(version: String): String = "$toolchainsDir/konanc/$version"
     fun konancBin(version: String): String = "${konancPath(version)}/bin/konanc"
+    fun cinteropBin(version: String): String = "${konancPath(version)}/bin/cinterop"
 }
 
 internal fun resolveKoltPaths(exitCode: Int): KoltPaths {

--- a/src/nativeTest/kotlin/kolt/TestFixtures.kt
+++ b/src/nativeTest/kotlin/kolt/TestFixtures.kt
@@ -1,5 +1,6 @@
 package kolt
 
+import kolt.config.CinteropConfig
 import kolt.config.KoltConfig
 import kolt.config.MAVEN_CENTRAL_BASE
 
@@ -13,7 +14,8 @@ fun testConfig(
     plugins: Map<String, Boolean> = emptyMap(),
     repositories: Map<String, String> = mapOf("central" to MAVEN_CENTRAL_BASE),
     jdk: String? = null,
-    target: String = "jvm"
+    target: String = "jvm",
+    cinterop: List<CinteropConfig> = emptyList()
 ) = KoltConfig(
     name = name,
     version = "0.1.0",
@@ -27,5 +29,6 @@ fun testConfig(
     testDependencies = testDependencies,
     plugins = plugins,
     repositories = repositories,
-    jdk = jdk
+    jdk = jdk,
+    cinterop = cinterop
 )

--- a/src/nativeTest/kotlin/kolt/build/BuildCacheTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuildCacheTest.kt
@@ -263,4 +263,110 @@ class BuildCacheTest {
         assertNotNull(parsed)
         assertNull(parsed.resourcesNewestMtime)
     }
+
+    // --- defNewestMtime ---
+
+    @Test
+    fun upToDateWhenDefMtimesMatch() {
+        // Given: both current and cached have the same defNewestMtime
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            defNewestMtime = 5000L
+        )
+        assertTrue(isBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun notUpToDateWhenDefMtimeChanged() {
+        // Given: cached has older defNewestMtime (def file was modified)
+        val cached = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            defNewestMtime = 5000L
+        )
+        val current = cached.copy(defNewestMtime = 6000L)
+        assertFalse(isBuildUpToDate(current = current, cached = cached))
+    }
+
+    @Test
+    fun notUpToDateWhenDefMtimeChangedFromNullToValue() {
+        // Given: cached has no def file (null), current has one (cinterop entry added)
+        val cached = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            defNewestMtime = null
+        )
+        val current = cached.copy(defNewestMtime = 5000L)
+        assertFalse(isBuildUpToDate(current = current, cached = cached))
+    }
+
+    @Test
+    fun notUpToDateWhenDefMtimeChangedFromValueToNull() {
+        // Given: cached had a def file, current has none (cinterop entry removed)
+        val cached = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            defNewestMtime = 5000L
+        )
+        val current = cached.copy(defNewestMtime = null)
+        assertFalse(isBuildUpToDate(current = current, cached = cached))
+    }
+
+    @Test
+    fun upToDateWhenBothDefMtimesNull() {
+        // Given: no cinterop entries in either current or cached
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            defNewestMtime = null
+        )
+        assertTrue(isBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun serializeAndDeserializeRoundTripWithDefMtime() {
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = 500L,
+            defNewestMtime = 5000L
+        )
+        val json = serializeBuildState(state)
+        val parsed = parseBuildState(json)
+        assertEquals(state, parsed)
+    }
+
+    @Test
+    fun serializationUsesDefNewestMtimeKey() {
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            defNewestMtime = 5000L
+        )
+        val json = serializeBuildState(state)
+        assertTrue(json.contains("def_newest_mtime"), "Expected JSON key 'def_newest_mtime' in: $json")
+    }
+
+    @Test
+    fun defNewestMtimeDefaultsToNullForOlderStateJson() {
+        // Given: older JSON without def_newest_mtime (pre-cinterop state file)
+        val oldJson = """{"config_mtime":1000,"sources_newest_mtime":2000,"classes_dir_mtime":3000,"lockfile_mtime":null}"""
+        val parsed = parseBuildState(oldJson)
+        assertNotNull(parsed)
+        assertNull(parsed.defNewestMtime)
+    }
 }

--- a/src/nativeTest/kotlin/kolt/build/CinteropSmokeTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CinteropSmokeTest.kt
@@ -1,0 +1,124 @@
+package kolt.build
+
+import com.github.michaelbull.result.get
+import kolt.config.KoltPaths
+import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.executeAndCapture
+import kolt.infra.executeCommand
+import kolt.infra.fileExists
+import kolt.infra.homeDirectory
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import platform.posix.getpid
+
+// E2E smoke test: exercises the full cinterop → konanc → kexe pipeline against
+// a real libcurl fixture. Requires the managed konanc toolchain (2.1.0) and
+// libcurl headers (/usr/include/x86_64-linux-gnu/curl/curl.h) to be present.
+class CinteropSmokeTest {
+
+    @Test
+    fun libcurlCinteropPipelineProducesRunningExecutable() {
+        val home = homeDirectory().get() ?: error("HOME not set")
+        val paths = KoltPaths(home)
+        val kotlinVersion = "2.1.0"
+        val cinteropBin = paths.cinteropBin(kotlinVersion)
+        val konancBin = paths.konancBin(kotlinVersion)
+
+        // Skip when managed toolchain is absent (CI without pre-installed konanc).
+        if (!fileExists(cinteropBin) || !fileExists(konancBin)) {
+            println("SKIP: managed konanc toolchain not found at ${paths.konancPath(kotlinVersion)}")
+            return
+        }
+
+        val tmpDir = "/tmp/kolt-e2e-cinterop-${getpid()}"
+        val buildDir = "$tmpDir/build"
+        ensureDirectoryRecursive(buildDir)
+
+        try {
+            // --- Fixture: libcurl.def ---
+            val defFile = "$tmpDir/libcurl.def"
+            writeFileAsString(
+                defFile,
+                """
+                headers = curl/curl.h
+                compilerOpts.linux = -I/usr/include -I/usr/include/x86_64-linux-gnu
+                linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -lcurl
+                """.trimIndent()
+            )
+
+            // --- Fixture: Main.kt (calls curl_version()) ---
+            val mainFile = "$tmpDir/Main.kt"
+            writeFileAsString(
+                mainFile,
+                """
+                import libcurl.*
+                import kotlinx.cinterop.ExperimentalForeignApi
+                import kotlinx.cinterop.toKString
+
+                @OptIn(ExperimentalForeignApi::class)
+                fun main() {
+                    val version = curl_version()?.toKString() ?: "unknown"
+                    println(version)
+                }
+                """.trimIndent()
+            )
+
+            // --- Step 1: cinterop — .def → libcurl.klib ---
+            val klibBase = "$buildDir/libcurl"
+            val cinteropResult = executeCommand(listOf(cinteropBin, "-def", defFile, "-o", klibBase))
+            assertNotNull(
+                cinteropResult.get(),
+                "cinterop failed to generate klib: $cinteropResult"
+            )
+            val klibFile = "$klibBase.klib"
+            assertTrue(fileExists(klibFile), "Expected .klib at $klibFile after cinterop")
+
+            // --- Step 2: konanc stage 1 — sources + cinterop klib → project klib ---
+            val appKlibBase = "$buildDir/smoke-klib"
+            val stage1Result = executeCommand(
+                listOf(
+                    konancBin, mainFile,
+                    "-p", "library", "-nopack",
+                    "-l", klibFile,
+                    "-o", appKlibBase
+                )
+            )
+            assertNotNull(
+                stage1Result.get(),
+                "konanc stage 1 (compile to klib) failed: $stage1Result"
+            )
+            assertTrue(fileExists(appKlibBase), "Expected project klib at $appKlibBase")
+
+            // --- Step 3: konanc stage 2 — project klib → executable ---
+            val exeBase = "$buildDir/smoke"
+            val stage2Result = executeCommand(
+                listOf(
+                    konancBin,
+                    "-p", "program",
+                    "-l", klibFile,
+                    "-Xinclude=$appKlibBase",
+                    "-o", exeBase
+                )
+            )
+            assertNotNull(
+                stage2Result.get(),
+                "konanc stage 2 (link to kexe) failed: $stage2Result"
+            )
+            val exeFile = "$exeBase.kexe"
+            assertTrue(fileExists(exeFile), "Expected executable at $exeFile after link")
+
+            // --- Step 4: run and verify curl_version() output ---
+            val runResult = executeAndCapture("$exeFile 2>&1")
+            val output = assertNotNull(runResult.get(), "executable run failed: $runResult")
+            assertTrue(
+                output.contains("curl/"),
+                "Expected curl version string (e.g. 'curl/8.x.y') in output, got: $output"
+            )
+        } finally {
+            removeDirectoryRecursive(tmpDir)
+        }
+    }
+}

--- a/src/nativeTest/kotlin/kolt/build/CinteropSmokeTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CinteropSmokeTest.kt
@@ -16,8 +16,28 @@ import platform.posix.getpid
 
 // E2E smoke test: exercises the full cinterop → konanc → kexe pipeline against
 // a real libcurl fixture. Requires the managed konanc toolchain (2.1.0) and
-// libcurl headers (/usr/include/x86_64-linux-gnu/curl/curl.h) to be present.
+// libcurl headers (curl/curl.h) to be present at one of several well-known
+// locations. Skips when either prerequisite is missing.
 class CinteropSmokeTest {
+
+    // Candidate include directories that may contain curl/curl.h. Covers:
+    // - Debian/Ubuntu multiarch (/usr/include/x86_64-linux-gnu)
+    // - Default /usr/include (Fedora/Arch/Alpine and most other Linux)
+    // - /usr/local/include (source/manual installs)
+    private val curlIncludeCandidates = listOf(
+        "/usr/include/x86_64-linux-gnu",
+        "/usr/include",
+        "/usr/local/include",
+    )
+
+    // Candidate library directories that may contain libcurl.so. Matches the
+    // same host layouts as the include candidates above.
+    private val curlLibCandidates = listOf(
+        "/usr/lib/x86_64-linux-gnu",
+        "/usr/lib64",
+        "/usr/lib",
+        "/usr/local/lib",
+    )
 
     @Test
     fun libcurlCinteropPipelineProducesRunningExecutable() {
@@ -33,6 +53,29 @@ class CinteropSmokeTest {
             return
         }
 
+        // Skip when libcurl headers are absent (non-Debian hosts without libcurl-dev).
+        // We always include /usr/include (base glibc headers) and add the directory
+        // holding curl/curl.h if it differs — on Debian/Ubuntu that's the multiarch path.
+        val curlIncludeDir = curlIncludeCandidates.firstOrNull { fileExists("$it/curl/curl.h") }
+        if (curlIncludeDir == null) {
+            println(
+                "SKIP: libcurl headers (curl/curl.h) not found in any of " +
+                    curlIncludeCandidates.joinToString()
+            )
+            return
+        }
+        val includeDirs = linkedSetOf("/usr/include", curlIncludeDir).toList()
+        val compilerOpts = includeDirs.joinToString(" ") { "-I$it" }
+
+        val curlLibDir = curlLibCandidates.firstOrNull { fileExists("$it/libcurl.so") }
+        if (curlLibDir == null) {
+            println(
+                "SKIP: libcurl.so not found in any of " + curlLibCandidates.joinToString()
+            )
+            return
+        }
+        val linkerOpts = "-L$curlLibDir -lcurl"
+
         val tmpDir = "/tmp/kolt-e2e-cinterop-${getpid()}"
         val buildDir = "$tmpDir/build"
         ensureDirectoryRecursive(buildDir)
@@ -44,8 +87,8 @@ class CinteropSmokeTest {
                 defFile,
                 """
                 headers = curl/curl.h
-                compilerOpts.linux = -I/usr/include -I/usr/include/x86_64-linux-gnu
-                linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -lcurl
+                compilerOpts.linux = $compilerOpts
+                linkerOpts.linux = $linkerOpts
                 """.trimIndent()
             )
 

--- a/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
@@ -1,0 +1,251 @@
+package kolt.build
+
+import kolt.config.CinteropConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CinteropTest {
+
+    // --- cinteropCommand ---
+
+    @Test
+    fun cinteropCommandMinimalProducesDefAndOutput() {
+        // Given: a minimal cinterop entry with only name and def
+        val entry = CinteropConfig(
+            name = "libcurl",
+            def = "src/nativeInterop/cinterop/libcurl.def"
+        )
+
+        // When: command is constructed
+        val cmd = cinteropCommand(entry)
+
+        // Then: args contain cinterop binary, -def, and -o flags
+        assertEquals(
+            listOf("cinterop", "-def", "src/nativeInterop/cinterop/libcurl.def", "-o", "build/libcurl"),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun cinteropCommandOutputPathIsInBuildDir() {
+        // Given: an entry named "libcurl"
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+
+        // When: command is constructed
+        val cmd = cinteropCommand(entry)
+
+        // Then: -o points to build/<name> (cinterop appends .klib itself)
+        assertEquals("build/libcurl", cmd.outputPath)
+    }
+
+    @Test
+    fun cinteropCommandWithPackageNameEmitsPkgFlag() {
+        // Given: entry with packageName set
+        val entry = CinteropConfig(
+            name = "libcurl",
+            def = "libcurl.def",
+            packageName = "libcurl"
+        )
+
+        // When: command is constructed
+        val cmd = cinteropCommand(entry)
+
+        // Then: -pkg flag is included
+        assertTrue(cmd.args.contains("-pkg"), "Expected -pkg flag in: ${cmd.args}")
+        val pkgIndex = cmd.args.indexOf("-pkg")
+        assertEquals("libcurl", cmd.args[pkgIndex + 1])
+    }
+
+    @Test
+    fun cinteropCommandWithoutPackageNameOmitsPkgFlag() {
+        // Given: entry with no packageName
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def", packageName = null)
+
+        // When: command is constructed
+        val cmd = cinteropCommand(entry)
+
+        // Then: -pkg flag is absent
+        assertFalse(cmd.args.contains("-pkg"), "Unexpected -pkg flag in: ${cmd.args}")
+    }
+
+    @Test
+    fun cinteropCommandWithCompilerOptionsEmitsCompilerOptionsFlag() {
+        // Given: entry with compilerOptions
+        val entry = CinteropConfig(
+            name = "libcurl",
+            def = "libcurl.def",
+            compilerOptions = "-I/usr/include"
+        )
+
+        // When: command is constructed
+        val cmd = cinteropCommand(entry)
+
+        // Then: -compiler-options flag is included with the value
+        assertTrue(cmd.args.contains("-compiler-options"), "Expected -compiler-options flag in: ${cmd.args}")
+        val flagIndex = cmd.args.indexOf("-compiler-options")
+        assertEquals("-I/usr/include", cmd.args[flagIndex + 1])
+    }
+
+    @Test
+    fun cinteropCommandWithoutCompilerOptionsOmitsFlag() {
+        // Given: entry with no compilerOptions
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def", compilerOptions = null)
+
+        // When: command is constructed
+        val cmd = cinteropCommand(entry)
+
+        // Then: -compiler-options flag is absent
+        assertFalse(cmd.args.contains("-compiler-options"), "Unexpected -compiler-options flag in: ${cmd.args}")
+    }
+
+    @Test
+    fun cinteropCommandWithLinkerOptionsEmitsLinkerOptionsFlag() {
+        // Given: entry with linkerOptions
+        val entry = CinteropConfig(
+            name = "libcurl",
+            def = "libcurl.def",
+            linkerOptions = "-lcurl"
+        )
+
+        // When: command is constructed
+        val cmd = cinteropCommand(entry)
+
+        // Then: -linker-options flag is included with the value
+        assertTrue(cmd.args.contains("-linker-options"), "Expected -linker-options flag in: ${cmd.args}")
+        val flagIndex = cmd.args.indexOf("-linker-options")
+        assertEquals("-lcurl", cmd.args[flagIndex + 1])
+    }
+
+    @Test
+    fun cinteropCommandWithoutLinkerOptionsOmitsFlag() {
+        // Given: entry with no linkerOptions
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def", linkerOptions = null)
+
+        // When: command is constructed
+        val cmd = cinteropCommand(entry)
+
+        // Then: -linker-options flag is absent
+        assertFalse(cmd.args.contains("-linker-options"), "Unexpected -linker-options flag in: ${cmd.args}")
+    }
+
+    @Test
+    fun cinteropCommandWithAllOptionsProducesFullArgs() {
+        // Given: entry with all optional fields set
+        val entry = CinteropConfig(
+            name = "libcurl",
+            def = "src/nativeInterop/cinterop/libcurl.def",
+            packageName = "libcurl",
+            compilerOptions = "-I/usr/include",
+            linkerOptions = "-lcurl"
+        )
+
+        // When: command is constructed
+        val cmd = cinteropCommand(entry)
+
+        // Then: full args in canonical order
+        assertEquals(
+            listOf(
+                "cinterop",
+                "-def", "src/nativeInterop/cinterop/libcurl.def",
+                "-o", "build/libcurl",
+                "-pkg", "libcurl",
+                "-compiler-options", "-I/usr/include",
+                "-linker-options", "-lcurl"
+            ),
+            cmd.args
+        )
+    }
+
+    @Test
+    fun cinteropCommandWithCustomCinteropPath() {
+        // Given: a managed cinterop binary path
+        val managedPath = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/cinterop"
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+
+        // When: command is constructed with custom cinteropPath
+        val cmd = cinteropCommand(entry, cinteropPath = managedPath)
+
+        // Then: managed path is used as the first arg, not system "cinterop"
+        assertEquals(managedPath, cmd.args.first())
+    }
+
+    @Test
+    fun cinteropCommandWithNullCinteropPathDefaultsToSystemCinterop() {
+        // Given: no managed path (null)
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+
+        // When: command is constructed with explicit null cinteropPath
+        val cmd = cinteropCommand(entry, cinteropPath = null)
+
+        // Then: falls back to system "cinterop"
+        assertEquals("cinterop", cmd.args.first())
+    }
+
+    @Test
+    fun cinteropCommandWithCustomOutputDir() {
+        // Given: a custom output directory
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+
+        // When: command is constructed with custom outputDir
+        val cmd = cinteropCommand(entry, outputDir = "custom/build")
+
+        // Then: -o uses the custom output dir
+        val outputIndex = cmd.args.indexOf("-o")
+        assertEquals("custom/build/libcurl", cmd.args[outputIndex + 1])
+        assertEquals("custom/build/libcurl", cmd.outputPath)
+    }
+
+    @Test
+    fun cinteropCommandOutputPathDoesNotIncludeKlibExtension() {
+        // cinterop tool appends .klib itself; we must not double-append it
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+
+        val cmd = cinteropCommand(entry)
+
+        assertFalse(cmd.outputPath.endsWith(".klib.klib"), "outputPath must not double .klib: ${cmd.outputPath}")
+        assertFalse(cmd.args.any { it.endsWith(".klib") }, "No .klib suffix expected in args: ${cmd.args}")
+    }
+
+    // --- cinteropOutputKlibPath ---
+
+    @Test
+    fun cinteropOutputKlibPathReturnsExpectedPath() {
+        // Given: an entry named "libcurl"
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+
+        // When: klib path is computed
+        val path = cinteropOutputKlibPath(entry)
+
+        // Then: path is build/<name>.klib
+        assertEquals("build/libcurl.klib", path)
+    }
+
+    @Test
+    fun cinteropOutputKlibPathWithCustomOutputDir() {
+        // Given: a custom output directory
+        val entry = CinteropConfig(name = "libssl", def = "libssl.def")
+
+        // When: klib path is computed with custom dir
+        val path = cinteropOutputKlibPath(entry, outputDir = "custom/build")
+
+        // Then: path uses custom dir
+        assertEquals("custom/build/libssl.klib", path)
+    }
+
+    @Test
+    fun cinteropOutputKlibPathUsesEntryName() {
+        // Given: two entries with different names
+        val curl = CinteropConfig(name = "libcurl", def = "libcurl.def")
+        val ssl = CinteropConfig(name = "openssl", def = "openssl.def")
+
+        // When: klib paths are computed
+        val curlPath = cinteropOutputKlibPath(curl)
+        val sslPath = cinteropOutputKlibPath(ssl)
+
+        // Then: paths differ by name
+        assertEquals("build/libcurl.klib", curlPath)
+        assertEquals("build/openssl.klib", sslPath)
+    }
+}

--- a/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
@@ -71,63 +71,100 @@ class CinteropTest {
     }
 
     @Test
-    fun cinteropCommandWithCompilerOptionsEmitsCompilerOptionsFlag() {
-        // Given: entry with compilerOptions
+    fun cinteropCommandWithSingleCompilerOptionEmitsOneCompilerOptionFlag() {
+        // Given: entry with one compilerOptions element
         val entry = CinteropConfig(
             name = "libcurl",
             def = "libcurl.def",
-            compilerOptions = "-I/usr/include"
+            compilerOptions = listOf("-I/usr/include")
         )
 
         // When: command is constructed
         val cmd = cinteropCommand(entry)
 
-        // Then: -compiler-options flag is included with the value
-        assertTrue(cmd.args.contains("-compiler-options"), "Expected -compiler-options flag in: ${cmd.args}")
-        val flagIndex = cmd.args.indexOf("-compiler-options")
+        // Then: a single -compiler-option flag is included with the value
+        assertEquals(1, cmd.args.count { it == "-compiler-option" })
+        val flagIndex = cmd.args.indexOf("-compiler-option")
         assertEquals("-I/usr/include", cmd.args[flagIndex + 1])
     }
 
     @Test
-    fun cinteropCommandWithoutCompilerOptionsOmitsFlag() {
-        // Given: entry with no compilerOptions
-        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def", compilerOptions = null)
-
-        // When: command is constructed
-        val cmd = cinteropCommand(entry)
-
-        // Then: -compiler-options flag is absent
-        assertFalse(cmd.args.contains("-compiler-options"), "Unexpected -compiler-options flag in: ${cmd.args}")
-    }
-
-    @Test
-    fun cinteropCommandWithLinkerOptionsEmitsLinkerOptionsFlag() {
-        // Given: entry with linkerOptions
+    fun cinteropCommandWithMultipleCompilerOptionsEmitsRepeatedCompilerOptionFlags() {
+        // Given: entry with multiple compilerOptions elements
         val entry = CinteropConfig(
             name = "libcurl",
             def = "libcurl.def",
-            linkerOptions = "-lcurl"
+            compilerOptions = listOf("-I/usr/include", "-I/usr/include/x86_64-linux-gnu", "-DFOO=1")
         )
 
         // When: command is constructed
         val cmd = cinteropCommand(entry)
 
-        // Then: -linker-options flag is included with the value
-        assertTrue(cmd.args.contains("-linker-options"), "Expected -linker-options flag in: ${cmd.args}")
-        val flagIndex = cmd.args.indexOf("-linker-options")
-        assertEquals("-lcurl", cmd.args[flagIndex + 1])
+        // Then: -compiler-option is repeated once per element, preserving order
+        val pairs = cmd.args.zipWithNext().filter { it.first == "-compiler-option" }.map { it.second }
+        assertEquals(
+            listOf("-I/usr/include", "-I/usr/include/x86_64-linux-gnu", "-DFOO=1"),
+            pairs
+        )
     }
 
     @Test
-    fun cinteropCommandWithoutLinkerOptionsOmitsFlag() {
-        // Given: entry with no linkerOptions
-        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def", linkerOptions = null)
+    fun cinteropCommandWithEmptyCompilerOptionsOmitsFlag() {
+        // Given: entry with empty compilerOptions list (the default)
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
         // When: command is constructed
         val cmd = cinteropCommand(entry)
 
-        // Then: -linker-options flag is absent
-        assertFalse(cmd.args.contains("-linker-options"), "Unexpected -linker-options flag in: ${cmd.args}")
+        // Then: no -compiler-option flag is emitted
+        assertFalse(cmd.args.contains("-compiler-option"), "Unexpected -compiler-option flag in: ${cmd.args}")
+    }
+
+    @Test
+    fun cinteropCommandWithSingleLinkerOptionEmitsOneLinkerOptionFlag() {
+        // Given: entry with one linkerOptions element
+        val entry = CinteropConfig(
+            name = "libcurl",
+            def = "libcurl.def",
+            linkerOptions = listOf("-lcurl")
+        )
+
+        // When: command is constructed
+        val cmd = cinteropCommand(entry)
+
+        // Then: a single -linker-option flag is included with the value
+        assertEquals(1, cmd.args.count { it == "-linker-option" })
+        val flagIndex = cmd.args.indexOf("-linker-option")
+        assertEquals("-lcurl", cmd.args[flagIndex + 1])
+    }
+
+    @Test
+    fun cinteropCommandWithMultipleLinkerOptionsEmitsRepeatedLinkerOptionFlags() {
+        // Given: entry with multiple linkerOptions elements
+        val entry = CinteropConfig(
+            name = "libcurl",
+            def = "libcurl.def",
+            linkerOptions = listOf("-L/usr/lib/x86_64-linux-gnu", "-lcurl")
+        )
+
+        // When: command is constructed
+        val cmd = cinteropCommand(entry)
+
+        // Then: -linker-option is repeated once per element, preserving order
+        val pairs = cmd.args.zipWithNext().filter { it.first == "-linker-option" }.map { it.second }
+        assertEquals(listOf("-L/usr/lib/x86_64-linux-gnu", "-lcurl"), pairs)
+    }
+
+    @Test
+    fun cinteropCommandWithEmptyLinkerOptionsOmitsFlag() {
+        // Given: entry with empty linkerOptions list (the default)
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+
+        // When: command is constructed
+        val cmd = cinteropCommand(entry)
+
+        // Then: no -linker-option flag is emitted
+        assertFalse(cmd.args.contains("-linker-option"), "Unexpected -linker-option flag in: ${cmd.args}")
     }
 
     @Test
@@ -137,22 +174,24 @@ class CinteropTest {
             name = "libcurl",
             def = "src/nativeInterop/cinterop/libcurl.def",
             packageName = "libcurl",
-            compilerOptions = "-I/usr/include",
-            linkerOptions = "-lcurl"
+            compilerOptions = listOf("-I/usr/include", "-DFOO=1"),
+            linkerOptions = listOf("-L/usr/lib", "-lcurl")
         )
 
         // When: command is constructed
         val cmd = cinteropCommand(entry)
 
-        // Then: full args in canonical order
+        // Then: full args in canonical order, with repeated singular flags
         assertEquals(
             listOf(
                 "cinterop",
                 "-def", "src/nativeInterop/cinterop/libcurl.def",
                 "-o", "build/libcurl",
                 "-pkg", "libcurl",
-                "-compiler-options", "-I/usr/include",
-                "-linker-options", "-lcurl"
+                "-compiler-option", "-I/usr/include",
+                "-compiler-option", "-DFOO=1",
+                "-linker-option", "-L/usr/lib",
+                "-linker-option", "-lcurl"
             ),
             cmd.args
         )

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
@@ -129,7 +129,7 @@ class CinteropNativeBuildIntegrationTest {
             name = "libcurl",
             def = "src/nativeInterop/cinterop/libcurl.def",
             packageName = "libcurl",
-            linkerOptions = "-lcurl"
+            linkerOptions = listOf("-lcurl")
         )
         val config = testConfig(
             name = "myapp",

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
@@ -1,6 +1,11 @@
 package kolt.cli
 
 import kolt.testConfig
+import kolt.build.cinteropCommand
+import kolt.build.cinteropOutputKlibPath
+import kolt.build.nativeLibraryCommand
+import kolt.build.nativeLinkCommand
+import kolt.config.CinteropConfig
 import kolt.config.KoltPaths
 import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.removeDirectoryRecursive
@@ -110,5 +115,93 @@ class FindOverlappingDependenciesTest {
         val result = findOverlappingDependencies(emptyMap(), emptyMap())
 
         assertTrue(result.isEmpty())
+    }
+}
+
+// Integration test: verifies the full cinterop data flow across Config → Builder → BuildCommands → KoltPaths.
+// This covers the native build pipeline that a `target = "native"` project with libcurl cinterop would exercise.
+class CinteropNativeBuildIntegrationTest {
+
+    @Test
+    fun nativeConfigWithCinteropPassesKlibToLibraryAndLinkCommands() {
+        // Given: a native project config with a libcurl cinterop entry
+        val libcurlEntry = CinteropConfig(
+            name = "libcurl",
+            def = "src/nativeInterop/cinterop/libcurl.def",
+            packageName = "libcurl",
+            linkerOptions = "-lcurl"
+        )
+        val config = testConfig(
+            name = "myapp",
+            target = "native",
+            cinterop = listOf(libcurlEntry)
+        )
+        val paths = KoltPaths("/home/testuser")
+
+        // When: cinterop command and klib path are derived from the config entry using KoltPaths
+        val cinteropCmd = cinteropCommand(
+            entry = libcurlEntry,
+            cinteropPath = paths.cinteropBin(config.kotlin)
+        )
+        val klibPath = cinteropOutputKlibPath(libcurlEntry)
+
+        // Then: the cinterop binary comes from the managed konanc distribution (KoltPaths → cinterop)
+        assertEquals(paths.cinteropBin(config.kotlin), cinteropCmd.args.first())
+        assertEquals("build/libcurl.klib", klibPath)
+
+        // When: the cinterop klib is passed to native build commands (cinterop → nativeLibraryCommand)
+        val libraryCmd = nativeLibraryCommand(config, klibs = listOf(klibPath))
+
+        // Then: the klib appears as -l in the library command
+        val libLIdx = libraryCmd.args.indexOf("-l")
+        assertEquals("build/libcurl.klib", libraryCmd.args[libLIdx + 1])
+
+        // When: the same klib is passed to the link command (cinterop → nativeLinkCommand)
+        val linkCmd = nativeLinkCommand(config, klibs = listOf(klibPath))
+
+        // Then: the klib appears as -l in the link command, and the output is the expected executable
+        val linkLIdx = linkCmd.args.indexOf("-l")
+        assertEquals("build/libcurl.klib", linkCmd.args[linkLIdx + 1])
+        assertEquals("build/myapp.kexe", linkCmd.outputPath)
+    }
+
+    @Test
+    fun cinteropOutputKlibPathIsConsistentWithCinteropCommandOutputBase() {
+        // The cinterop tool appends .klib to the -o path automatically.
+        // cinteropCommand.outputPath must not include .klib; cinteropOutputKlibPath adds it.
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+
+        // When: both are computed for the same entry
+        val cmd = cinteropCommand(entry)
+        val klibPath = cinteropOutputKlibPath(entry)
+
+        // Then: klibPath == cmd.outputPath + ".klib" (consistent across Build package functions)
+        assertEquals("${cmd.outputPath}.klib", klibPath)
+    }
+
+    @Test
+    fun nativeConfigWithMultipleCinteropEntriesProducesAllKlibsInBuildCommands() {
+        // Given: a native config with two cinterop entries (libcurl + libssl)
+        val libcurlEntry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+        val libsslEntry = CinteropConfig(name = "libssl", def = "libssl.def")
+        val config = testConfig(
+            target = "native",
+            cinterop = listOf(libcurlEntry, libsslEntry)
+        )
+
+        // When: klib paths are computed for all entries (mirrors what runCinterop does)
+        val klibPaths = config.cinterop.map { cinteropOutputKlibPath(it) }
+
+        // Then: each entry yields its own klib path under build/
+        assertEquals(listOf("build/libcurl.klib", "build/libssl.klib"), klibPaths)
+
+        // When: native library command is built with all cinterop klibs
+        val libraryCmd = nativeLibraryCommand(config, klibs = klibPaths)
+
+        // Then: -l flag is repeated for each klib in order
+        val lIndices = libraryCmd.args.indices.filter { libraryCmd.args[it] == "-l" }
+        assertEquals(2, lIndices.size)
+        assertEquals("build/libcurl.klib", libraryCmd.args[lIndices[0] + 1])
+        assertEquals("build/libssl.klib", libraryCmd.args[lIndices[1] + 1])
     }
 }

--- a/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
@@ -642,4 +642,136 @@ class ConfigTest {
         assertEquals("21", config.jdk)
         assertEquals("17", config.jvmTarget)
     }
+
+    // --- [[cinterop]] ---
+
+    @Test
+    fun parseMinimalConfigHasEmptyCinteropList() {
+        // Given: no [[cinterop]] section in TOML
+        // When: config is parsed
+        val config = assertNotNull(parseConfig(minimalToml).get())
+
+        // Then: cinterop defaults to empty list
+        assertEquals(emptyList(), config.cinterop)
+    }
+
+    @Test
+    fun parseConfigWithSingleCinteropEntry() {
+        // Given: one [[cinterop]] entry with only required fields
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "native"
+            main = "com.example.MainKt"
+            sources = ["src"]
+
+            [[cinterop]]
+            name = "libcurl"
+            def = "src/nativeInterop/cinterop/libcurl.def"
+        """.trimIndent()
+
+        // When: config is parsed
+        val config = assertNotNull(parseConfig(toml).get())
+
+        // Then: one entry is parsed with correct fields
+        assertEquals(1, config.cinterop.size)
+        val entry = config.cinterop[0]
+        assertEquals("libcurl", entry.name)
+        assertEquals("src/nativeInterop/cinterop/libcurl.def", entry.def)
+        assertNull(entry.packageName)
+        assertNull(entry.compilerOptions)
+        assertNull(entry.linkerOptions)
+    }
+
+    @Test
+    fun parseConfigWithCinteropEntryAllFields() {
+        // Given: one [[cinterop]] entry with all optional fields
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "native"
+            main = "com.example.MainKt"
+            sources = ["src"]
+
+            [[cinterop]]
+            name = "libcurl"
+            def = "src/nativeInterop/cinterop/libcurl.def"
+            package = "libcurl"
+            compiler_options = "-I/usr/include"
+            linker_options = "-lcurl"
+        """.trimIndent()
+
+        // When: config is parsed
+        val config = assertNotNull(parseConfig(toml).get())
+
+        // Then: all fields are parsed correctly
+        assertEquals(1, config.cinterop.size)
+        val entry = config.cinterop[0]
+        assertEquals("libcurl", entry.name)
+        assertEquals("src/nativeInterop/cinterop/libcurl.def", entry.def)
+        assertEquals("libcurl", entry.packageName)
+        assertEquals("-I/usr/include", entry.compilerOptions)
+        assertEquals("-lcurl", entry.linkerOptions)
+    }
+
+    @Test
+    fun parseConfigWithMultipleCinteropEntries() {
+        // Given: two [[cinterop]] entries
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "native"
+            main = "com.example.MainKt"
+            sources = ["src"]
+
+            [[cinterop]]
+            name = "libcurl"
+            def = "src/nativeInterop/cinterop/libcurl.def"
+
+            [[cinterop]]
+            name = "openssl"
+            def = "src/nativeInterop/cinterop/openssl.def"
+            package = "openssl"
+        """.trimIndent()
+
+        // When: config is parsed
+        val config = assertNotNull(parseConfig(toml).get())
+
+        // Then: both entries are parsed in order
+        assertEquals(2, config.cinterop.size)
+        assertEquals("libcurl", config.cinterop[0].name)
+        assertEquals("openssl", config.cinterop[1].name)
+        assertNull(config.cinterop[0].packageName)
+        assertEquals("openssl", config.cinterop[1].packageName)
+    }
+
+    @Test
+    fun parseConfigCinteropWithDependencies() {
+        // Given: [[cinterop]] alongside [dependencies]
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kotlin = "2.1.0"
+            target = "native"
+            main = "com.example.MainKt"
+            sources = ["src"]
+
+            [dependencies]
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core" = "1.9.0"
+
+            [[cinterop]]
+            name = "libcurl"
+            def = "libcurl.def"
+        """.trimIndent()
+
+        // When: config is parsed
+        val config = assertNotNull(parseConfig(toml).get())
+
+        // Then: both sections are parsed independently
+        assertEquals(1, config.dependencies.size)
+        assertEquals(1, config.cinterop.size)
+    }
 }

--- a/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
@@ -680,8 +680,8 @@ class ConfigTest {
         assertEquals("libcurl", entry.name)
         assertEquals("src/nativeInterop/cinterop/libcurl.def", entry.def)
         assertNull(entry.packageName)
-        assertNull(entry.compilerOptions)
-        assertNull(entry.linkerOptions)
+        assertEquals(emptyList(), entry.compilerOptions)
+        assertEquals(emptyList(), entry.linkerOptions)
     }
 
     @Test
@@ -699,8 +699,8 @@ class ConfigTest {
             name = "libcurl"
             def = "src/nativeInterop/cinterop/libcurl.def"
             package = "libcurl"
-            compiler_options = "-I/usr/include"
-            linker_options = "-lcurl"
+            compiler_options = ["-I/usr/include", "-DFOO=1"]
+            linker_options = ["-L/usr/lib", "-lcurl"]
         """.trimIndent()
 
         // When: config is parsed
@@ -712,8 +712,8 @@ class ConfigTest {
         assertEquals("libcurl", entry.name)
         assertEquals("src/nativeInterop/cinterop/libcurl.def", entry.def)
         assertEquals("libcurl", entry.packageName)
-        assertEquals("-I/usr/include", entry.compilerOptions)
-        assertEquals("-lcurl", entry.linkerOptions)
+        assertEquals(listOf("-I/usr/include", "-DFOO=1"), entry.compilerOptions)
+        assertEquals(listOf("-L/usr/lib", "-lcurl"), entry.linkerOptions)
     }
 
     @Test

--- a/src/nativeTest/kotlin/kolt/config/KoltPathsTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/KoltPathsTest.kt
@@ -173,4 +173,36 @@ class KoltPathsTest {
         assertEquals("$base/bin/java", paths.javaBin("21"))
         assertEquals("$base/bin/jar", paths.jarBin("21"))
     }
+
+    // --- cinteropBin ---
+
+    @Test
+    fun cinteropBinBuildsVersionedBinPath() {
+        // Given: KoltPaths with a known home
+        val paths = KoltPaths("/home/user")
+
+        // When: cinteropBin is called for a specific version
+        val bin = paths.cinteropBin("2.3.20")
+
+        // Then: bin path points to bin/cinterop inside the konanc versioned directory
+        assertEquals("/home/user/.kolt/toolchains/konanc/2.3.20/bin/cinterop", bin)
+    }
+
+    @Test
+    fun cinteropBinDifferentHome() {
+        val paths = KoltPaths("/root")
+
+        assertEquals("/root/.kolt/toolchains/konanc/2.1.0/bin/cinterop", paths.cinteropBin("2.1.0"))
+    }
+
+    @Test
+    fun cinteropBinSharesKonancDirectory() {
+        // Given: cinterop ships alongside konanc in the same distribution
+        val paths = KoltPaths("/home/user")
+        val version = "2.3.20"
+
+        // Then: cinteropBin is in the same directory as konancBin
+        val konancDir = paths.konancPath(version)
+        assertEquals("$konancDir/bin/cinterop", paths.cinteropBin(version))
+    }
 }


### PR DESCRIPTION
## Summary

Add cinterop support to kolt so `.def` files declared in `kolt.toml` are compiled to `.klib` via the konan distribution's `cinterop` tool and linked into the native build pipeline. This is the prerequisite for kolt self-hosting (#61): building `kolt.kexe` with kolt itself requires libcurl bindings, and those bindings come from cinterop.

## Changes

- **`[cinterop]` schema in `kolt.toml`** — declare `.def` file path, package name, compiler opts, linker opts
- **`cinteropCommand` (pure)** — maps a `CinteropEntry` to an argv for the cinterop tool
- **`runCinterop` (impure)** — orchestrates cinterop invocation and klib caching under the build directory
- **`.def` mtime tracking** — `BuildState` gains `defNewestMtime`; rebuild on `.def` change, schema-compat shim keeps pre-cinterop state files loadable (`defNewestMtimeDefaultsToNullForOlderStateJson`)
- **konanc `-l` wiring** — generated klibs are passed to both `nativeBuildCommand` and `nativeTestBuildCommand`
- **Tests**
  - Unit: `cinteropCommand` expansion, `.klib` suffix handling, helper consistency invariant
  - Integration: Config → Builder → KoltPaths end-to-end without touching the filesystem
  - E2E: `CinteropSmokeTest` walks cinterop → konanc stage 1 → stage 2 → run → `curl/` output match

## Out of scope

- Kotlin compiler plugin wiring on native (#62, landed in #66)
- Non-libcurl bindings beyond what's needed for kolt's own self-host
- Cross-platform host support (linux_x64 only)

Refs #61
Closes #64