### PR TITLE
Auto-install bootstrap JDK for the compiler daemon (#93)

### DIFF
--- a/docs/adr/0017-bootstrap-jdk-provisioning.md
+++ b/docs/adr/0017-bootstrap-jdk-provisioning.md
@@ -3,16 +3,24 @@
 ## Status
 
 Accepted (2026-04-14) as part of #14 PR3. The `kolt-compiler-daemon`
-has its own JDK slot independent of the user's `kolt.toml [build] jdk`,
-resolved **read-only** for PR3 — auto-provision is deferred until
-`ensureJdkBins` can return a `Result<_, _>` instead of calling
-`exitProcess`. The constant `BOOTSTRAP_JDK_VERSION` and the
-`resolveBootstrapJavaBin` helper landed in PR3 S5.5; the null-return
-fallback wiring (`DaemonPreconditionError.BootstrapJdkMissing` →
+has its own JDK slot independent of the user's `kolt.toml [build] jdk`.
+`BOOTSTRAP_JDK_VERSION` and the `resolveBootstrapJavaBin` helper
+landed in PR3 S5.5; the fallback wiring
+(`DaemonPreconditionError.BootstrapJdkInstallFailed` →
 `resolveCompilerBackend` skips the daemon wrapper and returns a plain
 `SubprocessCompilerBackend` with a one-line warning) landed in PR3 S7
-together with the daemon going default-on, satisfying the conditional
-on which this ADR was accepted.
+together with the daemon going default-on.
+
+Auto-install landed in issue #93: `installJdkToolchain`,
+`installKotlincToolchain`, `installKonancToolchain`, and their
+`ensure*` wrappers in `ToolchainManager.kt` now return
+`Result<_, ToolchainError>` instead of calling `exitProcess`, so
+`ensureBootstrapJavaBin(paths)` can synchronously download the pinned
+JDK on first use while keeping the daemon bring-up path non-load-
+bearing — a network failure surfaces as
+`BootstrapJdkInstallFailed(jdkInstallDir, cause)` and the build
+silently falls back to the subprocess compile path, honouring the
+ADR 0016 §5 invariant.
 
 ## Context
 
@@ -82,31 +90,27 @@ in the kolt binary as `BOOTSTRAP_JDK_VERSION` in
 JDKs, so a project that already pins JDK 21 shares the install for
 free.
 
-For PR3, `resolveBootstrapJavaBin(paths)` is **read-only**: it
-returns the `java` path if the JDK is already installed, else
-`null`. The caller (S7 `DaemonCompilerBackend` wiring) is expected
-to translate a `null` into `CompileError.BackendUnavailable` so the
-subprocess fallback takes over for the current build. The daemon
-being "never load-bearing for correctness" (ADR 0016 §5) requires
-that nothing on the daemon bring-up path can exit the kolt
-process; the existing `ensureJdkBins` violates that invariant by
-calling `exitProcess` on any failure, which is why auto-install is
-held back from this PR.
+The daemon bring-up path calls `ensureBootstrapJavaBin(paths)`, which
+auto-installs the pinned JDK under
+`~/.kolt/toolchains/jdk/<BOOTSTRAP_JDK_VERSION>/` the first time it
+is needed, using the same `installJdkToolchain` code path the user
+sees for explicit `kolt toolchain install`. The daemon being "never
+load-bearing for correctness" (ADR 0016 §5) is preserved because
+every failure on that path (download, checksum, extract) surfaces
+as `BootstrapJdkError` → `BootstrapJdkInstallFailed`, and the build
+degrades to the subprocess compile path with a one-line warning.
 
-**Install path today**: users install the bootstrap JDK via
-`kolt install jdk 21`. The daemon then activates automatically on
-the next build because `resolveBootstrapJavaBin` begins returning
-non-null. A user who has not run `kolt install` sees the existing
-~8 s subprocess compile until they do, with no behaviour regression
-from pre-daemon kolt.
+A read-only sibling, `resolveBootstrapJavaBin(paths)`, is kept next
+to `ensureBootstrapJavaBin` for diagnostic callers that want to
+probe state without triggering a download.
 
-**Auto-install is deferred**, tracked as follow-up work in the
-daemon epic. Landing it requires refactoring `installJdkToolchain`
-and `ensureJdkBins` to return `Result<_, _>` so the daemon path can
-surface download failures as `BackendUnavailable` without killing
-the kolt process. That refactor is mechanical but touches every
-existing `exitProcess(exitCode)` call in `ToolchainManager.kt`, and
-is kept out of PR3 so the native-client work is not blocked on it.
+**First-run UX today**: the first `kolt build` after a clean install
+pauses to download the bootstrap JDK once (progress reuses the
+existing `downloading jdk 21…` wording), then the daemon activates
+immediately. An offline first run falls back to the subprocess
+compile path silently and retries the install on the next online
+build. Users do **not** need a separate `kolt toolchain install`
+step for the bootstrap JDK.
 
 The bootstrap JDK is deliberately **not** wired through `kolt.toml`.
 Users cannot change `BOOTSTRAP_JDK_VERSION` per project. The daemon
@@ -148,15 +152,14 @@ wired into the toolchain code.
 
 ### Negative
 
-- **Users have to run `kolt install jdk 21` once before the daemon
-  speedup activates.** Without auto-install, the first-time UX is
-  "kolt build is fast only after you install the bootstrap JDK".
-  Acceptable because nothing regresses compared to pre-daemon kolt
-  (the subprocess fallback produces the same 8 s clean build as
-  before), and because the whole point of deferring auto-install
-  is to keep the fallback path from being held hostage to JDK
-  download state. The `kolt doctor`-style hint in the S7 fallback
-  message is the planned UX for pointing users at the one-line fix.
+- **First run pauses to download the bootstrap JDK.** With
+  auto-install, the first `kolt build` on a clean machine is gated
+  on a ~200 MB download before the daemon can start. Acceptable
+  because (a) the download reuses the existing toolchain install
+  progress wording, and (b) an offline first run silently
+  degrades to the subprocess compile path — the same ~8 s clean
+  build as pre-daemon kolt — and the next online run installs and
+  activates the daemon without any user intervention.
 - **Bootstrap version is a new thing to keep current.** Kolt release
   notes now have to cover "which JDK the daemon runs on this
   release". If the pinned bootstrap JDK falls behind in security
@@ -188,12 +191,14 @@ wired into the toolchain code.
    that the existing `installJdkToolchain` does not know about.
    Tracked as a follow-up under the daemon epic.
 5. **Auto-install from day one.** Considered and rejected for PR3:
-   the existing `installJdkToolchain` / `ensureJdkBins` exit the
+   the existing `installJdkToolchain` / `ensureJdkBins` exited the
    kolt process on any download or checksum failure, which would
-   break the daemon-is-never-load-bearing invariant (ADR 0016 §5).
-   Auto-install will land after those paths are refactored to
-   return `Result<_, _>`, in a follow-up that does not otherwise
-   change daemon semantics.
+   have broken the daemon-is-never-load-bearing invariant
+   (ADR 0016 §5). Landed in follow-up issue #93 by refactoring
+   those paths (and every other `exitProcess` call in
+   `ToolchainManager.kt`) to return `Result<_, ToolchainError>`, so
+   `ensureBootstrapJavaBin` can now install synchronously and
+   downgrade any failure to a fallback warning.
 
 ## Related
 

--- a/src/nativeMain/kotlin/kolt/build/daemon/BootstrapJdk.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/BootstrapJdk.kt
@@ -1,7 +1,14 @@
 package kolt.build.daemon
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltPaths
+import kolt.infra.eprintln
 import kolt.infra.fileExists
+import kolt.tool.ToolchainError
+import kolt.tool.installJdkToolchain
 
 // Version of the JDK kolt uses for running the compiler daemon.
 //
@@ -18,29 +25,93 @@ import kolt.infra.fileExists
 // ADR 0017.
 const val BOOTSTRAP_JDK_VERSION: String = "21"
 
+// Why bootstrap JDK provisioning failed for this build. The install
+// dir is carried so the warning can name the exact path kolt tried to
+// populate; [cause] is the underlying toolchain failure (download,
+// checksum, extract, …) already wrapped into a single user-facing
+// message by `ToolchainManager`. A single flat variant is enough —
+// nothing downstream classifies these; the daemon precondition path
+// just surfaces them in a one-line fallback warning. ADR 0016 §5
+// guarantees this is never load-bearing for correctness.
+internal data class BootstrapJdkError(
+    val jdkInstallDir: String,
+    val cause: ToolchainError,
+)
+
 /**
  * Read-only lookup for the bootstrap JDK's `java` binary. Returns
  * `null` if the JDK is not already installed under
  * `~/.kolt/toolchains/jdk/<version>/bin/java`.
  *
- * This function intentionally does **not** trigger a download. The
- * daemon is never load-bearing for correctness (ADR 0016 §5); an
- * unavailable bootstrap JDK must degrade to the subprocess compile
- * path, never to a kolt process exit. Auto-install of the bootstrap
- * JDK is future work (tracked in ADR 0017 Alternatives §5) that
- * requires refactoring the existing `ensureJdkBins` path to return a
- * `Result<_, _>` instead of calling `exitProcess` on failure.
- *
- * Until that lands, there is no dedicated one-line install command:
- * a user who wants to activate the daemon must populate
- * `~/.kolt/toolchains/jdk/$BOOTSTRAP_JDK_VERSION/` by other means
- * (e.g. configuring the project's `kolt.toml` to the same JDK
- * version, so the existing `ensureJdkBins` path installs it
- * incidentally). A caller that receives `null` should fall back to
- * [kolt.build.SubprocessCompilerBackend] and surface the probed
- * directory in its warning so the user knows what kolt looked for.
+ * Kept alongside [ensureBootstrapJavaBin] for tests and diagnostic
+ * callers that want to probe state without triggering a download.
+ * The daemon bring-up path in production goes through
+ * [ensureBootstrapJavaBin] (see ADR 0017 §Decision, revised once
+ * `installJdkToolchain` became `Result`-returning) so a missing
+ * bootstrap JDK is auto-provisioned on first use and the daemon
+ * activates immediately instead of requiring a separate install step.
  */
 internal fun resolveBootstrapJavaBin(paths: KoltPaths): String? {
     val javaBin = paths.javaBin(BOOTSTRAP_JDK_VERSION)
     return if (fileExists(javaBin)) javaBin else null
+}
+
+/**
+ * Resolves the bootstrap JDK's `java` binary, downloading and
+ * installing the pinned version under `~/.kolt/toolchains/jdk/` on
+ * first use. Returns `Ok(javaBin)` if the JDK is already installed
+ * or becomes installed as a side effect, or
+ * `Err(BootstrapJdkError)` if the download / checksum / extract
+ * pipeline fails.
+ *
+ * On failure, the caller (daemon precondition resolver) must treat
+ * this as a fallback signal — **never** as a build failure — because
+ * the daemon is not load-bearing for correctness (ADR 0016 §5).
+ * Specifically, an offline first run surfaces here as an `Err` and
+ * the build silently drops back to the subprocess compile path; the
+ * next online run will install the JDK and the daemon takes over.
+ *
+ * Progress output (`downloading jdk 21…` etc.) is routed through
+ * `eprintln` rather than `println` because the auto-install fires
+ * implicitly inside `doBuild` — it would otherwise interleave with
+ * build stdout the user cares about. Explicit `kolt toolchain install`
+ * still goes to stdout via the default `::println` progress sink on
+ * [installJdkToolchain].
+ *
+ * Seams:
+ * - [resolve] maps to [resolveBootstrapJavaBin] in production so a
+ *   test can skip the download path by returning a ready-made bin.
+ * - [install] maps to [installJdkToolchain] so a test can inject a
+ *   fake install pipeline (success, hard failure, partial install).
+ */
+internal fun ensureBootstrapJavaBin(
+    paths: KoltPaths,
+    resolve: (KoltPaths) -> String? = ::resolveBootstrapJavaBin,
+    install: (String, KoltPaths) -> Result<Unit, ToolchainError> =
+        { v, p -> installJdkToolchain(v, p, progressSink = ::eprintln) },
+): Result<String, BootstrapJdkError> {
+    resolve(paths)?.let { return Ok(it) }
+
+    val installDir = paths.jdkPath(BOOTSTRAP_JDK_VERSION)
+    install(BOOTSTRAP_JDK_VERSION, paths).getOrElse { err ->
+        return Err(BootstrapJdkError(installDir, err))
+    }
+
+    // Post-install re-check: running `resolve` again here
+    // guarantees the returned path observes the same "bin/java
+    // exists" invariant as the fast path above. Any mismatch means
+    // the [install] lambda lied about success — either a
+    // ToolchainManager bug, or a test-injected seam returning
+    // `Ok(Unit)` without populating the filesystem. Either way we
+    // surface it as an `Err` so the daemon path degrades
+    // gracefully instead of handing back a path the JVM launcher
+    // cannot exec.
+    val javaBin = resolve(paths)
+        ?: return Err(
+            BootstrapJdkError(
+                installDir,
+                ToolchainError("java binary not found at ${paths.javaBin(BOOTSTRAP_JDK_VERSION)} after installation"),
+            ),
+        )
+    return Ok(javaBin)
 }

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
@@ -32,12 +32,17 @@ internal data class DaemonSetup(
 // are build failures — ADR 0016 §5 guarantees the daemon is never
 // load-bearing for correctness.
 internal sealed interface DaemonPreconditionError {
-    // The bootstrap JDK is not yet installed at the expected path
-    // under ~/.kolt/toolchains/jdk/<BOOTSTRAP_JDK_VERSION>/bin/java.
-    // Carries the probed directory so the warning can point at the
-    // exact path the user needs to populate. Auto-install is future
-    // work tracked in ADR 0017 Alternatives §5.
-    data class BootstrapJdkMissing(val jdkInstallDir: String) : DaemonPreconditionError
+    // Auto-install of the bootstrap JDK failed (download, checksum,
+    // extract, or a leftover partial install under the probed
+    // directory). Carries the probed directory so the warning can
+    // name the exact path kolt tried to populate, plus the underlying
+    // cause message so the warning tells the user *why* it failed
+    // (HTTP status, offline, disk full, …) rather than just "missing".
+    // ADR 0017 §Decision (revised) describes this auto-install path.
+    data class BootstrapJdkInstallFailed(
+        val jdkInstallDir: String,
+        val cause: String,
+    ) : DaemonPreconditionError
 
     // The `kolt-compiler-daemon-all.jar` was not found in any of the
     // locations [resolveDaemonJar] probes (env override, libexec
@@ -60,22 +65,32 @@ internal sealed interface DaemonPreconditionError {
  * and picks [kolt.build.FallbackCompilerBackend] or a plain
  * [kolt.build.SubprocessCompilerBackend] accordingly.
  *
- * Seams ([resolveJavaBin], [resolveDaemonJar], [listCompilerJars]) are
+ * Seams ([ensureJavaBin], [resolveDaemonJar], [listCompilerJars]) are
  * parameterised so unit tests can drive every variant of
  * [DaemonPreconditionError] without touching the real filesystem.
  * Defaults wire up the production helpers; production callers pass
- * only [paths], [kotlincVersion], and [absProjectPath].
+ * only [paths], [kotlincVersion], and [absProjectPath]. [ensureJavaBin]
+ * is the auto-installing [ensureBootstrapJavaBin] — on a clean first
+ * run it downloads the pinned JDK synchronously before returning; on
+ * failure the daemon path degrades to the subprocess backend per
+ * ADR 0016 §5, never killing the build.
  */
 internal fun resolveDaemonPreconditions(
     paths: KoltPaths,
     kotlincVersion: String,
     absProjectPath: String,
-    resolveJavaBin: (KoltPaths) -> String? = ::resolveBootstrapJavaBin,
+    ensureJavaBin: (KoltPaths) -> Result<String, BootstrapJdkError> = ::ensureBootstrapJavaBin,
     resolveDaemonJar: () -> DaemonJarResolution = ::resolveDaemonJar,
     listCompilerJars: (String) -> List<String>? = { dir -> listJarFiles(dir).getOrElse { null } },
 ): Result<DaemonSetup, DaemonPreconditionError> {
-    val javaBin = resolveJavaBin(paths)
-        ?: return Err(DaemonPreconditionError.BootstrapJdkMissing(paths.jdkPath(BOOTSTRAP_JDK_VERSION)))
+    val javaBin = ensureJavaBin(paths).getOrElse { err ->
+        return Err(
+            DaemonPreconditionError.BootstrapJdkInstallFailed(
+                jdkInstallDir = err.jdkInstallDir,
+                cause = err.cause.message,
+            ),
+        )
+    }
 
     val daemonJar = when (val res = resolveDaemonJar()) {
         is DaemonJarResolution.Resolved -> res.path
@@ -104,16 +119,15 @@ internal fun resolveDaemonPreconditions(
 /**
  * One-line stderr warning for a precondition failure. Kept next to
  * the error enum so every new variant is forced to supply wording at
- * the same time. The wording names the on-disk location kolt probed
- * rather than an imperative install command — auto-install of the
- * bootstrap JDK is deferred (ADR 0017 Alternatives §5) and there is
- * no dedicated one-liner a user can run yet. Acceptable regression
- * from pre-daemon kolt because the subprocess fallback preserves the
- * old ~8 s clean build behaviour exactly.
+ * the same time. For [DaemonPreconditionError.BootstrapJdkInstallFailed]
+ * the wording now includes the underlying cause (HTTP status, offline,
+ * disk full, …) so a user staring at "slow builds" knows whether to
+ * retry online, free up disk, or investigate a proxy. ADR 0017
+ * §Decision (revised) made the auto-install path default-on.
  */
 internal fun formatDaemonPreconditionWarning(err: DaemonPreconditionError): String = when (err) {
-    is DaemonPreconditionError.BootstrapJdkMissing ->
-        "warning: bootstrap JDK not installed at ${err.jdkInstallDir} — falling back to subprocess compile"
+    is DaemonPreconditionError.BootstrapJdkInstallFailed ->
+        "warning: could not install bootstrap JDK at ${err.jdkInstallDir} (${err.cause}) — falling back to subprocess compile"
     DaemonPreconditionError.DaemonJarMissing ->
         "warning: kolt-compiler-daemon jar not found — falling back to subprocess compile"
     is DaemonPreconditionError.CompilerJarsMissing ->

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -53,7 +53,7 @@ internal fun doCheck(useDaemon: Boolean = true) {
         return
     }
     val paths = resolveKoltPaths(EXIT_BUILD_ERROR)
-    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths, EXIT_BUILD_ERROR)
+    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
 
     val classpath = resolveDependencies(config)
     val pArgs = resolvePluginArgs(config, managedKotlincBin)
@@ -61,7 +61,7 @@ internal fun doCheck(useDaemon: Boolean = true) {
 
     println("checking ${config.name}...")
     executeCommand(cmd).getOrElse { error ->
-        eprintln(formatProcessError(error, "check"))
+        eprintln("error: " + formatProcessError(error, "check"))
         exitProcess(EXIT_BUILD_ERROR)
     }
     val elapsed = startMark.elapsedNow()
@@ -100,7 +100,7 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
         ?.let { parseBuildState(it) }
 
     val paths = resolveKoltPaths(EXIT_BUILD_ERROR)
-    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths, EXIT_BUILD_ERROR)
+    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
     val (managedJavaBin, managedJarBin) = ensureJdkBinsFromConfig(config, paths)
 
     if (isBuildUpToDate(current = currentState, cached = cachedState)) {
@@ -188,7 +188,7 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
 
     val jarCmd = jarCommand(config, jarPath = managedJarBin)
     executeCommand(jarCmd.args).getOrElse { error ->
-        eprintln(formatProcessError(error, "jar packaging"))
+        eprintln("error: " + formatProcessError(error, "jar packaging"))
         exitProcess(EXIT_BUILD_ERROR)
     }
 
@@ -210,7 +210,7 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
     val startMark = TimeSource.Monotonic.markNow()
 
     val paths = resolveKoltPaths(EXIT_BUILD_ERROR)
-    val managedKonancBin = ensureKonancBin(config.kotlin, paths, EXIT_BUILD_ERROR)
+    val managedKonancBin = ensureKonancBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
 
     val depKlibs = resolveNativeDependencies(config, paths)
 
@@ -247,14 +247,14 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
     val libraryCmd = nativeLibraryCommand(config, pluginArgs = nativePluginArgs, konancPath = managedKonancBin, klibs = klibs)
     println("compiling ${config.name} (native)...")
     executeCommand(libraryCmd.args).getOrElse { error ->
-        eprintln(formatProcessError(error, "compilation"))
+        eprintln("error: " + formatProcessError(error, "compilation"))
         exitProcess(EXIT_BUILD_ERROR)
     }
 
     val linkCmd = nativeLinkCommand(config, konancPath = managedKonancBin, klibs = klibs)
     println("linking ${config.name} (native)...")
     executeCommand(linkCmd.args).getOrElse { error ->
-        eprintln(formatProcessError(error, "linking"))
+        eprintln("error: " + formatProcessError(error, "linking"))
         exitProcess(EXIT_BUILD_ERROR)
     }
 
@@ -309,7 +309,7 @@ private fun runCinterop(config: KoltConfig, paths: KoltPaths): List<String> {
         val cmd = cinteropCommand(entry, cinteropPath = managedCinteropBin)
         println("generating cinterop klib for ${entry.name}...")
         executeCommand(cmd.args).getOrElse { error ->
-            eprintln(formatProcessError(error, "cinterop (${entry.name})"))
+            eprintln("error: " + formatProcessError(error, "cinterop (${entry.name})"))
             exitProcess(EXIT_BUILD_ERROR)
         }
         if (currentStamp != null) {
@@ -392,13 +392,13 @@ internal fun doTest(testArgs: List<String> = emptyList(), useDaemon: Boolean = t
 
     val paths = resolveKoltPaths(EXIT_TEST_ERROR)
     val consoleLauncherPath = ensureTool(paths, CONSOLE_LAUNCHER_SPEC, EXIT_TEST_ERROR)
-    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths, EXIT_TEST_ERROR)
+    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_TEST_ERROR) }
 
     val testConfig = config.copy(testSources = existingTestSources)
     val testCmd = testBuildCommand(testConfig, CLASSES_DIR, classpath, pArgs, kotlincPath = managedKotlincBin)
     println("compiling tests...")
     executeCommand(testCmd.args).getOrElse { error ->
-        eprintln(formatProcessError(error, "test compilation"))
+        eprintln("error: " + formatProcessError(error, "test compilation"))
         exitProcess(EXIT_BUILD_ERROR)
     }
 
@@ -437,7 +437,7 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>) {
     val testStartMark = TimeSource.Monotonic.markNow()
 
     val paths = resolveKoltPaths(EXIT_TEST_ERROR)
-    val managedKonancBin = ensureKonancBin(config.kotlin, paths, EXIT_TEST_ERROR)
+    val managedKonancBin = ensureKonancBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_TEST_ERROR) }
     val nativePluginArgs = resolveNativePluginArgs(config, paths, EXIT_TEST_ERROR)
 
     val depKlibs = resolveNativeDependencies(config, paths)
@@ -454,14 +454,14 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>) {
     val libraryCmd = nativeTestLibraryCommand(testConfig, pluginArgs = nativePluginArgs, konancPath = managedKonancBin, klibs = klibs)
     println("compiling tests (native)...")
     executeCommand(libraryCmd.args).getOrElse { error ->
-        eprintln(formatProcessError(error, "test compilation"))
+        eprintln("error: " + formatProcessError(error, "test compilation"))
         exitProcess(EXIT_BUILD_ERROR)
     }
 
     val linkCmd = nativeTestLinkCommand(testConfig, konancPath = managedKonancBin, klibs = klibs)
     println("linking tests (native)...")
     executeCommand(linkCmd.args).getOrElse { error ->
-        eprintln(formatProcessError(error, "test linking"))
+        eprintln("error: " + formatProcessError(error, "test linking"))
         exitProcess(EXIT_BUILD_ERROR)
     }
 
@@ -488,7 +488,20 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>) {
 
 internal fun ensureJdkBinsFromConfig(config: KoltConfig, paths: KoltPaths): JdkBins {
     val version = config.jdk ?: return JdkBins(null, null)
-    return ensureJdkBins(version, paths, EXIT_BUILD_ERROR)
+    return ensureJdkBins(version, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
+}
+
+/**
+ * Single sink that maps a [ToolchainError] to an `eprintln` + exit.
+ * Every CLI entry point that unwraps a toolchain `Result` funnels
+ * through here so the pre-daemon UX (one line of "error: …" on
+ * stderr, then exit with the step-appropriate exit code) is
+ * preserved verbatim. Callers in `ToolchainCommands`,
+ * `PluginSupport`, and `BuildCommands` all share this helper.
+ */
+internal fun exitWithToolchainError(err: ToolchainError, exitCode: Int): Nothing {
+    eprintln("error: ${err.message}")
+    exitProcess(exitCode)
 }
 
 // Warning wording pinned as a constant so unit tests can assert on

--- a/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
+++ b/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
@@ -47,6 +47,6 @@ internal fun resolvePluginArgs(config: KoltConfig, managedKotlincBin: String? = 
 internal fun resolveNativePluginArgs(config: KoltConfig, paths: KoltPaths, exitCode: Int): List<String> {
     val hasEnabledPlugin = config.plugins.any { (_, enabled) -> enabled }
     if (!hasEnabledPlugin) return emptyList()
-    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths, exitCode)
+    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, exitCode) }
     return resolvePluginArgs(config, managedKotlincBin)
 }

--- a/src/nativeMain/kotlin/kolt/cli/ToolchainCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/ToolchainCommands.kt
@@ -42,12 +42,12 @@ private fun printToolchainUsage() {
 private fun doToolchainInstall() {
     val config = loadProjectConfig()
     val paths = resolveKoltPaths(EXIT_CONFIG_ERROR)
-    installKotlincToolchain(config.kotlin, paths, EXIT_BUILD_ERROR)
+    installKotlincToolchain(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
     if (config.jdk != null) {
-        installJdkToolchain(config.jdk, paths, EXIT_BUILD_ERROR)
+        installJdkToolchain(config.jdk, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
     }
     if (config.target == "native") {
-        installKonancToolchain(config.kotlin, paths, EXIT_BUILD_ERROR)
+        installKonancToolchain(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
     }
 }
 

--- a/src/nativeMain/kotlin/kolt/infra/Process.kt
+++ b/src/nativeMain/kotlin/kolt/infra/Process.kt
@@ -15,13 +15,19 @@ sealed class ProcessError {
     data object PopenFailed : ProcessError()
 }
 
+// Formats a [ProcessError] into a short, lowercase, prefix-free
+// message. Callers are responsible for prepending their own
+// "error:" / "warning:" tag at the output site — keeping the
+// prefix out here lets the same message round-trip through
+// [ToolchainError] (which re-prepends "error:" at eprintln time)
+// without a fragile `.removePrefix("error: ")`.
 fun formatProcessError(error: ProcessError, context: String): String = when (error) {
-    is ProcessError.NonZeroExit -> "error: $context failed with exit code ${error.exitCode}"
-    is ProcessError.EmptyArgs -> "error: no command to execute"
-    is ProcessError.ForkFailed -> "error: failed to start $context process"
-    is ProcessError.WaitFailed -> "error: failed waiting for $context process"
-    is ProcessError.SignalKilled -> "error: $context process was killed"
-    is ProcessError.PopenFailed -> "error: failed to start $context process"
+    is ProcessError.NonZeroExit -> "$context failed with exit code ${error.exitCode}"
+    is ProcessError.EmptyArgs -> "no command to execute"
+    is ProcessError.ForkFailed -> "failed to start $context process"
+    is ProcessError.WaitFailed -> "failed waiting for $context process"
+    is ProcessError.SignalKilled -> "$context process was killed"
+    is ProcessError.PopenFailed -> "failed to start $context process"
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/src/nativeMain/kotlin/kolt/tool/ToolchainManager.kt
+++ b/src/nativeMain/kotlin/kolt/tool/ToolchainManager.kt
@@ -1,10 +1,22 @@
 package kolt.tool
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltPaths
 import kolt.infra.*
 import kotlinx.serialization.json.*
-import kotlin.system.exitProcess
+
+// Failures from any toolchain install / ensure step. Carries a
+// pre-formatted, user-facing message so callers can `eprintln("error: ${err.message}")`
+// without re-deriving wording per error kind. A flat carrier is enough
+// because nothing downstream classifies these: the CLI entry points
+// map them 1:1 to an exit, and the daemon bring-up path wraps
+// `message` into a fallback warning. Keeping it a single value class
+// also means new failure sites do not have to touch callers — they
+// just produce a new `ToolchainError(...)`.
+internal data class ToolchainError(val message: String)
 
 internal fun jdkDownloadUrl(version: String): String =
     "https://api.adoptium.net/v3/binary/latest/$version/ga/linux/x64/jdk/hotspot/normal/eclipse"
@@ -39,87 +51,85 @@ internal fun resolveJarBinPath(version: String, paths: KoltPaths): String? {
     return if (fileExists(binPath)) binPath else null
 }
 
-internal fun installJdkToolchain(version: String, paths: KoltPaths, exitCode: Int) {
+private fun formatDownloadError(tool: String, version: String, writePath: String, err: DownloadError): String = when (err) {
+    is DownloadError.HttpFailed -> "failed to download $tool $version (HTTP ${err.statusCode})"
+    is DownloadError.WriteFailed -> "could not write $writePath"
+    is DownloadError.NetworkError -> "network error downloading $tool $version: ${err.message}"
+}
+
+internal fun installJdkToolchain(
+    version: String,
+    paths: KoltPaths,
+    progressSink: (String) -> Unit = ::println,
+): Result<Unit, ToolchainError> {
     val finalPath = paths.jdkPath(version)
     val javaBinPath = paths.javaBin(version)
 
     if (fileExists(javaBinPath)) {
-        println("jdk $version is already installed at $finalPath")
-        return
+        progressSink("jdk $version is already installed at $finalPath")
+        return Ok(Unit)
     }
 
     val jdkBaseDir = "${paths.toolchainsDir}/jdk"
     ensureDirectoryRecursive(jdkBaseDir).getOrElse { error ->
-        eprintln("error: could not create directory ${error.path}")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not create directory ${error.path}"))
     }
 
     val tarPath = "$jdkBaseDir/$version.tar.gz"
     val metadataPath = "$jdkBaseDir/$version.metadata.json"
     val extractTempDir = "$jdkBaseDir/${version}_extract"
 
-    println("downloading jdk $version...")
+    progressSink("downloading jdk $version...")
     downloadFile(jdkDownloadUrl(version), tarPath).getOrElse { error ->
-        when (error) {
-            is DownloadError.HttpFailed -> eprintln("error: failed to download jdk $version (HTTP ${error.statusCode})")
-            is DownloadError.WriteFailed -> eprintln("error: could not write $tarPath")
-            is DownloadError.NetworkError -> eprintln("error: network error downloading jdk $version: ${error.message}")
-        }
-        exitProcess(exitCode)
+        return Err(ToolchainError(formatDownloadError("jdk", version, tarPath, error)))
     }
 
     // SHA256 verification via Adoptium metadata API
     downloadFile(jdkMetadataUrl(version), metadataPath).getOrElse { error ->
         deleteFile(tarPath)
-        when (error) {
-            is DownloadError.HttpFailed -> eprintln("error: failed to download metadata for jdk $version (HTTP ${error.statusCode})")
-            is DownloadError.WriteFailed -> eprintln("error: could not write $metadataPath")
-            is DownloadError.NetworkError -> eprintln("error: network error downloading metadata: ${error.message}")
+        val msg = when (error) {
+            is DownloadError.HttpFailed -> "failed to download metadata for jdk $version (HTTP ${error.statusCode})"
+            is DownloadError.WriteFailed -> "could not write $metadataPath"
+            is DownloadError.NetworkError -> "network error downloading metadata: ${error.message}"
         }
-        exitProcess(exitCode)
+        return Err(ToolchainError(msg))
     }
 
     val metadataContent = readFileAsString(metadataPath).getOrElse { error ->
         deleteFile(tarPath)
         deleteFile(metadataPath)
-        eprintln("error: could not read ${error.path}")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not read ${error.path}"))
     }
     val expectedHash = parseJdkChecksum(metadataContent)
     deleteFile(metadataPath)
 
     if (expectedHash == null) {
         deleteFile(tarPath)
-        eprintln("error: could not parse checksum from jdk $version metadata")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not parse checksum from jdk $version metadata"))
     }
 
     val actualHash = computeSha256(tarPath).getOrElse { _ ->
         deleteFile(tarPath)
-        eprintln("error: could not compute sha256 for $tarPath")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not compute sha256 for $tarPath"))
     }
 
     if (actualHash != expectedHash) {
         deleteFile(tarPath)
-        eprintln("error: sha256 mismatch for jdk $version (expected $expectedHash, got $actualHash)")
-        exitProcess(exitCode)
+        return Err(ToolchainError("sha256 mismatch for jdk $version (expected $expectedHash, got $actualHash)"))
     }
 
     ensureDirectoryRecursive(extractTempDir).getOrElse { error ->
         deleteFile(tarPath)
-        eprintln("error: could not create directory ${error.path}")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not create directory ${error.path}"))
     }
 
-    println("extracting jdk $version...")
+    progressSink("extracting jdk $version...")
     executeCommand(listOf("tar", "xzf", tarPath, "-C", extractTempDir)).getOrElse { error ->
         deleteFile(tarPath)
         removeDirectoryRecursive(extractTempDir).getOrElse { e ->
             eprintln("warning: could not remove temp directory ${e.path}")
         }
-        eprintln(formatProcessError(error, "tar"))
-        exitProcess(exitCode)
+        return Err(ToolchainError(formatProcessError(error, "tar")))
     }
     deleteFile(tarPath)
 
@@ -128,35 +138,32 @@ internal fun installJdkToolchain(version: String, paths: KoltPaths, exitCode: In
         removeDirectoryRecursive(extractTempDir).getOrElse { e ->
             eprintln("warning: could not remove temp directory ${e.path}")
         }
-        eprintln("error: could not list extracted jdk directory")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not list extracted jdk directory"))
     }
     val topLevelDir = findSingleEntry(lsOutput)
     if (topLevelDir == null) {
         removeDirectoryRecursive(extractTempDir).getOrElse { e ->
             eprintln("warning: could not remove temp directory ${e.path}")
         }
-        eprintln("error: expected exactly one top-level directory in jdk archive, got: ${lsOutput.trim()}")
-        exitProcess(exitCode)
+        return Err(ToolchainError("expected exactly one top-level directory in jdk archive, got: ${lsOutput.trim()}"))
     }
 
     executeCommand(listOf("mv", "$extractTempDir/$topLevelDir", finalPath)).getOrElse { error ->
         removeDirectoryRecursive(extractTempDir).getOrElse { e ->
             eprintln("warning: could not remove temp directory ${e.path}")
         }
-        eprintln(formatProcessError(error, "mv"))
-        exitProcess(exitCode)
+        return Err(ToolchainError(formatProcessError(error, "mv")))
     }
     removeDirectoryRecursive(extractTempDir).getOrElse { e ->
         eprintln("warning: could not remove temp directory ${e.path}")
     }
 
     if (!fileExists(javaBinPath)) {
-        eprintln("error: java binary not found at $javaBinPath after installation")
-        exitProcess(exitCode)
+        return Err(ToolchainError("java binary not found at $javaBinPath after installation"))
     }
 
-    println("installed jdk $version at $finalPath")
+    progressSink("installed jdk $version at $finalPath")
+    return Ok(Unit)
 }
 
 internal fun kotlincDownloadUrl(version: String): String =
@@ -170,78 +177,69 @@ internal fun resolveKotlincPath(version: String, paths: KoltPaths): String? {
     return if (fileExists(binPath)) binPath else null
 }
 
-internal fun ensureKotlincBin(version: String, paths: KoltPaths, exitCode: Int): String {
-    resolveKotlincPath(version, paths)?.let { return it }
-    installKotlincToolchain(version, paths, exitCode)
+internal fun ensureKotlincBin(version: String, paths: KoltPaths): Result<String, ToolchainError> {
+    resolveKotlincPath(version, paths)?.let { return Ok(it) }
+    installKotlincToolchain(version, paths).getOrElse { return Err(it) }
     return resolveKotlincPath(version, paths)
-        ?: run {
-            eprintln("error: kotlinc $version not found after installation")
-            exitProcess(exitCode)
-        }
+        ?.let { Ok(it) }
+        ?: Err(ToolchainError("kotlinc $version not found after installation"))
 }
 
 internal data class JdkBins(val java: String?, val jar: String?)
 
-internal fun ensureJdkBins(version: String, paths: KoltPaths, exitCode: Int): JdkBins {
+internal fun ensureJdkBins(version: String, paths: KoltPaths): Result<JdkBins, ToolchainError> {
     val javaBin = resolveJavaBinPath(version, paths)
     if (javaBin != null) {
         val jarBin = resolveJarBinPath(version, paths)
-        return JdkBins(javaBin, jarBin)
+        return Ok(JdkBins(javaBin, jarBin))
     }
-    installJdkToolchain(version, paths, exitCode)
-    return JdkBins(
-        resolveJavaBinPath(version, paths) ?: run {
-            eprintln("error: java binary not found after installation")
-            exitProcess(exitCode)
-        },
-        resolveJarBinPath(version, paths)
-    )
+    installJdkToolchain(version, paths).getOrElse { return Err(it) }
+    val java = resolveJavaBinPath(version, paths)
+        ?: return Err(ToolchainError("java binary not found after installation"))
+    return Ok(JdkBins(java, resolveJarBinPath(version, paths)))
 }
 
-internal fun installKotlincToolchain(version: String, paths: KoltPaths, exitCode: Int) {
+internal fun installKotlincToolchain(
+    version: String,
+    paths: KoltPaths,
+    progressSink: (String) -> Unit = ::println,
+): Result<Unit, ToolchainError> {
     val finalPath = paths.kotlincPath(version)
     val binPath = paths.kotlincBin(version)
 
     if (fileExists(binPath)) {
-        println("kotlinc $version is already installed at $finalPath")
-        return
+        progressSink("kotlinc $version is already installed at $finalPath")
+        return Ok(Unit)
     }
 
     val kotlincBaseDir = "${paths.toolchainsDir}/kotlinc"
     ensureDirectoryRecursive(kotlincBaseDir).getOrElse { error ->
-        eprintln("error: could not create directory ${error.path}")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not create directory ${error.path}"))
     }
 
     val zipPath = "$kotlincBaseDir/$version.zip"
     val sha256Path = "$kotlincBaseDir/$version.zip.sha256"
     val extractTempDir = "$kotlincBaseDir/${version}_extract"
 
-    println("downloading kotlin-compiler-$version.zip...")
+    progressSink("downloading kotlin-compiler-$version.zip...")
     downloadFile(kotlincDownloadUrl(version), zipPath).getOrElse { error ->
-        when (error) {
-            is DownloadError.HttpFailed -> eprintln("error: failed to download kotlinc $version (HTTP ${error.statusCode})")
-            is DownloadError.WriteFailed -> eprintln("error: could not write $zipPath")
-            is DownloadError.NetworkError -> eprintln("error: network error downloading kotlinc $version: ${error.message}")
-        }
-        exitProcess(exitCode)
+        return Err(ToolchainError(formatDownloadError("kotlinc", version, zipPath, error)))
     }
 
     downloadFile(kotlincSha256Url(version), sha256Path).getOrElse { error ->
         deleteFile(zipPath)
-        when (error) {
-            is DownloadError.HttpFailed -> eprintln("error: failed to download sha256 for kotlinc $version (HTTP ${error.statusCode})")
-            is DownloadError.WriteFailed -> eprintln("error: could not write $sha256Path")
-            is DownloadError.NetworkError -> eprintln("error: network error downloading sha256: ${error.message}")
+        val msg = when (error) {
+            is DownloadError.HttpFailed -> "failed to download sha256 for kotlinc $version (HTTP ${error.statusCode})"
+            is DownloadError.WriteFailed -> "could not write $sha256Path"
+            is DownloadError.NetworkError -> "network error downloading sha256: ${error.message}"
         }
-        exitProcess(exitCode)
+        return Err(ToolchainError(msg))
     }
 
     val sha256Content = readFileAsString(sha256Path).getOrElse { error ->
         deleteFile(zipPath)
         deleteFile(sha256Path)
-        eprintln("error: could not read ${error.path}")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not read ${error.path}"))
     }
     // SHA256 files can be "<hash>  <filename>" or just "<hash>"
     val expectedHash = sha256Content.trim().split(Regex("\\s+")).first()
@@ -249,30 +247,26 @@ internal fun installKotlincToolchain(version: String, paths: KoltPaths, exitCode
 
     val actualHash = computeSha256(zipPath).getOrElse { _ ->
         deleteFile(zipPath)
-        eprintln("error: could not compute sha256 for $zipPath")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not compute sha256 for $zipPath"))
     }
 
     if (actualHash != expectedHash) {
         deleteFile(zipPath)
-        eprintln("error: sha256 mismatch for kotlinc $version (expected $expectedHash, got $actualHash)")
-        exitProcess(exitCode)
+        return Err(ToolchainError("sha256 mismatch for kotlinc $version (expected $expectedHash, got $actualHash)"))
     }
 
     ensureDirectoryRecursive(extractTempDir).getOrElse { error ->
         deleteFile(zipPath)
-        eprintln("error: could not create directory ${error.path}")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not create directory ${error.path}"))
     }
 
-    println("extracting kotlinc $version...")
+    progressSink("extracting kotlinc $version...")
     executeCommand(listOf("unzip", "-q", zipPath, "-d", extractTempDir)).getOrElse { error ->
         deleteFile(zipPath)
         removeDirectoryRecursive(extractTempDir).getOrElse { e ->
             eprintln("warning: could not remove temp directory ${e.path}")
         }
-        eprintln(formatProcessError(error, "unzip"))
-        exitProcess(exitCode)
+        return Err(ToolchainError(formatProcessError(error, "unzip")))
     }
     deleteFile(zipPath)
 
@@ -280,19 +274,18 @@ internal fun installKotlincToolchain(version: String, paths: KoltPaths, exitCode
         removeDirectoryRecursive(extractTempDir).getOrElse { e ->
             eprintln("warning: could not remove temp directory ${e.path}")
         }
-        eprintln(formatProcessError(error, "mv"))
-        exitProcess(exitCode)
+        return Err(ToolchainError(formatProcessError(error, "mv")))
     }
     removeDirectoryRecursive(extractTempDir).getOrElse { e ->
         eprintln("warning: could not remove temp directory ${e.path}")
     }
 
     if (!fileExists(binPath)) {
-        eprintln("error: kotlinc binary not found at $binPath after installation")
-        exitProcess(exitCode)
+        return Err(ToolchainError("kotlinc binary not found at $binPath after installation"))
     }
 
-    println("installed kotlinc $version at $finalPath")
+    progressSink("installed kotlinc $version at $finalPath")
+    return Ok(Unit)
 }
 
 internal fun konancDownloadUrl(version: String): String =
@@ -306,29 +299,30 @@ internal fun resolveKonancPath(version: String, paths: KoltPaths): String? {
     return if (fileExists(binPath)) binPath else null
 }
 
-internal fun ensureKonancBin(version: String, paths: KoltPaths, exitCode: Int): String {
-    resolveKonancPath(version, paths)?.let { return it }
-    installKonancToolchain(version, paths, exitCode)
+internal fun ensureKonancBin(version: String, paths: KoltPaths): Result<String, ToolchainError> {
+    resolveKonancPath(version, paths)?.let { return Ok(it) }
+    installKonancToolchain(version, paths).getOrElse { return Err(it) }
     return resolveKonancPath(version, paths)
-        ?: run {
-            eprintln("error: konanc $version not found after installation")
-            exitProcess(exitCode)
-        }
+        ?.let { Ok(it) }
+        ?: Err(ToolchainError("konanc $version not found after installation"))
 }
 
-internal fun installKonancToolchain(version: String, paths: KoltPaths, exitCode: Int) {
+internal fun installKonancToolchain(
+    version: String,
+    paths: KoltPaths,
+    progressSink: (String) -> Unit = ::println,
+): Result<Unit, ToolchainError> {
     val finalPath = paths.konancPath(version)
     val binPath = paths.konancBin(version)
 
     if (fileExists(binPath)) {
-        println("konanc $version is already installed at $finalPath")
-        return
+        progressSink("konanc $version is already installed at $finalPath")
+        return Ok(Unit)
     }
 
     val konancBaseDir = "${paths.toolchainsDir}/konanc"
     ensureDirectoryRecursive(konancBaseDir).getOrElse { error ->
-        eprintln("error: could not create directory ${error.path}")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not create directory ${error.path}"))
     }
 
     val tarPath = "$konancBaseDir/$version.tar.gz"
@@ -336,61 +330,51 @@ internal fun installKonancToolchain(version: String, paths: KoltPaths, exitCode:
     val extractTempDir = "$konancBaseDir/${version}_extract"
     val archiveTopLevelDir = "kotlin-native-prebuilt-linux-x86_64-$version"
 
-    println("downloading konanc $version...")
+    progressSink("downloading konanc $version...")
     downloadFile(konancDownloadUrl(version), tarPath).getOrElse { error ->
-        when (error) {
-            is DownloadError.HttpFailed -> eprintln("error: failed to download konanc $version (HTTP ${error.statusCode})")
-            is DownloadError.WriteFailed -> eprintln("error: could not write $tarPath")
-            is DownloadError.NetworkError -> eprintln("error: network error downloading konanc $version: ${error.message}")
-        }
-        exitProcess(exitCode)
+        return Err(ToolchainError(formatDownloadError("konanc", version, tarPath, error)))
     }
 
     downloadFile(konancSha256Url(version), sha256Path).getOrElse { error ->
         deleteFile(tarPath)
-        when (error) {
-            is DownloadError.HttpFailed -> eprintln("error: failed to download sha256 for konanc $version (HTTP ${error.statusCode})")
-            is DownloadError.WriteFailed -> eprintln("error: could not write $sha256Path")
-            is DownloadError.NetworkError -> eprintln("error: network error downloading sha256: ${error.message}")
+        val msg = when (error) {
+            is DownloadError.HttpFailed -> "failed to download sha256 for konanc $version (HTTP ${error.statusCode})"
+            is DownloadError.WriteFailed -> "could not write $sha256Path"
+            is DownloadError.NetworkError -> "network error downloading sha256: ${error.message}"
         }
-        exitProcess(exitCode)
+        return Err(ToolchainError(msg))
     }
 
     val sha256Content = readFileAsString(sha256Path).getOrElse { error ->
         deleteFile(tarPath)
         deleteFile(sha256Path)
-        eprintln("error: could not read ${error.path}")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not read ${error.path}"))
     }
     val expectedHash = sha256Content.trim().split(Regex("\\s+")).first()
     deleteFile(sha256Path)
 
     val actualHash = computeSha256(tarPath).getOrElse { _ ->
         deleteFile(tarPath)
-        eprintln("error: could not compute sha256 for $tarPath")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not compute sha256 for $tarPath"))
     }
 
     if (actualHash != expectedHash) {
         deleteFile(tarPath)
-        eprintln("error: sha256 mismatch for konanc $version (expected $expectedHash, got $actualHash)")
-        exitProcess(exitCode)
+        return Err(ToolchainError("sha256 mismatch for konanc $version (expected $expectedHash, got $actualHash)"))
     }
 
     ensureDirectoryRecursive(extractTempDir).getOrElse { error ->
         deleteFile(tarPath)
-        eprintln("error: could not create directory ${error.path}")
-        exitProcess(exitCode)
+        return Err(ToolchainError("could not create directory ${error.path}"))
     }
 
-    println("extracting konanc $version...")
+    progressSink("extracting konanc $version...")
     executeCommand(listOf("tar", "xzf", tarPath, "-C", extractTempDir)).getOrElse { error ->
         deleteFile(tarPath)
         removeDirectoryRecursive(extractTempDir).getOrElse { e ->
             eprintln("warning: could not remove temp directory ${e.path}")
         }
-        eprintln(formatProcessError(error, "tar"))
-        exitProcess(exitCode)
+        return Err(ToolchainError(formatProcessError(error, "tar")))
     }
     deleteFile(tarPath)
 
@@ -398,17 +382,16 @@ internal fun installKonancToolchain(version: String, paths: KoltPaths, exitCode:
         removeDirectoryRecursive(extractTempDir).getOrElse { e ->
             eprintln("warning: could not remove temp directory ${e.path}")
         }
-        eprintln(formatProcessError(error, "mv"))
-        exitProcess(exitCode)
+        return Err(ToolchainError(formatProcessError(error, "mv")))
     }
     removeDirectoryRecursive(extractTempDir).getOrElse { e ->
         eprintln("warning: could not remove temp directory ${e.path}")
     }
 
     if (!fileExists(binPath)) {
-        eprintln("error: konanc binary not found at $binPath after installation")
-        exitProcess(exitCode)
+        return Err(ToolchainError("konanc binary not found at $binPath after installation"))
     }
 
-    println("installed konanc $version at $finalPath")
+    progressSink("installed konanc $version at $finalPath")
+    return Ok(Unit)
 }

--- a/src/nativeTest/kotlin/kolt/build/daemon/BootstrapJdkTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/BootstrapJdkTest.kt
@@ -1,0 +1,94 @@
+package kolt.build.daemon
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.config.KoltPaths
+import kolt.tool.ToolchainError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Drives every branch of [ensureBootstrapJavaBin] with injected seams.
+ * The fast path (JDK already present) must not touch the installer,
+ * the slow path (JDK absent) must run the installer and re-probe,
+ * and a failing installer must surface as [BootstrapJdkError] with
+ * the probed install dir and the underlying ToolchainError.
+ */
+class EnsureBootstrapJavaBinTest {
+
+    private val paths = KoltPaths(home = "/fake/home")
+    private val expectedInstallDir = paths.jdkPath(BOOTSTRAP_JDK_VERSION)
+    private val expectedJavaBin = paths.javaBin(BOOTSTRAP_JDK_VERSION)
+
+    @Test
+    fun alreadyInstalledReturnsPathWithoutInvokingInstaller() {
+        val result = ensureBootstrapJavaBin(
+            paths = paths,
+            resolve = { expectedJavaBin },
+            install = { _, _ -> error("must not install when JDK is already present") },
+        )
+
+        assertEquals(expectedJavaBin, result.get())
+        assertNull(result.getError())
+    }
+
+    @Test
+    fun missingThenInstalledReturnsPathAfterInstaller() {
+        var resolveCalls = 0
+        var installCalls = 0
+        val result = ensureBootstrapJavaBin(
+            paths = paths,
+            resolve = {
+                resolveCalls++
+                if (resolveCalls == 1) null else expectedJavaBin
+            },
+            install = { version, _ ->
+                installCalls++
+                assertEquals(BOOTSTRAP_JDK_VERSION, version)
+                Ok(Unit)
+            },
+        )
+
+        assertEquals(expectedJavaBin, result.get())
+        assertEquals(2, resolveCalls) // probe → install → re-probe
+        assertEquals(1, installCalls)
+    }
+
+    @Test
+    fun installFailureSurfacesAsBootstrapJdkError() {
+        val cause = ToolchainError("network error downloading jdk 21: connection refused")
+        val result = ensureBootstrapJavaBin(
+            paths = paths,
+            resolve = { null },
+            install = { _, _ -> Err(cause) },
+        )
+
+        assertNull(result.get())
+        val err = assertNotNull(result.getError())
+        assertEquals(expectedInstallDir, err.jdkInstallDir)
+        assertEquals(cause, err.cause)
+    }
+
+    @Test
+    fun postInstallProbeFailureSurfacesAsBootstrapJdkError() {
+        // installJdkToolchain returned Ok but the post-install probe
+        // cannot find bin/java — a ToolchainManager bug we still
+        // translate into a graceful daemon fallback.
+        val result = ensureBootstrapJavaBin(
+            paths = paths,
+            resolve = { null },
+            install = { _, _ -> Ok(Unit) },
+        )
+
+        val err = assertNotNull(result.getError())
+        assertEquals(expectedInstallDir, err.jdkInstallDir)
+        assertEquals(
+            "java binary not found at $expectedJavaBin after installation",
+            err.cause.message,
+        )
+    }
+}

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
@@ -1,8 +1,11 @@
 package kolt.build.daemon
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import kolt.config.KoltPaths
+import kolt.tool.ToolchainError
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -23,7 +26,7 @@ class DaemonPreconditionsTest {
             paths = paths,
             kotlincVersion = kotlincVersion,
             absProjectPath = absProject,
-            resolveJavaBin = { "/fake/home/.kolt/toolchains/jdk/21/bin/java" },
+            ensureJavaBin = { Ok("/fake/home/.kolt/toolchains/jdk/21/bin/java") },
             resolveDaemonJar = { okJar },
             listCompilerJars = { fakeJars },
         )
@@ -39,19 +42,23 @@ class DaemonPreconditionsTest {
     }
 
     @Test
-    fun bootstrapJdkMissingShortCircuits() {
+    fun bootstrapJdkInstallFailedShortCircuits() {
+        val installDir = "/fake/home/.kolt/toolchains/jdk/$BOOTSTRAP_JDK_VERSION"
         val result = resolveDaemonPreconditions(
             paths = paths,
             kotlincVersion = kotlincVersion,
             absProjectPath = absProject,
-            resolveJavaBin = { null },
-            resolveDaemonJar = { error("must not run after BootstrapJdkMissing") },
-            listCompilerJars = { error("must not run after BootstrapJdkMissing") },
+            ensureJavaBin = {
+                Err(BootstrapJdkError(installDir, ToolchainError("network error downloading jdk 21: connection refused")))
+            },
+            resolveDaemonJar = { error("must not run after BootstrapJdkInstallFailed") },
+            listCompilerJars = { error("must not run after BootstrapJdkInstallFailed") },
         )
 
         assertNull(result.get())
-        val err = assertIs<DaemonPreconditionError.BootstrapJdkMissing>(result.getError())
-        assertEquals("/fake/home/.kolt/toolchains/jdk/$BOOTSTRAP_JDK_VERSION", err.jdkInstallDir)
+        val err = assertIs<DaemonPreconditionError.BootstrapJdkInstallFailed>(result.getError())
+        assertEquals(installDir, err.jdkInstallDir)
+        assertEquals("network error downloading jdk 21: connection refused", err.cause)
     }
 
     @Test
@@ -60,7 +67,7 @@ class DaemonPreconditionsTest {
             paths = paths,
             kotlincVersion = kotlincVersion,
             absProjectPath = absProject,
-            resolveJavaBin = { "/fake/java" },
+            ensureJavaBin = { Ok("/fake/java") },
             resolveDaemonJar = { DaemonJarResolution.NotFound },
             listCompilerJars = { error("must not run after DaemonJarMissing") },
         )
@@ -74,7 +81,7 @@ class DaemonPreconditionsTest {
             paths = paths,
             kotlincVersion = kotlincVersion,
             absProjectPath = absProject,
-            resolveJavaBin = { "/fake/java" },
+            ensureJavaBin = { Ok("/fake/java") },
             resolveDaemonJar = { okJar },
             listCompilerJars = { null },
         )
@@ -89,7 +96,7 @@ class DaemonPreconditionsTest {
             paths = paths,
             kotlincVersion = kotlincVersion,
             absProjectPath = absProject,
-            resolveJavaBin = { "/fake/java" },
+            ensureJavaBin = { Ok("/fake/java") },
             resolveDaemonJar = { okJar },
             listCompilerJars = { emptyList() },
         )
@@ -100,8 +107,10 @@ class DaemonPreconditionsTest {
     @Test
     fun warningWordingCoversAllVariants() {
         assertEquals(
-            "warning: bootstrap JDK not installed at /opt/jdks/21 — falling back to subprocess compile",
-            formatDaemonPreconditionWarning(DaemonPreconditionError.BootstrapJdkMissing("/opt/jdks/21")),
+            "warning: could not install bootstrap JDK at /opt/jdks/21 (HTTP 503) — falling back to subprocess compile",
+            formatDaemonPreconditionWarning(
+                DaemonPreconditionError.BootstrapJdkInstallFailed("/opt/jdks/21", "HTTP 503"),
+            ),
         )
         assertEquals(
             "warning: kolt-compiler-daemon jar not found — falling back to subprocess compile",

--- a/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
@@ -90,6 +90,50 @@ class ResolveCompilerBackendTest {
     }
 
     @Test
+    fun bootstrapJdkInstallFailureFallsBackWithCauseInWarning() {
+        // Binds ADR 0016 §5 "daemon is never load-bearing for
+        // correctness" for the auto-install path: a download failure
+        // during first-run bootstrap JDK provisioning must produce a
+        // one-line warning naming the cause and degrade to the
+        // subprocess backend, never propagate as a build failure.
+        val warnings = mutableListOf<String>()
+        val backend = resolveCompilerBackend(
+            config = config,
+            paths = paths,
+            subprocessBackend = subprocess,
+            useDaemon = true,
+            absProjectPath = absProject,
+            preconditionResolver = { _, _, _ ->
+                Err(
+                    DaemonPreconditionError.BootstrapJdkInstallFailed(
+                        jdkInstallDir = "/fake/home/.kolt/toolchains/jdk/21",
+                        cause = "network error downloading jdk 21: connection refused",
+                    ),
+                )
+            },
+            daemonDirCreator = { error("must not create daemon dir after precondition failure") },
+            daemonBackendFactory = { error("must not construct daemon backend after precondition failure") },
+            warningSink = { warnings.add(it) },
+        )
+
+        assertSame(subprocess, backend)
+        assertEquals(1, warnings.size)
+        val warning = warnings.single()
+        assertTrue(
+            warning.contains("could not install bootstrap JDK at /fake/home/.kolt/toolchains/jdk/21"),
+            "warning should name the probed install dir: $warning",
+        )
+        assertTrue(
+            warning.contains("network error downloading jdk 21: connection refused"),
+            "warning should carry the underlying cause: $warning",
+        )
+        assertTrue(
+            warning.contains("falling back to subprocess compile"),
+            "warning should say the build is falling back: $warning",
+        )
+    }
+
+    @Test
     fun daemonDirCreationFailureWarnsAndFallsBack() {
         val warnings = mutableListOf<String>()
         val backend = resolveCompilerBackend(

--- a/src/nativeTest/kotlin/kolt/infra/ProcessErrorFormatTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/ProcessErrorFormatTest.kt
@@ -8,36 +8,36 @@ class ProcessErrorFormatTest {
     @Test
     fun formatNonZeroExitWithContext() {
         val msg = formatProcessError(ProcessError.NonZeroExit(1), "compilation")
-        assertEquals("error: compilation failed with exit code 1", msg)
+        assertEquals("compilation failed with exit code 1", msg)
     }
 
     @Test
     fun formatEmptyArgs() {
         val msg = formatProcessError(ProcessError.EmptyArgs, "compilation")
-        assertEquals("error: no command to execute", msg)
+        assertEquals("no command to execute", msg)
     }
 
     @Test
     fun formatForkFailed() {
         val msg = formatProcessError(ProcessError.ForkFailed, "compiler")
-        assertEquals("error: failed to start compiler process", msg)
+        assertEquals("failed to start compiler process", msg)
     }
 
     @Test
     fun formatWaitFailed() {
         val msg = formatProcessError(ProcessError.WaitFailed, "compiler")
-        assertEquals("error: failed waiting for compiler process", msg)
+        assertEquals("failed waiting for compiler process", msg)
     }
 
     @Test
     fun formatSignalKilled() {
         val msg = formatProcessError(ProcessError.SignalKilled, "compiler")
-        assertEquals("error: compiler process was killed", msg)
+        assertEquals("compiler process was killed", msg)
     }
 
     @Test
     fun formatPopenFailed() {
         val msg = formatProcessError(ProcessError.PopenFailed, "compiler")
-        assertEquals("error: failed to start compiler process", msg)
+        assertEquals("failed to start compiler process", msg)
     }
 }

--- a/src/nativeTest/kotlin/kolt/tool/ToolchainManagerTest.kt
+++ b/src/nativeTest/kotlin/kolt/tool/ToolchainManagerTest.kt
@@ -1,5 +1,6 @@
 package kolt.tool
 
+import com.github.michaelbull.result.get
 import kolt.config.KoltPaths
 import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.removeDirectoryRecursive
@@ -464,10 +465,10 @@ class ToolchainManagerTest {
         writeFileAsString("$binDir/kotlinc", "#!/bin/sh")
         try {
             // When: ensureKotlincBin is called
-            val result = ensureKotlincBin("2.1.0", paths, 1)
+            val result = ensureKotlincBin("2.1.0", paths)
 
             // Then: returns the managed bin path without triggering download
-            assertEquals(paths.kotlincBin("2.1.0"), result)
+            assertEquals(paths.kotlincBin("2.1.0"), result.get())
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
         }
@@ -572,9 +573,9 @@ class ToolchainManagerTest {
         ensureDirectoryRecursive(binDir)
         writeFileAsString("$binDir/konanc", "#!/bin/sh")
         try {
-            val result = ensureKonancBin("2.1.0", paths, 1)
+            val result = ensureKonancBin("2.1.0", paths)
 
-            assertEquals(paths.konancBin("2.1.0"), result)
+            assertEquals(paths.konancBin("2.1.0"), result.get())
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
         }
@@ -592,11 +593,12 @@ class ToolchainManagerTest {
         writeFileAsString("$binDir/jar", "#!/bin/sh")
         try {
             // When: ensureJdkBins is called
-            val result = ensureJdkBins("21", paths, 1)
+            val result = ensureJdkBins("21", paths)
 
             // Then: returns managed java and jar paths
-            assertEquals(paths.javaBin("21"), result.java)
-            assertEquals(paths.jarBin("21"), result.jar)
+            val bins = result.get()!!
+            assertEquals(paths.javaBin("21"), bins.java)
+            assertEquals(paths.jarBin("21"), bins.jar)
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
         }


### PR DESCRIPTION
## Summary

- Refactors every `exitProcess` in `ToolchainManager.kt` to return `Result<_, ToolchainError>` so `ensureBootstrapJavaBin` can download the pinned bootstrap JDK synchronously on first `kolt build` while honouring ADR 0016 §5 (daemon never load-bearing for correctness) — failures surface as `BootstrapJdkInstallFailed(jdkInstallDir, cause)` and the build falls back to the subprocess compile path with a one-line warning.
- Implicit auto-install progress is routed through `eprintln` via a new `progressSink` seam so `doBuild` stdout is not polluted by `downloading jdk 21…` / `installed …` lines. Explicit `kolt toolchain install` still prints to stdout.
- Drops the `"error: "` prefix from `formatProcessError` and prepends it at the `eprintln` boundary, eliminating `.removePrefix("error: ")` hacks when round-tripping through `ToolchainError`.
- Renames `DaemonPreconditionError.BootstrapJdkMissing` → `BootstrapJdkInstallFailed` and surfaces the underlying cause in the fallback warning.

Closes #93. ADR 0017 updated to describe the shipped auto-install flow.

## Test plan
- [x] `./gradlew linuxX64Test` (green)
- [x] New `BootstrapJdkTest` exercises fast path / install success / install failure / post-install probe failure
- [x] New `ResolveCompilerBackendTest.bootstrapJdkInstallFailureFallsBackWithCauseInWarning` binds the ADR 0016 §5 contract for the auto-install path
- [x] `ProcessErrorFormatTest` updated to assert the prefix-free contract
- [x] Existing `ToolchainManagerTest` / `DaemonPreconditionsTest` / `EnsureJdkBinsFromConfigTest` pass against the new `Result`-returning signatures