### PR TITLE
Remove cinterop compiler_options / linker_options from kolt.toml

### DIFF
--- a/.claude/skills/kolt-usage/SKILL.md
+++ b/.claude/skills/kolt-usage/SKILL.md
@@ -60,8 +60,6 @@ serialization = true
 name = "libcurl"
 def = "src/nativeInterop/cinterop/libcurl.def"
 package = "libcurl"
-compiler_options = ["-I/usr/include", "-I/usr/include/x86_64-linux-gnu"]
-linker_options = ["-L/usr/lib/x86_64-linux-gnu", "-lcurl"]
 
 [dependencies]
 "org.jetbrains.kotlinx:kotlinx-coroutines-core" = "1.9.0"
@@ -95,7 +93,7 @@ jitpack = "https://jitpack.io"
 
 ### C Interop
 
-For `target = "native"` projects, declare one `[[cinterop]]` entry per `.def` file. kolt invokes the konan `cinterop` tool, caches `build/<name>.klib`, and links it via `konanc -l`. Fields: `name` (klib base), `def` (.def path), `package` (optional Kotlin package), `compiler_options` (list — emitted as repeated `-compiler-option`), `linker_options` (list — emitted as repeated `-linker-option`). Klibs are regenerated when the `.def` file's mtime changes.
+For `target = "native"` projects, declare one `[[cinterop]]` entry per `.def` file. kolt invokes the konan `cinterop` tool, caches `build/<name>.klib`, and links it via `konanc -l`. Fields: `name` (klib base), `def` (.def path), `package` (optional Kotlin package). Compiler and linker flags belong inside the `.def` file itself via the Kotlin/Native standard `compilerOpts.<platform>` / `linkerOpts.<platform>` keys — kolt does not duplicate them in `kolt.toml`. Klibs are regenerated when the `.def` file's mtime changes.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -165,8 +165,6 @@ For `target = "native"` projects that need to call C libraries, declare one `[[c
 name = "libcurl"
 def = "src/nativeInterop/cinterop/libcurl.def"
 package = "libcurl"
