### PR TITLE
Redefine kolt.toml main field as a Kotlin function FQN

### DIFF
--- a/.claude/skills/kolt-usage/SKILL.md
+++ b/.claude/skills/kolt-usage/SKILL.md
@@ -46,7 +46,7 @@ version = "0.1.0"
 kotlin = "2.1.0"
 target = "jvm"
 jvm_target = "17"
-main = "MainKt"
+main = "main"
 sources = ["src"]
 test_sources = ["test"]
 resources = ["resources"]
@@ -81,7 +81,7 @@ jitpack = "https://jitpack.io"
 | `kotlin` | Kotlin compiler version | (required) |
 | `target` | `"jvm"` | (required) |
 | `jvm_target` | JVM bytecode target | `"17"` |
-| `main` | Entry point class | (required) |
+| `main` | Entry point function FQN (e.g. `"main"` or `"com.example.main"`) | (required) |
 | `sources` | Source directories | (required) |
 | `test_sources` | Test source directories | `["test"]` |
 | `resources` | Resource directories included in JAR | `[]` |

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ version = "0.1.0"
 kotlin = "2.1.0"
 target = "jvm"
 jvm_target = "17"
-main = "MainKt"
+main = "main"
 sources = ["src"]
 resources = ["resources"]
 test_resources = ["test-resources"]
@@ -99,7 +99,7 @@ jitpack = "https://jitpack.io"
 | `kotlin` | Kotlin compiler version | (required) |
 | `target` | `"jvm"` | (required) |
 | `jvm_target` | JVM bytecode target | `"17"` |
-| `main` | Entry point class | (required) |
+| `main` | Entry point function FQN (e.g. `"main"` or `"com.example.main"`) | (required) |
 | `sources` | Source directories | (required) |
 | `test_sources` | Test source directories | `["test"]` |
 | `resources` | Resource directories to include in build output | `[]` |

--- a/docs/adr/0012-derive-native-entry-point-from-config-main.md
+++ b/docs/adr/0012-derive-native-entry-point-from-config-main.md
@@ -2,7 +2,13 @@
 
 ## Status
 
-Accepted (2026-04-13)
+Superseded by ADR 0015 (2026-04-13).
+
+The direction described here — `config.main` holds a JVM facade class
+name and kolt derives the native entry point from it — was reversed
+once `target = "native"` became a first-class target. See ADR 0015 for
+the new scheme: `config.main` holds a Kotlin function FQN, and kolt
+derives the JVM Main-Class from it instead.
 
 ## Context
 

--- a/docs/adr/0014-native-two-stage-library-link.md
+++ b/docs/adr/0014-native-two-stage-library-link.md
@@ -4,6 +4,13 @@
 
 Accepted (2026-04-13). Supersedes [ADR 0013](0013-native-test-single-step-compile.md).
 
+> **Note (2026-04-13, ADR 0015):** This ADR's discussion still references
+> `nativeEntryPoint()` / `needsNativeEntryPointWarning()` as live code.
+> Those helpers were deleted by [ADR 0015](0015-main-field-is-kotlin-function-fqn.md)
+> when `config.main` was redefined as a Kotlin function FQN. `nativeLinkCommand`
+> now emits `-e config.main` on the link stage. The core decision of this ADR
+> (two-stage library → link) is unaffected.
+
 ## Context
 
 Issue #62 added Kotlin compiler plugin support (`serialization`, `allopen`,

