### PR TITLE
Rewrite README pitch, bump to v0.10.0, update kolt-dev SKILL

### DIFF
--- a/.claude/skills/kolt-dev/SKILL.md
+++ b/.claude/skills/kolt-dev/SKILL.md
@@ -39,8 +39,9 @@ Binary: `build/bin/linuxX64/debugExecutable/kolt.kexe`
 | config | Config.kt | Parse kolt.toml, KoltConfig data class |
 | config | KoltPaths.kt | ~/.kolt/ path resolution (cache, tools, toolchains) |
 | config | Init.kt | Project template generation (kolt.toml, Main.kt) |
+| config | Main.kt | Validate `main` field as Kotlin function FQN; derive JVM facade class name for JVM builds; see ADR 0015 |
 | config | Version.kt | Kolt version string |
-| build | Builder.kt | Build kotlinc / konanc command args (pure function). Native builds are a library → link two-stage split; see ADR 0014 |
+| build | Builder.kt | Build kotlinc / konanc command args (pure function). Native builds are a library → link two-stage split (ADR 0014); link stage emits `-e config.main` and every konanc / cinterop call carries `-target linux_x64` (ADR 0015) |
 | build | BuildCache.kt | Build state tracking via mtime comparison |
 | build | Runner.kt | Build java -jar command args (pure function) |
 | build | TestBuilder.kt | Build kotlinc command for test compilation (pure function) |

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ kls-classpath
 
 # Claude Code
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Exclude zigpj directory
 zigpj/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # kolt
 
-> v0.9.0 — Early-stage project. Expect breaking changes.
+[![Unit tests](https://github.com/snicmakino/kolt/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/snicmakino/kolt/actions/workflows/unit-tests.yml)
+[![Self-host smoke test](https://github.com/snicmakino/kolt/actions/workflows/self-host-smoke.yml/badge.svg)](https://github.com/snicmakino/kolt/actions/workflows/self-host-smoke.yml)
 
-A lightweight build tool for Kotlin. Compiles with `kotlinc` directly — no Gradle, no JVM startup tax.
+> v0.10.0 — Early-stage project. Expect breaking changes.
 
-Written in Kotlin/Native. Single binary, instant startup. Incremental builds via mtime-based caching — unchanged sources skip compilation entirely.
+A lightweight build tool for Kotlin. TOML config — no Kotlin DSL build scripts to evaluate. Distributed as a single Kotlin/Native binary — no Java install required to use it.
+
+The tool itself starts instantly. Actual compilation delegates to `kotlinc` / `konanc`, so build times track the Kotlin compiler directly. Incremental builds via mtime-based caching skip unchanged sources entirely.
+
+A `kotlinc` daemon integration is planned for an upcoming release to amortize JVM startup across successive builds.
 
 ## Installation
 
@@ -21,6 +26,8 @@ The binary is produced at `build/bin/linuxX64/debugExecutable/kolt.kexe`. Copy i
 ```sh
 cp build/bin/linuxX64/debugExecutable/kolt.kexe ~/.local/bin/kolt
 ```
+
+Gradle is the bootstrap path only. Once you have a kolt binary on PATH, kolt builds itself from its own `kolt.toml` — `kolt build` from the repo root produces an equivalent `build/kolt.kexe` without Gradle. A CI smoke test keeps this loop green on every commit.
 
 ## Quick Start
 

--- a/kolt.toml
+++ b/kolt.toml
@@ -1,5 +1,5 @@
 name = "kolt"
-version = "0.9.0"
+version = "0.10.0"
 kotlin = "2.3.20"
 target = "native"
 main = "kolt.cli.main"

--- a/src/nativeMain/kotlin/kolt/config/Version.kt
+++ b/src/nativeMain/kotlin/kolt/config/Version.kt
@@ -1,5 +1,5 @@
 package kolt.config
 
-const val KOLT_VERSION = "0.9.0"
+const val KOLT_VERSION = "0.10.0"
 
 fun versionString(): String = "kolt $KOLT_VERSION"


### PR DESCRIPTION
## Summary
- Rewrite README's opening pitch to drop the misleading "no JVM startup tax" claim
- Bump kolt to v0.10.0 (two breaking TOML schema changes since 0.9.0: #76 and #77)
- Add CI status badges for both workflows
- Add self-host note to the Installation section
- Update kolt-dev SKILL architecture table for #77 / #79

## Why the pitch rewrite

The prior header claimed \`Compiles with kotlinc directly — no Gradle, no JVM startup tax\`. That's accurate only for kolt's own CLI dispatch: \`kolt build\` still subprocess-launches \`kotlinc\` / \`konanc\`, which are JVM tools and pay the full startup cost on every invocation. A kotlinc daemon is planned for the next release but not yet landed, so claiming the gap is closed is misleading.

New pitch leads with what kolt *actually* differentiates on today:
- TOML config (no Kotlin DSL script compilation)
- Single Kotlin/Native binary (no Java install required to use kolt)
- Instant CLI dispatch
- mtime incremental cache
- Honest one-liner about the planned daemon integration

## Why the version bump

Today's merges included two breaking TOML schema changes:
- #76 removed \`compiler_options\` / \`linker_options\` from \`[[cinterop]]\`
- #77 flipped \`main\` from a JVM class name (\`"com.example.MainKt"\`) to a Kotlin function FQN (\`"com.example.main"\`)

Pre-1.0 semver says a minor bump is the right signal. The bump is trivial (\`KOLT_VERSION\` + \`kolt.toml\` version field), and the self-host smoke test's \`--version\` regex already accepts any semver.

## Test plan

- [x] \`./gradlew linuxX64Test\` — green
- [ ] CI runs on this PR: smoke test + unit tests must pass (smoke will rebuild with the new version and verify \`kolt 0.10.0\` matches the regex)