### PR TITLE
Add self-host smoke test CI workflow (#61)

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -1,0 +1,87 @@
+name: Self-host smoke test
+
+# Builds kolt.kexe from its own kolt.toml as a smoke test against HEAD.
+# See #61 — this is the minimum signal that the self-host path stays
+# unbroken across changes. A Gradle-built kolt.kexe bootstraps itself
+# to rebuild kolt from kolt.toml, and we verify the resulting binary
+# responds to `--version`.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same branch / PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  self-host:
+    name: Self-host build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      # libcurl headers are required by the libcurl cinterop binding.
+      - name: Install libcurl dev headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      # Gradle's Kotlin Native plugin downloads konanc (~500 MB) into ~/.konan.
+      # Caching keeps runs under ~2 minutes after the first cold build. Keyed
+      # on build.gradle.kts because that's where the Kotlin (and therefore
+      # konanc) version lives for the Gradle path.
+      - name: Cache Gradle Kotlin Native
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('build.gradle.kts') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
+
+      # kolt downloads its own kotlinc / konanc / JDK into ~/.kolt on first
+      # run. Cache keyed on the Kotlin version from kolt.toml.
+      - name: Cache kolt toolchains
+        uses: actions/cache@v4
+        with:
+          path: ~/.kolt
+          key: kolt-${{ runner.os }}-${{ hashFiles('kolt.toml') }}
+          restore-keys: |
+            kolt-${{ runner.os }}-
+
+      - name: Bootstrap kolt.kexe via Gradle
+        run: ./gradlew --no-daemon linkDebugExecutableLinuxX64
+
+      - name: Self-host build (kolt builds itself from kolt.toml)
+        run: ./build/bin/linuxX64/debugExecutable/kolt.kexe build
+
+      - name: Verify self-hosted binary
+        run: |
+          set -euo pipefail
+          version=$(./build/kolt.kexe --version)
+          echo "$version"
+          echo "$version" | grep -Eq '^kolt [0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'


### PR DESCRIPTION
## Summary
- First CI file in the repo: \`.github/workflows/self-host-smoke.yml\`
- Single job that Gradle-bootstraps \`kolt.kexe\`, runs \`kolt build\` against \`kolt.toml\`, and verifies \`--version\`
- Closes the last #61 sub-task

## What it checks

The same loop we've been running by hand since PR #78:

1. Bootstrap via \`./gradlew linkDebugExecutableLinuxX64\`
2. Self-host via \`./build/bin/linuxX64/debugExecutable/kolt.kexe build\`
3. \`./build/kolt.kexe --version\` must match \`^kolt \d+\.\d+\.\d+(-[A-Za-z0-9.]+)?$\`

## Design choices

- **ubuntu-latest only** — per #61 non-goals (linux_x64 host)
- **30-min timeout** — cold build is ~8 min on ubuntu-latest, warm is ~2 min; 30 is a generous ceiling
- **Cancel-in-progress concurrency** — superseded PR pushes don't waste CI time
- **\`contents: read\` permissions** — minimal
- **Actions pinned to major v4** (\`actions/checkout\`, \`actions/setup-java\`, \`actions/cache\`)
- **Caches**
  - \`~/.gradle\`: keyed on \`**/*.gradle*\` + gradle-wrapper.properties
  - \`~/.konan\`: keyed on \`build.gradle.kts\` hash (Kotlin version lives there)
  - \`~/.kolt\`: keyed on \`kolt.toml\` hash (kolt's internal toolchains download)
- **libcurl4-openssl-dev** apt-installed for the libcurl cinterop binding

## Scope

**This PR does not add unit test CI.** \`./gradlew linuxX64Test\` running in CI is a trivial follow-up (one additional job) and was deliberately deferred to keep this PR minimal, matching #61's exact sub-task wording.

## Test plan

- [x] YAML syntactically valid
- [x] Steps match what we've been running by hand end-to-end (verified since PR #78 and #79)
- [x] Cache keys don't over-invalidate unreasonably (konan keyed on build.gradle.kts, kolt on kolt.toml, both with restore-keys as fallback)
- [ ] First CI run on this PR itself will be the functional verification

Closes #61