### PR TITLE
Pass -target linux_x64 explicitly to konanc and cinterop (#61)

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -6,6 +6,13 @@ import kolt.config.KoltConfig
 internal const val BUILD_DIR = "build"
 internal const val CLASSES_DIR = "$BUILD_DIR/classes"
 
+// Kotlin/Native target triple. Currently linux_x64 is the only supported
+// target (see #61 non-goals). Passed explicitly on every konanc and cinterop
+// invocation so a future cross-build (e.g. running kolt on macOS targeting
+// linux_x64) cannot silently fall back to the host default and produce a
+// wrong-architecture klib. Mirrors what the Kotlin Gradle plugin does.
+internal const val NATIVE_TARGET = "linux_x64"
+
 internal fun outputJarPath(config: KoltConfig): String = "$BUILD_DIR/${config.name}.jar"
 
 internal fun outputKexePath(config: KoltConfig): String = "$BUILD_DIR/${config.name}.kexe"
@@ -78,6 +85,8 @@ fun nativeLibraryCommand(
     val outputBase = outputNativeKlibPath(config)
     val args = buildList {
         add(konancPath ?: "konanc")
+        add("-target")
+        add(NATIVE_TARGET)
         addAll(config.sources)
         add("-p")
         add("library")
@@ -111,6 +120,8 @@ fun nativeLinkCommand(
     val klibPath = outputNativeKlibPath(config)
     val args = buildList {
         add(konancPath ?: "konanc")
+        add("-target")
+        add(NATIVE_TARGET)
         add("-p")
         add("program")
         add("-e")
@@ -138,6 +149,8 @@ fun nativeTestLibraryCommand(
     val outputBase = outputNativeTestKlibPath(config)
     val args = buildList {
         add(konancPath ?: "konanc")
+        add("-target")
+        add(NATIVE_TARGET)
         addAll(config.sources)
         addAll(config.testSources)
         add("-p")
@@ -166,6 +179,8 @@ fun nativeTestLinkCommand(
     val klibPath = outputNativeTestKlibPath(config)
     val args = buildList {
         add(konancPath ?: "konanc")
+        add("-target")
+        add(NATIVE_TARGET)
         add("-p")
         add("program")
         add("-generate-test-runner")
@@ -189,6 +204,8 @@ fun cinteropCommand(
     val outputBase = "$outputDir/${entry.name}"
     val args = buildList {
         add(cinteropPath ?: "cinterop")
+        add("-target")
+        add(NATIVE_TARGET)
         add("-def")
         add(entry.def)
         add("-o")

--- a/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
@@ -339,7 +339,7 @@ class BuilderTest {
         val cmd = nativeLibraryCommand(testConfig(target = "native"))
 
         assertEquals(
-            listOf("konanc", "src", "-p", "library", "-nopack", "-o", "build/my-app-klib"),
+            listOf("konanc", "-target", "linux_x64", "src", "-p", "library", "-nopack", "-o", "build/my-app-klib"),
             cmd.args
         )
         assertEquals("build/my-app-klib", cmd.outputPath)
@@ -352,7 +352,7 @@ class BuilderTest {
         )
 
         assertEquals(
-            listOf("konanc", "src", "generated", "-p", "library", "-nopack", "-o", "build/my-app-klib"),
+            listOf("konanc", "-target", "linux_x64", "src", "generated", "-p", "library", "-nopack", "-o", "build/my-app-klib"),
             cmd.args
         )
     }
@@ -363,7 +363,7 @@ class BuilderTest {
 
         assertEquals("build/hello-klib", cmd.outputPath)
         assertEquals(
-            listOf("konanc", "src", "-p", "library", "-nopack", "-o", "build/hello-klib"),
+            listOf("konanc", "-target", "linux_x64", "src", "-p", "library", "-nopack", "-o", "build/hello-klib"),
             cmd.args
         )
     }
@@ -385,7 +385,7 @@ class BuilderTest {
 
         assertEquals(
             listOf(
-                "konanc", "src",
+                "konanc", "-target", "linux_x64", "src",
                 "-p", "library", "-nopack",
                 "-o", "build/my-app-klib",
                 "-Xplugin=foo.jar"
@@ -403,7 +403,7 @@ class BuilderTest {
 
         assertEquals(
             listOf(
-                "konanc", "src",
+                "konanc", "-target", "linux_x64", "src",
                 "-p", "library", "-nopack",
                 "-l", "/cache/a.klib",
                 "-l", "/cache/b.klib",
@@ -430,6 +430,7 @@ class BuilderTest {
         assertEquals(
             listOf(
                 "konanc",
+                "-target", "linux_x64",
                 "-p", "program",
                 "-e", "com.example.main",
                 "-Xinclude=build/my-app-klib",
@@ -448,6 +449,7 @@ class BuilderTest {
         assertEquals(
             listOf(
                 "konanc",
+                "-target", "linux_x64",
                 "-p", "program",
                 "-e", "com.example.main",
                 "-Xinclude=build/hello-klib",
@@ -479,6 +481,7 @@ class BuilderTest {
         assertEquals(
             listOf(
                 "konanc",
+                "-target", "linux_x64",
                 "-p", "program",
                 "-e", "com.example.main",
                 "-l", "/cache/a.klib",
@@ -527,6 +530,7 @@ class BuilderTest {
         assertEquals(
             listOf(
                 "konanc",
+                "-target", "linux_x64",
                 "src", "test",
                 "-p", "library", "-nopack",
                 "-o", "build/my-app-test-klib"
@@ -549,6 +553,7 @@ class BuilderTest {
         assertEquals(
             listOf(
                 "konanc",
+                "-target", "linux_x64",
                 "src", "generated", "test", "integration-test",
                 "-p", "library", "-nopack",
                 "-o", "build/my-app-test-klib"
@@ -567,6 +572,7 @@ class BuilderTest {
         assertEquals(
             listOf(
                 "konanc",
+                "-target", "linux_x64",
                 "src", "test",
                 "-p", "library", "-nopack",
                 "-o", "build/my-app-test-klib",
@@ -586,6 +592,7 @@ class BuilderTest {
         assertEquals(
             listOf(
                 "konanc",
+                "-target", "linux_x64",
                 "src", "test",
                 "-p", "library", "-nopack",
                 "-l", "/cache/a.klib",
@@ -613,6 +620,7 @@ class BuilderTest {
         assertEquals(
             listOf(
                 "konanc",
+                "-target", "linux_x64",
                 "-p", "program",
                 "-generate-test-runner",
                 "-Xinclude=build/my-app-test-klib",
@@ -638,6 +646,7 @@ class BuilderTest {
         assertEquals(
             listOf(
                 "konanc",
+                "-target", "linux_x64",
                 "-p", "program",
                 "-generate-test-runner",
                 "-Xinclude=build/hello-test-klib",
@@ -657,6 +666,7 @@ class BuilderTest {
         assertEquals(
             listOf(
                 "konanc",
+                "-target", "linux_x64",
                 "-p", "program",
                 "-generate-test-runner",
                 "-l", "/cache/a.klib",

--- a/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
@@ -23,7 +23,7 @@ class CinteropTest {
 
         // Then: args contain cinterop binary, -def, and -o flags
         assertEquals(
-            listOf("cinterop", "-def", "src/nativeInterop/cinterop/libcurl.def", "-o", "build/libcurl"),
+            listOf("cinterop", "-target", "linux_x64", "-def", "src/nativeInterop/cinterop/libcurl.def", "-o", "build/libcurl"),
             cmd.args
         )
     }
@@ -86,6 +86,7 @@ class CinteropTest {
         assertEquals(
             listOf(
                 "cinterop",
+                "-target", "linux_x64",
                 "-def", "src/nativeInterop/cinterop/libcurl.def",
                 "-o", "build/libcurl",
                 "-pkg", "libcurl"


### PR DESCRIPTION
## Summary
- Add \`NATIVE_TARGET = "linux_x64"\` constant in Builder.kt
- Emit \`-target linux_x64\` from every \`konanc\` and \`cinterop\` invocation kolt makes
- Update 14 BuilderTest + 2 CinteropTest canonical-arg-list assertions

## Why

Self-host parity audit against the Kotlin Gradle plugin for #61. Gradle passes \`-target linux_x64\` unconditionally; kolt was relying on konanc/cinterop defaulting to the host target. The default is load-bearing — a future cross-build (kolt running on macOS producing a linux_x64 klib) would silently fall back to the macOS host target and emit a wrong-architecture binary. Adding \`-target\` now closes the latent bug at zero cost.

## Audit results

| Flag | kolt prior state | Decision |
|---|---|---|
| \`-target linux_x64\` | omitted (host default) | **adopt** — prevents silent cross-build breakage |
| \`-g\` (debug info) | omitted | skip — smaller binaries; future \`[binary]\` config |
| \`-Xmodule-name\` | omitted | skip — no effect on program output |
| \`-manifest\` | omitted | skip — library-stage only |
| \`-repo\` | omitted | skip — absolute \`-l\` paths are equivalent |
| \`-Xmulti-platform\` / \`-Xcommon-sources\` | omitted | N/A — kolt has no \`commonMain\` / expect-actual |
| \`-Xbinary=gc=...\` | omitted | N/A — matches konanc default |

The audit could not mechanically diff Gradle's full argv because KotlinNativeCompile runs konanc in-process and the Gradle debug logger prints flag names only (not values). The table was built from first-principles reading of the Kotlin Gradle plugin's known behavior, cross-checked against the one konanc command kolt captured from the out-of-process cinterop task log.

## Test plan

- [x] \`./gradlew linuxX64Test\` — green (pre-existing 14 BuilderTest + 2 CinteropTest arg-list assertions updated to expect \`-target linux_x64\` in canonical order; were red before the Builder.kt change)
- [x] Self-host end-to-end still works: \`./build/bin/linuxX64/debugExecutable/kolt.kexe build\` produces \`build/kolt.kexe\` in ~67s; \`./build/kolt.kexe --version\` prints \`kolt 0.9.0\`
- [x] Covers every konanc / cinterop callsite in \`src/nativeMain\` (audited)

Refs #61 (Linker args / binary options parity sub-task)