### PR TITLE
Skip cinterop per entry when .def and config are unchanged

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -236,6 +236,34 @@ fun cinteropCommand(
 fun cinteropOutputKlibPath(entry: CinteropConfig, outputDir: String = BUILD_DIR): String =
     "$outputDir/${entry.name}.klib"
 
+// Path of the sidecar stamp file written next to a cinterop klib. The stamp
+// records a canonical serialization of every CinteropConfig field plus the
+// .def file's mtime. runCinterop reads it to decide whether a previously
+// generated klib can be reused without re-invoking the cinterop tool.
+fun cinteropStampPath(entry: CinteropConfig, outputDir: String = BUILD_DIR): String =
+    "$outputDir/${entry.name}.klib.stamp"
+
+// Canonical freshness stamp for a cinterop entry. Two stamps compare equal
+// iff a re-run of cinterop would produce an equivalent klib for cache purposes.
+// We observe:
+//   - name / def path / package — rename or relocation must invalidate
+//   - compiler_options / linker_options — editing these must invalidate even
+//     though the .def file is untouched (this is the subtle failure mode
+//     called out in #68: a naive mtime-only check silently reuses a stale
+//     klib after a kolt.toml edit)
+//   - the .def file's mtime — the usual "contents changed" signal
+//
+// Order of compilerOption / linkerOption lines follows declaration order
+// so the stamp is sensitive to reordering.
+fun cinteropStamp(entry: CinteropConfig, defMtime: Long): String = buildString {
+    append("name=").append(entry.name).append('\n')
+    append("def=").append(entry.def).append('\n')
+    append("defMtime=").append(defMtime).append('\n')
+    append("package=").append(entry.packageName ?: "").append('\n')
+    for (opt in entry.compilerOptions) append("compilerOption=").append(opt).append('\n')
+    for (opt in entry.linkerOptions) append("linkerOption=").append(opt).append('\n')
+}
+
 fun jarCommand(config: KoltConfig, jarPath: String? = null): BuildCommand {
     val outputPath = outputJarPath(config)
     return BuildCommand(

--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -252,10 +252,14 @@ fun cinteropStampPath(entry: CinteropConfig, outputDir: String = BUILD_DIR): Str
 //     called out in #68: a naive mtime-only check silently reuses a stale
 //     klib after a kolt.toml edit)
 //   - the .def file's mtime — the usual "contents changed" signal
+//   - the Kotlin/Native version — bumping `kotlin = "..."` in kolt.toml
+//     switches the cinterop/konanc toolchain, and the klib format is not
+//     guaranteed to be compatible across Kotlin versions
 //
 // Order of compilerOption / linkerOption lines follows declaration order
 // so the stamp is sensitive to reordering.
-fun cinteropStamp(entry: CinteropConfig, defMtime: Long): String = buildString {
+fun cinteropStamp(entry: CinteropConfig, defMtime: Long, kotlinVersion: String): String = buildString {
+    append("kotlinVersion=").append(kotlinVersion).append('\n')
     append("name=").append(entry.name).append('\n')
     append("def=").append(entry.def).append('\n')
     append("defMtime=").append(defMtime).append('\n')

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -245,7 +245,7 @@ private fun runCinterop(config: KoltConfig, paths: KoltPaths): List<String> {
         val klibPath = cinteropOutputKlibPath(entry)
         val stampPath = cinteropStampPath(entry)
         val defMtime = fileMtime(entry.def)
-        val currentStamp = defMtime?.let { cinteropStamp(entry, it) }
+        val currentStamp = defMtime?.let { cinteropStamp(entry, it, config.kotlin) }
 
         if (currentStamp != null && fileExists(klibPath) && fileExists(stampPath)) {
             val previousStamp = readFileAsString(stampPath).get()

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -1,5 +1,6 @@
 package kolt.cli
 
+import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getOrElse
 import kolt.build.*
 import kolt.config.*
@@ -227,19 +228,46 @@ private fun newestDefMtime(config: KoltConfig): Long? {
 
 /**
  * Runs `cinterop` for each [[cinterop]] entry in the config.
+ *
+ * Per-entry freshness check: if the previously generated klib and its sidecar
+ * `.klib.stamp` file both exist and the stamp matches the stamp that would be
+ * produced by the current entry + its .def mtime, the cinterop invocation is
+ * skipped and the cached klib is reused. The stamp observes every field of
+ * CinteropConfig, so editing compiler_options / linker_options in kolt.toml
+ * invalidates the cache even though the .def file is untouched.
+ *
  * Returns the list of generated .klib paths to pass to konanc via -l.
  */
 private fun runCinterop(config: KoltConfig, paths: KoltPaths): List<String> {
     if (config.cinterop.isEmpty()) return emptyList()
     val managedCinteropBin = paths.cinteropBin(config.kotlin)
     return config.cinterop.map { entry ->
+        val klibPath = cinteropOutputKlibPath(entry)
+        val stampPath = cinteropStampPath(entry)
+        val defMtime = fileMtime(entry.def)
+        val currentStamp = defMtime?.let { cinteropStamp(entry, it) }
+
+        if (currentStamp != null && fileExists(klibPath) && fileExists(stampPath)) {
+            val previousStamp = readFileAsString(stampPath).get()
+            if (previousStamp == currentStamp) {
+                return@map klibPath
+            }
+        }
+
         val cmd = cinteropCommand(entry, cinteropPath = managedCinteropBin)
         println("generating cinterop klib for ${entry.name}...")
         executeCommand(cmd.args).getOrElse { error ->
             eprintln(formatProcessError(error, "cinterop (${entry.name})"))
             exitProcess(EXIT_BUILD_ERROR)
         }
-        cinteropOutputKlibPath(entry)
+        if (currentStamp != null) {
+            writeFileAsString(stampPath, currentStamp).getOrElse { error ->
+                // Stamp write failure is non-fatal: the next build will simply
+                // re-run cinterop instead of reusing the cached klib.
+                eprintln("warning: failed to write cinterop stamp ${error.path}")
+            }
+        }
+        klibPath
     }
 }
 

--- a/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
@@ -284,34 +284,34 @@ class CinteropTest {
             compilerOptions = listOf("-I/usr/include"),
             linkerOptions = listOf("-lcurl")
         )
-        assertEquals(cinteropStamp(entry, 1000L), cinteropStamp(entry, 1000L))
+        assertEquals(cinteropStamp(entry, 1000L, "2.1.0"), cinteropStamp(entry, 1000L, "2.1.0"))
     }
 
     @Test
     fun cinteropStampChangesWhenDefMtimeChanges() {
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
-        assertFalse(cinteropStamp(entry, 1000L) == cinteropStamp(entry, 1001L))
+        assertFalse(cinteropStamp(entry, 1000L, "2.1.0") == cinteropStamp(entry, 1001L, "2.1.0"))
     }
 
     @Test
     fun cinteropStampChangesWhenNameChanges() {
         val a = CinteropConfig(name = "libcurl", def = "libcurl.def")
         val b = CinteropConfig(name = "libssl", def = "libcurl.def")
-        assertFalse(cinteropStamp(a, 1000L) == cinteropStamp(b, 1000L))
+        assertFalse(cinteropStamp(a, 1000L, "2.1.0") == cinteropStamp(b, 1000L, "2.1.0"))
     }
 
     @Test
     fun cinteropStampChangesWhenDefPathChanges() {
         val a = CinteropConfig(name = "libcurl", def = "a/libcurl.def")
         val b = CinteropConfig(name = "libcurl", def = "b/libcurl.def")
-        assertFalse(cinteropStamp(a, 1000L) == cinteropStamp(b, 1000L))
+        assertFalse(cinteropStamp(a, 1000L, "2.1.0") == cinteropStamp(b, 1000L, "2.1.0"))
     }
 
     @Test
     fun cinteropStampChangesWhenPackageChanges() {
         val a = CinteropConfig(name = "libcurl", def = "libcurl.def", packageName = null)
         val b = CinteropConfig(name = "libcurl", def = "libcurl.def", packageName = "libcurl")
-        assertFalse(cinteropStamp(a, 1000L) == cinteropStamp(b, 1000L))
+        assertFalse(cinteropStamp(a, 1000L, "2.1.0") == cinteropStamp(b, 1000L, "2.1.0"))
     }
 
     @Test
@@ -326,7 +326,7 @@ class CinteropTest {
             name = "libcurl", def = "libcurl.def",
             compilerOptions = listOf("-I/bar")
         )
-        assertFalse(cinteropStamp(a, 1000L) == cinteropStamp(b, 1000L))
+        assertFalse(cinteropStamp(a, 1000L, "2.1.0") == cinteropStamp(b, 1000L, "2.1.0"))
     }
 
     @Test
@@ -339,7 +339,17 @@ class CinteropTest {
             name = "libcurl", def = "libcurl.def",
             linkerOptions = listOf("-lcurl-gnutls")
         )
-        assertFalse(cinteropStamp(a, 1000L) == cinteropStamp(b, 1000L))
+        assertFalse(cinteropStamp(a, 1000L, "2.1.0") == cinteropStamp(b, 1000L, "2.1.0"))
+    }
+
+    @Test
+    fun cinteropStampChangesWhenKotlinVersionChanges() {
+        // Bumping `kotlin = "..."` in kolt.toml switches the cinterop/konanc
+        // toolchain. Kotlin/Native klib format is not guaranteed compatible
+        // across versions, so a cached klib from a previous Kotlin must not
+        // be reused.
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+        assertFalse(cinteropStamp(entry, 1000L, "2.1.0") == cinteropStamp(entry, 1000L, "2.3.20"))
     }
 
     @Test
@@ -354,7 +364,7 @@ class CinteropTest {
             name = "libcurl", def = "libcurl.def",
             compilerOptions = listOf("-I/bar", "-I/foo")
         )
-        assertFalse(cinteropStamp(a, 1000L) == cinteropStamp(b, 1000L))
+        assertFalse(cinteropStamp(a, 1000L, "2.1.0") == cinteropStamp(b, 1000L, "2.1.0"))
     }
 
     // --- cinteropStampPath ---

--- a/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
@@ -273,6 +273,105 @@ class CinteropTest {
         assertEquals("custom/build/libssl.klib", path)
     }
 
+    // --- cinteropStamp ---
+
+    @Test
+    fun cinteropStampIsStableForIdenticalInputs() {
+        val entry = CinteropConfig(
+            name = "libcurl",
+            def = "libcurl.def",
+            packageName = "libcurl",
+            compilerOptions = listOf("-I/usr/include"),
+            linkerOptions = listOf("-lcurl")
+        )
+        assertEquals(cinteropStamp(entry, 1000L), cinteropStamp(entry, 1000L))
+    }
+
+    @Test
+    fun cinteropStampChangesWhenDefMtimeChanges() {
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+        assertFalse(cinteropStamp(entry, 1000L) == cinteropStamp(entry, 1001L))
+    }
+
+    @Test
+    fun cinteropStampChangesWhenNameChanges() {
+        val a = CinteropConfig(name = "libcurl", def = "libcurl.def")
+        val b = CinteropConfig(name = "libssl", def = "libcurl.def")
+        assertFalse(cinteropStamp(a, 1000L) == cinteropStamp(b, 1000L))
+    }
+
+    @Test
+    fun cinteropStampChangesWhenDefPathChanges() {
+        val a = CinteropConfig(name = "libcurl", def = "a/libcurl.def")
+        val b = CinteropConfig(name = "libcurl", def = "b/libcurl.def")
+        assertFalse(cinteropStamp(a, 1000L) == cinteropStamp(b, 1000L))
+    }
+
+    @Test
+    fun cinteropStampChangesWhenPackageChanges() {
+        val a = CinteropConfig(name = "libcurl", def = "libcurl.def", packageName = null)
+        val b = CinteropConfig(name = "libcurl", def = "libcurl.def", packageName = "libcurl")
+        assertFalse(cinteropStamp(a, 1000L) == cinteropStamp(b, 1000L))
+    }
+
+    @Test
+    fun cinteropStampChangesWhenCompilerOptionsChange() {
+        // This is the subtle case #68 calls out: .def untouched but
+        // compiler_options edited in kolt.toml — stamp MUST differ.
+        val a = CinteropConfig(
+            name = "libcurl", def = "libcurl.def",
+            compilerOptions = listOf("-I/foo")
+        )
+        val b = CinteropConfig(
+            name = "libcurl", def = "libcurl.def",
+            compilerOptions = listOf("-I/bar")
+        )
+        assertFalse(cinteropStamp(a, 1000L) == cinteropStamp(b, 1000L))
+    }
+
+    @Test
+    fun cinteropStampChangesWhenLinkerOptionsChange() {
+        val a = CinteropConfig(
+            name = "libcurl", def = "libcurl.def",
+            linkerOptions = listOf("-lcurl")
+        )
+        val b = CinteropConfig(
+            name = "libcurl", def = "libcurl.def",
+            linkerOptions = listOf("-lcurl-gnutls")
+        )
+        assertFalse(cinteropStamp(a, 1000L) == cinteropStamp(b, 1000L))
+    }
+
+    @Test
+    fun cinteropStampIsSensitiveToOptionOrder() {
+        // Reordering compiler options can change clang's include search order
+        // and therefore the resolved header set. Treat as a semantic change.
+        val a = CinteropConfig(
+            name = "libcurl", def = "libcurl.def",
+            compilerOptions = listOf("-I/foo", "-I/bar")
+        )
+        val b = CinteropConfig(
+            name = "libcurl", def = "libcurl.def",
+            compilerOptions = listOf("-I/bar", "-I/foo")
+        )
+        assertFalse(cinteropStamp(a, 1000L) == cinteropStamp(b, 1000L))
+    }
+
+    // --- cinteropStampPath ---
+
+    @Test
+    fun cinteropStampPathIsKlibPathPlusStamp() {
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+        assertEquals("build/libcurl.klib.stamp", cinteropStampPath(entry))
+        assertEquals("build/libcurl.klib", cinteropOutputKlibPath(entry))
+    }
+
+    @Test
+    fun cinteropStampPathHonorsCustomOutputDir() {
+        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
+        assertEquals("custom/build/libcurl.klib.stamp", cinteropStampPath(entry, "custom/build"))
+    }
+
     @Test
     fun cinteropOutputKlibPathUsesEntryName() {
         // Given: two entries with different names


### PR DESCRIPTION
## Summary

Add a sidecar stamp file next to each cinterop klib so `runCinterop` can skip the cinterop tool invocation when the entry's inputs are unchanged, instead of re-running it on every non-cached build.

## How it works

- `cinteropStamp(entry, defMtime)` — pure function producing a canonical text serialization of every `CinteropConfig` field (name, def, package, compilerOptions, linkerOptions) plus the `.def` file's mtime
- `cinteropStampPath(entry)` — returns `build/<name>.klib.stamp`
- `runCinterop` reads the on-disk stamp before each entry; if it matches the stamp the current entry would produce AND the klib still exists, cinterop is skipped and the cached klib path is returned. Otherwise cinterop runs and the new stamp is written alongside the klib.

## Why the stamp observes compiler_options / linker_options

A naive mtime-only check (`klibMtime >= defMtime`) is unsafe — #68 calls this out explicitly. Editing `compiler_options` in `kolt.toml` leaves the `.def` file untouched but the resulting klib would differ. The stamp observes every field so such edits invalidate correctly, while unrelated `kolt.toml` edits (e.g. `version` bumps) don't force a cinterop re-run.

Option order is also preserved: reordering `-I` flags changes clang's include search order and can change the resolved header set.

## Test plan

- [x] 9 new pure-function tests for `cinteropStamp` / `cinteropStampPath` covering stability, all invalidating fields, and option reordering
- [x] `./gradlew linuxX64Test` fully green
- [x] Manual end-to-end verification in `/tmp/cinterop-skip-test`:
  - cold build → `generating cinterop klib for libcurl...` appears
  - warm build after source edit → no cinterop invocation, klib reused
  - kolt.toml edit reordering `compiler_options` → cinterop re-runs, stamp reflects new order

## Out of scope

- Tracking C headers transitively included by the `.def` — only the `.def` itself is observed, consistent with the issue's scope
- Moving the stamp into the outer `BuildState` — keeping it colocated with the klib avoids coupling to the project-level cache schema (matches issue recommendation)

Fixes #68