### PR TITLE
Skip kotlin-stdlib-common in native dependency resolution

### DIFF
--- a/docs/adr/0011-skip-kotlin-stdlib-for-native-resolution.md
+++ b/docs/adr/0011-skip-kotlin-stdlib-for-native-resolution.md
@@ -50,12 +50,13 @@ kolt resolving any dependency.
 ## Decision
 
 `NativeResolver` explicitly skips `org.jetbrains.kotlin:kotlin-stdlib`
-at every entry point. The skip is implemented as a single predicate at
-the top of the file:
+and `org.jetbrains.kotlin:kotlin-stdlib-common` at every entry point.
+The skip is implemented as a single predicate at the top of the file:
 
 ```kotlin
 private fun isKotlinStdlib(groupArtifact: String): Boolean =
-    groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib"
+    groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib" ||
+        groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib-common"
 ```
 
 The check is applied in three places:

--- a/docs/adr/0011-skip-kotlin-stdlib-for-native-resolution.md
+++ b/docs/adr/0011-skip-kotlin-stdlib-for-native-resolution.md
@@ -104,11 +104,16 @@ stdlib against the bundled konanc release.
   `kotlin-stdlib` in `[dependencies]` will see it disappear from the
   resolved set with no message. This is intentional (it would always
   be wrong to include) but may confuse users porting a JVM project.
