### PR TITLE
Add compile-bench spike for Phase A daemon PoC (#86)

### DIFF
--- a/spike/compile-bench/.gitignore
+++ b/spike/compile-bench/.gitignore
@@ -1,0 +1,2 @@
+build/
+.gradle/

--- a/spike/compile-bench/build.gradle.kts
+++ b/spike/compile-bench/build.gradle.kts
@@ -1,0 +1,42 @@
+plugins {
+    kotlin("jvm") version "2.3.20"
+    application
+}
+
+repositories {
+    mavenCentral()
+}
+
+val kotlincClasspath: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+val fixtureClasspath: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    kotlincClasspath("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.3.20")
+    fixtureClasspath("org.jetbrains.kotlin:kotlin-stdlib:2.3.20")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+application {
+    mainClass.set("bench.BenchKt")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    systemProperty("kotlinc.classpath", kotlincClasspath.asPath)
+    systemProperty("fixture.classpath", fixtureClasspath.asPath)
+}
+
+tasks.named<JavaExec>("run") {
+    systemProperty("kotlinc.classpath", kotlincClasspath.asPath)
+    systemProperty("fixture.classpath", fixtureClasspath.asPath)
+}

--- a/spike/compile-bench/fixtures/Hello.kt
+++ b/spike/compile-bench/fixtures/Hello.kt
@@ -1,0 +1,5 @@
+package fixtures
+
+fun main() {
+    println("hello from the warm-jvm spike")
+}

--- a/spike/compile-bench/settings.gradle.kts
+++ b/spike/compile-bench/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "compile-bench"

--- a/spike/compile-bench/src/main/kotlin/bench/Bench.kt
+++ b/spike/compile-bench/src/main/kotlin/bench/Bench.kt
@@ -1,0 +1,100 @@
+package bench
+
+import java.io.File
+import kotlin.system.measureTimeMillis
+
+fun main() {
+    val jars = cpProp("kotlinc.classpath")
+    val fixtureCp = cpProp("fixture.classpath")
+    val sources = listOf(File("fixtures/Hello.kt").absoluteFile)
+    check(sources.first().exists()) { "missing fixture: ${sources.first().path}" }
+
+    val iterations = 10
+
+    println("=== Scenario A: shared URLClassLoader (baseline, n=$iterations) ===")
+    val shared = SharedLoaderCompileDriver(jars, fixtureCp)
+    val sharedTimes = runScenario(iterations) { shared.compile(sources, freshOutputDir()) }
+    reportTimes(sharedTimes)
+
+    System.gc()
+    Thread.sleep(200)
+
+    println()
+    println("=== Scenario B: fresh URLClassLoader per compile (isolated, n=$iterations) ===")
+    val iso = IsolatingCompileDriver(jars, fixtureCp)
+    val isoTimes = runScenario(iterations) { iso.compile(sources, freshOutputDir()) }
+    reportTimes(isoTimes)
+
+    System.gc()
+    Thread.sleep(200)
+
+    val longN = 50
+    println()
+    println("=== Scenario C: shared loader long run (n=$longN, watch-mode simulation) ===")
+    val sharedC = SharedLoaderCompileDriver(jars, fixtureCp)
+    val memBefore = usedHeapMb()
+    val longTimes = runScenario(longN) { sharedC.compile(sources, freshOutputDir()) }
+    System.gc()
+    Thread.sleep(200)
+    val memAfter = usedHeapMb()
+    reportTimes(longTimes)
+    println("  heap before: $memBefore MB")
+    println("  heap after : $memAfter MB")
+    println("  heap delta : ${memAfter - memBefore} MB")
+    val firstQuarter = longTimes.drop(1).take(longN / 4).average()
+    val lastQuarter = longTimes.takeLast(longN / 4).average()
+    println("  early warm avg : ${firstQuarter.toLong()} ms")
+    println("  late  warm avg : ${lastQuarter.toLong()} ms")
+    println("  drift (late - early): ${(lastQuarter - firstQuarter).toLong()} ms")
+
+    val sharedWarm = sharedTimes.drop(1).average()
+    val isoWarm = isoTimes.drop(1).average()
+    val overhead = (isoWarm - sharedWarm).toLong()
+    val gate = 1000L
+    val verdictB = if (overhead < gate) "PASS" else "FAIL"
+    val driftGate = 500L
+    val verdictC = if ((lastQuarter - firstQuarter) < driftGate && (memAfter - memBefore) < 200) "PASS" else "FAIL"
+
+    println()
+    println("=== Verdict ===")
+    println("Scenario A (shared warm avg): ${sharedWarm.toLong()} ms")
+    println("Scenario B (isolated warm avg): ${isoWarm.toLong()} ms")
+    println("Scenario B overhead: $overhead ms  ->  kill criterion < $gate ms  ->  $verdictB")
+    println("Scenario C drift: ${(lastQuarter - firstQuarter).toLong()} ms, heap delta: ${memAfter - memBefore} MB  ->  $verdictC")
+}
+
+private fun usedHeapMb(): Long {
+    val rt = Runtime.getRuntime()
+    return (rt.totalMemory() - rt.freeMemory()) / (1024 * 1024)
+}
+
+private fun runScenario(n: Int, block: () -> CompileResult): List<Long> = List(n) {
+    var result: CompileResult? = null
+    val ms = measureTimeMillis { result = block() }
+    check(result is CompileResult.Ok) { "compile failed: $result" }
+    ms
+}
+
+private fun reportTimes(ms: List<Long>) {
+    val cold = ms.first()
+    val warm2 = ms.getOrNull(1) ?: -1L
+    val sorted = ms.sorted()
+    val median = sorted[ms.size / 2]
+    val avgWarm = ms.drop(1).average().toLong()
+    println("  cold   : $cold ms")
+    println("  warm-2 : $warm2 ms")
+    println("  median : $median ms")
+    println("  warm avg (excl. cold): $avgWarm ms")
+    println("  all    : $ms")
+}
+
+private fun freshOutputDir(): File {
+    val d = File.createTempFile("bench-out-", "").apply { delete() }
+    d.mkdirs()
+    d.deleteOnExit()
+    return d
+}
+
+private fun cpProp(key: String): List<File> =
+    (System.getProperty(key) ?: error("$key not set"))
+        .split(File.pathSeparatorChar).map(::File)

--- a/spike/compile-bench/src/main/kotlin/bench/Bench.kt
+++ b/spike/compile-bench/src/main/kotlin/bench/Bench.kt
@@ -79,7 +79,11 @@ private fun reportTimes(ms: List<Long>) {
     val cold = ms.first()
     val warm2 = ms.getOrNull(1) ?: -1L
     val sorted = ms.sorted()
-    val median = sorted[ms.size / 2]
+    val median = if (sorted.size % 2 == 1) {
+        sorted[sorted.size / 2]
+    } else {
+        (sorted[sorted.size / 2 - 1] + sorted[sorted.size / 2]) / 2
+    }
     val avgWarm = ms.drop(1).average().toLong()
     println("  cold   : $cold ms")
     println("  warm-2 : $warm2 ms")

--- a/spike/compile-bench/src/main/kotlin/bench/CompileResult.kt
+++ b/spike/compile-bench/src/main/kotlin/bench/CompileResult.kt
@@ -1,0 +1,6 @@
+package bench
+
+sealed class CompileResult {
+    object Ok : CompileResult()
+    data class Failed(val exitCode: String, val messages: List<String>) : CompileResult()
+}

--- a/spike/compile-bench/src/main/kotlin/bench/IsolatingCompileDriver.kt
+++ b/spike/compile-bench/src/main/kotlin/bench/IsolatingCompileDriver.kt
@@ -1,0 +1,35 @@
+package bench
+
+import java.io.File
+import java.io.PrintStream
+import java.net.URLClassLoader
+
+sealed class CompileResult {
+    object Ok : CompileResult()
+    data class Failed(val exitCode: String, val messages: List<String>) : CompileResult()
+}
+
+class IsolatingCompileDriver(
+    private val compilerJars: List<File>,
+    private val compileClasspath: List<File> = emptyList(),
+) {
+    fun compile(sources: List<File>, outputDir: File): CompileResult {
+        val urls = compilerJars.map { it.toURI().toURL() }.toTypedArray()
+        val loader = URLClassLoader(urls, ClassLoader.getPlatformClassLoader())
+
+        val args = buildCompileArgs(sources, outputDir, compileClasspath)
+        val compilerClass = Class.forName("org.jetbrains.kotlin.cli.jvm.K2JVMCompiler", true, loader)
+        val compiler = compilerClass.getDeclaredConstructor().newInstance()
+        val cliCompiler = Class.forName("org.jetbrains.kotlin.cli.common.CLICompiler", true, loader)
+        val execMethod = cliCompiler.getMethod("exec", PrintStream::class.java, Array<String>::class.java)
+
+        val exitCode = execMethod.invoke(compiler, nullPrintStream, args) as Enum<*>
+        loader.close()
+        return if (exitCode.name == "OK") CompileResult.Ok
+        else CompileResult.Failed(exitCode.name, emptyList())
+    }
+
+    companion object {
+        private val nullPrintStream = PrintStream(java.io.OutputStream.nullOutputStream())
+    }
+}

--- a/spike/compile-bench/src/main/kotlin/bench/IsolatingCompileDriver.kt
+++ b/spike/compile-bench/src/main/kotlin/bench/IsolatingCompileDriver.kt
@@ -4,11 +4,6 @@ import java.io.File
 import java.io.PrintStream
 import java.net.URLClassLoader
 
-sealed class CompileResult {
-    object Ok : CompileResult()
-    data class Failed(val exitCode: String, val messages: List<String>) : CompileResult()
-}
-
 class IsolatingCompileDriver(
     private val compilerJars: List<File>,
     private val compileClasspath: List<File> = emptyList(),

--- a/spike/compile-bench/src/main/kotlin/bench/SharedLoaderCompileDriver.kt
+++ b/spike/compile-bench/src/main/kotlin/bench/SharedLoaderCompileDriver.kt
@@ -1,0 +1,54 @@
+package bench
+
+import java.io.File
+import java.io.PrintStream
+import java.lang.reflect.Method
+import java.net.URLClassLoader
+
+class SharedLoaderCompileDriver(
+    compilerJars: List<File>,
+    private val compileClasspath: List<File> = emptyList(),
+) {
+    private val loader: URLClassLoader
+    private val compiler: Any
+    private val execMethod: Method
+
+    init {
+        val urls = compilerJars.map { it.toURI().toURL() }.toTypedArray()
+        loader = URLClassLoader(urls, ClassLoader.getPlatformClassLoader())
+        val compilerClass = Class.forName("org.jetbrains.kotlin.cli.jvm.K2JVMCompiler", true, loader)
+        compiler = compilerClass.getDeclaredConstructor().newInstance()
+        val cliCompiler = Class.forName("org.jetbrains.kotlin.cli.common.CLICompiler", true, loader)
+        execMethod = cliCompiler.getMethod("exec", PrintStream::class.java, Array<String>::class.java)
+    }
+
+    fun compile(sources: List<File>, outputDir: File): CompileResult {
+        val args = buildCompileArgs(sources, outputDir, compileClasspath)
+        val exitCode = execMethod.invoke(compiler, nullPrintStream, args) as Enum<*>
+        return if (exitCode.name == "OK") CompileResult.Ok
+        else CompileResult.Failed(exitCode.name, emptyList())
+    }
+
+    companion object {
+        private val nullPrintStream = PrintStream(java.io.OutputStream.nullOutputStream())
+    }
+}
+
+internal fun buildCompileArgs(
+    sources: List<File>,
+    outputDir: File,
+    compileClasspath: List<File>,
+): Array<String> {
+    val cp = compileClasspath.joinToString(File.pathSeparator) { it.absolutePath }
+    val args = mutableListOf(
+        "-d", outputDir.absolutePath,
+        "-no-stdlib",
+        "-no-reflect",
+    )
+    if (cp.isNotEmpty()) {
+        args += "-classpath"
+        args += cp
+    }
+    sources.forEach { args += it.absolutePath }
+    return args.toTypedArray()
+}

--- a/spike/compile-bench/src/test/kotlin/bench/IsolatingCompileDriverTest.kt
+++ b/spike/compile-bench/src/test/kotlin/bench/IsolatingCompileDriverTest.kt
@@ -1,0 +1,38 @@
+package bench
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class IsolatingCompileDriverTest {
+    @Test
+    fun `compiles a single source file in an isolating classloader`() {
+        val jars = classpathFromSystemProperty("kotlinc.classpath")
+        val fixtureCp = classpathFromSystemProperty("fixture.classpath")
+        val driver = IsolatingCompileDriver(jars, fixtureCp)
+
+        val source = File("fixtures/Hello.kt").absoluteFile
+        assertTrue(source.exists(), "fixture missing: ${source.path}")
+
+        val outputDir = createTempOutputDir()
+        val result = driver.compile(listOf(source), outputDir)
+
+        assertEquals(CompileResult.Ok, result, "compile should succeed")
+        val expected = outputDir.resolve("fixtures/HelloKt.class")
+        assertTrue(expected.exists(), "expected class file at ${expected.path}")
+    }
+
+    private fun classpathFromSystemProperty(key: String): List<File> {
+        val raw = System.getProperty(key)
+            ?: error("$key system property not set (run via Gradle)")
+        return raw.split(File.pathSeparatorChar).map(::File)
+    }
+
+    private fun createTempOutputDir(): File {
+        val dir = File.createTempFile("bench-out-", "").apply { delete() }
+        dir.mkdirs()
+        dir.deleteOnExit()
+        return dir
+    }
+}

--- a/spike/compile-bench/src/test/kotlin/bench/IsolatingCompileDriverTest.kt
+++ b/spike/compile-bench/src/test/kotlin/bench/IsolatingCompileDriverTest.kt
@@ -12,6 +12,7 @@ class IsolatingCompileDriverTest {
         val fixtureCp = classpathFromSystemProperty("fixture.classpath")
         val driver = IsolatingCompileDriver(jars, fixtureCp)
 
+        // Relative path: Gradle runs tests with working dir = spike/compile-bench/.
         val source = File("fixtures/Hello.kt").absoluteFile
         assertTrue(source.exists(), "fixture missing: ${source.path}")
 


### PR DESCRIPTION
## Summary

- Adds a standalone Gradle JVM subproject at `spike/compile-bench/` that measures the per-compile overhead of different classloader strategies for reusing `kotlin-compiler-embeddable` across warm-JVM invocations.
- Empirically answers the single biggest open question for #14 / #86 Phase A: **is classloader-per-compile isolation viable, or do we need shared-loader reuse?**
- Result: fresh `URLClassLoader` per compile fails the kill criterion by ~2.6×; shared loader reuse holds at ~85–230 ms warm with only +9 MB heap delta over 50 iterations. Phase A will be built on classloader reuse with a periodic-restart safety net.

Full write-up and decision record: https://github.com/snicmakino/kolt/issues/86#issuecomment-4235031208 and the revised #86 body.

## Scope of this PR

This PR lands **only the spike** — the measurement code that justifies the Phase A architecture decision. It does not touch kolt's main build, CLI, or any production code path.

- Standalone Gradle project under `spike/compile-bench/` — not wired into root `settings.gradle.kts`, so `./gradlew build` from repo root is unaffected
- Three components:
  - `IsolatingCompileDriver` — fresh `URLClassLoader` per compile (rejected strategy, kept for benchmark comparison)
  - `SharedLoaderCompileDriver` — single `URLClassLoader` reused across compiles (chosen strategy)
  - `Bench.kt` — runs three scenarios (shared short, isolated short, shared long-run) and decides against kill criteria
- One JUnit test verifying the isolating driver actually compiles `fixtures/Hello.kt` (Red → Green history preserved in the commit message of the spike-up work)

## Benchmark results (reproducible)

From `./gradlew run` inside `spike/compile-bench/` on OpenJDK 21 / Kotlin 2.3.20:

| Scenario | n | cold | warm median | warm avg | heap Δ |
|---|---|---|---|---|---|
| A — shared `URLClassLoader` | 10 | 3147 ms | 250 ms | 233 ms | — |
| B — fresh `URLClassLoader` per compile | 10 | 2620 ms | 2645 ms | 2857 ms | — |
| **C — shared loader long run** | 50 | 2634 ms | 108 ms | **123 ms** | **+9 MB** |

Late warm avg on scenario C: **85 ms** (JIT warmup improved times over the run; no upward drift).

## Follow-ups (out of scope for this PR)

The 50-iteration measurement is reassuring but narrow. Before flipping the daemon to default in a later phase, separate spikes will measure:

1. Varying sources across iterations (rotating fixture) — PSI cache realism
2. Multi-file / multi-module realistic workloads
3. Very-long-run (1000+ iter) leak check
4. Thread-safety of concurrent compiles on a shared loader

These will be tracked as separate issues after Phase A lands.

## Test plan

- [x] `./gradlew test` inside `spike/compile-bench/` — passes (isolating driver compiles `Hello.kt` successfully)
- [x] `./gradlew run` inside `spike/compile-bench/` — runs all three scenarios, prints verdict
- [x] Root `./gradlew build` is unaffected (spike is not in root `settings.gradle.kts`)
- [ ] Reviewer sanity-checks the benchmark methodology and kill criteria