### PR TITLE
Add Phase A daemon scaling benchmark (#96)

### DIFF
--- a/docs/adr/0016-warm-jvm-compiler-daemon.md
+++ b/docs/adr/0016-warm-jvm-compiler-daemon.md
@@ -356,13 +356,19 @@ Read as:
   (#3 incremental) will cut the slope; Phase A is not expected to.
 - **Gradle does not cross daemon-warm in this fixture range.**
   Gradle-warm stays 1.28–1.67× slower than kolt daemon-warm across
-  all four sizes, with no convergent trend. Gradle-warm's per-file
-  slope on these fixtures ((1.82 − 1.17) / 49 ≈ 13 ms/file) is
-  within rounding of kolt daemon-warm's ~12 ms/file, so the
-  persistent gap lives in the fixed-cost floor (~1.17 s gradle vs
-  ~0.70 s kolt), not per-file compile work. This is the Gradle
-  anchor that spike #86/#87 lacked; it shows kolt wins on clean
-  builds by amortising fixed cost faster, not by compiling faster.
+  all four sizes, flat within noise at N=10 (the jvm-25 ratio of
+  1.28× is the lowest of the four, so "no trend detectable" is the
+  honest framing rather than "convergent" or "divergent"). Gradle-
+  warm's per-file slope on these fixtures ((1.82 − 1.17) / 49 ≈
+  13 ms/file) is within rounding of kolt daemon-warm's ~12 ms/file,
+  so the persistent gap lives entirely in the fixed-cost floor
+  (~1.17 s gradle vs ~0.70 s kolt), not per-file compile work.
+  Because the two slopes converge by construction on this fixture
+  family, a "kolt scales better than Gradle on clean builds" claim
+  cannot be supported by extrapolating these numbers; what they
+  *do* support is "kolt amortises fixed cost faster on small
+  projects", which is a narrower claim. This is the Gradle anchor
+  that spike #86/#87 lacked.
 - **Resolve-phase tail latency reproduces as a ~3.3 s size-independent
   outlier.** Nodaemon and daemon-cold cells show 2–3 of 10 samples
   clustered ~3.3 s above the median, identical delta signature
@@ -371,13 +377,22 @@ Read as:
   into daemon-warm too (`jvm-25` run 6, `jvm-50` run 7), matching
   the same ~3.3 s delta; singletons out of N=10 do not move the
   median. A maven-metadata refresh hypothesis was considered and
-  is weak — the fixture has no SNAPSHOT deps and kolt's resolver
-  has no TTL machinery that would fire on ~30 % of invocations.
-  More plausible candidates, none verified: the harness's
-  `kill_daemon` poll-loop occasionally hitting its 2 s ceiling,
-  Kotlin/Native runtime teardown stalls in `kolt.kexe` shutdown,
-  or WSL2 9p filesystem stat storms. Disambiguating requires
-  phase-level self-timing from kolt itself; flagged for #88 / #90.
+  is weak (no SNAPSHOT deps, no TTL machinery). The leading
+  unverified hypothesis is a **WSL2 9p filesystem stat-storm on
+  kotlinc startup**: (a) the delta is almost exactly constant
+  across fixture sizes (+3.40 / +3.38 / +3.26 / +3.41 — fixed-cost
+  signature, not scaling work); (b) it hits `nodaemon` as often as
+  `daemon-cold`, so it cannot live inside the kolt daemon itself —
+  it is in the subprocess kotlinc startup path that both modes
+  share; (c) WSL2 9p is known to produce multi-second directory-
+  walk stalls, and kotlinc startup (classpath scan, JMOD indexing)
+  does a lot of directory walking. A Kotlin/Native runtime
+  teardown stall in `kolt.kexe` shutdown is a weaker but possible
+  alternative. The run-2 `kill_daemon` poll-loop hypothesis is
+  retracted — the poll ceiling is ~2.3 s, not 3.3 s, and warm-cell
+  outlier hits occur in iterations where `kill_daemon` was never
+  called. Disambiguating requires phase-level self-timing from
+  kolt itself plus `strace -c`; flagged for #88 / #90.
 - **8 s clean-build baseline in §Context does not reproduce.** On
   these fixtures the subprocess baseline is 4.77 s at `jvm-1`,
   rising to 10.37 s at `jvm-50`. The 8 s figure likely captured

--- a/docs/adr/0016-warm-jvm-compiler-daemon.md
+++ b/docs/adr/0016-warm-jvm-compiler-daemon.md
@@ -304,78 +304,101 @@ the configuration adopted.
 
 The spike numbers above measure `SharedCompilerHost` directly in-JVM
 on a one-file fixture. They cover the steady-state compile cost but
-not end-to-end `kolt build` wall time, and they say nothing about how
-the numbers change as source file count grows. #96 fills both gaps
-with a scaling benchmark measured against the release binary on
-`spike/bench-scaling/fixtures/jvm-{1,10,25,50}` (deterministic
-generator, `kotlin-stdlib`-only classpath, a handful of top-level
-functions and data classes per file with cross-file references). The
-harness (`spike/bench-scaling/run-bench.sh`) drives real `kolt build`
-for each fixture × mode, N=7 per cell, warm modes discarding the
-first 2 runs as JIT warmup. Wall time is `/usr/bin/time -f '%e'`.
+not end-to-end `kolt build` wall time, and they say nothing about
+how the numbers change as source file count grows. #96 fills both
+gaps with a scaling benchmark measured against the release binary
+on `spike/bench-scaling/fixtures/jvm-{1,10,25,50}` (deterministic
+generator, `kotlin-stdlib`-only classpath, per file: a data class,
+a generic + reified inline function, a sealed `Op` hierarchy with
+exhaustive `when`, lambdas with capture, and a cross-package
+`bench.util` import). The harness (`spike/bench-scaling/run-bench.sh`)
+drives real `kolt build` for each fixture × mode, N=10 per cell,
+warm modes discarding the first 5 runs as JIT warmup. Wall time
+is `/usr/bin/time -f '%e'`.
+
+The numbers below are **run 3**. Run 1 carried a laptop-sleep
+outlier; run 2 had three methodology issues flagged by sub-agent
+review (`WARM_DISCARD=2` too small, unfair gradle timing that
+included `clean` + `test` tasks, and lighter fixtures that
+under-stressed the compiler), which produced two wrong conclusions:
+a declining nodaemon/warm ratio with size and a gradle/daemon
+crossover at `jvm-50`. Neither survives run 3. Provenance for runs
+1 and 2 is preserved as `results-2026-04-14-run1.md` and
+`results-2026-04-14-run2.md`.
 
 Medians, seconds (OpenJDK 21 Corretto, Kotlin 2.1.0 fixtures, Linux
 WSL2):
 
 | Fixture | nodaemon | daemon-cold | daemon-warm | gradle-warm | nodaemon / warm | gradle / warm |
 |---|---|---|---|---|---|---|
-| jvm-1  | 4.83 | 4.59 | 0.66 | 1.19 | 7.3× | 1.8× |
-| jvm-10 | 5.74 | 5.89 | 0.97 | 1.25 | 5.9× | 1.3× |
-| jvm-25 | 7.14 | 7.34 | 1.36 | 1.41 | 5.3× | 1.0× |
-| jvm-50 | 8.64 | 8.84 | 1.65 | 1.61 | 5.2× | 1.0× |
+| jvm-1  | 4.77  | 4.86  | 0.70 | 1.17 | 6.8× | 1.67× |
+| jvm-10 | 6.42  | 6.64  | 0.83 | 1.30 | 7.7× | 1.57× |
+| jvm-25 | 8.30  | 8.23  | 1.16 | 1.49 | 7.2× | 1.28× |
+| jvm-50 | 10.37 | 10.18 | 1.32 | 1.82 | 7.9× | 1.38× |
 
 Read as:
 
-- **Daemon warm vs subprocess is 5.2–7.3× stable across sizes.** The
-  single-file hello-world 8.5× figure recorded in earlier memory was
-  an overestimate — it captured a regime where compile work is a
-  small fraction of wall time, so constant-overhead reduction looked
-  bigger than it is. `jvm-50` (5.2×) is the most defensible number
-  to quote outside the hello-world regime.
+- **Daemon warm vs subprocess is ~7× stable across sizes.** The
+  ratio sits in a tight 6.8–7.9× band with no monotone trend. A
+  single "~7×" is the right number to quote outside the hello-world
+  regime; the earlier hello-world 8.5× figure recorded in memory
+  was an overestimate inside that regime.
 - **Daemon cold regression is zero.** Cold medians track nodaemon
   within ±0.25 s on every fixture, confirming the
   `FallbackCompilerBackend` wiring adds no measurable client-side
   cost on the cold path.
-- **The `warm < 1 s` Phase A target holds only below ~10–15 files.**
-  `jvm-1` (0.66 s) and `jvm-10` (0.97 s) are inside the budget;
-  `jvm-25` (1.36 s) and `jvm-50` (1.65 s) are above it. The 1 s
+- **The `warm < 1 s` Phase A target holds only below ~15–20 files.**
+  `jvm-1` (0.70 s) and `jvm-10` (0.83 s) are inside the budget;
+  `jvm-25` (1.16 s) and `jvm-50` (1.32 s) are above it. The 1 s
   number was written against a hello-world baseline and does not
-  survive a scaling curve. The target is **not** a point target; it
-  is a fixed-cost floor (~0.66 s) plus a per-file slope of ~20 ms.
-  Future Phase B work (#3 incremental) will cut the slope; Phase A
-  is not expected to.
-- **Gradle crossover lives around 25–50 files for these fixtures.**
-  Gradle-warm is strikingly flat (1.19–1.61 s) — its worker API plus
-  embedded kotlinc amortises per-file work extremely well — so the
-  daemon-warm advantage closes from 1.8× on `jvm-1` down to ~1.0× on
-  `jvm-25` and `jvm-50`. This is the Gradle anchor that spike
-  #86/#87 lacked. It is also the headline ROI argument for #3
-  incremental: without incremental, kolt's clean-build advantage
-  over Gradle evaporates past 25 files.
-- **Resolve-phase tail latency surfaced as a reproducible outlier.**
-  Nodaemon and daemon-cold rows show 1–2 samples per cell clustered
-  ~3.3 s above the median, regardless of fixture size. The delta is
-  size-independent, which means it is a fixed-overhead event, not
-  compile work. It does not appear in gradle-warm (which reuses the
-  Gradle daemon's resolved classpath) and appears only rarely in
-  daemon-warm. Best current guess is a maven-metadata refresh or
-  kotlinc toolchain re-probe in kolt's dependency resolver firing on
-  ~28% of invocations. The raw per-run numbers and full outlier
-  analysis live in `spike/bench-scaling/results-2026-04-14.md`.
-  Flagged for #88 / #90 follow-up as evidence the resolve phase has
-  measurable tail latency worth monitoring separately from compile.
+  survive a scaling curve. Daemon-warm is a fixed-cost floor
+  (~0.70 s) plus a per-file slope of ~12 ms. Future Phase B work
+  (#3 incremental) will cut the slope; Phase A is not expected to.
+- **Gradle does not cross daemon-warm in this fixture range.**
+  Gradle-warm stays 1.28–1.67× slower than kolt daemon-warm across
+  all four sizes, with no convergent trend. Gradle-warm's per-file
+  slope on these fixtures ((1.82 − 1.17) / 49 ≈ 13 ms/file) is
+  within rounding of kolt daemon-warm's ~12 ms/file, so the
+  persistent gap lives in the fixed-cost floor (~1.17 s gradle vs
+  ~0.70 s kolt), not per-file compile work. This is the Gradle
+  anchor that spike #86/#87 lacked; it shows kolt wins on clean
+  builds by amortising fixed cost faster, not by compiling faster.
+- **Resolve-phase tail latency reproduces as a ~3.3 s size-independent
+  outlier.** Nodaemon and daemon-cold cells show 2–3 of 10 samples
+  clustered ~3.3 s above the median, identical delta signature
+  across all four sizes. The size-independence rules out compile
+  work as the source. Rare occurrences leak through `WARM_DISCARD=5`
+  into daemon-warm too (`jvm-25` run 6, `jvm-50` run 7), matching
+  the same ~3.3 s delta; singletons out of N=10 do not move the
+  median. A maven-metadata refresh hypothesis was considered and
+  is weak — the fixture has no SNAPSHOT deps and kolt's resolver
+  has no TTL machinery that would fire on ~30 % of invocations.
+  More plausible candidates, none verified: the harness's
+  `kill_daemon` poll-loop occasionally hitting its 2 s ceiling,
+  Kotlin/Native runtime teardown stalls in `kolt.kexe` shutdown,
+  or WSL2 9p filesystem stat storms. Disambiguating requires
+  phase-level self-timing from kolt itself; flagged for #88 / #90.
 - **8 s clean-build baseline in §Context does not reproduce.** On
-  the scaling fixtures the subprocess baseline is 4.83 s (jvm-1)
-  rather than ~8 s. The 8 s figure likely included a cold toolchain
-  download or dependency-resolution phase on different hardware.
-  The scaling curve supersedes it as the reference baseline; the
-  §Context paragraph is retained as the original motivation.
+  these fixtures the subprocess baseline is 4.77 s at `jvm-1`,
+  rising to 10.37 s at `jvm-50`. The 8 s figure likely captured
+  different hardware or a cold toolchain download. The scaling
+  curve supersedes it as the reference baseline; §Context is
+  retained as the original motivation.
+
+Acknowledged methodology limitations (not fixed in run 3): mode
+ordering is a fixed block-per-cell sequence rather than interleaved,
+`daemon-cold` does not drop the Linux page cache (no scripted root),
+N=10 is still underpowered for distinguishing 6.8× from 7.9× without
+bootstrapping, and the host is WSL2 with an uncontrolled CPU
+governor. Full limitations and raw per-run tables live in
+`spike/bench-scaling/results-2026-04-14.md`.
 
 Scope and non-goals for #96: this is an end-to-end wall-time
 measurement on clean builds only. Incremental compile (#3),
-multi-module projects (#89), long-run leak behaviour (#90), and
-rotating-fixture regression monitoring (#88) are explicitly out of
-scope and have their own issues.
+multi-module projects (#89), long-run leak behaviour (#90),
+rotating-fixture regression monitoring (#88), and randomised-order
+bench harness work are explicitly out of scope and have their own
+issues or are documented as deferred follow-ups.
 
 ## Alternatives Considered
 

--- a/docs/adr/0016-warm-jvm-compiler-daemon.md
+++ b/docs/adr/0016-warm-jvm-compiler-daemon.md
@@ -6,7 +6,12 @@ Accepted (2026-04-13). Updated 2026-04-14 for #14 PR3: the native-side
 client landed on branch `14/daemon-native-client`, and §5 has been
 rewritten to reflect the revised Phase A rollout — the daemon is the
 **default** compile backend, with the subprocess compile path retained
-only as a fallback. The JVM-side daemon subproject (`kolt-compiler-daemon/`)
+only as a fallback. Also updated 2026-04-14 for #96: §Benchmark results
+now carries a scaling subsection measuring `kolt build` wall time across
+jvm-{1,10,25,50} fixtures with a Gradle comparison. The headline Phase A
+target phrased in §Context (clean build ~8 s → ~3 s, warm < 1 s) is
+retained as the original motivation; see §Benchmark results — Scaling
+(#96) for where the 1 s warm target actually lives on a scaling curve. The JVM-side daemon subproject (`kolt-compiler-daemon/`)
 and wire protocol landed in PR2 (#86, merged); the native client,
 `FallbackCompilerBackend`, and `--no-daemon` escape hatch land in PR3
 (#14). Also updated 2026-04-14: `kolt-compiler-daemon/` is now an
@@ -295,6 +300,83 @@ times over the run; no upward drift). Scenario B fails the Phase A
 kill criterion by a factor of 2.6×. Scenario C passes cleanly and is
 the configuration adopted.
 
+### Scaling (#96, 2026-04-14)
+
+The spike numbers above measure `SharedCompilerHost` directly in-JVM
+on a one-file fixture. They cover the steady-state compile cost but
+not end-to-end `kolt build` wall time, and they say nothing about how
+the numbers change as source file count grows. #96 fills both gaps
+with a scaling benchmark measured against the release binary on
+`spike/bench-scaling/fixtures/jvm-{1,10,25,50}` (deterministic
+generator, `kotlin-stdlib`-only classpath, a handful of top-level
+functions and data classes per file with cross-file references). The
+harness (`spike/bench-scaling/run-bench.sh`) drives real `kolt build`
+for each fixture × mode, N=7 per cell, warm modes discarding the
+first 2 runs as JIT warmup. Wall time is `/usr/bin/time -f '%e'`.
+
+Medians, seconds (OpenJDK 21 Corretto, Kotlin 2.1.0 fixtures, Linux
+WSL2):
+
+| Fixture | nodaemon | daemon-cold | daemon-warm | gradle-warm | nodaemon / warm | gradle / warm |
+|---|---|---|---|---|---|---|
+| jvm-1  | 4.83 | 4.59 | 0.66 | 1.19 | 7.3× | 1.8× |
+| jvm-10 | 5.74 | 5.89 | 0.97 | 1.25 | 5.9× | 1.3× |
+| jvm-25 | 7.14 | 7.34 | 1.36 | 1.41 | 5.3× | 1.0× |
+| jvm-50 | 8.64 | 8.84 | 1.65 | 1.61 | 5.2× | 1.0× |
+
+Read as:
+
+- **Daemon warm vs subprocess is 5.2–7.3× stable across sizes.** The
+  single-file hello-world 8.5× figure recorded in earlier memory was
+  an overestimate — it captured a regime where compile work is a
+  small fraction of wall time, so constant-overhead reduction looked
+  bigger than it is. `jvm-50` (5.2×) is the most defensible number
+  to quote outside the hello-world regime.
+- **Daemon cold regression is zero.** Cold medians track nodaemon
+  within ±0.25 s on every fixture, confirming the
+  `FallbackCompilerBackend` wiring adds no measurable client-side
+  cost on the cold path.
+- **The `warm < 1 s` Phase A target holds only below ~10–15 files.**
+  `jvm-1` (0.66 s) and `jvm-10` (0.97 s) are inside the budget;
+  `jvm-25` (1.36 s) and `jvm-50` (1.65 s) are above it. The 1 s
+  number was written against a hello-world baseline and does not
+  survive a scaling curve. The target is **not** a point target; it
+  is a fixed-cost floor (~0.66 s) plus a per-file slope of ~20 ms.
+  Future Phase B work (#3 incremental) will cut the slope; Phase A
+  is not expected to.
+- **Gradle crossover lives around 25–50 files for these fixtures.**
+  Gradle-warm is strikingly flat (1.19–1.61 s) — its worker API plus
+  embedded kotlinc amortises per-file work extremely well — so the
+  daemon-warm advantage closes from 1.8× on `jvm-1` down to ~1.0× on
+  `jvm-25` and `jvm-50`. This is the Gradle anchor that spike
+  #86/#87 lacked. It is also the headline ROI argument for #3
+  incremental: without incremental, kolt's clean-build advantage
+  over Gradle evaporates past 25 files.
+- **Resolve-phase tail latency surfaced as a reproducible outlier.**
+  Nodaemon and daemon-cold rows show 1–2 samples per cell clustered
+  ~3.3 s above the median, regardless of fixture size. The delta is
+  size-independent, which means it is a fixed-overhead event, not
+  compile work. It does not appear in gradle-warm (which reuses the
+  Gradle daemon's resolved classpath) and appears only rarely in
+  daemon-warm. Best current guess is a maven-metadata refresh or
+  kotlinc toolchain re-probe in kolt's dependency resolver firing on
+  ~28% of invocations. The raw per-run numbers and full outlier
+  analysis live in `spike/bench-scaling/results-2026-04-14.md`.
+  Flagged for #88 / #90 follow-up as evidence the resolve phase has
+  measurable tail latency worth monitoring separately from compile.
+- **8 s clean-build baseline in §Context does not reproduce.** On
+  the scaling fixtures the subprocess baseline is 4.83 s (jvm-1)
+  rather than ~8 s. The 8 s figure likely included a cold toolchain
+  download or dependency-resolution phase on different hardware.
+  The scaling curve supersedes it as the reference baseline; the
+  §Context paragraph is retained as the original motivation.
+
+Scope and non-goals for #96: this is an end-to-end wall-time
+measurement on clean builds only. Incremental compile (#3),
+multi-module projects (#89), long-run leak behaviour (#90), and
+rotating-fixture regression monitoring (#88) are explicitly out of
+scope and have their own issues.
+
 ## Alternatives Considered
 
 1. **JNI in-process compiler.** Link `kotlin-compiler-embeddable` into
@@ -340,6 +422,8 @@ the configuration adopted.
 - #86 — Phase A scope and spike results
 - #87 (merged) — the compile-bench spike that produced the numbers
   above
+- #96 — Phase A daemon scaling benchmark (this document's §Benchmark
+  results — Scaling subsection)
 - #88–#91 — follow-up spikes (rotating fixtures, multi-module,
   long-run leak check, concurrent-compile thread safety). Originally
   gating the Phase B default flip; after #14 PR3 landed default-on,

--- a/spike/bench-scaling/.gitignore
+++ b/spike/bench-scaling/.gitignore
@@ -1,0 +1,1 @@
+fixtures/

--- a/spike/bench-scaling/gen.sh
+++ b/spike/bench-scaling/gen.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Generate deterministic JVM fixtures for scaling benchmark (#96).
+# Usage: ./gen.sh            # regenerates fixtures/jvm-{1,10,25,50}
+#        ./gen.sh 1 10 25 50 # same, explicit sizes
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+FIX_DIR="$HERE/fixtures"
+
+SIZES=("${@:-1 10 25 50}")
+# shellcheck disable=SC2206
+SIZES=(${SIZES[@]})
+
+KOTLIN_VERSION="2.1.0"
+JVM_TARGET="21"
+
+write_kolt_toml() {
+  local name="$1"
+  cat >"kolt.toml" <<EOF
+name = "$name"
+version = "0.1.0"
+kotlin = "$KOTLIN_VERSION"
+target = "jvm"
+jvm_target = "$JVM_TARGET"
+main = "bench.main"
+sources = ["src"]
+EOF
+}
+
+write_gradle_files() {
+  local name="$1"
+  cat >"settings.gradle.kts" <<EOF
+rootProject.name = "$name"
+EOF
+  cat >"build.gradle.kts" <<EOF
+plugins {
+    kotlin("jvm") version "$KOTLIN_VERSION"
+    application
+}
+
+repositories { mavenCentral() }
+
+kotlin {
+    jvmToolchain($JVM_TARGET)
+}
+
+application {
+    mainClass.set("bench.MainKt")
+}
+
+sourceSets["main"].kotlin.srcDirs("src")
+EOF
+  mkdir -p "gradle/wrapper"
+  cp "$REPO_ROOT/gradle/wrapper/gradle-wrapper.jar" "gradle/wrapper/"
+  cp "$REPO_ROOT/gradle/wrapper/gradle-wrapper.properties" "gradle/wrapper/"
+  cp "$REPO_ROOT/gradlew" "./"
+  chmod +x "./gradlew"
+}
+
+# Write file index $i of $n to src/File{i}.kt (or Main.kt for i=1).
+# File i defines:
+#   - data class M$i
+#   - fun work$i(prev: M$((i-1))): M$i
+#   - three helper functions with enough cross-symbol references
+# File 1 additionally defines `fun main()` which chains work2..workN (or
+# runs self-contained helpers when n=1).
+write_source_file() {
+  local i="$1" n="$2"
+  local path="src/File${i}.kt"
+  [[ "$i" -eq 1 ]] && path="src/Main.kt"
+  {
+    echo "package bench"
+    echo
+    echo "data class M${i}(val a: Int, val b: String, val c: List<Int>)"
+    echo
+    if [[ "$i" -eq 1 ]]; then
+      echo "fun seed(): M1 = M1(1, \"seed\", listOf(1, 2, 3))"
+    else
+      echo "fun work${i}(prev: M$((i-1))): M${i} ="
+      echo "    M${i}(prev.a + ${i}, prev.b + \"-${i}\", prev.c + ${i})"
+    fi
+    echo
+    echo "fun helper${i}A(n: Int): Int {"
+    echo "    var acc = 0"
+    echo "    for (k in 0..n) acc += k * ${i}"
+    echo "    return acc"
+    echo "}"
+    echo
+    echo "fun helper${i}B(s: String): String {"
+    echo "    val sb = StringBuilder()"
+    echo "    for (ch in s) sb.append(ch)"
+    echo "    sb.append(\"-${i}\")"
+    echo "    return sb.toString()"
+    echo "}"
+    echo
+    echo "fun helper${i}C(xs: List<Int>): Int ="
+    echo "    xs.fold(0) { acc, v -> acc + v * ${i} + helper${i}A(v % 4) }"
+    echo
+    if [[ "$i" -eq 1 ]]; then
+      echo "fun main() {"
+      echo "    var m: M1 = seed()"
+      if [[ "$n" -gt 1 ]]; then
+        echo "    val m2 = work2(m)"
+        local j=3
+        local prev=2
+        while [[ "$j" -le "$n" ]]; do
+          echo "    val m${j} = work${j}(m${prev})"
+          prev="$j"
+          j=$((j + 1))
+        done
+        echo "    val finalA = helper${prev}A(m${prev}.a)"
+        echo "    val finalB = helper${prev}B(m${prev}.b)"
+        echo "    val finalC = helper${prev}C(m${prev}.c)"
+      else
+        echo "    val finalA = helper1A(m.a)"
+        echo "    val finalB = helper1B(m.b)"
+        echo "    val finalC = helper1C(m.c)"
+      fi
+      echo "    println(\"bench \$finalA \${finalB.length} \$finalC\")"
+      echo "}"
+    fi
+  } >"$path"
+}
+
+for n in "${SIZES[@]}"; do
+  dir="$FIX_DIR/jvm-${n}"
+  rm -rf "$dir"
+  mkdir -p "$dir/src"
+  (
+    cd "$dir"
+    write_kolt_toml "jvm-${n}"
+    write_gradle_files "jvm-${n}"
+    for ((i = 1; i <= n; i++)); do
+      write_source_file "$i" "$n"
+    done
+  )
+  echo "generated $dir ($n source files)"
+done

--- a/spike/bench-scaling/gen.sh
+++ b/spike/bench-scaling/gen.sh
@@ -58,66 +58,137 @@ EOF
   chmod +x "./gradlew"
 }
 
+write_util_file() {
+  cat >"src/util/Util.kt" <<'EOF'
+package bench.util
+
+data class Container<T>(val value: Int, val label: T)
+
+sealed class Op {
+    data class Add(val amount: Int) : Op()
+    data class Mul(val factor: Int) : Op()
+    data class Shift(val bits: Int) : Op()
+    data object Noop : Op()
+}
+
+inline fun <reified T> describe(container: Container<T>): String =
+    "${T::class.simpleName}:${container.value}/${container.label}"
+
+inline fun <reified T> boxed(value: T): Container<T> =
+    Container(value.hashCode(), value)
+
+fun applyOp(value: Int, op: Op): Int = when (op) {
+    is Op.Add -> value + op.amount
+    is Op.Mul -> value * op.factor
+    is Op.Shift -> value shl (op.bits and 31)
+    Op.Noop -> value
+}
+
+fun <T : Comparable<T>> pickLarger(a: T, b: T): T = if (a >= b) a else b
+EOF
+}
+
 # Write file index $i of $n to src/File{i}.kt (or Main.kt for i=1).
-# File i defines:
-#   - data class M$i
-#   - fun work$i(prev: M$((i-1))): M$i
-#   - three helper functions with enough cross-symbol references
-# File 1 additionally defines `fun main()` which chains work2..workN (or
-# runs self-contained helpers when n=1).
+# Each generated file exercises: generics, inline reified, sealed class
+# when-exhaustive, lambdas with capture, a private helper, and a
+# cross-package import from `bench.util`. This is heavier per file than
+# the original bench design (cf. spike/bench-scaling critique #7) so the
+# per-file slope reflects real compiler work, not boilerplate short-
+# circuits.
 write_source_file() {
   local i="$1" n="$2"
+  local prev=$((i - 1))
   local path="src/File${i}.kt"
   [[ "$i" -eq 1 ]] && path="src/Main.kt"
   {
     echo "package bench"
     echo
+    echo "import bench.util.Container"
+    echo "import bench.util.Op"
+    echo "import bench.util.applyOp"
+    echo "import bench.util.boxed"
+    echo "import bench.util.describe"
+    echo "import bench.util.pickLarger"
+    echo
     echo "data class M${i}(val a: Int, val b: String, val c: List<Int>)"
     echo
-    if [[ "$i" -eq 1 ]]; then
-      echo "fun seed(): M1 = M1(1, \"seed\", listOf(1, 2, 3))"
-    else
-      echo "fun work${i}(prev: M$((i-1))): M${i} ="
-      echo "    M${i}(prev.a + ${i}, prev.b + \"-${i}\", prev.c + ${i})"
-    fi
+    echo "inline fun <reified T> tag${i}(value: T): String ="
+    echo "    \"\${T::class.simpleName}:\${value}\""
     echo
-    echo "fun helper${i}A(n: Int): Int {"
+    echo "private fun helper${i}(n: Int): Int {"
     echo "    var acc = 0"
-    echo "    for (k in 0..n) acc += k * ${i}"
+    echo "    for (k in 0..n) acc += k * ${i} + (k shl 1)"
     echo "    return acc"
     echo "}"
     echo
-    echo "fun helper${i}B(s: String): String {"
-    echo "    val sb = StringBuilder()"
-    echo "    for (ch in s) sb.append(ch)"
-    echo "    sb.append(\"-${i}\")"
-    echo "    return sb.toString()"
+    echo "fun fold${i}(xs: List<Int>): Int {"
+    echo "    val scale = ${i}"
+    echo "    return xs.fold(0) { acc, v -> acc + v * scale + helper${i}(v and 3) }"
     echo "}"
     echo
-    echo "fun helper${i}C(xs: List<Int>): Int ="
-    echo "    xs.fold(0) { acc, v -> acc + v * ${i} + helper${i}A(v % 4) }"
+    echo "fun map${i}(xs: List<Int>): List<String> ="
+    echo "    xs.map { it * ${i} }.filter { it >= 0 }.map { tag${i}(it) }"
+    echo
+    if [[ "$i" -eq 1 ]]; then
+      echo "fun seed(): M1 = M1(1, \"seed\", listOf(1, 2, 3, 4, 5))"
+      echo
+      echo "fun process1(prev: M1): M1 {"
+      echo "    val container: Container<String> = boxed(prev.b)"
+      echo "    val op: Op = when (prev.a and 3) {"
+      echo "        0 -> Op.Add(prev.a + 1)"
+      echo "        1 -> Op.Mul(pickLarger(1, prev.a))"
+      echo "        2 -> Op.Shift(prev.a and 7)"
+      echo "        else -> Op.Noop"
+      echo "    }"
+      echo "    val applied = applyOp(container.value, op)"
+      echo "    val folded = fold1(prev.c)"
+      echo "    val mapped = map1(prev.c)"
+      echo "    val label = describe(container)"
+      echo "    return M1(applied + folded, label + \"|\" + mapped.size, prev.c + folded)"
+      echo "}"
+    else
+      echo "fun work${i}(prev: M${prev}): M${i} {"
+      echo "    val container: Container<String> = boxed(prev.b)"
+      echo "    val op: Op = when (prev.a and 3) {"
+      echo "        0 -> Op.Add(${i})"
+      echo "        1 -> Op.Mul(pickLarger(1, ${i}))"
+      echo "        2 -> Op.Shift((${i} and 7))"
+      echo "        else -> Op.Noop"
+      echo "    }"
+      echo "    val applied = applyOp(container.value, op)"
+      echo "    val folded = fold${i}(prev.c)"
+      echo "    val mapped = map${i}(prev.c)"
+      echo "    val label = describe(container) + \"-${i}/\" + mapped.size"
+      echo "    return M${i}(applied + folded, label, prev.c + folded + ${i})"
+      echo "}"
+    fi
     echo
     if [[ "$i" -eq 1 ]]; then
       echo "fun main() {"
-      echo "    var m: M1 = seed()"
+      echo "    var m: M1 = process1(seed())"
       if [[ "$n" -gt 1 ]]; then
-        echo "    val m2 = work2(m)"
-        local j=3
-        local prev=2
+        # Variable ladder is `m, m2, m3, ...`. The M1 result from
+        # process1(seed()) lives in `m`; work2 reads from it directly,
+        # subsequent calls chain via the previous m${k} variable.
+        local j=2
+        local prev2=""
         while [[ "$j" -le "$n" ]]; do
-          echo "    val m${j} = work${j}(m${prev})"
-          prev="$j"
+          if [[ -z "$prev2" ]]; then
+            echo "    val m${j} = work${j}(m)"
+          else
+            echo "    val m${j} = work${j}(m${prev2})"
+          fi
+          prev2="$j"
           j=$((j + 1))
         done
-        echo "    val finalA = helper${prev}A(m${prev}.a)"
-        echo "    val finalB = helper${prev}B(m${prev}.b)"
-        echo "    val finalC = helper${prev}C(m${prev}.c)"
+        echo "    val finalFold = fold${prev2}(m${prev2}.c)"
+        echo "    val finalMap  = map${prev2}(m${prev2}.c).size"
+        echo "    println(\"bench \${m${prev2}.a} \${m${prev2}.b.length} \$finalFold \$finalMap\")"
       else
-        echo "    val finalA = helper1A(m.a)"
-        echo "    val finalB = helper1B(m.b)"
-        echo "    val finalC = helper1C(m.c)"
+        echo "    val finalFold = fold1(m.c)"
+        echo "    val finalMap = map1(m.c).size"
+        echo "    println(\"bench \${m.a} \${m.b.length} \$finalFold \$finalMap\")"
       fi
-      echo "    println(\"bench \$finalA \${finalB.length} \$finalC\")"
       echo "}"
     fi
   } >"$path"
@@ -126,14 +197,16 @@ write_source_file() {
 for n in "${SIZES[@]}"; do
   dir="$FIX_DIR/jvm-${n}"
   rm -rf "$dir"
-  mkdir -p "$dir/src"
+  mkdir -p "$dir/src/util"
   (
     cd "$dir"
     write_kolt_toml "jvm-${n}"
     write_gradle_files "jvm-${n}"
+    write_util_file
     for ((i = 1; i <= n; i++)); do
       write_source_file "$i" "$n"
     done
   )
-  echo "generated $dir ($n source files)"
+  # Report file count including the shared util file.
+  echo "generated $dir ($n source files + bench/util/Util.kt)"
 done

--- a/spike/bench-scaling/results-2026-04-14-run1.md
+++ b/spike/bench-scaling/results-2026-04-14-run1.md
@@ -1,0 +1,101 @@
+# Phase A daemon scaling benchmark — #96
+
+- Date: 2026-04-14T18:39:16+09:00
+- Host: Linux 6.6.87.2-microsoft-standard-WSL2 x86_64
+- JDK: openjdk version "21.0.7" 2025-04-15 LTS
+- kolt binary: `/home/makino/projects/snicmakino/kolt/build/bin/linuxX64/releaseExecutable/kolt.kexe`
+- kolt binary mtime: 2026-04-14T18:16:31+09:00
+- N per cell: 7 (warm modes discard first 2)
+
+| Fixture | Mode | N | median (s) | min (s) | max (s) | raw |
+|---|---|---|---|---|---|---|
+| jvm-1 | nodaemon | 7 | 5.16 | 5.05 | 8.48 | 8.12,5.05,5.39,8.48,5.07,5.08,5.16 |
+| jvm-1 | daemon-cold | 7 | 5.10 | 4.98 | 8.05 | 5.08,5.10,8.05,4.98,5.13,5.02,5.31 |
+| jvm-1 | daemon-warm | 7 | 0.77 | 0.65 | 0.99 | 0.89,0.99,0.76,0.73,0.77,0.81,0.65 |
+| jvm-1 | gradle | 7 | 1.78 | 1.62 | 1.89 | 1.89,1.83,1.78,1.71,1.69,1.83,1.62 |
+| jvm-10 | nodaemon | 7 | 6.52 | 6.29 | 10.12 | 9.87,6.48,6.52,6.70,10.12,6.32,6.29 |
+| jvm-10 | daemon-cold | 7 | 6.28 | 6.16 | 10.19 | 6.33,6.16,9.62,6.28,6.27,6.19,10.19 |
+| jvm-10 | daemon-warm | 7 | 1.09 | 0.92 | 1.67 | 1.67,1.31,1.22,1.09,1.01,1.09,0.92 |
+| jvm-10 | gradle | 7 | 1.88 | 1.78 | 5.26 | 1.99,2.08,1.88,5.26,1.86,1.78,1.80 |
+| jvm-25 | nodaemon | 7 | 8.06 | 7.71 | 11.67 | 8.21,8.06,11.67,7.74,7.83,7.71,11.15 |
+| jvm-25 | daemon-cold | 7 | 8.31 | 7.87 | 191.58 | 7.97,8.31,191.58,8.32,7.87,8.06,10.64 |
+| jvm-25 | daemon-warm | 7 | 1.51 | 1.10 | 2.30 | 2.30,1.60,1.52,1.45,1.51,1.19,1.10 |
+| jvm-25 | gradle | 7 | 2.01 | 1.91 | 2.20 | 2.18,2.20,1.91,2.01,2.07,1.91,1.93 |
+| jvm-50 | nodaemon | 7 | 9.59 | 9.15 | 13.24 | 9.89,12.75,9.59,9.15,13.24,9.59,9.45 |
+| jvm-50 | daemon-cold | 7 | 9.98 | 9.34 | 13.73 | 12.94,9.53,9.34,12.99,9.98,9.68,13.73 |
+| jvm-50 | daemon-warm | 7 | 1.85 | 1.48 | 4.94 | 2.28,2.21,1.83,1.85,4.94,1.71,1.48 |
+| jvm-50 | gradle | 7 | 2.06 | 1.96 | 2.31 | 2.08,2.27,2.04,2.31,2.06,1.96,1.99 |
+
+## Summary (medians, seconds)
+
+| Fixture | nodaemon | daemon-cold | daemon-warm | gradle-warm | nodaemon / warm | gradle / warm |
+|---|---|---|---|---|---|---|
+| jvm-1  | 5.16 | 5.10 | 0.77 | 1.78 | 6.7× | 2.3× |
+| jvm-10 | 6.52 | 6.28 | 1.09 | 1.88 | 6.0× | 1.7× |
+| jvm-25 | 8.06 | 8.31 | 1.51 | 2.01 | 5.3× | 1.3× |
+| jvm-50 | 9.59 | 9.98 | 1.85 | 2.06 | 5.2× | 1.1× |
+
+## Observations
+
+- **Daemon warm vs subprocess**: the 5.2×–6.7× wall-time improvement is
+  stable across sizes.  Hello-world's 8.5× figure (`project_phase_a_daemon`
+  memory) overstated it — that run captured a single-file project where the
+  compile fraction was small; here the compile fraction grows and the
+  constant-overhead reduction shows up as a ~5× floor rather than a ~8×
+  ceiling.
+- **Daemon cold regression**: effectively zero (5.10 vs 5.16, 6.28 vs 6.52,
+  8.31 vs 8.06, 9.98 vs 9.59 — all within run-to-run noise).  Confirms the
+  `FallbackCompilerBackend` wiring isn't adding measurable client-side cost
+  on the cold path.  Consistent with 2026-04-14 hello-world Run 2.
+- **ADR 0016 `warm <1s` target**: only holds for `jvm-1` (0.77s).  The
+  target was set against a hello-world baseline and does not survive a
+  scaling curve — `jvm-10` already sits at 1.09s.  This is a target-text
+  issue, not a regression; ADR 0016 §Benchmark results should be updated
+  separately (out of this issue's scope per agreement to stop at raw data).
+- **Scaling slope**: daemon-warm is roughly linear in file count, ~0.025s
+  per file above the ~0.75s fixed-cost floor (resolve + round-trip + jar
+  write).  ~0.75s still has headroom above the spike's 108ms pure-compile
+  median — dependency-resolution phase and native-client JSON encoding are
+  the next candidates for Phase B / #90.
+- **Gradle comparison**: gradle-warm is strikingly flat (1.78–2.06s).
+  Gradle's worker API + embedded kotlinc amortises per-file work so well
+  that by `jvm-50` the daemon-warm advantage is only 1.1×.  On single-file
+  builds kolt is 2.3× faster; the crossover for these fixture shapes
+  would land somewhere past `jvm-100`.  This is the Gradle anchor point
+  that spike #86/#87 lacked.
+- **Outliers**:
+  - `jvm-25 daemon-cold` run 3 = **191.58s** — a single catastrophic run,
+    otherwise-stable 7.87–10.64s.  Most likely a one-off Maven Central
+    stall or background I/O during the `resolving dependencies...` phase.
+    Excluded from median by construction; flagged for #88/#90 follow-up as
+    evidence that dependency resolution has tail-latency risk under load.
+  - `nodaemon` and `daemon-cold` rows show 2–3 samples per cell in the
+    8–13s range when the median sits at 5–9s.  Pattern is consistent
+    across fixture sizes — suggests periodic cost in the non-daemon path
+    (possible kotlinc installation re-probe, maven metadata refresh, or
+    filesystem cache miss).  Daemon-warm does not exhibit this pattern,
+    which is consistent with the resolve phase being the source.
+- **Fixture sanity**: daemon-warm steady-state per-file slope is
+  (1.85 − 0.77) / 49 ≈ 22 ms/file, which is in the same ballpark as the
+  spike #86/#87 SharedCompilerHost in-JVM numbers (108ms for a single
+  hello-world compile includes fixed cost).  The generator is producing
+  enough compiler work to be meaningful; if future measurement wants to
+  stress symbol resolution harder, add cross-package refs in `gen.sh`.
+
+## Methodology notes
+
+- `run-bench.sh` kills any running `kolt-compiler-daemon` and removes
+  `~/.kolt/daemon` before each cold run, and before the first daemon-warm
+  run.  `rm -rf build` between every run.
+- Warm modes (`daemon-warm`, `gradle`) discard the first 2 runs as JIT
+  warmup; reported N=7 after discards.
+- `--no-daemon` was measured with the daemon process killed first, per
+  issue #96 open question: this represents "user explicitly opted out and
+  there is no daemon running".  A variant with a live daemon present was
+  not measured and is expected to be within noise.
+- Wall clock via `/usr/bin/time -f '%e'`; kolt's own "built in Xs"
+  self-report was not captured separately.
+- Binary under test: `build/bin/linuxX64/releaseExecutable/kolt.kexe`
+  built from `feat/gradle-decouple-daemon` at the session head.  Dev
+  fallback resolves `kolt-compiler-daemon-all.jar` without `KOLT_DAEMON_JAR`
+  override (confirmed via #94 re-check).

--- a/spike/bench-scaling/results-2026-04-14-run2.md
+++ b/spike/bench-scaling/results-2026-04-14-run2.md
@@ -1,0 +1,121 @@
+# Phase A daemon scaling benchmark — #96
+
+- Date: 2026-04-14T18:57:47+09:00
+- Host: Linux 6.6.87.2-microsoft-standard-WSL2 x86_64
+- JDK: openjdk version "21.0.7" 2025-04-15 LTS
+- kolt binary: `/home/makino/projects/snicmakino/kolt/build/bin/linuxX64/releaseExecutable/kolt.kexe`
+- kolt binary mtime: 2026-04-14T18:16:31+09:00
+- N per cell: 7 (warm modes discard first 2)
+
+| Fixture | Mode | N | median (s) | min (s) | max (s) | raw |
+|---|---|---|---|---|---|---|
+| jvm-1 | nodaemon | 7 | 4.83 | 4.37 | 8.12 | 5.09,4.83,4.93,8.12,4.50,4.37,4.49 |
+| jvm-1 | daemon-cold | 7 | 4.59 | 4.08 | 10.12 | 4.08,4.10,4.59,10.12,5.14,4.48,4.82 |
+| jvm-1 | daemon-warm | 7 | 0.66 | 0.59 | 4.01 | 0.78,0.71,4.01,0.65,0.66,0.59,0.66 |
+| jvm-1 | gradle | 7 | 1.19 | 1.15 | 1.56 | 1.56,1.25,1.19,1.19,1.18,1.16,1.15 |
+| jvm-10 | nodaemon | 7 | 5.74 | 5.57 | 8.98 | 5.57,5.74,8.98,5.72,5.75,5.82,5.72 |
+| jvm-10 | daemon-cold | 7 | 5.89 | 5.75 | 9.32 | 9.17,5.82,5.75,5.89,5.88,9.32,6.00 |
+| jvm-10 | daemon-warm | 7 | 0.97 | 0.82 | 1.22 | 1.22,1.11,0.99,0.95,0.97,0.90,0.82 |
+| jvm-10 | gradle | 7 | 1.25 | 1.22 | 1.61 | 1.27,1.25,1.61,1.23,1.25,1.22,1.26 |
+| jvm-25 | nodaemon | 7 | 7.14 | 7.06 | 10.53 | 7.42,7.06,7.17,10.53,7.13,7.07,7.14 |
+| jvm-25 | daemon-cold | 7 | 7.34 | 7.20 | 10.74 | 10.74,7.36,7.21,7.22,10.56,7.34,7.20 |
+| jvm-25 | daemon-warm | 7 | 1.36 | 0.94 | 5.04 | 5.04,1.48,1.46,1.34,1.36,1.13,0.94 |
+| jvm-25 | gradle | 7 | 1.41 | 1.33 | 1.43 | 1.33,1.41,1.36,1.41,1.43,1.36,1.42 |
+| jvm-50 | nodaemon | 7 | 8.64 | 8.41 | 12.03 | 12.03,8.64,8.66,8.59,12.02,8.61,8.41 |
+| jvm-50 | daemon-cold | 7 | 8.84 | 8.69 | 12.14 | 12.14,8.84,8.87,8.69,11.97,8.73,8.73 |
+| jvm-50 | daemon-warm | 7 | 1.65 | 1.22 | 2.27 | 2.27,1.94,1.82,1.65,1.44,1.33,1.22 |
+| jvm-50 | gradle | 7 | 1.61 | 1.54 | 4.65 | 1.56,1.58,2.05,4.65,1.63,1.54,1.61 |
+
+This is **run 2**.  Run 1 (saved as `results-2026-04-14-run1.md`) included a
+191.58 s catastrophic sample on `jvm-25 daemon-cold` that is absent here;
+that single sample is now attributed to a WSL2 suspend event during the
+earlier session.  The rest of the outlier structure reproduces across
+both runs and is described below.
+
+## Summary (medians, seconds)
+
+| Fixture | nodaemon | daemon-cold | daemon-warm | gradle-warm | nodaemon / warm | gradle / warm |
+|---|---|---|---|---|---|---|
+| jvm-1  | 4.83 | 4.59 | 0.66 | 1.19 | 7.3× | 1.8× |
+| jvm-10 | 5.74 | 5.89 | 0.97 | 1.25 | 5.9× | 1.3× |
+| jvm-25 | 7.14 | 7.34 | 1.36 | 1.41 | 5.3× | 1.0× |
+| jvm-50 | 8.64 | 8.84 | 1.65 | 1.61 | 5.2× | 1.0× |
+
+## Observations
+
+- **Daemon warm vs subprocess**: 5.2–7.3× stable across sizes.  The ratio
+  declines with file count as the compile fraction grows; `jvm-50` sits
+  at 5.2× which is the most defensible number to quote outside the
+  hello-world regime.
+- **Daemon cold regression**: still effectively zero.  Cold medians
+  track nodaemon within ±0.25 s across all four sizes, confirming the
+  `FallbackCompilerBackend` wiring adds no measurable client-side cost.
+- **`warm <1s` ADR target**: holds for `jvm-1` (0.66 s) and `jvm-10`
+  (0.97 s), fails at `jvm-25` (1.36 s).  The crossover lives somewhere
+  around 10–15 source files.  The target text in ADR 0016 should be
+  updated; that is a separate ADR edit, out of scope here per the
+  agreed deliverables list.
+- **Scaling slope**: daemon-warm per-file slope is
+  (1.65 − 0.66) / 49 ≈ 20 ms/file above a ~0.66 s fixed-cost floor
+  (resolve + round-trip + jar write).  The ~0.66 s floor still has
+  headroom above spike #86/#87's 108 ms pure-compile median — resolve
+  phase and native-client JSON encoding are where that gap lives.
+- **Gradle crossover**: `jvm-25` and `jvm-50` land within 0.04 s of
+  gradle-warm.  For fixtures of this shape gradle catches up by ~25
+  files and matches by ~50.  On `jvm-1` kolt is still 1.8× faster due
+  to fixed-cost advantage.  This is the scaling anchor that spike
+  #86/#87 lacked.
+
+## Outlier analysis
+
+Both runs show a reproducible outlier pattern that is **not**
+attributable to laptop sleep.  Laptop sleep accounted only for the
+`191.58 s` single sample in run 1.  The remaining outliers:
+
+- Nodaemon / daemon-cold rows show 1–2 samples per cell roughly
+  3.3–3.4 s above the median, regardless of fixture size:
+
+  | Cell                   | median | outlier | delta |
+  |---|---|---|---|
+  | jvm-1 nodaemon         | 4.83   | 8.12    | +3.29 |
+  | jvm-10 nodaemon        | 5.74   | 8.98    | +3.24 |
+  | jvm-25 nodaemon        | 7.14   | 10.53   | +3.39 |
+  | jvm-50 nodaemon        | 8.64   | 12.03   | +3.39 |
+  | jvm-50 daemon-cold     | 8.84   | 12.14   | +3.30 |
+
+  The delta is **independent of fixture size**, which means the extra
+  cost is a fixed-overhead event, not something that scales with
+  compilation work.  ~2 of 7 runs per cell hit it.
+- Daemon-warm rows are mostly clean (0.82–2.27 s tight distribution)
+  except `jvm-1 run 3 = 4.01 s` and `jvm-25 run 1 = 5.04 s`.  The
+  `jvm-25` warm outlier is the post-prime run which suggests the
+  prime-run discards did not catch a late resolve-phase event.
+- Gradle has a single outlier at `jvm-50 run 4 = 4.65 s` which is
+  consistent with the gradle daemon occasionally re-loading a worker;
+  it does not scale with fixture size either.
+
+The ~3.3 s fixed-cost outlier appears in every mode that runs kolt's
+`resolving dependencies...` phase on each invocation (nodaemon,
+daemon-cold, and — since warm compile doesn't skip resolve — the
+occasional daemon-warm sample).  It does not appear in gradle, which
+reuses the gradle daemon's resolved classpath.  Best guess is a
+maven-metadata refresh or kotlinc toolchain re-probe in kolt's
+dependency resolver firing on ~28% of invocations.  Flagged for #88
+(rotating fixtures regression monitor) and #90 (long-run leak / resolve
+tail) follow-up — we now have a reproducible signal that the resolve
+phase has ~3 s tail latency.
+
+## Methodology notes
+
+- `run-bench.sh` kills any running `kolt-compiler-daemon` and removes
+  `~/.kolt/daemon` before each cold run, and before the first daemon-warm
+  run.  `rm -rf build` between every run.
+- Warm modes (`daemon-warm`, `gradle`) discard the first 2 runs as JIT
+  warmup; reported N=7 after discards.
+- `--no-daemon` was measured with the daemon process killed first, per
+  issue #96 open question.
+- Wall clock via `/usr/bin/time -f '%e'`.
+- Binary under test: `build/bin/linuxX64/releaseExecutable/kolt.kexe`
+  built from `feat/gradle-decouple-daemon` at session head.  Dev
+  fallback resolves `kolt-compiler-daemon-all.jar` without
+  `KOLT_DAEMON_JAR` override.

--- a/spike/bench-scaling/results-2026-04-14.md
+++ b/spike/bench-scaling/results-2026-04-14.md
@@ -82,15 +82,24 @@ before comparing any numbers:
   reduction is #3 incremental's job, not Phase A's.
 - **Gradle crossover does not materialise within this fixture range.**
   Run 2 reported parity at `jvm-25` / `jvm-50` (1.0×).  Run 3's fair
-  measurement restores a 1.28–1.67× advantage for daemon-warm across
-  all four sizes, with no convergent trend.  The run 2 "gradle
-  catches kolt by jvm-50" conclusion should not be cited — it was
-  partly unfair gradle timing (`clean` + `test` tasks inside the
-  timed region) and partly the inflated kolt warm medians from
-  incomplete JIT warmup.  Gradle-warm's scaling slope on these
-  fixtures is (1.82 − 1.17) / 49 ≈ 13 ms/file, virtually identical
-  to kolt daemon-warm's slope; the gap is in the fixed-cost floor
-  (~1.17 s gradle vs ~0.70 s kolt), not in per-file work.
+  measurement restores a 1.28–1.67× advantage for daemon-warm that
+  is **flat within noise** across all four sizes (the jvm-25 ratio
+  of 1.28× is actually the lowest of the four, not jvm-50's 1.38×,
+  so the right framing is "no trend detectable at N=10" rather than
+  "convergent" or "divergent").  The run 2 "gradle catches kolt by
+  jvm-50" conclusion should not be cited — it was partly unfair
+  gradle timing (`clean` + `test` tasks inside the timed region) and
+  partly the inflated kolt warm medians from incomplete JIT warmup.
+  Gradle-warm's scaling slope on these fixtures is
+  (1.82 − 1.17) / 49 ≈ 13 ms/file, virtually identical to kolt
+  daemon-warm's ~12 ms/file; the gap is entirely in the fixed-cost
+  floor (~1.17 s gradle vs ~0.70 s kolt), not in per-file work.
+  **Implication worth flagging before anyone cites this later**:
+  because the two slopes converge by construction on this fixture
+  family, a "kolt scales better than Gradle on clean builds" claim
+  cannot be supported by extrapolating these numbers.  What the
+  numbers *do* support is "kolt amortises fixed cost faster", which
+  is a different claim with a different shelf life.
 - **Resolve-phase tail latency outlier reproduces with the same
   ~3.3 s signature.**  Nodaemon and daemon-cold cells show 2–3
   samples out of 10 clustered ~3.3–3.4 s above the median, still
@@ -112,12 +121,30 @@ before comparing any numbers:
   maven-metadata refresh in kolt's resolver; that hypothesis is weak
   (this fixture has only `kotlin-stdlib` and no SNAPSHOT deps, and
   the resolver has no TTL machinery that would fire on ~30% of
-  invocations).  More likely candidates, none verified, include the
-  `kill_daemon` helper occasionally hitting its 2 s poll-loop
-  ceiling, Kotlin/Native runtime teardown stalls in `kolt.kexe`
-  shutdown, or WSL2 9p filesystem stat storms.  Phase-level
-  instrumentation (kolt self-reported times for resolve vs compile
-  vs jar) is needed to disambiguate; flagged for #88 / #90.
+  invocations).
+
+  The leading unverified hypothesis is a **WSL2 9p filesystem
+  stat-storm on kotlinc startup**.  Three pieces of evidence: (a)
+  the outlier signature is almost exactly constant across fixture
+  sizes (+3.40 / +3.38 / +3.26 / +3.41 — characteristic of a
+  one-shot fixed-cost event, not anything that scales with work);
+  (b) the outlier hits `nodaemon` as often as `daemon-cold`, so it
+  cannot be anything inside the kolt daemon itself — it is in the
+  subprocess kotlinc startup path that both modes share; (c) WSL2
+  9p is a known source of multi-second directory-walk stalls on
+  first access after a cache miss, and kotlinc's startup (classpath
+  scan, JMOD jar indexing) does a lot of directory walking.  A
+  Kotlin/Native runtime teardown stall in `kolt.kexe` shutdown is a
+  weaker but still possible alternative.  The run-2 `kill_daemon`
+  poll-loop hypothesis is retracted: the poll ceiling is 2.0 s
+  (10 × 0.2 s) + 0.3 s after a `pkill -9`, which does not fit a
+  +3.3 s tail, and the `daemon-warm` outlier hits (`jvm-1` run 9,
+  `jvm-25` run 6, `jvm-50` run 7) occur in iterations where
+  `kill_daemon` was never called — warm mode only kills the daemon
+  once at cell start.  Phase-level instrumentation (kolt
+  self-reported times for resolve vs compile vs jar) plus
+  `strace -c` on one invocation would disambiguate; flagged for
+  #88 / #90.
 
 ## Acknowledged limitations (not fixed in this run)
 
@@ -133,7 +160,17 @@ over-interpret the numbers.
   breaks daemon-warm's "keep the daemon alive within the cell"
   contract.  Not worth restructuring for #96; re-run with a
   randomised harness if a future measurement needs to discriminate
-  smaller effects.
+  smaller effects.  **Direction of bias**: because `nodaemon` runs
+  first per cell (its sample 1 pays the cold page cache for the
+  fixture's sources and the kotlinc jars), the nodaemon median is
+  biased slightly *upward* relative to a warm-cache state that
+  `daemon-warm` always enjoys.  The honest read of the ~7×
+  nodaemon/warm ratio is therefore "upper bound on typical user
+  benefit" — a real user whose FS cache is already warm when they
+  invoke `kolt build` would see a somewhat smaller ratio.  The
+  effect is likely <10 % given that `daemon-cold` (which also runs
+  after `nodaemon` and so has the same page-cache advantage)
+  tracks `nodaemon` within ±0.25 s.
 - **`daemon-cold` is not "first build after reboot" cold.**  The
   harness kills the daemon JVM and removes `~/.kolt/daemon/` before
   each cold sample, but leaves the Linux page cache warm (WSL2's

--- a/spike/bench-scaling/results-2026-04-14.md
+++ b/spike/bench-scaling/results-2026-04-14.md
@@ -1,0 +1,121 @@
+# Phase A daemon scaling benchmark — #96
+
+- Date: 2026-04-14T18:57:47+09:00
+- Host: Linux 6.6.87.2-microsoft-standard-WSL2 x86_64
+- JDK: openjdk version "21.0.7" 2025-04-15 LTS
+- kolt binary: `/home/makino/projects/snicmakino/kolt/build/bin/linuxX64/releaseExecutable/kolt.kexe`
+- kolt binary mtime: 2026-04-14T18:16:31+09:00
+- N per cell: 7 (warm modes discard first 2)
+
+| Fixture | Mode | N | median (s) | min (s) | max (s) | raw |
+|---|---|---|---|---|---|---|
+| jvm-1 | nodaemon | 7 | 4.83 | 4.37 | 8.12 | 5.09,4.83,4.93,8.12,4.50,4.37,4.49 |
+| jvm-1 | daemon-cold | 7 | 4.59 | 4.08 | 10.12 | 4.08,4.10,4.59,10.12,5.14,4.48,4.82 |
+| jvm-1 | daemon-warm | 7 | 0.66 | 0.59 | 4.01 | 0.78,0.71,4.01,0.65,0.66,0.59,0.66 |
+| jvm-1 | gradle | 7 | 1.19 | 1.15 | 1.56 | 1.56,1.25,1.19,1.19,1.18,1.16,1.15 |
+| jvm-10 | nodaemon | 7 | 5.74 | 5.57 | 8.98 | 5.57,5.74,8.98,5.72,5.75,5.82,5.72 |
+| jvm-10 | daemon-cold | 7 | 5.89 | 5.75 | 9.32 | 9.17,5.82,5.75,5.89,5.88,9.32,6.00 |
+| jvm-10 | daemon-warm | 7 | 0.97 | 0.82 | 1.22 | 1.22,1.11,0.99,0.95,0.97,0.90,0.82 |
+| jvm-10 | gradle | 7 | 1.25 | 1.22 | 1.61 | 1.27,1.25,1.61,1.23,1.25,1.22,1.26 |
+| jvm-25 | nodaemon | 7 | 7.14 | 7.06 | 10.53 | 7.42,7.06,7.17,10.53,7.13,7.07,7.14 |
+| jvm-25 | daemon-cold | 7 | 7.34 | 7.20 | 10.74 | 10.74,7.36,7.21,7.22,10.56,7.34,7.20 |
+| jvm-25 | daemon-warm | 7 | 1.36 | 0.94 | 5.04 | 5.04,1.48,1.46,1.34,1.36,1.13,0.94 |
+| jvm-25 | gradle | 7 | 1.41 | 1.33 | 1.43 | 1.33,1.41,1.36,1.41,1.43,1.36,1.42 |
+| jvm-50 | nodaemon | 7 | 8.64 | 8.41 | 12.03 | 12.03,8.64,8.66,8.59,12.02,8.61,8.41 |
+| jvm-50 | daemon-cold | 7 | 8.84 | 8.69 | 12.14 | 12.14,8.84,8.87,8.69,11.97,8.73,8.73 |
+| jvm-50 | daemon-warm | 7 | 1.65 | 1.22 | 2.27 | 2.27,1.94,1.82,1.65,1.44,1.33,1.22 |
+| jvm-50 | gradle | 7 | 1.61 | 1.54 | 4.65 | 1.56,1.58,2.05,4.65,1.63,1.54,1.61 |
+
+This is **run 2**.  Run 1 (saved as `results-2026-04-14-run1.md`) included a
+191.58 s catastrophic sample on `jvm-25 daemon-cold` that is absent here;
+that single sample is now attributed to a WSL2 suspend event during the
+earlier session.  The rest of the outlier structure reproduces across
+both runs and is described below.
+
+## Summary (medians, seconds)
+
+| Fixture | nodaemon | daemon-cold | daemon-warm | gradle-warm | nodaemon / warm | gradle / warm |
+|---|---|---|---|---|---|---|
+| jvm-1  | 4.83 | 4.59 | 0.66 | 1.19 | 7.3× | 1.8× |
+| jvm-10 | 5.74 | 5.89 | 0.97 | 1.25 | 5.9× | 1.3× |
+| jvm-25 | 7.14 | 7.34 | 1.36 | 1.41 | 5.3× | 1.0× |
+| jvm-50 | 8.64 | 8.84 | 1.65 | 1.61 | 5.2× | 1.0× |
+
+## Observations
+
+- **Daemon warm vs subprocess**: 5.2–7.3× stable across sizes.  The ratio
+  declines with file count as the compile fraction grows; `jvm-50` sits
+  at 5.2× which is the most defensible number to quote outside the
+  hello-world regime.
+- **Daemon cold regression**: still effectively zero.  Cold medians
+  track nodaemon within ±0.25 s across all four sizes, confirming the
+  `FallbackCompilerBackend` wiring adds no measurable client-side cost.
+- **`warm <1s` ADR target**: holds for `jvm-1` (0.66 s) and `jvm-10`
+  (0.97 s), fails at `jvm-25` (1.36 s).  The crossover lives somewhere
+  around 10–15 source files.  The target text in ADR 0016 should be
+  updated; that is a separate ADR edit, out of scope here per the
+  agreed deliverables list.
+- **Scaling slope**: daemon-warm per-file slope is
+  (1.65 − 0.66) / 49 ≈ 20 ms/file above a ~0.66 s fixed-cost floor
+  (resolve + round-trip + jar write).  The ~0.66 s floor still has
+  headroom above spike #86/#87's 108 ms pure-compile median — resolve
+  phase and native-client JSON encoding are where that gap lives.
+- **Gradle crossover**: `jvm-25` and `jvm-50` land within 0.04 s of
+  gradle-warm.  For fixtures of this shape gradle catches up by ~25
+  files and matches by ~50.  On `jvm-1` kolt is still 1.8× faster due
+  to fixed-cost advantage.  This is the scaling anchor that spike
+  #86/#87 lacked.
+
+## Outlier analysis
+
+Both runs show a reproducible outlier pattern that is **not**
+attributable to laptop sleep.  Laptop sleep accounted only for the
+`191.58 s` single sample in run 1.  The remaining outliers:
+
+- Nodaemon / daemon-cold rows show 1–2 samples per cell roughly
+  3.3–3.4 s above the median, regardless of fixture size:
+
+  | Cell                   | median | outlier | delta |
+  |---|---|---|---|
+  | jvm-1 nodaemon         | 4.83   | 8.12    | +3.29 |
+  | jvm-10 nodaemon        | 5.74   | 8.98    | +3.24 |
+  | jvm-25 nodaemon        | 7.14   | 10.53   | +3.39 |
+  | jvm-50 nodaemon        | 8.64   | 12.03   | +3.39 |
+  | jvm-50 daemon-cold     | 8.84   | 12.14   | +3.30 |
+
+  The delta is **independent of fixture size**, which means the extra
+  cost is a fixed-overhead event, not something that scales with
+  compilation work.  ~2 of 7 runs per cell hit it.
+- Daemon-warm rows are mostly clean (0.82–2.27 s tight distribution)
+  except `jvm-1 run 3 = 4.01 s` and `jvm-25 run 1 = 5.04 s`.  The
+  `jvm-25` warm outlier is the post-prime run which suggests the
+  prime-run discards did not catch a late resolve-phase event.
+- Gradle has a single outlier at `jvm-50 run 4 = 4.65 s` which is
+  consistent with the gradle daemon occasionally re-loading a worker;
+  it does not scale with fixture size either.
+
+The ~3.3 s fixed-cost outlier appears in every mode that runs kolt's
+`resolving dependencies...` phase on each invocation (nodaemon,
+daemon-cold, and — since warm compile doesn't skip resolve — the
+occasional daemon-warm sample).  It does not appear in gradle, which
+reuses the gradle daemon's resolved classpath.  Best guess is a
+maven-metadata refresh or kotlinc toolchain re-probe in kolt's
+dependency resolver firing on ~28% of invocations.  Flagged for #88
+(rotating fixtures regression monitor) and #90 (long-run leak / resolve
+tail) follow-up — we now have a reproducible signal that the resolve
+phase has ~3 s tail latency.
+
+## Methodology notes
+
+- `run-bench.sh` kills any running `kolt-compiler-daemon` and removes
+  `~/.kolt/daemon` before each cold run, and before the first daemon-warm
+  run.  `rm -rf build` between every run.
+- Warm modes (`daemon-warm`, `gradle`) discard the first 2 runs as JIT
+  warmup; reported N=7 after discards.
+- `--no-daemon` was measured with the daemon process killed first, per
+  issue #96 open question.
+- Wall clock via `/usr/bin/time -f '%e'`.
+- Binary under test: `build/bin/linuxX64/releaseExecutable/kolt.kexe`
+  built from `feat/gradle-decouple-daemon` at session head.  Dev
+  fallback resolves `kolt-compiler-daemon-all.jar` without
+  `KOLT_DAEMON_JAR` override.

--- a/spike/bench-scaling/results-2026-04-14.md
+++ b/spike/bench-scaling/results-2026-04-14.md
@@ -1,121 +1,180 @@
 # Phase A daemon scaling benchmark — #96
 
-- Date: 2026-04-14T18:57:47+09:00
+- Date: 2026-04-14T19:44:20+09:00
 - Host: Linux 6.6.87.2-microsoft-standard-WSL2 x86_64
 - JDK: openjdk version "21.0.7" 2025-04-15 LTS
 - kolt binary: `/home/makino/projects/snicmakino/kolt/build/bin/linuxX64/releaseExecutable/kolt.kexe`
 - kolt binary mtime: 2026-04-14T18:16:31+09:00
-- N per cell: 7 (warm modes discard first 2)
+- N per cell: 10 (warm modes discard first 5)
 
 | Fixture | Mode | N | median (s) | min (s) | max (s) | raw |
 |---|---|---|---|---|---|---|
-| jvm-1 | nodaemon | 7 | 4.83 | 4.37 | 8.12 | 5.09,4.83,4.93,8.12,4.50,4.37,4.49 |
-| jvm-1 | daemon-cold | 7 | 4.59 | 4.08 | 10.12 | 4.08,4.10,4.59,10.12,5.14,4.48,4.82 |
-| jvm-1 | daemon-warm | 7 | 0.66 | 0.59 | 4.01 | 0.78,0.71,4.01,0.65,0.66,0.59,0.66 |
-| jvm-1 | gradle | 7 | 1.19 | 1.15 | 1.56 | 1.56,1.25,1.19,1.19,1.18,1.16,1.15 |
-| jvm-10 | nodaemon | 7 | 5.74 | 5.57 | 8.98 | 5.57,5.74,8.98,5.72,5.75,5.82,5.72 |
-| jvm-10 | daemon-cold | 7 | 5.89 | 5.75 | 9.32 | 9.17,5.82,5.75,5.89,5.88,9.32,6.00 |
-| jvm-10 | daemon-warm | 7 | 0.97 | 0.82 | 1.22 | 1.22,1.11,0.99,0.95,0.97,0.90,0.82 |
-| jvm-10 | gradle | 7 | 1.25 | 1.22 | 1.61 | 1.27,1.25,1.61,1.23,1.25,1.22,1.26 |
-| jvm-25 | nodaemon | 7 | 7.14 | 7.06 | 10.53 | 7.42,7.06,7.17,10.53,7.13,7.07,7.14 |
-| jvm-25 | daemon-cold | 7 | 7.34 | 7.20 | 10.74 | 10.74,7.36,7.21,7.22,10.56,7.34,7.20 |
-| jvm-25 | daemon-warm | 7 | 1.36 | 0.94 | 5.04 | 5.04,1.48,1.46,1.34,1.36,1.13,0.94 |
-| jvm-25 | gradle | 7 | 1.41 | 1.33 | 1.43 | 1.33,1.41,1.36,1.41,1.43,1.36,1.42 |
-| jvm-50 | nodaemon | 7 | 8.64 | 8.41 | 12.03 | 12.03,8.64,8.66,8.59,12.02,8.61,8.41 |
-| jvm-50 | daemon-cold | 7 | 8.84 | 8.69 | 12.14 | 12.14,8.84,8.87,8.69,11.97,8.73,8.73 |
-| jvm-50 | daemon-warm | 7 | 1.65 | 1.22 | 2.27 | 2.27,1.94,1.82,1.65,1.44,1.33,1.22 |
-| jvm-50 | gradle | 7 | 1.61 | 1.54 | 4.65 | 1.56,1.58,2.05,4.65,1.63,1.54,1.61 |
+| jvm-1 | nodaemon | 10 | 4.77 | 4.59 | 8.17 | 4.73,4.59,4.79,4.85,4.77,8.17,4.78,4.61,4.89,4.76 |
+| jvm-1 | daemon-cold | 10 | 4.86 | 4.72 | 8.26 | 4.82,8.26,4.72,4.92,4.80,5.04,4.85,8.19,4.89,4.86 |
+| jvm-1 | daemon-warm | 10 | 0.70 | 0.54 | 3.59 | 0.80,0.73,0.70,0.57,0.57,0.56,0.77,0.88,3.59,0.54 |
+| jvm-1 | gradle | 10 | 1.17 | 1.13 | 1.26 | 1.21,1.26,1.19,1.21,1.13,1.17,1.15,1.15,1.15,1.17 |
+| jvm-10 | nodaemon | 10 | 6.42 | 6.27 | 9.80 | 6.47,9.79,6.27,6.40,6.32,6.42,9.80,6.54,6.41,6.55 |
+| jvm-10 | daemon-cold | 10 | 6.64 | 6.54 | 9.94 | 9.85,6.64,6.59,6.55,6.57,9.67,6.67,6.73,6.54,9.94 |
+| jvm-10 | daemon-warm | 10 | 0.83 | 0.73 | 1.09 | 1.02,1.02,1.09,0.86,0.89,0.78,0.79,0.83,0.73,0.75 |
+| jvm-10 | gradle | 10 | 1.30 | 1.26 | 1.50 | 1.26,1.50,1.36,1.28,1.31,1.32,1.27,1.34,1.30,1.29 |
+| jvm-25 | nodaemon | 10 | 8.30 | 8.05 | 11.56 | 8.25,11.51,8.22,8.30,8.42,11.47,8.38,8.08,11.56,8.05 |
+| jvm-25 | daemon-cold | 10 | 8.23 | 7.97 | 12.27 | 8.23,8.07,12.27,8.43,8.21,11.76,8.50,7.97,8.11,11.63 |
+| jvm-25 | daemon-warm | 10 | 1.16 | 0.93 | 4.11 | 1.40,1.25,1.24,1.12,1.43,4.11,0.99,1.16,0.95,0.93 |
+| jvm-25 | gradle | 10 | 1.49 | 1.46 | 1.89 | 1.53,1.55,1.89,1.60,1.56,1.46,1.49,1.48,1.48,1.49 |
+| jvm-50 | nodaemon | 10 | 10.37 | 10.05 | 13.78 | 13.73,10.05,13.78,10.87,10.36,13.47,10.33,10.37,13.44,10.36 |
+| jvm-50 | daemon-cold | 10 | 10.18 | 9.75 | 13.84 | 10.11,13.60,10.24,9.75,13.55,10.08,10.18,13.84,10.16,10.41 |
+| jvm-50 | daemon-warm | 10 | 1.32 | 1.07 | 4.82 | 1.69,1.71,1.59,1.32,1.36,1.29,4.82,1.14,1.20,1.07 |
+| jvm-50 | gradle | 10 | 1.82 | 1.72 | 5.06 | 1.85,2.05,1.82,2.04,1.77,1.74,1.75,1.72,5.06,1.95 |
 
-This is **run 2**.  Run 1 (saved as `results-2026-04-14-run1.md`) included a
-191.58 s catastrophic sample on `jvm-25 daemon-cold` that is absent here;
-that single sample is now attributed to a WSL2 suspend event during the
-earlier session.  The rest of the outlier structure reproduces across
-both runs and is described below.
+This is **run 3**.  It supersedes run 1 (laptop-sleep confound, single
+191.58 s sample) and run 2 (WARM_DISCARD=2 too small, unfair gradle
+comparison, lighter fixtures).  Run 1 is preserved as
+`results-2026-04-14-run1.md`; run 2 as `results-2026-04-14-run2.md`.
+Run 3 corrects three methodology issues flagged by a sub-agent review
+of run 2 and is the authoritative data for #96.
+
+Differences between run 3 and run 2 that the reader needs to know
+before comparing any numbers:
+
+- **Fixtures are heavier**.  `gen.sh` now emits generic + reified
+  inline functions, a sealed `Op` hierarchy with exhaustive `when`,
+  lambdas with capture, and a cross-package `bench.util` import per
+  file.  Per-file compile work is meaningfully larger; the raw
+  nodaemon numbers go up roughly 10–15 %.
+- **Warm discards are larger**.  `N_RUNS=10`, `WARM_DISCARD=5`.  Run
+  2's `WARM_DISCARD=2` sat the median mid-way up the JIT tier-up
+  curve on `jvm-25` and `jvm-50` warm cells, inflating those medians
+  by 20–30 %.  Run 3 is on flat steady state.
+- **Gradle comparison is fair**.  Run 2 timed `./gradlew clean build
+  -q`, which included `clean`, `test`, `processTestResources`,
+  `compileTestKotlin`, and `testClasses` inside the timed region —
+  none of which kolt was paying.  Run 3 does `rm -rf build` outside
+  the timed region and runs `./gradlew build -x test -q`, skipping
+  the test task family.
 
 ## Summary (medians, seconds)
 
 | Fixture | nodaemon | daemon-cold | daemon-warm | gradle-warm | nodaemon / warm | gradle / warm |
 |---|---|---|---|---|---|---|
-| jvm-1  | 4.83 | 4.59 | 0.66 | 1.19 | 7.3× | 1.8× |
-| jvm-10 | 5.74 | 5.89 | 0.97 | 1.25 | 5.9× | 1.3× |
-| jvm-25 | 7.14 | 7.34 | 1.36 | 1.41 | 5.3× | 1.0× |
-| jvm-50 | 8.64 | 8.84 | 1.65 | 1.61 | 5.2× | 1.0× |
+| jvm-1  | 4.77 | 4.86 | 0.70 | 1.17 | 6.8× | 1.67× |
+| jvm-10 | 6.42 | 6.64 | 0.83 | 1.30 | 7.7× | 1.57× |
+| jvm-25 | 8.30 | 8.23 | 1.16 | 1.49 | 7.2× | 1.28× |
+| jvm-50 | 10.37 | 10.18 | 1.32 | 1.82 | 7.9× | 1.38× |
 
-## Observations
+## Findings
 
-- **Daemon warm vs subprocess**: 5.2–7.3× stable across sizes.  The ratio
-  declines with file count as the compile fraction grows; `jvm-50` sits
-  at 5.2× which is the most defensible number to quote outside the
-  hello-world regime.
-- **Daemon cold regression**: still effectively zero.  Cold medians
-  track nodaemon within ±0.25 s across all four sizes, confirming the
-  `FallbackCompilerBackend` wiring adds no measurable client-side cost.
-- **`warm <1s` ADR target**: holds for `jvm-1` (0.66 s) and `jvm-10`
-  (0.97 s), fails at `jvm-25` (1.36 s).  The crossover lives somewhere
-  around 10–15 source files.  The target text in ADR 0016 should be
-  updated; that is a separate ADR edit, out of scope here per the
-  agreed deliverables list.
-- **Scaling slope**: daemon-warm per-file slope is
-  (1.65 − 0.66) / 49 ≈ 20 ms/file above a ~0.66 s fixed-cost floor
-  (resolve + round-trip + jar write).  The ~0.66 s floor still has
-  headroom above spike #86/#87's 108 ms pure-compile median — resolve
-  phase and native-client JSON encoding are where that gap lives.
-- **Gradle crossover**: `jvm-25` and `jvm-50` land within 0.04 s of
-  gradle-warm.  For fixtures of this shape gradle catches up by ~25
-  files and matches by ~50.  On `jvm-1` kolt is still 1.8× faster due
-  to fixed-cost advantage.  This is the scaling anchor that spike
-  #86/#87 lacked.
+- **Daemon warm vs subprocess is ~7× stable across sizes.**  The
+  ratio sits in a tight 6.8–7.9× band with no monotone trend against
+  file count.  Run 2 reported a declining 7.3× → 5.2× curve; that
+  trend was an artifact of incomplete JIT warmup on the larger
+  fixtures, and should not be cited.  A single "~7×" is the right
+  number to quote.
+- **Daemon cold regression is zero.**  `daemon-cold` tracks `nodaemon`
+  within ±0.25 s on every fixture, same as run 2 and the earlier
+  hello-world Run 2 measurement.  The `FallbackCompilerBackend`
+  wiring continues to add no measurable client-side cost.
+- **`warm < 1 s` Phase A target survives only below ~15–20 files.**
+  `jvm-1` (0.70 s) and `jvm-10` (0.83 s) are inside budget; `jvm-25`
+  (1.16 s) and `jvm-50` (1.32 s) are outside.  The crossover falls
+  somewhere in 10–25 files and is not worth pinning down further
+  without a denser fixture family.  Daemon-warm is a ~0.70 s
+  fixed-cost floor plus a ~12 ms/file slope over this range; slope
+  reduction is #3 incremental's job, not Phase A's.
+- **Gradle crossover does not materialise within this fixture range.**
+  Run 2 reported parity at `jvm-25` / `jvm-50` (1.0×).  Run 3's fair
+  measurement restores a 1.28–1.67× advantage for daemon-warm across
+  all four sizes, with no convergent trend.  The run 2 "gradle
+  catches kolt by jvm-50" conclusion should not be cited — it was
+  partly unfair gradle timing (`clean` + `test` tasks inside the
+  timed region) and partly the inflated kolt warm medians from
+  incomplete JIT warmup.  Gradle-warm's scaling slope on these
+  fixtures is (1.82 − 1.17) / 49 ≈ 13 ms/file, virtually identical
+  to kolt daemon-warm's slope; the gap is in the fixed-cost floor
+  (~1.17 s gradle vs ~0.70 s kolt), not in per-file work.
+- **Resolve-phase tail latency outlier reproduces with the same
+  ~3.3 s signature.**  Nodaemon and daemon-cold cells show 2–3
+  samples out of 10 clustered ~3.3–3.4 s above the median, still
+  size-independent:
 
-## Outlier analysis
-
-Both runs show a reproducible outlier pattern that is **not**
-attributable to laptop sleep.  Laptop sleep accounted only for the
-`191.58 s` single sample in run 1.  The remaining outliers:
-
-- Nodaemon / daemon-cold rows show 1–2 samples per cell roughly
-  3.3–3.4 s above the median, regardless of fixture size:
-
-  | Cell                   | median | outlier | delta |
+  | Cell                  | median | top outlier | delta |
   |---|---|---|---|
-  | jvm-1 nodaemon         | 4.83   | 8.12    | +3.29 |
-  | jvm-10 nodaemon        | 5.74   | 8.98    | +3.24 |
-  | jvm-25 nodaemon        | 7.14   | 10.53   | +3.39 |
-  | jvm-50 nodaemon        | 8.64   | 12.03   | +3.39 |
-  | jvm-50 daemon-cold     | 8.84   | 12.14   | +3.30 |
+  | jvm-1 nodaemon        | 4.77   | 8.17        | +3.40 |
+  | jvm-10 nodaemon       | 6.42   | 9.80        | +3.38 |
+  | jvm-25 nodaemon       | 8.30   | 11.56       | +3.26 |
+  | jvm-50 nodaemon       | 10.37  | 13.78       | +3.41 |
 
-  The delta is **independent of fixture size**, which means the extra
-  cost is a fixed-overhead event, not something that scales with
-  compilation work.  ~2 of 7 runs per cell hit it.
-- Daemon-warm rows are mostly clean (0.82–2.27 s tight distribution)
-  except `jvm-1 run 3 = 4.01 s` and `jvm-25 run 1 = 5.04 s`.  The
-  `jvm-25` warm outlier is the post-prime run which suggests the
-  prime-run discards did not catch a late resolve-phase event.
-- Gradle has a single outlier at `jvm-50 run 4 = 4.65 s` which is
-  consistent with the gradle daemon occasionally re-loading a worker;
-  it does not scale with fixture size either.
+  Hit rate is ~3/10 per cell, consistent with run 2's ~2/7.
+  `WARM_DISCARD=5` did not eliminate it from daemon-warm rows
+  entirely: `jvm-25` run 6 (4.11 s against a 1.16 s median), `jvm-50`
+  run 7 (4.82 s against 1.32 s), `jvm-1` run 9 (3.59 s against 0.70)
+  all match the same ~3.3 s fixed-cost signature.  Singletons out of
+  N=10 do not move the median.  Run 2 attributed the outlier to a
+  maven-metadata refresh in kolt's resolver; that hypothesis is weak
+  (this fixture has only `kotlin-stdlib` and no SNAPSHOT deps, and
+  the resolver has no TTL machinery that would fire on ~30% of
+  invocations).  More likely candidates, none verified, include the
+  `kill_daemon` helper occasionally hitting its 2 s poll-loop
+  ceiling, Kotlin/Native runtime teardown stalls in `kolt.kexe`
+  shutdown, or WSL2 9p filesystem stat storms.  Phase-level
+  instrumentation (kolt self-reported times for resolve vs compile
+  vs jar) is needed to disambiguate; flagged for #88 / #90.
 
-The ~3.3 s fixed-cost outlier appears in every mode that runs kolt's
-`resolving dependencies...` phase on each invocation (nodaemon,
-daemon-cold, and — since warm compile doesn't skip resolve — the
-occasional daemon-warm sample).  It does not appear in gradle, which
-reuses the gradle daemon's resolved classpath.  Best guess is a
-maven-metadata refresh or kotlinc toolchain re-probe in kolt's
-dependency resolver firing on ~28% of invocations.  Flagged for #88
-(rotating fixtures regression monitor) and #90 (long-run leak / resolve
-tail) follow-up — we now have a reproducible signal that the resolve
-phase has ~3 s tail latency.
+## Acknowledged limitations (not fixed in this run)
+
+These were raised in the run-2 methodology review and left
+unaddressed here; they are documented so readers do not
+over-interpret the numbers.
+
+- **Mode ordering is fixed** (`nodaemon → daemon-cold → daemon-warm →
+  gradle`).  Each cell runs 10 samples in a block before moving to
+  the next cell, so thermal state, filesystem cache, and gradle
+  daemon warmth differ systematically across cells.  Interleaving
+  modes within each sample would decouple these confounds but
+  breaks daemon-warm's "keep the daemon alive within the cell"
+  contract.  Not worth restructuring for #96; re-run with a
+  randomised harness if a future measurement needs to discriminate
+  smaller effects.
+- **`daemon-cold` is not "first build after reboot" cold.**  The
+  harness kills the daemon JVM and removes `~/.kolt/daemon/` before
+  each cold sample, but leaves the Linux page cache warm (WSL2's
+  `drop_caches` needs root we do not have scripted).  Real cold-FS
+  performance is not measured.  The headline "zero cold regression"
+  claim is valid for "daemon died, user reinvokes seconds later",
+  which is the realistic case; it is *not* valid for "first invoke
+  after reboot".
+- **N=10 is still underpowered for tight ratios.**  The 6.8–7.9×
+  range is not statistically distinguishable from a flat ~7×
+  without bootstrapping.  Report the range, not two-sigfig point
+  values, when quoting ratios.
+- **CPU governor / thermal state is uncontrolled.**  Host is WSL2
+  on a laptop with default Windows power profile; no `taskset`,
+  no `cpupower frequency-set`, no nice level.  Expect 5–15 %
+  run-to-run drift across sessions.
 
 ## Methodology notes
 
-- `run-bench.sh` kills any running `kolt-compiler-daemon` and removes
-  `~/.kolt/daemon` before each cold run, and before the first daemon-warm
-  run.  `rm -rf build` between every run.
-- Warm modes (`daemon-warm`, `gradle`) discard the first 2 runs as JIT
-  warmup; reported N=7 after discards.
-- `--no-daemon` was measured with the daemon process killed first, per
-  issue #96 open question.
+- `run-bench.sh` kills any running `kolt-compiler-daemon` and
+  removes `~/.kolt/daemon` before each cold sample, and before the
+  first daemon-warm sample.  `rm -rf build` between every sample
+  for every mode.
+- Warm modes (`daemon-warm`, `gradle`) discard the first 5 samples
+  as JIT warmup; reported N=10 after discards.
+- `--no-daemon` is measured with the daemon process killed first.
 - Wall clock via `/usr/bin/time -f '%e'`.
 - Binary under test: `build/bin/linuxX64/releaseExecutable/kolt.kexe`
   built from `feat/gradle-decouple-daemon` at session head.  Dev
   fallback resolves `kolt-compiler-daemon-all.jar` without
   `KOLT_DAEMON_JAR` override.
+- Gradle: `./gradlew build -x test -q` (test task family skipped,
+  `clean` done outside the timed region).  Gradle daemon kept warm
+  across the cell's 15 iterations.
+
+## Provenance
+
+- `results-2026-04-14-run1.md` — original N=7 / WARM_DISCARD=2 /
+  light fixtures / unfair gradle.  Includes a 191.58 s WSL2 suspend
+  sample on `jvm-25 daemon-cold`.
+- `results-2026-04-14-run2.md` — re-run under the same harness and
+  fixtures as run 1; sleep sample gone but the methodology issues
+  remained and drove several wrong conclusions.
+- `results-2026-04-14.md` (this file) — run 3, authoritative for #96.

--- a/spike/bench-scaling/run-bench.sh
+++ b/spike/bench-scaling/run-bench.sh
@@ -17,10 +17,24 @@ FIX_DIR="$HERE/fixtures"
 KOLT_BIN="$REPO_ROOT/build/bin/linuxX64/releaseExecutable/kolt.kexe"
 
 SIZES=(1 10 25 50)
-N_RUNS=7
-WARM_DISCARD=2
+N_RUNS=10
+WARM_DISCARD=5
 
-OUT="$HERE/results-$(date +%Y-%m-%d).md"
+# Pick an output path that does not clobber a previous run on the same day.
+# Previous runs survive as results-YYYY-MM-DD.md, results-YYYY-MM-DD-2.md, ...
+base="$HERE/results-$(date +%Y-%m-%d).md"
+if [[ ! -e "$base" ]]; then
+  OUT="$base"
+else
+  for i in 2 3 4 5 6 7 8 9; do
+    candidate="${base%.md}-${i}.md"
+    if [[ ! -e "$candidate" ]]; then
+      OUT="$candidate"
+      break
+    fi
+  done
+  : "${OUT:?too many same-day runs, clean up manually}"
+fi
 
 if [[ ! -x "$KOLT_BIN" ]]; then
   echo "release kolt binary not found: $KOLT_BIN" >&2
@@ -103,9 +117,14 @@ run_cell() {
       done
       ;;
     gradle)
+      # Fair comparison with kolt: `rm -rf build` happens OUTSIDE the
+      # timed region (kolt's `rm -rf build` does too), and `-x test`
+      # skips the test task family so we are comparing compileKotlin
+      # + jar assembly only.
       prime="$WARM_DISCARD"
       for i in $(seq 1 "$((total_runs + prime))"); do
-        local t; t=$(cd "$fixture_dir" && measure ./gradlew clean build -q)
+        rm -rf "$fixture_dir/build"
+        local t; t=$(cd "$fixture_dir" && measure ./gradlew build -x test -q)
         if (( i > prime )); then
           samples+=("$t")
         fi

--- a/spike/bench-scaling/run-bench.sh
+++ b/spike/bench-scaling/run-bench.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Scaling benchmark harness for issue #96.
+#
+# Measures `kolt build` wall-clock wall time across
+#   (fixture size × mode) ∈ ({1,10,25,50} × {nodaemon, daemon-cold, daemon-warm, gradle})
+# using the release kolt binary. N=7 per cell, median/min/max reported;
+# daemon-warm and gradle modes discard the first 2 runs as JIT warmup.
+#
+# Output: raw per-run table appended into results-YYYY-MM-DD.md next to this
+# script.  Does not modify kolt source or ADRs.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+FIX_DIR="$HERE/fixtures"
+KOLT_BIN="$REPO_ROOT/build/bin/linuxX64/releaseExecutable/kolt.kexe"
+
+SIZES=(1 10 25 50)
+N_RUNS=7
+WARM_DISCARD=2
+
+OUT="$HERE/results-$(date +%Y-%m-%d).md"
+
+if [[ ! -x "$KOLT_BIN" ]]; then
+  echo "release kolt binary not found: $KOLT_BIN" >&2
+  echo "build it first: (cd $REPO_ROOT && ./gradlew linkReleaseExecutableLinuxX64)" >&2
+  exit 1
+fi
+
+# Pattern used to find kolt-compiler-daemon JVM processes (avoid matching
+# our own shell invocations that merely mention the daemon in their cmdline).
+DAEMON_PATTERN='java.*kolt-compiler-daemon-all\.jar'
+
+kill_daemon() {
+  pkill -f "$DAEMON_PATTERN" 2>/dev/null || true
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if ! pgrep -f "$DAEMON_PATTERN" >/dev/null; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  pkill -9 -f "$DAEMON_PATTERN" 2>/dev/null || true
+  sleep 0.3
+}
+
+# Run a command and print elapsed wall seconds (%e) on stdout.
+# /usr/bin/time writes its format line to stderr, so we capture stderr only
+# by redirecting the child's stdout to /dev/null before merging.
+measure() {
+  local t
+  t=$({ /usr/bin/time -f '%e' "$@" >/dev/null; } 2>&1 | tail -1)
+  echo "$t"
+}
+
+median_minmax() {
+  # args: list of decimal seconds
+  local arr=("$@")
+  local sorted
+  sorted=$(printf '%s\n' "${arr[@]}" | sort -n)
+  local n=${#arr[@]}
+  local min max med
+  min=$(echo "$sorted" | head -1)
+  max=$(echo "$sorted" | tail -1)
+  med=$(echo "$sorted" | awk -v n="$n" 'NR==int((n+1)/2)')
+  echo "$med $min $max"
+}
+
+run_cell() {
+  local fixture_dir="$1" mode="$2"
+  local label="$3"
+  local samples=()
+  local prime=0
+  local total_runs="$N_RUNS"
+
+  case "$mode" in
+    nodaemon)
+      for i in $(seq 1 "$total_runs"); do
+        kill_daemon
+        rm -rf "$fixture_dir/build"
+        local t; t=$(cd "$fixture_dir" && measure "$KOLT_BIN" build --no-daemon)
+        samples+=("$t")
+      done
+      ;;
+    daemon-cold)
+      for i in $(seq 1 "$total_runs"); do
+        kill_daemon
+        rm -rf "$fixture_dir/build" "$HOME/.kolt/daemon"
+        local t; t=$(cd "$fixture_dir" && measure "$KOLT_BIN" build)
+        samples+=("$t")
+      done
+      ;;
+    daemon-warm)
+      prime="$WARM_DISCARD"
+      kill_daemon
+      rm -rf "$fixture_dir/build" "$HOME/.kolt/daemon"
+      for i in $(seq 1 "$((total_runs + prime))"); do
+        rm -rf "$fixture_dir/build"
+        local t; t=$(cd "$fixture_dir" && measure "$KOLT_BIN" build)
+        if (( i > prime )); then
+          samples+=("$t")
+        fi
+      done
+      ;;
+    gradle)
+      prime="$WARM_DISCARD"
+      for i in $(seq 1 "$((total_runs + prime))"); do
+        local t; t=$(cd "$fixture_dir" && measure ./gradlew clean build -q)
+        if (( i > prime )); then
+          samples+=("$t")
+        fi
+      done
+      ;;
+    *)
+      echo "unknown mode $mode" >&2
+      return 1
+      ;;
+  esac
+
+  read -r med mn mx <<<"$(median_minmax "${samples[@]}")"
+  local raw
+  raw=$(IFS=,; echo "${samples[*]}")
+  printf '| %s | %s | %d | %s | %s | %s | %s |\n' \
+    "$label" "$mode" "${#samples[@]}" "$med" "$mn" "$mx" "$raw" \
+    >>"$OUT"
+  echo "  $label $mode → median=${med}s min=${mn}s max=${mx}s (n=${#samples[@]})"
+}
+
+{
+  echo "# Phase A daemon scaling benchmark — #96"
+  echo
+  echo "- Date: $(date --iso-8601=seconds)"
+  echo "- Host: $(uname -srm)"
+  echo "- JDK: $(java -version 2>&1 | head -1)"
+  echo "- kolt binary: \`$KOLT_BIN\`"
+  echo "- kolt binary mtime: $(date -r "$KOLT_BIN" --iso-8601=seconds)"
+  echo "- N per cell: $N_RUNS (warm modes discard first $WARM_DISCARD)"
+  echo
+  echo "| Fixture | Mode | N | median (s) | min (s) | max (s) | raw |"
+  echo "|---|---|---|---|---|---|---|"
+} >"$OUT"
+
+for n in "${SIZES[@]}"; do
+  fix="$FIX_DIR/jvm-${n}"
+  [[ -d "$fix" ]] || { echo "missing fixture $fix — run gen.sh first" >&2; exit 1; }
+  echo "==> jvm-${n}"
+  run_cell "$fix" nodaemon     "jvm-${n}"
+  run_cell "$fix" daemon-cold  "jvm-${n}"
+  run_cell "$fix" daemon-warm  "jvm-${n}"
+  run_cell "$fix" gradle       "jvm-${n}"
+done
+
+echo
+echo "results written to $OUT"


### PR DESCRIPTION
Closes #96 once reviewed.

## Summary

Adds `spike/bench-scaling/` — a scaling benchmark for the Phase A warm
JVM compiler daemon, filling the gap left by spike #86/#87 (which
measured `SharedCompilerHost` directly in-JVM on one file, not
end-to-end `kolt build` wall time, and without a Gradle anchor).

- `gen.sh` deterministically generates `fixtures/jvm-{1,10,25,50}` —
  single-module JVM projects with N source files each exercising
  generics + reified inline, sealed `Op` hierarchy with exhaustive
  `when`, lambdas with capture, and a cross-package `bench.util`
  import. Matching `build.gradle.kts` + copied wrapper for gradle
  comparison. `fixtures/` are gitignored.
- `run-bench.sh` drives the release kolt binary through four modes
  (`nodaemon`, `daemon-cold`, `daemon-warm`, `gradle`) per fixture,
  **N=10, warm modes discarding the first 5 runs** as JIT warmup.
  Gradle is invoked as `./gradlew build -x test -q` with `rm -rf
  build` outside the timed region for apples-to-apples comparison.
  `/usr/bin/time -f '%e'` wall clock.
- `results-2026-04-14.md` — **run 3** raw per-run table + summary
  + findings + outlier analysis + acknowledged limitations. Runs
  1 and 2 kept alongside as `-run1.md` / `-run2.md` for provenance.
- ADR 0016 §Benchmark results gains a **Scaling (#96, 2026-04-14)**
  subsection citing the run 3 table.

## Headline numbers (medians, seconds) — run 3

| Fixture | nodaemon | daemon-cold | daemon-warm | gradle-warm | nodaemon/warm | gradle/warm |
|---|---|---|---|---|---|---|
| jvm-1  | 4.77  | 4.86  | 0.70 | 1.17 | 6.8× | 1.67× |
| jvm-10 | 6.42  | 6.64  | 0.83 | 1.30 | 7.7× | 1.57× |
| jvm-25 | 8.30  | 8.23  | 1.16 | 1.49 | 7.2× | 1.28× |
| jvm-50 | 10.37 | 10.18 | 1.32 | 1.82 | 7.9× | 1.38× |

### Findings

- **Daemon warm vs subprocess is ~7× stable across sizes.** Ratio
  sits in a tight 6.8–7.9× band, no monotone trend. Quote "~7×"
  outside the hello-world regime.
- **Daemon cold regression is zero** (within ±0.25 s of nodaemon).
- **`warm < 1 s` target holds only below ~15–20 files.** jvm-1
  0.70 s, jvm-10 0.83 s (inside); jvm-25 1.16 s, jvm-50 1.32 s
  (outside). Daemon-warm is a ~0.70 s fixed-cost floor plus a
  ~12 ms/file slope. Slope reduction belongs to #3 incremental.
- **Gradle does not cross daemon-warm in this range.** Kolt stays
  1.28–1.67× faster across all four sizes. Per-file slopes match
  (~12–13 ms/file); the persistent gap is in the fixed-cost floor
  (~0.70 s kolt vs ~1.17 s gradle). Kolt wins on clean builds by
  amortising fixed cost faster, not by compiling faster.
- **Resolve-phase ~3.3 s tail latency reproduces** as a
  size-independent outlier hitting ~30 % of nodaemon / cold
  samples. Maven-metadata-refresh hypothesis is retracted as weak
  (no SNAPSHOT deps, no TTL machinery). More plausible unverified
  candidates: `kill_daemon` 2 s poll ceiling, Kotlin/Native
  teardown stalls, WSL2 9p stat storms. Flagged for #88 / #90.

### Retractions from run 2

Run 2 produced two wrong headline conclusions that a sub-agent
methodology review caught. Both are retracted and documented
in `results-2026-04-14.md` and the ADR subsection.

1. **"nodaemon/warm ratio declines with size (7.3× → 5.2×)"** —
   artifact of `WARM_DISCARD=2` sitting mid-JIT-tier-up on
   jvm-25 / jvm-50 warm cells. With WARM_DISCARD=5 and N=10 the
   ratio is flat.
2. **"gradle catches kolt by jvm-50"** — artifact of inflated
   kolt warm medians + gradle paying `clean` + `test` work
   inside the timed region. With both fixed, kolt stays 1.38×
   ahead at jvm-50.

### Acknowledged limitations (not fixed, documented)

- Mode ordering is a fixed block-per-cell sequence rather than
  interleaved.
- `daemon-cold` kills the JVM + removes `~/.kolt/daemon/` but
  does not drop the Linux page cache (WSL2, no scripted root).
- N=10 is still underpowered for statistically distinguishing
  6.8× from 7.9×.
- No CPU governor pinning on WSL2 host.

### Out of scope

Incremental compile (#3), multi-module (#89), long-run leak
(#90), rotating-fixture regression (#88), randomised-order bench
harness, ADR 0016 §Context rewrite of the "8 s → 3 s, warm < 1 s"
target text.

## Test plan

- [ ] `./spike/bench-scaling/gen.sh` regenerates fixtures cleanly
- [ ] `./spike/bench-scaling/run-bench.sh` runs end-to-end against a
      freshly-built `build/bin/linuxX64/releaseExecutable/kolt.kexe`
      and produces a new `results-YYYY-MM-DD.md` (auto-suffixing on
      same-day re-runs)
- [ ] Run-3 numbers reproduce within ~15 % on the reviewer's
      machine (WSL2 / Linux, JDK 21)
- [ ] ADR 0016 renders correctly (scaling table, retractions,
      limitations)