--- a/docs/adr/0015-main-field-is-kotlin-function-fqn.md
+++ b/docs/adr/0015-main-field-is-kotlin-function-fqn.md
@@ -1,0 +1,134 @@
+# ADR 0015: `main` field is a Kotlin function FQN
+
+## Status
+
+Accepted (2026-04-13). Supersedes ADR 0012.
+
+## Context
+
+kolt.toml's `main` field originally held a JVM facade class name:
+
+```toml
+main = "com.example.MainKt"
+```
+
+This worked for `target = "jvm"` because the JVM runner passes the
+value directly to `java -cp ... <main>`. For `target = "native"`,
+konanc wants the fully-qualified name of the entry **function** (e.g.
+`com.example.main`), so ADR 0012 introduced `nativeEntryPoint()` to
+derive the FQN by stripping the trailing class segment and appending
+`.main`.
+
+Two problems surfaced once `target = "native"` became a first-class
+path rather than an add-on:
+
+1. **Leaky abstraction.** `MainKt` is a JVM implementation artifact —
+   kotlinc synthesizes it from the file name, and it only exists to
+   satisfy JVM interop. Forcing users to write a JVM class name in a
+   build-tool config file that also targets native exposes something
+   they did not ask for and that has no meaning outside the JVM.
+2. **Target switching requires edits.** Flipping a project from
+   `target = "jvm"` to `target = "native"` should not require rewriting
+   `main`. With the class-name scheme, it technically does not (the
+   derivation papers over it), but the field's declared meaning no
+   longer matches its effect on the native path — `MainKt` is not an
+   entry for konanc.
+
+While verifying the self-host effort (#61), the inverse bug bit us:
+kolt's own `fun kolt.cli.main()` lives in a named package, and
+`nativeLinkCommand` intentionally omitted `-e` on the assumption that
+`-Xinclude` would carry the entry point through. konanc then failed
+with `could not find '/main' function` because it looked for `main` in
+the root package. The assumption only holds when `fun main()` sits at
+the root.
+
+## Decision
+
+**`main` holds a Kotlin top-level function FQN**, not a JVM class
+name. The field is target-independent; kolt derives whatever each
+backend needs:
+
+| `main` value         | JVM Main-Class        | Native `-e`         |
+| :---                 | :---                  | :---                |
+| `main`               | `MainKt`              | `main`              |
+| `com.example.main`   | `com.example.MainKt`  | `com.example.main`  |
+
+### Parsing and validation
+
+`parseConfig` calls `validateMainFqn` after schema decoding:
+
+- Accepts the bare literal `"main"`, or any dotted package followed
+  by `".main"`.
+- Rejects any value ending in `Kt` with a migration hint that
+  back-derives the function FQN: `main = "com.example.MainKt"` →
+  `"Use a Kotlin function FQN instead: main = \"com.example.main\""`.
+- Rejects other malformed values with a generic error.
+
+There is no migration period. kolt is pre-1.0 (v0.9.0) and the
+field's new meaning cannot coexist with the old — either the JVM path
+treats `MainKt` as a class name directly (old) or it derives
+`MainKt` from `main` (new). A hard error at parse time is less
+confusing than a silent two-mode interpretation.
+
+### JVM facade derivation
+
+`jvmMainClass(main)` replaces the final `main` segment with `MainKt`:
+
+```kotlin
+fun jvmMainClass(main: String): String {
+    val prefix = main.substringBeforeLast("main")
+    return "${prefix}MainKt"
+}
+```
+
+This is a best-effort heuristic that assumes the entry function lives
+in a file named `Main.kt`, which is kolt init's template convention.
+Projects that put `fun main()` in a file with a different name will
+compile to `<FileName>Kt` on the JVM side, and kolt's derivation will
+point at the wrong class.
+
+### Native entry derivation
+
+The native path forwards `config.main` to konanc verbatim via `-e`:
+
+```kotlin
+add("-e")
+add(config.main)
+```
+
+No derivation is needed — the FQN in `main` is already what konanc
+expects.
+
+## Consequences
+
+- `config.main` is finally target-agnostic: the same `kolt.toml` works
+  for both `target = "jvm"` and `target = "native"` without touching
+  the field.
+- The `nativeEntryPoint()` / `needsNativeEntryPointWarning()` helpers
+  introduced by ADR 0012 are deleted. The comment on
+  `nativeLinkCommand` warning against `-e` is removed — the flag is
+  now load-bearing.
+- `kolt init` generates `main = "main"` instead of `main = "MainKt"`.
+- Users migrating from the old scheme see a precise error at parse
+  time telling them exactly what to change.
+
+### Non-goal: `@JvmName`
+
+Projects that override the JVM class name via `@JvmName("Foo")` or
+place `fun main()` in a non-`Main.kt` file produce a JVM class whose
+name `jvmMainClass()` cannot recover from `main` alone. This is
+deliberately out of scope: YAGNI until someone actually needs it. The
+eventual fix would be an explicit `jvm_main_class` override in
+`kolt.toml`, derived on demand and unused for `target = "native"`.
+
+## References
+
+- ADR 0012 — the superseded scheme
+- Issue #61 — self-host work, where the old `nativeLinkCommand`
+  assumption broke on kolt's own `kolt.cli.main`
+- `src/nativeMain/kotlin/kolt/config/Main.kt` — `jvmMainClass`,
+  `validateMainFqn`
+- `src/nativeMain/kotlin/kolt/build/Builder.kt` — `nativeLinkCommand`
+  now emits `-e config.main`
+- `src/nativeMain/kotlin/kolt/build/Runner.kt` — JVM `runCommand` uses
+  `jvmMainClass(config.main)`

--- a/docs/design.md
+++ b/docs/design.md
@@ -45,7 +45,7 @@ version = "0.1.0"
 kotlin = "2.1.0"
 target = "jvm"
 jvm_target = "17"
-main = "com.example.MainKt"
+main = "com.example.main"
 sources = ["src"]
 
 [dependencies]

--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -18,35 +18,6 @@ internal fun outputNativeKlibPath(config: KoltConfig): String = "$BUILD_DIR/${co
 
 internal fun outputNativeTestKlibPath(config: KoltConfig): String = "$BUILD_DIR/${config.name}-test-klib"
 
-// Derives the Kotlin/Native entry point FQN from config.main.
-//
-// config.main is a JVM-style class name (e.g. "com.example.MainKt"). For
-// Kotlin/Native, konanc needs the fully-qualified function name instead. We
-// take the package portion (everything before the last dot) and append
-// ".main". The class-name suffix itself is discarded.
-//
-// Limitations (Phase A): we assume the entry function is a top-level `fun main`
-// in the same package as the JVM facade class. Non-standard entry points
-// (custom function name, `@JvmStatic` on a companion, etc.) are not supported
-// and will produce a konanc "entry point not found" error. Callers should
-// prefer top-level `fun main()` and a `*Kt` facade class name. See
-// needsNativeEntryPointWarning for the heuristic used to flag likely issues.
-internal fun nativeEntryPoint(config: KoltConfig): String {
-    val lastDot = config.main.lastIndexOf('.')
-    val pkg = if (lastDot >= 0) config.main.substring(0, lastDot) else ""
-    return if (pkg.isEmpty()) "main" else "$pkg.main"
-}
-
-// Returns true when config.main's class-name segment does not end with "Kt",
-// which is the conventional suffix kotlinc generates for top-level functions
-// in file Foo.kt. A non-Kt class name suggests the user may have pointed main
-// at a non-top-level entry, and nativeEntryPoint's derivation will likely not
-// match their intent.
-internal fun needsNativeEntryPointWarning(config: KoltConfig): Boolean {
-    val lastSegment = config.main.substringAfterLast('.')
-    return lastSegment.isNotEmpty() && !lastSegment.endsWith("Kt")
-}
-
 data class BuildCommand(
     val args: List<String>,
     val outputPath: String
@@ -125,8 +96,11 @@ fun nativeLibraryCommand(
 // Stage 2 consumes the klib produced by nativeLibraryCommand via -Xinclude,
 // which pulls the klib's IR (including the main() function) into the final
 // program. The plugin flag is not needed here — the IR is already transformed.
-// We intentionally omit -e: -Xinclude brings the compiled entry point with it,
-// and passing -e risks conflicting with the linked-in main().
+//
+// -e points konanc at the entry function. config.main holds the Kotlin
+// function FQN verbatim, so we forward it as-is. Without this, konanc looks
+// for a function named `main` in the root package and fails when main lives
+// in a named package (e.g. `kolt.cli.main`).
 fun nativeLinkCommand(
     config: KoltConfig,
     konancPath: String? = null,
@@ -139,6 +113,8 @@ fun nativeLinkCommand(
         add(konancPath ?: "konanc")
         add("-p")
         add("program")
+        add("-e")
+        add(config.main)
         for (klib in klibs) {
             add("-l")
             add(klib)

--- a/src/nativeMain/kotlin/kolt/build/Runner.kt
+++ b/src/nativeMain/kotlin/kolt/build/Runner.kt
@@ -1,6 +1,7 @@
 package kolt.build
 
 import kolt.config.KoltConfig
+import kolt.config.jvmMainClass
 
 data class RunCommand(
     val args: List<String>
@@ -14,7 +15,7 @@ fun runCommand(
 ): RunCommand {
     val cp = if (!classpath.isNullOrEmpty()) "$CLASSES_DIR:$classpath" else CLASSES_DIR
     return RunCommand(
-        args = listOf(javaPath ?: "java", "-cp", cp, config.main) + appArgs
+        args = listOf(javaPath ?: "java", "-cp", cp, jvmMainClass(config.main)) + appArgs
     )
 }
 

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -146,15 +146,6 @@ internal fun doBuild(): BuildResult {
 private fun doNativeBuild(config: KoltConfig): BuildResult {
     val startMark = TimeSource.Monotonic.markNow()
 
-    if (needsNativeEntryPointWarning(config)) {
-        eprintln(
-            "warning: main = \"${config.main}\" does not end with 'Kt'; " +
-                "native build assumes a top-level 'fun main' in package " +
-                "'${nativeEntryPoint(config).substringBeforeLast('.', "")}' " +
-                "(derived entry point: ${nativeEntryPoint(config)})"
-        )
-    }
-
     val paths = resolveKoltPaths(EXIT_BUILD_ERROR)
     val managedKonancBin = ensureKonancBin(config.kotlin, paths, EXIT_BUILD_ERROR)
 

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -5,6 +5,7 @@ import com.akuleshov7.ktoml.TomlInputConfig
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
@@ -57,6 +58,7 @@ fun parseConfig(tomlString: String): Result<KoltConfig, ConfigError> {
                 "invalid target '${config.target}' (valid targets: ${VALID_TARGETS.joinToString(", ")})"
             ))
         }
+        validateMainFqn(config.main).getError()?.let { return Err(it) }
         // ktoml preserves quotes in map keys; strip them
         val cleanedDeps = config.dependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }
         val cleanedTestDeps = config.testDependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }

--- a/src/nativeMain/kotlin/kolt/config/Init.kt
+++ b/src/nativeMain/kotlin/kolt/config/Init.kt
@@ -6,7 +6,7 @@ fun generateKoltToml(projectName: String): String = buildString {
     appendLine("""kotlin = "2.1.0"""")
     appendLine("""target = "jvm"""")
     appendLine("""jvm_target = "17"""")
-    appendLine("""main = "MainKt"""")
+    appendLine("""main = "main"""")
     appendLine("""sources = ["src"]""")
 }
 

--- a/src/nativeMain/kotlin/kolt/config/Main.kt
+++ b/src/nativeMain/kotlin/kolt/config/Main.kt
@@ -1,0 +1,51 @@
+package kolt.config
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+
+// kolt.toml's `main` field holds a Kotlin top-level function FQN. The bare
+// name "main" refers to `fun main()` in the root package; "com.example.main"
+// refers to `fun main()` in `com.example`.
+//
+// For target = "native", konanc consumes the FQN directly as its `-e` flag.
+// For target = "jvm", we derive the JVM facade class name assuming the file
+// is named `Main.kt`, which is the init template's convention and the only
+// shape kolt supports without `@JvmName`. A future `jvm_main_class` override
+// is noted as YAGNI in the PR that introduced this scheme.
+fun jvmMainClass(main: String): String {
+    val prefix = main.substringBeforeLast("main")
+    return "${prefix}MainKt"
+}
+
+// Validates that [main] is a Kotlin top-level function FQN. Either the bare
+// literal "main", or a dotted package followed by ".main".
+//
+// Rejects JVM-style class names (anything ending in "Kt") with a migration
+// hint showing the equivalent function FQN the user likely meant. Other
+// malformed values get a generic error.
+fun validateMainFqn(main: String): Result<Unit, ConfigError.ParseFailed> {
+    if (main.endsWith("Kt")) {
+        return Err(ConfigError.ParseFailed(
+            "main = \"$main\" is a JVM class name. " +
+                "Use a Kotlin function FQN instead: main = \"${jvmClassToFqnHint(main)}\""
+        ))
+    }
+    if (main != "main" && !main.endsWith(".main")) {
+        return Err(ConfigError.ParseFailed(
+            "main = \"$main\" is not a valid Kotlin function FQN " +
+                "(expected \"main\" or \"<package>.main\")"
+        ))
+    }
+    return Ok(Unit)
+}
+
+// Best-effort suggestion when the user supplied a JVM facade class name:
+// drop the trailing "Kt" and replace the last segment with "main".
+// "MainKt" → "main"; "com.example.MainKt" → "com.example.main";
+// "com.example.AppKt" → "com.example.main".
+private fun jvmClassToFqnHint(main: String): String {
+    val withoutKt = main.removeSuffix("Kt")
+    val dot = withoutKt.lastIndexOf('.')
+    return if (dot < 0) "main" else "${withoutKt.substring(0, dot)}.main"
+}

--- a/src/nativeTest/kotlin/kolt/TestFixtures.kt
+++ b/src/nativeTest/kotlin/kolt/TestFixtures.kt
@@ -22,7 +22,7 @@ fun testConfig(
     kotlin = "2.1.0",
     target = target,
     jvmTarget = jvmTarget,
-    main = "com.example.MainKt",
+    main = "com.example.main",
     sources = sources,
     dependencies = dependencies,
     testSources = testSources,

--- a/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
@@ -431,6 +431,7 @@ class BuilderTest {
             listOf(
                 "konanc",
                 "-p", "program",
+                "-e", "com.example.main",
                 "-Xinclude=build/my-app-klib",
                 "-o", "build/my-app"
             ),
@@ -448,6 +449,7 @@ class BuilderTest {
             listOf(
                 "konanc",
                 "-p", "program",
+                "-e", "com.example.main",
                 "-Xinclude=build/hello-klib",
                 "-o", "build/hello"
             ),
@@ -478,6 +480,7 @@ class BuilderTest {
             listOf(
                 "konanc",
                 "-p", "program",
+                "-e", "com.example.main",
                 "-l", "/cache/a.klib",
                 "-l", "/cache/b.klib",
                 "-Xinclude=build/my-app-klib",
@@ -495,51 +498,24 @@ class BuilderTest {
     }
 
     @Test
-    fun nativeLinkCommandDoesNotEmitEntryPointFlag() {
-        // -Xinclude pulls in the compiled main() from the klib. -e would be
-        // redundant and risks conflicting with what the klib already declares.
+    fun nativeLinkCommandEmitsEntryPointFromConfigMain() {
+        // config.main is already a Kotlin function FQN (validated by parseConfig),
+        // so konanc -e consumes it verbatim. Without -e, konanc looks for `main`
+        // in the root package and fails when the function lives in a named package.
         val cmd = nativeLinkCommand(testConfig(target = "native"))
 
-        assertFalse(cmd.args.contains("-e"))
+        val eIndex = cmd.args.indexOf("-e")
+        assertTrue(eIndex >= 0, "Expected -e in: ${cmd.args}")
+        assertEquals("com.example.main", cmd.args[eIndex + 1])
     }
 
     @Test
-    fun nativeEntryPointStripsClassNameAndAppendsMain() {
-        assertEquals("com.example.main", nativeEntryPoint(testConfig()))
-    }
+    fun nativeLinkCommandEmitsRootPackageEntryPoint() {
+        val cmd = nativeLinkCommand(testConfig(target = "native").copy(main = "main"))
 
-    @Test
-    fun nativeEntryPointRootPackage() {
-        val config = testConfig().copy(main = "MainKt")
-        assertEquals("main", nativeEntryPoint(config))
-    }
-
-    @Test
-    fun nativeEntryPointDeepPackage() {
-        val config = testConfig().copy(main = "foo.bar.baz.AppKt")
-        assertEquals("foo.bar.baz.main", nativeEntryPoint(config))
-    }
-
-    // --- needsNativeEntryPointWarning ---
-
-    @Test
-    fun needsNativeEntryPointWarningFalseForKtSuffix() {
-        assertFalse(needsNativeEntryPointWarning(testConfig()))
-    }
-
-    @Test
-    fun needsNativeEntryPointWarningFalseForRootKtSuffix() {
-        assertFalse(needsNativeEntryPointWarning(testConfig().copy(main = "MainKt")))
-    }
-
-    @Test
-    fun needsNativeEntryPointWarningTrueForNonKtClass() {
-        assertTrue(needsNativeEntryPointWarning(testConfig().copy(main = "com.example.App")))
-    }
-
-    @Test
-    fun needsNativeEntryPointWarningTrueForRootNonKt() {
-        assertTrue(needsNativeEntryPointWarning(testConfig().copy(main = "Main")))
+        val eIndex = cmd.args.indexOf("-e")
+        assertTrue(eIndex >= 0)
+        assertEquals("main", cmd.args[eIndex + 1])
     }
 
     // --- nativeTestLibraryCommand (Stage 1: main+test sources -> klib) ---

--- a/src/nativeTest/kotlin/kolt/build/TestDepsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/TestDepsTest.kt
@@ -22,7 +22,7 @@ class TestDepsTest {
     fun nativeTargetInjectsNothing() {
         val config = KoltConfig(
             name = "my-app", version = "0.1.0", kotlin = "2.1.0",
-            target = "native", main = "MainKt", sources = listOf("src")
+            target = "native", main = "main", sources = listOf("src")
         )
         val injected = autoInjectedTestDeps(config)
 
@@ -33,7 +33,7 @@ class TestDepsTest {
     fun kotlinVersionMatchesConfig() {
         val config = KoltConfig(
             name = "my-app", version = "0.1.0", kotlin = "2.2.0",
-            target = "jvm", main = "MainKt", sources = listOf("src")
+            target = "jvm", main = "main", sources = listOf("src")
         )
         val injected = autoInjectedTestDeps(config)
 
@@ -96,7 +96,7 @@ class TestDepsTest {
     fun mergeAllDepsNativeTargetHasNoAutoInjected() {
         val config = KoltConfig(
             name = "my-app", version = "0.1.0", kotlin = "2.1.0",
-            target = "native", main = "MainKt", sources = listOf("src"),
+            target = "native", main = "main", sources = listOf("src"),
             dependencies = mapOf("com.example:lib" to "1.0.0")
         )
         val allDeps = mergeAllDeps(config)

--- a/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
@@ -15,7 +15,7 @@ class ConfigTest {
         version = "0.1.0"
         kotlin = "2.1.0"
         target = "jvm"
-        main = "com.example.MainKt"
+        main = "com.example.main"
         sources = ["src"]
     """.trimIndent()
 
@@ -28,7 +28,7 @@ class ConfigTest {
         assertEquals("0.1.0", config.version)
         assertEquals("2.1.0", config.kotlin)
         assertEquals("jvm", config.target)
-        assertEquals("com.example.MainKt", config.main)
+        assertEquals("com.example.main", config.main)
         assertEquals(listOf("src"), config.sources)
         assertEquals("17", config.jvmTarget)
         assertEquals(emptyMap(), config.dependencies)
@@ -42,7 +42,7 @@ class ConfigTest {
             kotlin = "2.1.0"
             target = "jvm"
             jvm_target = "21"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
         """.trimIndent()
 
@@ -57,7 +57,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [dependencies]
@@ -78,7 +78,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src", "generated"]
         """.trimIndent()
 
@@ -92,7 +92,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
         """.trimIndent()
 
@@ -117,7 +117,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = []
         """.trimIndent()
 
@@ -132,7 +132,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
         """.trimIndent()
 
@@ -149,7 +149,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [dependencies]
@@ -169,7 +169,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "native"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
         """.trimIndent()
 
@@ -184,7 +184,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "wasm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
         """.trimIndent()
 
@@ -205,7 +205,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
             unknown_field = "value"
         """.trimIndent()
@@ -228,7 +228,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
             test_sources = ["test", "integration-test"]
         """.trimIndent()
@@ -244,7 +244,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [test-dependencies]
@@ -263,7 +263,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [dependencies]
@@ -291,7 +291,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
             fmt_style = "kotlinlang"
         """.trimIndent()
@@ -313,7 +313,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [plugins]
@@ -332,7 +332,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [plugins]
@@ -355,7 +355,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [dependencies]
@@ -388,7 +388,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [repositories]
@@ -408,7 +408,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [repositories]
@@ -433,7 +433,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [dependencies]
@@ -457,7 +457,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [repositories]
@@ -489,7 +489,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
             resources = ["resources"]
         """.trimIndent()
@@ -505,7 +505,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
             resources = ["resources", "assets"]
         """.trimIndent()
@@ -521,7 +521,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
             test_resources = ["test-resources"]
         """.trimIndent()
@@ -537,7 +537,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
             resources = ["resources"]
             test_resources = ["test-resources"]
@@ -555,7 +555,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
             resources = []
         """.trimIndent()
@@ -572,7 +572,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"] # main source directory
         """.trimIndent()
 
@@ -610,7 +610,7 @@ class ConfigTest {
             kotlin = "2.1.0"
             target = "jvm"
             jdk = "21"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
         """.trimIndent()
 
@@ -631,7 +631,7 @@ class ConfigTest {
             target = "jvm"
             jdk = "21"
             jvm_target = "17"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
         """.trimIndent()
 
@@ -663,7 +663,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "native"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [[cinterop]]
@@ -690,7 +690,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "native"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [[cinterop]]
@@ -718,7 +718,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "native"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [[cinterop]]
@@ -750,7 +750,7 @@ class ConfigTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "native"
-            main = "com.example.MainKt"
+            main = "com.example.main"
             sources = ["src"]
 
             [dependencies]

--- a/src/nativeTest/kotlin/kolt/config/InitTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/InitTest.kt
@@ -23,9 +23,11 @@ class InitTest {
     }
 
     @Test
-    fun generateTomlMainMatchesProjectName() {
+    fun generateTomlUsesKotlinFunctionFqnForMain() {
+        // Init writes the bare function FQN "main" (root package) rather than
+        // a JVM facade class name. See ADR 0015.
         val toml = generateKoltToml("my-app")
-        assertTrue(toml.contains("main = \"MainKt\""))
+        assertTrue(toml.contains("main = \"main\""))
     }
 
     @Test

--- a/src/nativeTest/kotlin/kolt/config/MainTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/MainTest.kt
@@ -1,0 +1,100 @@
+package kolt.config
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class MainTest {
+
+    // --- jvmMainClass ---
+
+    @Test
+    fun jvmMainClassForRootPackage() {
+        assertEquals("MainKt", jvmMainClass("main"))
+    }
+
+    @Test
+    fun jvmMainClassForSingleSegmentPackage() {
+        assertEquals("com.MainKt", jvmMainClass("com.main"))
+    }
+
+    @Test
+    fun jvmMainClassForDeepPackage() {
+        assertEquals("com.example.app.MainKt", jvmMainClass("com.example.app.main"))
+    }
+
+    // --- validateMainFqn: accepts ---
+
+    @Test
+    fun validateMainFqnAcceptsRootMain() {
+        assertNull(validateMainFqn("main").getError())
+    }
+
+    @Test
+    fun validateMainFqnAcceptsPackagedMain() {
+        assertNull(validateMainFqn("com.example.main").getError())
+    }
+
+    @Test
+    fun validateMainFqnAcceptsDeeplyPackagedMain() {
+        assertNull(validateMainFqn("foo.bar.baz.main").getError())
+    }
+
+    // --- validateMainFqn: rejects JVM class style with the migration hint ---
+
+    @Test
+    fun validateMainFqnRejectsRootMainKtWithHint() {
+        val err = assertNotNull(validateMainFqn("MainKt").getError())
+        val msg = err.message
+        assertTrue(msg.contains("\"MainKt\""), msg)
+        assertTrue(msg.contains("JVM class name"), msg)
+        assertTrue(msg.contains("main = \"main\""), msg)
+    }
+
+    @Test
+    fun validateMainFqnRejectsPackagedMainKtWithHint() {
+        val err = assertNotNull(validateMainFqn("com.example.MainKt").getError())
+        val msg = err.message
+        assertTrue(msg.contains("\"com.example.MainKt\""), msg)
+        assertTrue(msg.contains("main = \"com.example.main\""), msg)
+    }
+
+    @Test
+    fun validateMainFqnRejectsArbitraryKtFacade() {
+        // Non-"MainKt" Kt-suffixed class names (e.g. from an App.kt file) are
+        // also rejected — they're still JVM class names, not Kotlin FQNs.
+        val err = assertNotNull(validateMainFqn("com.example.AppKt").getError())
+        assertTrue(err.message.contains("JVM class name"))
+    }
+
+    // --- validateMainFqn: rejects other malformed values ---
+
+    @Test
+    fun validateMainFqnRejectsEmpty() {
+        assertNotNull(validateMainFqn("").getError())
+    }
+
+    @Test
+    fun validateMainFqnRejectsCapitalizedNonKt() {
+        // "Main" looks like a JVM class but doesn't end with Kt. Still invalid
+        // because it's neither "main" nor "<pkg>.main".
+        val err = assertNotNull(validateMainFqn("Main").getError())
+        assertTrue(err.message.contains("Kotlin function FQN"))
+    }
+
+    @Test
+    fun validateMainFqnRejectsNonMainSuffix() {
+        // Ends with a different function name.
+        assertNotNull(validateMainFqn("com.example.run").getError())
+    }
+
+    @Test
+    fun validateMainFqnRejectsEndingInRemain() {
+        // "remain" ends in "main" as a substring but not as a dotted segment.
+        assertNotNull(validateMainFqn("remain").getError())
+    }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/AddDependencyTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/AddDependencyTest.kt
@@ -17,7 +17,7 @@ class AddDependencyTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "MainKt"
+            main = "main"
             sources = ["src"]
 
             [dependencies]
@@ -37,7 +37,7 @@ class AddDependencyTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "MainKt"
+            main = "main"
             sources = ["src"]
         """.trimIndent()
 
@@ -54,7 +54,7 @@ class AddDependencyTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "MainKt"
+            main = "main"
             sources = ["src"]
 
             [dependencies]
@@ -74,7 +74,7 @@ class AddDependencyTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "MainKt"
+            main = "main"
             sources = ["src"]
 
             [dependencies]
@@ -92,7 +92,7 @@ class AddDependencyTest {
             version = "0.1.0"
             kotlin = "2.1.0"
             target = "jvm"
-            main = "MainKt"
+            main = "main"
             sources = ["src"]
 
             [dependencies]


### PR DESCRIPTION
## Summary
- `main` in kolt.toml now holds a Kotlin top-level function FQN (e.g. `"main"` or `"com.example.main"`), not a JVM facade class name (`"MainKt"`)
- Native build forwards `config.main` to konanc `-e` verbatim; JVM build derives the Main-Class via `jvmMainClass()`
- `parseConfig` rejects JVM-class-style values with a migration hint pointing at the equivalent function FQN

## Why

`MainKt` is a JVM implementation artifact — kotlinc synthesizes it from the file name purely for JVM interop. Surfacing it in a target-agnostic build config leaks backend detail into user-facing surface.

The latent bug that forced the decision: `nativeLinkCommand` previously omitted `-e` on the assumption that `-Xinclude` would carry `main()` through. That only holds when `fun main()` sits at the root package. For kolt's own `fun kolt.cli.main()` (discovered while verifying self-host in #61), konanc fails with `could not find '/main' function` because it looks for `main` in the root package by default.

Flipping the semantics fixes both issues with a single field redefinition, and lets `target = "jvm"` and `target = "native"` share the same `main` value without derivation per target.

Full rationale and the YAGNI note on `@JvmName` / `jvm_main_class` are in [ADR 0015](docs/adr/0015-main-field-is-kotlin-function-fqn.md).

## Migration

Pre-1.0 (v0.9.0), no migration period. Old configs get a precise parse error:

```
main = "com.example.MainKt" is a JVM class name. Use a Kotlin function FQN instead: main = "com.example.main"
```

## Mapping

| `main` value | JVM Main-Class | Native `-e` |
|---|---|---|
| `"main"` | `MainKt` | `main` |
| `"com.example.main"` | `com.example.MainKt` | `com.example.main` |

## Test plan

- [x] TDD: `MainTest` Red → `Main.kt` Green
- [x] `BuilderTest.nativeLinkCommand*` updated to pin `-e config.main` in the canonical arg order
- [x] `RunnerTest` unchanged (still expects `com.example.MainKt` — now as output of `jvmMainClass` applied to the updated fixture)
- [x] `ConfigTest` / `InitTest` / `TestDepsTest` / `AddDependencyTest` fixtures updated
- [x] `./gradlew linuxX64Test` — green (623 tests)
- [x] ADR 0012 marked superseded; ADR 0014 gets a cross-reference note