### PR TITLE
Add unit tests CI workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,65 @@
+name: Unit tests
+
+# Runs the linuxX64Test gradle task on every push and PR. Complements the
+# self-host smoke workflow: smoke verifies the build pipeline end-to-end,
+# this job catches unit-level regressions in build / resolve / config /
+# infra logic before they reach main.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  linuxX64-test:
+    name: linuxX64Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      # libcurl headers are required by the libcurl cinterop binding that
+      # compiles as part of the main klib that tests depend on.
+      - name: Install libcurl dev headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev
+
+      # Cache keys deliberately mirror self-host-smoke.yml so the two
+      # workflows share underlying cache entries (keyed per repo, not per
+      # workflow). First run of either populates the caches for both.
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Cache Gradle Kotlin Native
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('build.gradle.kts') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
+
+      - name: Run linuxX64Test
+        run: ./gradlew --no-daemon linuxX64Test


### PR DESCRIPTION
## Summary
- New \`.github/workflows/unit-tests.yml\` running \`./gradlew linuxX64Test\` on every push/PR
- Complements the self-host smoke workflow from #80

## Why a separate file

Per the discussion on the smoke test PR, two workflows is clearer than one multi-job workflow:

- **Distinct status checks** — a red CI is immediately diagnosable as a pipeline regression (smoke) or a code regression (unit tests) before you even click in
- **Independent cancel-in-progress** — flakes in one don't take down the other
- **No history break** — no renaming of existing workflow files

The only cost is ~15 lines of duplicated setup steps, which is acceptable.

## Cache sharing

Cache keys deliberately mirror \`self-host-smoke.yml\`:
- \`gradle-\${runner.os}-\${hash(**/*.gradle*, gradle-wrapper.properties)}\`
- \`konan-\${runner.os}-\${hash(build.gradle.kts)}\`

GitHub Actions cache is scoped per repo, not per workflow, so the first run of either workflow populates both caches for the other. Cold starts only happen when \`build.gradle.kts\` or wrapper properties change.

## What this job does NOT do

- No self-host bootstrap — that's smoke's job
- No \`~/.kolt\` cache — \`linuxX64Test\` doesn't exercise kolt's own toolchain downloads
- No matrix — linux_x64 only, per #61 non-goals

## Test plan

- [x] YAML syntactically valid
- [ ] First run on this PR itself is the functional gate (~4-5 min cold, should be warm and ~1 min on subsequent runs thanks to cache sharing with the smoke workflow)