### PR TITLE
Accept non-string Gradle module attribute values

### DIFF
--- a/src/nativeMain/kotlin/kolt/resolve/GradleMetadata.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/GradleMetadata.kt
@@ -3,6 +3,7 @@ package kolt.resolve
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Redirect target when a Kotlin Multiplatform module's .module file
@@ -30,7 +31,7 @@ fun parseJvmRedirect(moduleJson: String): JvmRedirect? {
 
     var redirect: JvmRedirect? = null
     for (variant in metadata.variants) {
-        val platformType = variant.attributes["org.jetbrains.kotlin.platform.type"]
+        val platformType = variant.attributes["org.jetbrains.kotlin.platform.type"]?.content
         if (platformType != "jvm") continue
 
         val availableAt = variant.availableAt
@@ -157,11 +158,11 @@ internal fun isValidGradleModuleJson(moduleJson: String): Boolean =
         false
     }
 
-private fun matchesNativeVariant(attrs: Map<String, String>, nativeTarget: String): Boolean =
-    attrs["org.jetbrains.kotlin.platform.type"] == "native" &&
-        attrs["org.jetbrains.kotlin.native.target"] == nativeTarget &&
-        attrs["org.gradle.usage"] == "kotlin-api" &&
-        attrs["org.gradle.category"] == "library"
+private fun matchesNativeVariant(attrs: Map<String, JsonPrimitive>, nativeTarget: String): Boolean =
+    attrs["org.jetbrains.kotlin.platform.type"]?.content == "native" &&
+        attrs["org.jetbrains.kotlin.native.target"]?.content == nativeTarget &&
+        attrs["org.gradle.usage"]?.content == "kotlin-api" &&
+        attrs["org.gradle.category"]?.content == "library"
 
 private val lenientJson = Json { ignoreUnknownKeys = true }
 
@@ -170,9 +171,14 @@ private data class GradleModuleMetadata(
     val variants: List<GradleVariant> = emptyList()
 )
 
+// Attribute values use JsonPrimitive, not String, because Gradle Module Metadata
+// does not require attribute values to be strings. For example, kotlinx-datetime
+// emits `"org.gradle.jvm.version": 8` (integer) on its JVM variants. Callers read
+// the value via `.content`, which returns the stringified form for both strings
+// and numbers and is sufficient for the literal equality checks kolt performs.
 @Serializable
 private data class GradleVariant(
-    val attributes: Map<String, String> = emptyMap(),
+    val attributes: Map<String, JsonPrimitive> = emptyMap(),
     @SerialName("available-at")
     val availableAt: AvailableAt? = null,
     val files: List<GradleFile> = emptyList(),

--- a/src/nativeTest/kotlin/kolt/resolve/GradleMetadataTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/GradleMetadataTest.kt
@@ -623,4 +623,97 @@ class GradleMetadataTest {
         assertEquals("lib-jvm", redirect?.module)
         assertEquals("1.0", redirect?.version)
     }
+
+    // --- numeric attribute values ---
+    //
+    // kotlinx-datetime:0.7.1-0.6.x-compat emits `"org.gradle.jvm.version": 8`
+    // (integer, not string) on its JVM variants. Gradle Module Metadata does
+    // not require attribute values to be strings, so the resolver must accept
+    // numeric values — treating them as their string form is fine because all
+    // comparisons are against known string literals like "jvm" or "linux_x64".
+
+    @Test
+    fun parseNativeRedirectToleratesNumericAttributeValueOnUnrelatedVariant() {
+        // A JVM variant with an integer attribute sits alongside the native
+        // variant we actually want. Previously Map<String, String> deserialization
+        // threw on the integer and the whole document was rejected as invalid.
+        val json = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "jvmApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "java-api",
+                "org.gradle.jvm.version": 8,
+                "org.jetbrains.kotlin.platform.type": "jvm"
+              },
+              "available-at": {
+                "url": "../../lib-jvm/1.0/lib-jvm-1.0.module",
+                "group": "com.example",
+                "module": "lib-jvm",
+                "version": "1.0"
+              }
+            },
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../lib-linuxx64/1.0/lib-linuxx64-1.0.module",
+                "group": "com.example",
+                "module": "lib-linuxx64",
+                "version": "1.0"
+              }
+            }
+          ]
+        }
+        """.trimIndent()
+
+        val redirect = parseNativeRedirect(json, "linux_x64")
+
+        assertEquals("com.example", redirect?.group)
+        assertEquals("lib-linuxx64", redirect?.module)
+        assertEquals("1.0", redirect?.version)
+    }
+
+    @Test
+    fun parseJvmRedirectToleratesNumericJvmVersionAttribute() {
+        // The JVM variant we actually want carries the integer attribute.
+        // `org.gradle.jvm.version` is checked nowhere, but its mere presence
+        // as a non-string broke decoding before the fix.
+        val json = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "jvmApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.jvm.version": 8,
+                "org.gradle.usage": "java-api",
+                "org.jetbrains.kotlin.platform.type": "jvm"
+              },
+              "available-at": {
+                "url": "../../lib-jvm/1.0/lib-jvm-1.0.module",
+                "group": "com.example",
+                "module": "lib-jvm",
+                "version": "1.0"
+              }
+            }
+          ]
+        }
+        """.trimIndent()
+
+        val redirect = parseJvmRedirect(json)
+
+        assertEquals("com.example", redirect?.group)
+        assertEquals("lib-jvm", redirect?.module)
+        assertEquals("1.0", redirect?.version)
+    }
 }


### PR DESCRIPTION
## Summary
- `GradleVariant.attributes` の値型を `Map<String, String>` → `Map<String, JsonPrimitive>` に変更
- アクセス箇所は `.content` 経由に書き換え — `JsonPrimitive.content` は文字列・数値どちらも文字列として返すので、既存の等価比較ロジック (`matchesNativeVariant`, `parseJvmRedirect`) はそのまま動く

## Root cause

`kotlinx-datetime:0.7.1-0.6.x-compat` の JVM バリアントが `"org.gradle.jvm.version": 8` (整数) を持っており、`Map<String, String>` のデシリアライズが型不一致で失敗していました。結果として `isValidGradleModuleJson` が false を返し、`NativeResolver` が「failed to parse Gradle module metadata」を報告。Gradle Module Metadata 仕様は属性値が文字列であることを要求していないため、これは resolver 側のバグです。

## Test plan

- [x] 数値属性を含む fixture で `parseNativeRedirect` / `parseJvmRedirect` の新規テスト追加 (Red → Green 確認)
- [x] `./gradlew linuxX64Test` 全既存テストグリーン
- [x] Issue のリプロ手順 (`/tmp/probe` で `ktoml-core:0.7.1` を `target = "native"` で install) が成功し、推移的依存 `kotlinx-datetime-linuxx64-0.7.1-0.6.x-compat.klib` までクラスパスに出現することを手元確認

Fixes #69