### PR TITLE
Render native dependency graph in kolt tree for target = "native"

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -219,6 +219,30 @@ internal fun doTree() {
 
     val paths = resolveKoltPaths(EXIT_DEPENDENCY_ERROR)
 
+    if (config.target == "native") {
+        // Native target: walk Gradle Module Metadata, not POMs. The rendered
+        // graph mirrors what NativeResolver actually links (redirected
+        // -linuxx64 names, kotlin-stdlib skipped per ADR 0011). Native builds
+        // do not auto-inject kotlin.test into test dependencies — it's
+        // provided by the konanc stdlib — so only regular deps are shown.
+        val nativeLookup = createNativeLookup(
+            config.repositories.values.toList(),
+            paths.cacheBase,
+            createResolverDeps()
+        )
+        if (config.dependencies.isNotEmpty()) {
+            val tree = buildNativeDependencyTree(config.dependencies, nativeLookup)
+            println(formatDependencyTree(tree))
+        }
+        if (config.testDependencies.isNotEmpty()) {
+            if (config.dependencies.isNotEmpty()) println()
+            println("test dependencies:")
+            val testTree = buildNativeDependencyTree(config.testDependencies, nativeLookup)
+            println(formatDependencyTree(testTree))
+        }
+        return
+    }
+
     val pomLookup = createPomLookup(config.repositories.values.toList(), paths.cacheBase, createResolverDeps())
     if (config.dependencies.isNotEmpty()) {
         val tree = buildDependencyTree(config.dependencies, pomLookup)

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -211,8 +211,15 @@ internal fun doUpdate() {
 
 internal fun doTree() {
     val config = loadProjectConfig()
-    val allTestDeps = autoInjectedTestDeps(config) + config.testDependencies
-    if (config.dependencies.isEmpty() && allTestDeps.isEmpty()) {
+
+    // For JVM, `autoInjectedTestDeps` unconditionally injects kotlin-test-junit5
+    // so `kolt tree` has something to show even when the user declared no test
+    // deps. For native, that function returns empty (konanc bundles kotlin.test),
+    // so we gate on user-declared deps only.
+    val hasAnyDeps = config.dependencies.isNotEmpty() ||
+        config.testDependencies.isNotEmpty() ||
+        autoInjectedTestDeps(config).isNotEmpty()
+    if (!hasAnyDeps) {
         println("no dependencies")
         return
     }
@@ -222,9 +229,7 @@ internal fun doTree() {
     if (config.target == "native") {
         // Native target: walk Gradle Module Metadata, not POMs. The rendered
         // graph mirrors what NativeResolver actually links (redirected
-        // -linuxx64 names, kotlin-stdlib skipped per ADR 0011). Native builds
-        // do not auto-inject kotlin.test into test dependencies — it's
-        // provided by the konanc stdlib — so only regular deps are shown.
+        // -linuxx64 names, kotlin-stdlib skipped per ADR 0011).
         val nativeLookup = createNativeLookup(
             config.repositories.values.toList(),
             paths.cacheBase,
@@ -243,6 +248,7 @@ internal fun doTree() {
         return
     }
 
+    val allTestDeps = autoInjectedTestDeps(config) + config.testDependencies
     val pomLookup = createPomLookup(config.repositories.values.toList(), paths.cacheBase, createResolverDeps())
     if (config.dependencies.isNotEmpty()) {
         val tree = buildDependencyTree(config.dependencies, pomLookup)

--- a/src/nativeMain/kotlin/kolt/resolve/DepsTree.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/DepsTree.kt
@@ -47,6 +47,69 @@ private fun isIncludedDep(dep: PomDependency): Boolean {
     return scope == "compile" || scope == "runtime"
 }
 
+/**
+ * Information required to render a single node in the native dependency tree.
+ * The display coordinate is the *redirected* target (e.g. `...-linuxx64`), so
+ * users see the klib that will actually be linked rather than the root module
+ * coordinate they declared in `kolt.toml`. Transitive deps are the contents of
+ * the linux_x64 variant's `dependencies[]` from Gradle Module Metadata.
+ */
+data class NativeNodeInfo(
+    val displayGroupArtifact: String,
+    val displayVersion: String,
+    val dependencies: List<Pair<String, String>> = emptyList()
+)
+
+/**
+ * Native counterpart of [buildDependencyTree]. Walks Gradle Module Metadata
+ * via [nativeLookup] instead of POMs. The rendered graph mirrors what
+ * NativeResolver would link: redirected `-linuxx64` display names and
+ * kotlin-stdlib skipped everywhere.
+ *
+ * When [nativeLookup] returns null (metadata missing or unparseable for a
+ * coordinate), the tree renders that coordinate as a leaf with no children
+ * rather than aborting — a partial tree is still useful.
+ */
+fun buildNativeDependencyTree(
+    directDeps: Map<String, String>,
+    nativeLookup: (groupArtifact: String, version: String) -> NativeNodeInfo?
+): List<TreeNode> {
+    val visited = mutableSetOf<String>()
+    return directDeps.mapNotNull { (groupArtifact, version) ->
+        if (isNativeStdlibSkipped(groupArtifact)) null
+        else buildNativeNode(groupArtifact, version, nativeLookup, visited)
+    }
+}
+
+private fun buildNativeNode(
+    groupArtifact: String,
+    version: String,
+    lookup: (String, String) -> NativeNodeInfo?,
+    visited: MutableSet<String>
+): TreeNode {
+    val info = lookup(groupArtifact, version)
+        ?: return TreeNode(groupArtifact, version)
+
+    val key = "${info.displayGroupArtifact}:${info.displayVersion}"
+    if (key in visited) {
+        return TreeNode(info.displayGroupArtifact, info.displayVersion)
+    }
+    visited.add(key)
+
+    val children = info.dependencies
+        .filterNot { (ga, _) -> isNativeStdlibSkipped(ga) }
+        .map { (childGa, childVersion) -> buildNativeNode(childGa, childVersion, lookup, visited) }
+
+    return TreeNode(info.displayGroupArtifact, info.displayVersion, children)
+}
+
+// Mirrors NativeResolver's stdlib skip policy (ADR 0011). Duplicated here so
+// the tree walker can be used with a stub lookup in tests without pulling in
+// NativeResolver; the two predicates must stay in sync.
+private fun isNativeStdlibSkipped(groupArtifact: String): Boolean =
+    groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib" ||
+        groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib-common"
+
 private const val BRANCH = "├── "
 private const val CORNER = "└── "
 private const val PIPE = "│   "

--- a/src/nativeMain/kotlin/kolt/resolve/DepsTree.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/DepsTree.kt
@@ -62,9 +62,16 @@ data class NativeNodeInfo(
 
 /**
  * Native counterpart of [buildDependencyTree]. Walks Gradle Module Metadata
- * via [nativeLookup] instead of POMs. The rendered graph mirrors what
- * NativeResolver would link: redirected `-linuxx64` display names and
- * kotlin-stdlib skipped everywhere.
+ * via [nativeLookup] instead of POMs, rendering the redirected `-linuxx64`
+ * display names and skipping kotlin-stdlib / kotlin-stdlib-common (ADR 0011)
+ * at both direct and transitive positions.
+ *
+ * Note: this is a *display* walker, not a resolver. It does not perform the
+ * "highest-version-wins" conflict resolution that [kolt.resolve.resolveNative]
+ * applies across the whole graph, so two branches of the rendered tree can
+ * show different versions of the same coordinate while the actual link would
+ * pick only the highest. Matches the behaviour of [buildDependencyTree] for
+ * JVM targets.
  *
  * When [nativeLookup] returns null (metadata missing or unparseable for a
  * coordinate), the tree renders that coordinate as a leaf with no children

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -157,6 +157,38 @@ fun resolveNative(
 }
 
 /**
+ * Builds a lookup function for [buildNativeDependencyTree]. For each
+ * (groupArtifact, version), fetches and parses the Gradle module metadata
+ * twice (root + redirect target) and returns a [NativeNodeInfo] containing
+ * the redirected display coordinate and the transitive dependencies from
+ * the linux_x64 variant. Returns null on any fetch or parse failure so the
+ * tree walker can render a partial graph instead of aborting.
+ */
+fun createNativeLookup(
+    repos: List<String>,
+    cacheBase: String,
+    deps: ResolverDeps,
+    nativeTarget: String = NATIVE_TARGET_LINUX_X64
+): (String, String) -> NativeNodeInfo? = lookup@{ groupArtifact, version ->
+    val resolved = fetchNativeMetadata(
+        groupArtifact = groupArtifact,
+        version = version,
+        nativeTarget = nativeTarget,
+        cacheBase = cacheBase,
+        repos = repos,
+        deps = deps
+    ).getOrElse { return@lookup null }
+
+    NativeNodeInfo(
+        displayGroupArtifact = "${resolved.redirect.group}:${resolved.redirect.module}",
+        displayVersion = resolved.redirect.version,
+        dependencies = resolved.artifact.dependencies.map { dep ->
+            "${dep.group}:${dep.module}" to dep.version
+        }
+    )
+}
+
+/**
  * Fetches and parses both the root `.module` (for the available-at redirect)
  * and the platform-specific `.module` (for the klib file + dependencies) for
  * a single coordinate.

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -163,29 +163,42 @@ fun resolveNative(
  * the redirected display coordinate and the transitive dependencies from
  * the linux_x64 variant. Returns null on any fetch or parse failure so the
  * tree walker can render a partial graph instead of aborting.
+ *
+ * Results are memoized by (groupArtifact, version) so diamond dependencies
+ * don't re-fetch and re-parse the same `.module` files on every occurrence,
+ * matching [createPomLookup]'s caching behaviour.
  */
 fun createNativeLookup(
     repos: List<String>,
     cacheBase: String,
     deps: ResolverDeps,
     nativeTarget: String = NATIVE_TARGET_LINUX_X64
-): (String, String) -> NativeNodeInfo? = lookup@{ groupArtifact, version ->
-    val resolved = fetchNativeMetadata(
-        groupArtifact = groupArtifact,
-        version = version,
-        nativeTarget = nativeTarget,
-        cacheBase = cacheBase,
-        repos = repos,
-        deps = deps
-    ).getOrElse { return@lookup null }
+): (String, String) -> NativeNodeInfo? {
+    val cache = mutableMapOf<String, NativeNodeInfo?>()
 
-    NativeNodeInfo(
-        displayGroupArtifact = "${resolved.redirect.group}:${resolved.redirect.module}",
-        displayVersion = resolved.redirect.version,
-        dependencies = resolved.artifact.dependencies.map { dep ->
-            "${dep.group}:${dep.module}" to dep.version
+    return { groupArtifact, version ->
+        val cacheKey = "$groupArtifact:$version"
+        cache.getOrPut(cacheKey) {
+            val resolved = fetchNativeMetadata(
+                groupArtifact = groupArtifact,
+                version = version,
+                nativeTarget = nativeTarget,
+                cacheBase = cacheBase,
+                repos = repos,
+                deps = deps
+            ).getOrElse { null }
+
+            resolved?.let {
+                NativeNodeInfo(
+                    displayGroupArtifact = "${it.redirect.group}:${it.redirect.module}",
+                    displayVersion = it.redirect.version,
+                    dependencies = it.artifact.dependencies.map { dep ->
+                        "${dep.group}:${dep.module}" to dep.version
+                    }
+                )
+            }
         }
-    )
+    }
 }
 
 /**

--- a/src/nativeTest/kotlin/kolt/resolve/DepsTreeTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/DepsTreeTest.kt
@@ -122,6 +122,152 @@ class DepsTreeTest {
         assertEquals(expected, output)
     }
 
+    // --- buildNativeDependencyTree ---
+    //
+    // Native tree walks Gradle Module Metadata (not POMs): each lookup returns
+    // the redirected *native* display coordinate (e.g. ...-linuxx64) and the
+    // transitive list from the linux_x64 variant. kotlin-stdlib is skipped to
+    // mirror NativeResolver.
+
+    private fun nativeInfo(
+        displayGroupArtifact: String,
+        displayVersion: String,
+        deps: List<Pair<String, String>> = emptyList()
+    ) = NativeNodeInfo(displayGroupArtifact, displayVersion, deps)
+
+    @Test
+    fun nativeTreeDisplaysRedirectedCoordinate() {
+        // The user declared kotlinx-serialization-json but what actually gets
+        // linked is the -linuxx64 redirect target. The tree must reflect that.
+        val directDeps = mapOf("org.jetbrains.kotlinx:kotlinx-serialization-json" to "1.7.3")
+        val lookup = { ga: String, v: String ->
+            if (ga == "org.jetbrains.kotlinx:kotlinx-serialization-json" && v == "1.7.3") {
+                nativeInfo("org.jetbrains.kotlinx:kotlinx-serialization-json-linuxx64", "1.7.3")
+            } else null
+        }
+
+        val tree = buildNativeDependencyTree(directDeps, lookup)
+
+        assertEquals(1, tree.size)
+        assertEquals("org.jetbrains.kotlinx:kotlinx-serialization-json-linuxx64", tree[0].groupArtifact)
+        assertEquals("1.7.3", tree[0].version)
+        assertEquals(0, tree[0].children.size)
+    }
+
+    @Test
+    fun nativeTreeWalksTransitiveDependencies() {
+        val directDeps = mapOf("org.jetbrains.kotlinx:kotlinx-serialization-json" to "1.7.3")
+        val lookup = { ga: String, _: String ->
+            when (ga) {
+                "org.jetbrains.kotlinx:kotlinx-serialization-json" -> nativeInfo(
+                    "org.jetbrains.kotlinx:kotlinx-serialization-json-linuxx64", "1.7.3",
+                    deps = listOf("org.jetbrains.kotlinx:kotlinx-serialization-core" to "1.7.3")
+                )
+                "org.jetbrains.kotlinx:kotlinx-serialization-core" -> nativeInfo(
+                    "org.jetbrains.kotlinx:kotlinx-serialization-core-linuxx64", "1.7.3"
+                )
+                else -> null
+            }
+        }
+
+        val tree = buildNativeDependencyTree(directDeps, lookup)
+
+        assertEquals(1, tree.size)
+        val root = tree[0]
+        assertEquals("org.jetbrains.kotlinx:kotlinx-serialization-json-linuxx64", root.groupArtifact)
+        assertEquals(1, root.children.size)
+        assertEquals("org.jetbrains.kotlinx:kotlinx-serialization-core-linuxx64", root.children[0].groupArtifact)
+        assertEquals("1.7.3", root.children[0].version)
+    }
+
+    @Test
+    fun nativeTreeSkipsKotlinStdlibAsDirect() {
+        // Mirrors NativeResolver's stdlib skip (ADR 0011).
+        val directDeps = mapOf(
+            "org.jetbrains.kotlin:kotlin-stdlib" to "2.0.20",
+            "org.jetbrains.kotlinx:kotlinx-serialization-json" to "1.7.3"
+        )
+        val lookup = { ga: String, _: String ->
+            if (ga == "org.jetbrains.kotlinx:kotlinx-serialization-json")
+                nativeInfo("org.jetbrains.kotlinx:kotlinx-serialization-json-linuxx64", "1.7.3")
+            else null
+        }
+
+        val tree = buildNativeDependencyTree(directDeps, lookup)
+
+        assertEquals(1, tree.size)
+        assertEquals("org.jetbrains.kotlinx:kotlinx-serialization-json-linuxx64", tree[0].groupArtifact)
+    }
+
+    @Test
+    fun nativeTreeSkipsKotlinStdlibAsTransitive() {
+        // Gradle module metadata declares kotlin-stdlib as a transitive dep on
+        // every native variant; the tree must not render it as a child either.
+        val directDeps = mapOf("org.jetbrains.kotlinx:kotlinx-serialization-json" to "1.7.3")
+        val lookup = { ga: String, _: String ->
+            if (ga == "org.jetbrains.kotlinx:kotlinx-serialization-json") nativeInfo(
+                "org.jetbrains.kotlinx:kotlinx-serialization-json-linuxx64", "1.7.3",
+                deps = listOf(
+                    "org.jetbrains.kotlin:kotlin-stdlib" to "2.0.20",
+                    "org.jetbrains.kotlin:kotlin-stdlib-common" to "2.0.20"
+                )
+            ) else null
+        }
+
+        val tree = buildNativeDependencyTree(directDeps, lookup)
+
+        assertEquals(1, tree.size)
+        assertEquals(0, tree[0].children.size)
+    }
+
+    @Test
+    fun nativeTreeHandlesCycleViaVisited() {
+        val directDeps = mapOf("com.example:lib-a" to "1.0")
+        val lookup = { ga: String, _: String ->
+            when (ga) {
+                "com.example:lib-a" -> nativeInfo(
+                    "com.example:lib-a-linuxx64", "1.0",
+                    deps = listOf("com.example:lib-b" to "1.0")
+                )
+                "com.example:lib-b" -> nativeInfo(
+                    "com.example:lib-b-linuxx64", "1.0",
+                    deps = listOf("com.example:lib-a" to "1.0") // cycle back
+                )
+                else -> null
+            }
+        }
+
+        val tree = buildNativeDependencyTree(directDeps, lookup)
+
+        // First visit of lib-a should walk to lib-b, which walks back to lib-a
+        // but cuts off (no grandchildren). The tree terminates rather than
+        // recursing forever.
+        assertEquals(1, tree.size)
+        val libA = tree[0]
+        assertEquals("com.example:lib-a-linuxx64", libA.groupArtifact)
+        assertEquals(1, libA.children.size)
+        val libB = libA.children[0]
+        assertEquals("com.example:lib-b-linuxx64", libB.groupArtifact)
+        // lib-b's only dep is lib-a, which was already visited → no children.
+        assertEquals(1, libB.children.size)
+        assertEquals(0, libB.children[0].children.size)
+    }
+
+    @Test
+    fun nativeTreeRendersOriginalCoordinateWhenLookupReturnsNull() {
+        // If metadata can't be fetched or parsed, the tree should still show
+        // what the user declared (so they see something), with no children.
+        val directDeps = mapOf("com.example:missing" to "9.9.9")
+        val lookup = { _: String, _: String -> null }
+
+        val tree = buildNativeDependencyTree(directDeps, lookup)
+
+        assertEquals(1, tree.size)
+        assertEquals("com.example:missing", tree[0].groupArtifact)
+        assertEquals("9.9.9", tree[0].version)
+        assertEquals(0, tree[0].children.size)
+    }
+
     @Test
     fun formatTreeEmpty() {
         assertEquals("no dependencies", formatDependencyTree(emptyList()))


### PR DESCRIPTION
## Summary

`kolt tree` previously ignored `config.target` and walked POMs unconditionally. On a `target = "native"` project that meant the rendered graph showed JVM variants and `kotlin-stdlib` subtrees — a picture bearing no relation to what `NativeResolver` actually links for native builds. Users couldn't use `tree` to verify the native dependency closure.

Branch `doTree` on `config.target`:

- `jvm` (default): unchanged, walks POMs via `createPomLookup`
- `native`: walks Gradle Module Metadata via a new `createNativeLookup` factory, rendering the redirected `-linuxx64` display coordinates and skipping `kotlin-stdlib` / `kotlin-stdlib-common` at both direct and transitive positions (ADR 0011)

## Before / after

Same `kolt.toml` with `target = "native"`, depending on `kotlinx-serialization-json:1.7.3`:

**Before:**
```
└── org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3
    └── org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3
        ├── org.jetbrains.kotlin:kotlin-stdlib:2.0.20
        │   └── org.jetbrains:annotations:13.0
        └── org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.7.3
            └── org.jetbrains.kotlin:kotlin-stdlib:2.0.20 (*)
```

**After:**
```
└── org.jetbrains.kotlinx:kotlinx-serialization-json-linuxx64:1.7.3
    └── org.jetbrains.kotlinx:kotlinx-serialization-core-linuxx64:1.7.3
```

## Shape of the change

- **`buildNativeDependencyTree` (pure)** in `DepsTree.kt` — walks a `(ga, v) -> NativeNodeInfo?` lookup closure, producing the same `TreeNode` shape as the JVM walker so `formatDependencyTree` renders both without modification
- **`NativeNodeInfo`** carries the redirected display coordinate (e.g. `...-linuxx64`) plus the transitive dependency list
- **`createNativeLookup`** in `NativeResolver.kt` is the I/O factory; it reuses the existing `fetchNativeMetadata` helper (root + redirect `.module` fetch and parse) and returns `null` on any failure so the walker can render partial graphs
- **Native-only**: `autoInjectedTestDeps` (JUnit platform, kotlin-test-junit5) is skipped for `target = "native"` since Kotlin/Native bundles `kotlin.test` via the konanc stdlib — matches `BuildCommands.doNativeTest`

## Test plan

- [x] 6 new pure-function tests for `buildNativeDependencyTree` (redirect rendering, transitive walk, stdlib skip at direct and transitive positions, cycle handling, null lookup fallback)
- [x] `./gradlew linuxX64Test` fully green
- [x] Manual verification on `/tmp/probe-71` (`target = "native"`, `kotlinx-serialization-json:1.7.3`) — output matches the "After" block above
- [x] JVM regression check on `/tmp/probe-71-jvm` — tree unchanged including test dependency subtree

## Out of scope

- Lockfile interaction (native has no lockfile in Phase B)
- Cross-platform native target selection (linux_x64 only for now)
- Caching fetched `.module` files across `tree` / `install` runs (already shared via `~/.kolt/cache`)

Fixes #71