-compiler_options = ["-I/usr/include", "-I/usr/include/x86_64-linux-gnu"]
-linker_options = ["-L/usr/lib/x86_64-linux-gnu", "-lcurl"]
 ```
 
 | Field | Description | Default |
@@ -174,8 +172,14 @@ linker_options = ["-L/usr/lib/x86_64-linux-gnu", "-lcurl"]
 | `name` | Output klib base name (`build/<name>.klib`) | (required) |
 | `def` | Path to the `.def` file describing the binding | (required) |
 | `package` | Kotlin package for generated bindings | (derived from `.def`) |
-| `compiler_options` | Extra flags forwarded to clang as repeated `-compiler-option` | `[]` |
-| `linker_options` | Extra flags forwarded to the linker as repeated `-linker-option` | `[]` |
+
+Compiler and linker options belong inside the `.def` file itself, using the Kotlin/Native standard `compilerOpts.<platform>` / `linkerOpts.<platform>` keys. For example:
+
+```ini
+headers = curl/curl.h
+compilerOpts.linux = -I/usr/include -I/usr/include/x86_64-linux-gnu
+linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -lcurl
+```
 
 The `cinterop` klib is regenerated when the `.def` file's mtime changes; source-only edits reuse the cached klib. Multiple `[[cinterop]]` entries are allowed and are linked in declaration order.
 

--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -221,14 +221,6 @@ fun cinteropCommand(
             add("-pkg")
             add(entry.packageName)
         }
-        for (opt in entry.compilerOptions) {
-            add("-compiler-option")
-            add(opt)
-        }
-        for (opt in entry.linkerOptions) {
-            add("-linker-option")
-            add(opt)
-        }
     }
     return BuildCommand(args = args, outputPath = outputBase)
 }
@@ -247,25 +239,18 @@ fun cinteropStampPath(entry: CinteropConfig, outputDir: String = BUILD_DIR): Str
 // iff a re-run of cinterop would produce an equivalent klib for cache purposes.
 // We observe:
 //   - name / def path / package — rename or relocation must invalidate
-//   - compiler_options / linker_options — editing these must invalidate even
-//     though the .def file is untouched (this is the subtle failure mode
-//     called out in #68: a naive mtime-only check silently reuses a stale
-//     klib after a kolt.toml edit)
-//   - the .def file's mtime — the usual "contents changed" signal
+//   - the .def file's mtime — the usual "contents changed" signal; since
+//     compilerOpts / linkerOpts live inside the .def file, editing them
+//     bumps mtime and invalidates the cache for free
 //   - the Kotlin/Native version — bumping `kotlin = "..."` in kolt.toml
 //     switches the cinterop/konanc toolchain, and the klib format is not
 //     guaranteed to be compatible across Kotlin versions
-//
-// Order of compilerOption / linkerOption lines follows declaration order
-// so the stamp is sensitive to reordering.
 fun cinteropStamp(entry: CinteropConfig, defMtime: Long, kotlinVersion: String): String = buildString {
     append("kotlinVersion=").append(kotlinVersion).append('\n')
     append("name=").append(entry.name).append('\n')
     append("def=").append(entry.def).append('\n')
     append("defMtime=").append(defMtime).append('\n')
     append("package=").append(entry.packageName ?: "").append('\n')
-    for (opt in entry.compilerOptions) append("compilerOption=").append(opt).append('\n')
-    for (opt in entry.linkerOptions) append("linkerOption=").append(opt).append('\n')
 }
 
 fun jarCommand(config: KoltConfig, jarPath: String? = null): BuildCommand {

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -232,9 +232,7 @@ private fun newestDefMtime(config: KoltConfig): Long? {
  * Per-entry freshness check: if the previously generated klib and its sidecar
  * `.klib.stamp` file both exist and the stamp matches the stamp that would be
  * produced by the current entry + its .def mtime, the cinterop invocation is
- * skipped and the cached klib is reused. The stamp observes every field of
- * CinteropConfig, so editing compiler_options / linker_options in kolt.toml
- * invalidates the cache even though the .def file is untouched.
+ * skipped and the cached klib is reused.
  *
  * Returns the list of generated .klib paths to pass to konanc via -l.
  */

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -21,9 +21,7 @@ sealed class ConfigError {
 data class CinteropConfig(
     val name: String,
     val def: String,
-    @SerialName("package") val packageName: String? = null,
-    @SerialName("compiler_options") val compilerOptions: List<String> = emptyList(),
-    @SerialName("linker_options") val linkerOptions: List<String> = emptyList()
+    @SerialName("package") val packageName: String? = null
 )
 
 @Serializable

--- a/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
@@ -71,127 +71,24 @@ class CinteropTest {
     }
 
     @Test
-    fun cinteropCommandWithSingleCompilerOptionEmitsOneCompilerOptionFlag() {
-        // Given: entry with one compilerOptions element
-        val entry = CinteropConfig(
-            name = "libcurl",
-            def = "libcurl.def",
-            compilerOptions = listOf("-I/usr/include")
-        )
-
-        // When: command is constructed
-        val cmd = cinteropCommand(entry)
-
-        // Then: a single -compiler-option flag is included with the value
-        assertEquals(1, cmd.args.count { it == "-compiler-option" })
-        val flagIndex = cmd.args.indexOf("-compiler-option")
-        assertEquals("-I/usr/include", cmd.args[flagIndex + 1])
-    }
-
-    @Test
-    fun cinteropCommandWithMultipleCompilerOptionsEmitsRepeatedCompilerOptionFlags() {
-        // Given: entry with multiple compilerOptions elements
-        val entry = CinteropConfig(
-            name = "libcurl",
-            def = "libcurl.def",
-            compilerOptions = listOf("-I/usr/include", "-I/usr/include/x86_64-linux-gnu", "-DFOO=1")
-        )
-
-        // When: command is constructed
-        val cmd = cinteropCommand(entry)
-
-        // Then: -compiler-option is repeated once per element, preserving order
-        val pairs = cmd.args.zipWithNext().filter { it.first == "-compiler-option" }.map { it.second }
-        assertEquals(
-            listOf("-I/usr/include", "-I/usr/include/x86_64-linux-gnu", "-DFOO=1"),
-            pairs
-        )
-    }
-
-    @Test
-    fun cinteropCommandWithEmptyCompilerOptionsOmitsFlag() {
-        // Given: entry with empty compilerOptions list (the default)
-        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
-
-        // When: command is constructed
-        val cmd = cinteropCommand(entry)
-
-        // Then: no -compiler-option flag is emitted
-        assertFalse(cmd.args.contains("-compiler-option"), "Unexpected -compiler-option flag in: ${cmd.args}")
-    }
-
-    @Test
-    fun cinteropCommandWithSingleLinkerOptionEmitsOneLinkerOptionFlag() {
-        // Given: entry with one linkerOptions element
-        val entry = CinteropConfig(
-            name = "libcurl",
-            def = "libcurl.def",
-            linkerOptions = listOf("-lcurl")
-        )
-
-        // When: command is constructed
-        val cmd = cinteropCommand(entry)
-
-        // Then: a single -linker-option flag is included with the value
-        assertEquals(1, cmd.args.count { it == "-linker-option" })
-        val flagIndex = cmd.args.indexOf("-linker-option")
-        assertEquals("-lcurl", cmd.args[flagIndex + 1])
-    }
-
-    @Test
-    fun cinteropCommandWithMultipleLinkerOptionsEmitsRepeatedLinkerOptionFlags() {
-        // Given: entry with multiple linkerOptions elements
-        val entry = CinteropConfig(
-            name = "libcurl",
-            def = "libcurl.def",
-            linkerOptions = listOf("-L/usr/lib/x86_64-linux-gnu", "-lcurl")
-        )
-
-        // When: command is constructed
-        val cmd = cinteropCommand(entry)
-
-        // Then: -linker-option is repeated once per element, preserving order
-        val pairs = cmd.args.zipWithNext().filter { it.first == "-linker-option" }.map { it.second }
-        assertEquals(listOf("-L/usr/lib/x86_64-linux-gnu", "-lcurl"), pairs)
-    }
-
-    @Test
-    fun cinteropCommandWithEmptyLinkerOptionsOmitsFlag() {
-        // Given: entry with empty linkerOptions list (the default)
-        val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
-
-        // When: command is constructed
-        val cmd = cinteropCommand(entry)
-
-        // Then: no -linker-option flag is emitted
-        assertFalse(cmd.args.contains("-linker-option"), "Unexpected -linker-option flag in: ${cmd.args}")
-    }
-
-    @Test
     fun cinteropCommandWithAllOptionsProducesFullArgs() {
         // Given: entry with all optional fields set
         val entry = CinteropConfig(
             name = "libcurl",
             def = "src/nativeInterop/cinterop/libcurl.def",
-            packageName = "libcurl",
-            compilerOptions = listOf("-I/usr/include", "-DFOO=1"),
-            linkerOptions = listOf("-L/usr/lib", "-lcurl")
+            packageName = "libcurl"
         )
 
         // When: command is constructed
         val cmd = cinteropCommand(entry)
 
-        // Then: full args in canonical order, with repeated singular flags
+        // Then: full args in canonical order
         assertEquals(
             listOf(
                 "cinterop",
                 "-def", "src/nativeInterop/cinterop/libcurl.def",
                 "-o", "build/libcurl",
-                "-pkg", "libcurl",
-                "-compiler-option", "-I/usr/include",
-                "-compiler-option", "-DFOO=1",
-                "-linker-option", "-L/usr/lib",
-                "-linker-option", "-lcurl"
+                "-pkg", "libcurl"
             ),
             cmd.args
         )
@@ -280,9 +177,7 @@ class CinteropTest {
         val entry = CinteropConfig(
             name = "libcurl",
             def = "libcurl.def",
-            packageName = "libcurl",
-            compilerOptions = listOf("-I/usr/include"),
-            linkerOptions = listOf("-lcurl")
+            packageName = "libcurl"
         )
         assertEquals(cinteropStamp(entry, 1000L, "2.1.0"), cinteropStamp(entry, 1000L, "2.1.0"))
     }
@@ -315,34 +210,6 @@ class CinteropTest {
     }
 
     @Test
-    fun cinteropStampChangesWhenCompilerOptionsChange() {
-        // This is the subtle case #68 calls out: .def untouched but
-        // compiler_options edited in kolt.toml — stamp MUST differ.
-        val a = CinteropConfig(
-            name = "libcurl", def = "libcurl.def",
-            compilerOptions = listOf("-I/foo")
-        )
-        val b = CinteropConfig(
-            name = "libcurl", def = "libcurl.def",
-            compilerOptions = listOf("-I/bar")
-        )
-        assertFalse(cinteropStamp(a, 1000L, "2.1.0") == cinteropStamp(b, 1000L, "2.1.0"))
-    }
-
-    @Test
-    fun cinteropStampChangesWhenLinkerOptionsChange() {
-        val a = CinteropConfig(
-            name = "libcurl", def = "libcurl.def",
-            linkerOptions = listOf("-lcurl")
-        )
-        val b = CinteropConfig(
-            name = "libcurl", def = "libcurl.def",
-            linkerOptions = listOf("-lcurl-gnutls")
-        )
-        assertFalse(cinteropStamp(a, 1000L, "2.1.0") == cinteropStamp(b, 1000L, "2.1.0"))
-    }
-
-    @Test
     fun cinteropStampChangesWhenKotlinVersionChanges() {
         // Bumping `kotlin = "..."` in kolt.toml switches the cinterop/konanc
         // toolchain. Kotlin/Native klib format is not guaranteed compatible
@@ -350,21 +217,6 @@ class CinteropTest {
         // be reused.
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
         assertFalse(cinteropStamp(entry, 1000L, "2.1.0") == cinteropStamp(entry, 1000L, "2.3.20"))
-    }
-
-    @Test
-    fun cinteropStampIsSensitiveToOptionOrder() {
-        // Reordering compiler options can change clang's include search order
-        // and therefore the resolved header set. Treat as a semantic change.
-        val a = CinteropConfig(
-            name = "libcurl", def = "libcurl.def",
-            compilerOptions = listOf("-I/foo", "-I/bar")
-        )
-        val b = CinteropConfig(
-            name = "libcurl", def = "libcurl.def",
-            compilerOptions = listOf("-I/bar", "-I/foo")
-        )
-        assertFalse(cinteropStamp(a, 1000L, "2.1.0") == cinteropStamp(b, 1000L, "2.1.0"))
     }
 
     // --- cinteropStampPath ---

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
@@ -128,8 +128,7 @@ class CinteropNativeBuildIntegrationTest {
         val libcurlEntry = CinteropConfig(
             name = "libcurl",
             def = "src/nativeInterop/cinterop/libcurl.def",
-            packageName = "libcurl",
-            linkerOptions = listOf("-lcurl")
+            packageName = "libcurl"
         )
         val config = testConfig(
             name = "myapp",

--- a/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
@@ -680,8 +680,6 @@ class ConfigTest {
         assertEquals("libcurl", entry.name)
         assertEquals("src/nativeInterop/cinterop/libcurl.def", entry.def)
         assertNull(entry.packageName)
-        assertEquals(emptyList(), entry.compilerOptions)
-        assertEquals(emptyList(), entry.linkerOptions)
     }
 
     @Test
@@ -699,8 +697,6 @@ class ConfigTest {
             name = "libcurl"
             def = "src/nativeInterop/cinterop/libcurl.def"
             package = "libcurl"
-            compiler_options = ["-I/usr/include", "-DFOO=1"]
-            linker_options = ["-L/usr/lib", "-lcurl"]
         """.trimIndent()
 
         // When: config is parsed
@@ -712,8 +708,6 @@ class ConfigTest {
         assertEquals("libcurl", entry.name)
         assertEquals("src/nativeInterop/cinterop/libcurl.def", entry.def)
         assertEquals("libcurl", entry.packageName)
-        assertEquals(listOf("-I/usr/include", "-DFOO=1"), entry.compilerOptions)
-        assertEquals(listOf("-L/usr/lib", "-lcurl"), entry.linkerOptions)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Drop `compiler_options` / `linker_options` from `[[cinterop]]` TOML schema
- Stop emitting `-compiler-option` / `-linker-option` from `cinteropCommand`
- Direct users to the `.def` file's standard `compilerOpts.<platform>` / `linkerOpts.<platform>` keys (KGP convention)

## Root cause (per #75)

The two fields were added in #67, but upstream cinterop makes them unreliable:

1. cinterop silently rejects `-linker-option(s)` with a warning — `linker_options` has always been dead code.
2. cinterop's argparser crashes on `-compiler-option -DFOO=1`, so `-D` macros can't be forwarded.

The `.def` file already covers both via `compilerOpts.linux = ...` / `linkerOpts.linux = ...`, which is the Kotlin/Native standard and bypasses both bugs. Maintaining a second, broken channel in `kolt.toml` only creates ambiguity about which source of truth wins — so this PR collapses to the `.def`.

## Cache invalidation

`cinteropStamp` previously observed `compilerOptions` / `linkerOptions` explicitly to catch kolt.toml edits that didn't touch the `.def`. Once flags live only inside the `.def`, editing them bumps the file's mtime, which the existing `defMtime=` stamp line already watches. No new stamp field needed.

## Test plan

- [x] `./gradlew linuxX64Test` — green
- [x] Removed tests only exercised deleted behavior (`cinteropCommandWith*CompilerOption*`, `cinteropCommandWith*LinkerOption*`, `cinteropStampChangesWhen{Compiler,Linker}OptionsChange`, `cinteropStampIsSensitiveToOptionOrder`)
- [x] Baseline shape tests retained (`cinteropCommandMinimalProducesDefAndOutput`, `cinteropCommandWithAllOptionsProducesFullArgs`)
- [x] README + `kolt-usage` skill updated to point at `.def`

Closes #75