-- **The constant `"org.jetbrains.kotlin:kotlin-stdlib"` is hard-coded
-  in `NativeResolver.kt`.** Future related modules (`kotlin-stdlib-jdk8`,
-  `kotlin-stdlib-common`, etc.) would need explicit additions if they
-  ever appeared in a native variant's dependencies. As of Phase B, only
-  the bare `kotlin-stdlib` is observed in real-world `.module` files.
+- **The constants `"org.jetbrains.kotlin:kotlin-stdlib"` and
+  `"org.jetbrains.kotlin:kotlin-stdlib-common"` are hard-coded in
+  `NativeResolver.kt`.** Future related modules (`kotlin-stdlib-jdk8`
+  etc.) would need explicit additions if they ever appeared in a
+  native variant's dependencies. `kotlin-stdlib-common` was added
+  alongside the original `kotlin-stdlib` skip after observing it in the
+  transitive closure of `org.kotlincrypto.hash:sha2-256:0.2.7`, which
+  pins `kotlin-stdlib-common:1.8.21` — a pre-Gradle-metadata artifact
+  that publishes only a `.pom`, causing the native resolver's `.module`
+  fetch to 404.
 
 ### Neutral
 

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -31,8 +31,8 @@ private data class NativeResolved(val redirect: NativeRedirect, val artifact: Na
  *    the current native target (linux_x64 in Phase B).
  * 2. Fetch the redirect target's `.module` file and extract the `.klib`
  *    file reference (url + sha256) and the variant's `dependencies[]`.
- * 3. Enqueue each transitive dependency (except `kotlin-stdlib`, which
- *    konanc bundles).
+ * 3. Enqueue each transitive dependency (except the stdlib artifacts
+ *    covered by [isKotlinStdlib], which konanc bundles).
  *
  * After BFS, each resolved `(groupArtifact, version)` has its `.klib`
  * downloaded and hashed; the sha256 is verified against the metadata.

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -12,8 +12,14 @@ internal const val NATIVE_TARGET_LINUX_X64 = "linux_x64"
 // Kotlin/Native bundles the stdlib in the konanc distribution — it must be
 // skipped during dependency resolution even though Gradle module metadata
 // declares it as a dependency on every native variant.
+// kotlin-stdlib and kotlin-stdlib-common are both bundled by konanc and must
+// not be resolved from Maven: the former has no native variant published in
+// the shape our resolver expects, and the latter (a pre-Gradle-metadata
+// artifact from the 1.8-era split) publishes only a `.pom`, not a `.module`,
+// so the native resolver's `.module` fetch would 404. See ADR 0011.
 private fun isKotlinStdlib(groupArtifact: String): Boolean =
-    groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib"
+    groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib" ||
+        groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib-common"
 
 private data class NativeResolved(val redirect: NativeRedirect, val artifact: NativeArtifact)
 

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -139,6 +139,68 @@ class NativeResolverTest {
     }
 
     @Test
+    fun skipsKotlinStdlibCommonFromTransitives() {
+        // kotlin-stdlib-common has no Gradle module metadata (pre-GMM artifact),
+        // so the resolver must skip it alongside kotlin-stdlib. Appears in the
+        // transitive closure of e.g. org.kotlincrypto.hash:sha2-256.
+        val config = testConfig(target = "native").copy(
+            dependencies = mapOf("com.example:lib" to "1.0.0")
+        )
+
+        val libRoot = rootModuleJson("com.example", "lib-linuxx64", "1.0.0")
+        val libPlatform = platformModuleJson(
+            klibFileName = "lib-linuxx64-1.0.0.klib",
+            klibSha256 = "h",
+            dependencies = listOf(
+                NativeDependency("org.jetbrains.kotlin", "kotlin-stdlib-common", "1.8.21")
+            )
+        )
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to libRoot,
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to libPlatform
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "h"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        assertEquals(1, resolved.deps.size)
+        assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
+    }
+
+    @Test
+    fun skipsKotlinStdlibCommonAsDirectDependencyToo() {
+        val config = testConfig(target = "native").copy(
+            dependencies = mapOf(
+                "com.example:lib" to "1.0.0",
+                "org.jetbrains.kotlin:kotlin-stdlib-common" to "1.8.21"
+            )
+        )
+
+        val libRoot = rootModuleJson("com.example", "lib-linuxx64", "1.0.0")
+        val libPlatform = platformModuleJson("lib-linuxx64-1.0.0.klib", "h", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to libRoot,
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to libPlatform
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "h"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        assertEquals(1, resolved.deps.size)
+        assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
+    }
+
+    @Test
     fun skipsKotlinStdlibAsDirectDependencyToo() {
         val config = testConfig(target = "native").copy(
             dependencies = mapOf(


### PR DESCRIPTION
## Summary

- Extend `NativeResolver`'s skip predicate to cover `org.jetbrains.kotlin:kotlin-stdlib-common` alongside the existing `kotlin-stdlib` skip, so native resolution no longer 404s on libraries that pin the 1.8-era split stdlib.
- Update ADR 0011 to record the addition (the \"Negative consequences\" section already anticipated this extension).

## Context

Discovered while verifying runtime dependencies for self-host (#61).

`org.kotlincrypto.hash:sha2-256:0.2.7` transitively pins `kotlin-stdlib-common:1.8.21`. That coordinate is a **pre-Gradle-metadata artifact** — it publishes a `.pom` but no `.module` file. `NativeResolver.fetchNativeMetadata` requires a `.module` and the fetch 404s:

```
resolving dependencies...
error: failed to download org.jetbrains.kotlin:kotlin-stdlib-common
```

The root cause mirrors the original `kotlin-stdlib` skip (ADR 0011): konanc bundles its own stdlib, so we don't need to resolve it from Maven at all. The same reasoning applies to `kotlin-stdlib-common` — it's a legacy split module whose common code was later merged into the unified stdlib, which konanc ships as part of its distribution. We just need to not try to fetch it.

## Why this is the right fix (not a parser change)

The alternative would be to teach the native resolver to fall back to `.pom` when `.module` is missing. Rejected because:
- It would encourage resolving *other* non-GMM artifacts that have no native publication at all, surfacing link errors instead of clean skips.
- The `kotlin-stdlib-common` case is terminal: nothing inside konanc's bundled stdlib needs this module, so fetching it would be pure waste even if the fetch worked.

## Test plan

- [x] `./gradlew linuxX64Test` green
- [x] Added `skipsKotlinStdlibCommonFromTransitives` + `skipsKotlinStdlibCommonAsDirectDependencyToo` mirroring the pre-existing `kotlin-stdlib` tests
- [x] Manual smoke: `kolt install` against a minimal `kolt.toml` with `org.kotlincrypto.hash:sha2-256:0.2.7` now succeeds end-to-end, and the cache contains the full native klib chain (`sha2-256-linuxx64`, `sha2-linuxx64`, `digest-linuxx64`, `common-linuxx64`)

## Refs

Refs #61