### PR TITLE
Map daemon protocol-error replies to BackendUnavailable (#14)

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
@@ -281,28 +281,30 @@ internal fun mapFrameErrorToReceiveError(err: FrameError): CompileError = when (
 
 internal fun mapReplyToOutcome(reply: Message): Result<CompileOutcome, CompileError> = when (reply) {
     is Message.CompileResult ->
-        if (reply.exitCode == 0) {
-            Ok(CompileOutcome(stdout = reply.stdout, stderr = reply.stderr))
-        } else {
-            // TODO(#14 S7): distinguish "kotlinc said nonzero" (real
-            // CompilationFailed, not fallback-eligible) from "daemon
-            // raised a host-level error and wrote a protocol-error
-            // reply" (ADR 0016 §3 — host-level failures surface as
-            // `writeProtocolError` with exitCode=2 and an empty
-            // diagnostics list). Today both collapse into
-            // CompilationFailed, meaning a daemon internal error
-            // blocks the subprocess fallback. The distinction needs
-            // either (a) a new wire field or (b) sniffing exitCode==2
-            // + empty diagnostics + a marker stderr — neither is
-            // worth doing before the real integration test at S7
-            // proves which host-level failure modes are common.
-            Err(
-                CompileError.CompilationFailed(
-                    exitCode = reply.exitCode,
-                    stdout = reply.stdout,
-                    stderr = reply.stderr,
-                ),
-            )
+        when {
+            reply.exitCode == 0 ->
+                Ok(CompileOutcome(stdout = reply.stdout, stderr = reply.stderr))
+            isDaemonProtocolError(reply) ->
+                // The JVM daemon's `writeProtocolError` wire contract
+                // (ADR 0016 §3, `DaemonServer.writeProtocolError`)
+                // emits exactly this shape on host-level failures:
+                // exitCode=2, empty diagnostics, empty stdout, and a
+                // stderr prefixed with "protocol error: ". Route it
+                // to BackendUnavailable so FallbackCompilerBackend can
+                // drop to subprocess compile instead of surfacing a
+                // confusing "compilation failed: protocol error" to
+                // the user. Narrow enough to not false-positive on a
+                // real kotlinc internal-error exitCode=2, because the
+                // stderr prefix is unique to the daemon contract.
+                Err(CompileError.BackendUnavailable.Other("daemon protocol error: ${reply.stderr}"))
+            else ->
+                Err(
+                    CompileError.CompilationFailed(
+                        exitCode = reply.exitCode,
+                        stdout = reply.stdout,
+                        stderr = reply.stderr,
+                    ),
+                )
         }
     is Message.Compile,
     is Message.Ping,
@@ -314,6 +316,14 @@ internal fun mapReplyToOutcome(reply: Message): Result<CompileOutcome, CompileEr
         ),
     )
 }
+
+private const val DAEMON_PROTOCOL_ERROR_PREFIX = "protocol error: "
+
+private fun isDaemonProtocolError(reply: Message.CompileResult): Boolean =
+    reply.exitCode == 2 &&
+        reply.diagnostics.isEmpty() &&
+        reply.stdout.isEmpty() &&
+        reply.stderr.startsWith(DAEMON_PROTOCOL_ERROR_PREFIX)
 
 // Wire contract: the fields of Message.Compile must stay aligned with
 // CompileRequest so the native client and the JVM server can talk

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
@@ -144,6 +144,57 @@ class DaemonCompilerBackendHappyPathTest {
         assertEquals(1, failed.exitCode)
         assertEquals("Main.kt:3:5 error: expected ';'", failed.stderr)
     }
+
+    @Test
+    fun daemonProtocolErrorMapsToBackendUnavailable() {
+        // The JVM daemon's writeProtocolError wire contract emits
+        // exitCode=2, empty diagnostics, empty stdout, and a stderr
+        // prefixed "protocol error: ". Route those to
+        // BackendUnavailable so FallbackCompilerBackend falls through
+        // to subprocess compile instead of surfacing a confusing
+        // CompilationFailed.
+        val fake = FakeConnection(
+            reply = Ok(
+                Message.CompileResult(
+                    exitCode = 2,
+                    diagnostics = emptyList(),
+                    stdout = "",
+                    stderr = "protocol error: malformed frame body",
+                ),
+            ),
+        )
+        val backend = newBackend(connector = { Ok(fake) })
+
+        val err = assertNotNull(backend.compile(sampleRequest()).getError())
+        val unavailable = assertIs<CompileError.BackendUnavailable.Other>(err)
+        assertTrue(
+            unavailable.detail.contains("protocol error: malformed frame body"),
+            "detail should carry the daemon's stderr: ${unavailable.detail}",
+        )
+    }
+
+    @Test
+    fun kotlincInternalErrorExitCode2DoesNotFalsePositive() {
+        // A real kotlinc internal error can also produce exitCode=2
+        // but carries real compiler output, not the "protocol error:"
+        // prefix. Make sure the sniff is narrow enough to leave that
+        // path as CompilationFailed.
+        val fake = FakeConnection(
+            reply = Ok(
+                Message.CompileResult(
+                    exitCode = 2,
+                    diagnostics = emptyList(),
+                    stdout = "",
+                    stderr = "error: compiler backend internal error: NPE in JVMBackend",
+                ),
+            ),
+        )
+        val backend = newBackend(connector = { Ok(fake) })
+
+        val err = assertNotNull(backend.compile(sampleRequest()).getError())
+        val failed = assertIs<CompileError.CompilationFailed>(err)
+        assertEquals(2, failed.exitCode)
+    }
 }
 
 class DaemonCompilerBackendConnectAndSpawnTest {


### PR DESCRIPTION
## Summary

Resolves the `TODO(#14 S7)` that was deferred from PR #92 (Phase A daemon PR3). The JVM daemon's `writeProtocolError` (see `DaemonServer.writeProtocolError` and ADR 0016 §3) emits host-level failures as a very specific wire shape:

- `exitCode = 2`
- `diagnostics = []`
- `stdout = ""`
- `stderr` prefixed with `"protocol error: "`

Previously `mapReplyToOutcome` collapsed every non-zero exit into `CompilationFailed`, which blocks `FallbackCompilerBackend` from dropping to the subprocess path on a daemon internal error and surfaces a confusing "compilation failed: protocol error" to the user. This PR adds a narrow `isDaemonProtocolError` sniff that matches the four-field signature exactly and routes those replies to `BackendUnavailable.Other` so fallback kicks in.

The sniff is justified by a **documented wire contract** rather than empirical observation: the shape is produced by a single helper on the server, ADR 0016 §3 locks it in, and the stderr prefix is unique enough that a real `kotlinc` internal error (which can also return exitCode=2, but with real compiler output on stderr) is left on the `CompilationFailed` path unchanged.

## Changes

- `src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt`:
  - `mapReplyToOutcome` now has three branches (success, daemon protocol error, real compilation failure) instead of two.
  - New private `isDaemonProtocolError(Message.CompileResult): Boolean` helper matching all four contract fields.
  - The `TODO(#14 S7)` comment block is removed.
- `src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt`:
  - New test `daemonProtocolErrorMapsToBackendUnavailable` — the sniff path, confirms fallback-eligible.
  - New test `kotlincInternalErrorExitCode2DoesNotFalsePositive` — same exitCode=2 but a real compiler error message, confirms it stays as `CompilationFailed`.
  - Existing `nonZeroExitCodeMapsToCompilationFailed` unchanged.

## Why this is safe

- The sniff requires **all four** signature fields to match. A real `kotlinc` internal error (`exitCode=2` but with non-empty stderr like `"error: compiler backend internal error: ..."`) does not false-positive — covered by the new test.
- If the daemon ever changes `writeProtocolError` to use a different stderr prefix, the sniff stops matching and the behaviour silently falls back to the pre-PR state (everything collapses into `CompilationFailed`). The change is safe to revert and safe to extend.
- No wire protocol change, no ADR 0016 §3 change — this is purely a client-side interpretation of an already-contracted shape.

## Test plan

- [x] `./gradlew linuxX64Test --tests "kolt.build.daemon.DaemonCompilerBackendHappyPathTest"` — 5 tests green (3 existing + 2 new)
- [x] Full suite `./gradlew linuxX64Test` still green

## Related

- #14 — parent daemon epic
- #92 — Phase A PR3 that introduced the TODO
- ADR 0016 §3 — exit code table and `writeProtocolError` contract