### PR TITLE
Add kolt.toml for self-host build (#61 Phase 1)

### DIFF
--- a/kolt.toml
+++ b/kolt.toml
@@ -1,0 +1,20 @@
+name = "kolt"
+version = "0.9.0"
+kotlin = "2.3.20"
+target = "native"
+main = "kolt.cli.main"
+sources = ["src/nativeMain/kotlin"]
+test_sources = ["src/nativeTest/kotlin"]
+
+[[cinterop]]
+name = "libcurl"
+def = "src/nativeInterop/cinterop/libcurl.def"
+
+[plugins]
+serialization = true
+
+[dependencies]
+"org.jetbrains.kotlinx:kotlinx-serialization-json" = "1.7.3"
+"com.michael-bull.kotlin-result:kotlin-result" = "2.3.1"
+"org.kotlincrypto.hash:sha2-256" = "0.2.7"
+"com.akuleshov7:ktoml-core" = "0.7.1"


### PR DESCRIPTION
## Summary
- Add \`kolt.toml\` describing kolt itself (translates \`build.gradle.kts\`)
- kolt can now build itself end-to-end: Gradle kolt.kexe → self-hosted kolt.kexe → re-self-hosted kolt.kexe, all pass
- Gradle remains as the bootstrap path per #61's non-goals

## What's verified

- [x] 4 runtime deps resolve as native klibs (ktoml-core, kotlin-result, kotlinx-serialization-json, kotlincrypto sha2-256). No resolver changes needed after #70 and #72.
- [x] \`kolt check\` / \`kolt build\` succeed from a clean \`build/\`
- [x] The self-hosted kolt.kexe can then rebuild kolt from scratch (double-bootstrap)
- [x] Resulting binary prints \`kolt 0.9.0\` from \`--version\`
- [x] \`main = "kolt.cli.main"\` uses the function FQN format from #77 / ADR 0015

## What's deferred

- [ ] Linker args / binary options parity with the Gradle setup (binary sizes currently differ — ~6 MB self-hosted vs ~15 MB Gradle debugExecutable; expected, but worth a side-by-side audit in a follow-up)
- [ ] CI smoke test running \`./kolt.kexe build\` against HEAD

Both tracked in #61.

## Scope

This PR adds exactly one file — \`kolt.toml\` — and touches nothing else. The end-to-end build being functional is a direct consequence of the preceding PRs (#67 cinterop, #66 plugins, #70 stdlib-common skip, #72 native resolver int attributes, #77 main as function FQN). The remaining self-host work is small and can land incrementally.

## Test plan

- [x] Fresh \`build/\` → \`./build/bin/linuxX64/debugExecutable/kolt.kexe build\` → \`build/kolt.kexe\` runs with \`--version\`
- [x] Double bootstrap via stashed self-hosted binary
- [x] Gradle \`./gradlew linuxX64Test\` still green (no source changes)

Refs #61