### PR TITLE
Add rotating-fixture bench scenario to compile-bench (#88)

### DIFF
--- a/spike/compile-bench/fixtures/rotating/Fixture01.kt
+++ b/spike/compile-bench/fixtures/rotating/Fixture01.kt
@@ -1,0 +1,28 @@
+package fixtures.rotating
+
+data class Point01(val x: Int, val y: Int) {
+    fun translate(dx: Int, dy: Int): Point01 = Point01(x + dx, y + dy)
+}
+
+class Counter01(private var value: Int = 0) {
+    fun inc(): Int {
+        value += 1
+        return value
+    }
+    fun get(): Int = value
+}
+
+fun <T> wrap01(v: T): List<T> = listOf(v, v, v)
+
+fun sum01(xs: List<Int>): Int {
+    var acc = 0
+    for (x in xs) acc += x
+    return acc
+}
+
+fun main01() {
+    val p = Point01(1, 2).translate(3, 4)
+    val c = Counter01()
+    c.inc(); c.inc()
+    println("${p.x},${p.y} -> ${c.get()} -> ${wrap01(sum01(listOf(1, 2, 3)))}")
+}

--- a/spike/compile-bench/fixtures/rotating/Fixture02.kt
+++ b/spike/compile-bench/fixtures/rotating/Fixture02.kt
@@ -1,0 +1,26 @@
+package fixtures.rotating
+
+sealed class Shape02 {
+    data class Circle(val r: Double) : Shape02()
+    data class Square(val side: Double) : Shape02()
+}
+
+fun Shape02.area02(): Double = when (this) {
+    is Shape02.Circle -> 3.14159 * r * r
+    is Shape02.Square -> side * side
+}
+
+class Registry02<T : Any> {
+    private val items = mutableListOf<T>()
+    fun add(v: T) { items += v }
+    fun snapshot(): List<T> = items.toList()
+}
+
+fun describe02(s: Shape02): String = "shape=${s::class.simpleName} area=${s.area02()}"
+
+fun main02() {
+    val reg = Registry02<Shape02>()
+    reg.add(Shape02.Circle(2.0))
+    reg.add(Shape02.Square(3.0))
+    reg.snapshot().forEach { println(describe02(it)) }
+}

--- a/spike/compile-bench/fixtures/rotating/Fixture03.kt
+++ b/spike/compile-bench/fixtures/rotating/Fixture03.kt
@@ -1,0 +1,25 @@
+package fixtures.rotating
+
+data class User03(val id: Long, val name: String, val email: String)
+
+class UserStore03 {
+    private val byId = mutableMapOf<Long, User03>()
+    fun put(u: User03): User03? = byId.put(u.id, u)
+    fun get(id: Long): User03? = byId[id]
+    fun all(): Collection<User03> = byId.values
+    fun size(): Int = byId.size
+}
+
+fun <K, V> invert03(m: Map<K, V>): Map<V, K> {
+    val out = mutableMapOf<V, K>()
+    for ((k, v) in m) out[v] = k
+    return out
+}
+
+fun main03() {
+    val store = UserStore03()
+    store.put(User03(1, "alice", "a@x"))
+    store.put(User03(2, "bob", "b@x"))
+    println(store.all())
+    println(invert03(mapOf("a" to 1, "b" to 2)))
+}

--- a/spike/compile-bench/fixtures/rotating/Fixture04.kt
+++ b/spike/compile-bench/fixtures/rotating/Fixture04.kt
@@ -1,0 +1,27 @@
+package fixtures.rotating
+
+interface Parser04<T> {
+    fun parse(s: String): T?
+}
+
+object IntParser04 : Parser04<Int> {
+    override fun parse(s: String): Int? = s.toIntOrNull()
+}
+
+class ListParser04<T>(private val element: Parser04<T>, private val sep: String = ",") : Parser04<List<T>> {
+    override fun parse(s: String): List<T>? {
+        val parts = s.split(sep)
+        val out = mutableListOf<T>()
+        for (p in parts) {
+            val v = element.parse(p.trim()) ?: return null
+            out += v
+        }
+        return out
+    }
+}
+
+fun main04() {
+    val p = ListParser04(IntParser04)
+    println(p.parse("1, 2, 3, 4"))
+    println(p.parse("1, x, 3"))
+}

--- a/spike/compile-bench/fixtures/rotating/Fixture05.kt
+++ b/spike/compile-bench/fixtures/rotating/Fixture05.kt
@@ -1,0 +1,24 @@
+package fixtures.rotating
+
+data class Vec05(val x: Double, val y: Double, val z: Double) {
+    operator fun plus(o: Vec05) = Vec05(x + o.x, y + o.y, z + o.z)
+    operator fun times(k: Double) = Vec05(x * k, y * k, z * k)
+    fun dot(o: Vec05): Double = x * o.x + y * o.y + z * o.z
+    fun length(): Double {
+        val l2 = dot(this)
+        var g = l2
+        repeat(8) { g = 0.5 * (g + l2 / g) }
+        return g
+    }
+}
+
+fun centroid05(points: List<Vec05>): Vec05 {
+    var acc = Vec05(0.0, 0.0, 0.0)
+    for (p in points) acc = acc + p
+    return acc * (1.0 / points.size)
+}
+
+fun main05() {
+    val c = centroid05(listOf(Vec05(1.0, 0.0, 0.0), Vec05(0.0, 1.0, 0.0), Vec05(0.0, 0.0, 1.0)))
+    println("$c ${c.length()}")
+}

--- a/spike/compile-bench/fixtures/rotating/Fixture06.kt
+++ b/spike/compile-bench/fixtures/rotating/Fixture06.kt
@@ -1,0 +1,26 @@
+package fixtures.rotating
+
+sealed interface Tree06<out T> {
+    data object Empty : Tree06<Nothing>
+    data class Node<T>(val value: T, val left: Tree06<T>, val right: Tree06<T>) : Tree06<T>
+}
+
+fun <T : Comparable<T>> insert06(t: Tree06<T>, v: T): Tree06<T> = when (t) {
+    Tree06.Empty -> Tree06.Node(v, Tree06.Empty, Tree06.Empty)
+    is Tree06.Node -> when {
+        v < t.value -> Tree06.Node(t.value, insert06(t.left, v), t.right)
+        v > t.value -> Tree06.Node(t.value, t.left, insert06(t.right, v))
+        else -> t
+    }
+}
+
+fun <T> size06(t: Tree06<T>): Int = when (t) {
+    Tree06.Empty -> 0
+    is Tree06.Node -> 1 + size06(t.left) + size06(t.right)
+}
+
+fun main06() {
+    var t: Tree06<Int> = Tree06.Empty
+    for (v in listOf(5, 3, 7, 1, 4, 6, 8)) t = insert06(t, v)
+    println(size06(t))
+}

--- a/spike/compile-bench/fixtures/rotating/Fixture07.kt
+++ b/spike/compile-bench/fixtures/rotating/Fixture07.kt
@@ -1,0 +1,26 @@
+package fixtures.rotating
+
+data class Event07(val topic: String, val payload: String, val ts: Long)
+
+class EventBus07 {
+    private val handlers = mutableMapOf<String, MutableList<(Event07) -> Unit>>()
+    fun subscribe(topic: String, h: (Event07) -> Unit) {
+        handlers.getOrPut(topic) { mutableListOf() }.add(h)
+    }
+    fun publish(e: Event07) {
+        handlers[e.topic]?.forEach { it(e) }
+    }
+}
+
+fun <T, R> pipeline07(input: List<T>, vararg stages: (T) -> R): List<R> {
+    val out = mutableListOf<R>()
+    for (x in input) for (s in stages) out += s(x)
+    return out
+}
+
+fun main07() {
+    val bus = EventBus07()
+    bus.subscribe("t") { println(it.payload) }
+    bus.publish(Event07("t", "hi", 0))
+    println(pipeline07(listOf(1, 2, 3), { it + 1 }, { it * 2 }))
+}

--- a/spike/compile-bench/fixtures/rotating/Fixture08.kt
+++ b/spike/compile-bench/fixtures/rotating/Fixture08.kt
@@ -1,0 +1,30 @@
+package fixtures.rotating
+
+enum class Level08 { DEBUG, INFO, WARN, ERROR }
+
+data class LogLine08(val level: Level08, val msg: String, val tags: List<String>)
+
+class Logger08(val minimum: Level08 = Level08.INFO) {
+    private val sink = mutableListOf<LogLine08>()
+    fun log(level: Level08, msg: String, vararg tags: String) {
+        if (level.ordinal >= minimum.ordinal) sink += LogLine08(level, msg, tags.toList())
+    }
+    fun drain(): List<LogLine08> {
+        val copy = sink.toList()
+        sink.clear()
+        return copy
+    }
+}
+
+fun groupByLevel08(lines: List<LogLine08>): Map<Level08, Int> {
+    val counts = mutableMapOf<Level08, Int>()
+    for (l in lines) counts[l.level] = (counts[l.level] ?: 0) + 1
+    return counts
+}
+
+fun main08() {
+    val log = Logger08()
+    log.log(Level08.INFO, "hello", "boot")
+    log.log(Level08.ERROR, "oops", "io", "fatal")
+    println(groupByLevel08(log.drain()))
+}

--- a/spike/compile-bench/fixtures/rotating/Fixture09.kt
+++ b/spike/compile-bench/fixtures/rotating/Fixture09.kt
@@ -1,0 +1,33 @@
+package fixtures.rotating
+
+class RingBuffer09<T>(private val capacity: Int) {
+    private val buf = arrayOfNulls<Any?>(capacity)
+    private var head = 0
+    private var count = 0
+    fun push(v: T) {
+        val idx = (head + count) % capacity
+        buf[idx] = v
+        if (count < capacity) count += 1 else head = (head + 1) % capacity
+    }
+    @Suppress("UNCHECKED_CAST")
+    fun toList(): List<T> {
+        val out = mutableListOf<T>()
+        for (i in 0 until count) out += buf[(head + i) % capacity] as T
+        return out
+    }
+    fun size(): Int = count
+}
+
+fun <T> slidingWindow09(xs: List<T>, size: Int): List<List<T>> {
+    val rb = RingBuffer09<T>(size)
+    val out = mutableListOf<List<T>>()
+    for (x in xs) {
+        rb.push(x)
+        if (rb.size() == size) out += rb.toList()
+    }
+    return out
+}
+
+fun main09() {
+    println(slidingWindow09(listOf(1, 2, 3, 4, 5), 3))
+}

--- a/spike/compile-bench/fixtures/rotating/Fixture10.kt
+++ b/spike/compile-bench/fixtures/rotating/Fixture10.kt
@@ -1,0 +1,37 @@
+package fixtures.rotating
+
+data class Money10(val amount: Long, val currency: String) {
+    init { require(currency.length == 3) }
+    operator fun plus(o: Money10): Money10 {
+        require(currency == o.currency)
+        return Money10(amount + o.amount, currency)
+    }
+}
+
+interface Account10 {
+    val id: String
+    fun balance(): Money10
+    fun deposit(m: Money10)
+}
+
+class InMemoryAccount10(override val id: String, currency: String) : Account10 {
+    private var bal = Money10(0, currency)
+    override fun balance(): Money10 = bal
+    override fun deposit(m: Money10) { bal = bal + m }
+}
+
+fun totalByCurrency10(accounts: List<Account10>): Map<String, Long> {
+    val out = mutableMapOf<String, Long>()
+    for (a in accounts) {
+        val b = a.balance()
+        out[b.currency] = (out[b.currency] ?: 0) + b.amount
+    }
+    return out
+}
+
+fun main10() {
+    val a = InMemoryAccount10("a", "JPY")
+    a.deposit(Money10(100, "JPY"))
+    a.deposit(Money10(250, "JPY"))
+    println(totalByCurrency10(listOf(a)))
+}

--- a/spike/compile-bench/src/main/kotlin/bench/Bench.kt
+++ b/spike/compile-bench/src/main/kotlin/bench/Bench.kt
@@ -47,6 +47,45 @@ fun main() {
     println("  late  warm avg : ${lastQuarter.toLong()} ms")
     println("  drift (late - early): ${(lastQuarter - firstQuarter).toLong()} ms")
 
+    System.gc()
+    Thread.sleep(200)
+
+    val rotatingDir = File("fixtures/rotating").absoluteFile
+    val rotatingSources = rotatingDir.listFiles { f -> f.isFile && f.name.endsWith(".kt") }
+        ?.sortedBy { it.name }
+        ?: error("missing rotating fixtures dir: ${rotatingDir.path}")
+    check(rotatingSources.size >= 10) {
+        "expected at least 10 rotating fixtures, got ${rotatingSources.size}"
+    }
+
+    // n=50 mirrors Scenario C for apples-to-apples comparison. Note that with 10 fixtures
+    // the first and last quarters (12 samples each) see slightly different fixture mixes;
+    // the rotation/JIT noise floor is larger than per-fixture variance so this is tolerated.
+    val rotatingN = 50
+    println()
+    println("=== Scenario D: shared loader rotating fixtures (n=$rotatingN, ${rotatingSources.size} files) ===")
+    val sharedD = SharedLoaderCompileDriver(jars, fixtureCp)
+    val memBeforeD = usedHeapMb()
+    val rotatingTimes = List(rotatingN) { i ->
+        var result: CompileResult? = null
+        val source = listOf(rotatingSources[i % rotatingSources.size])
+        val ms = measureTimeMillis { result = sharedD.compile(source, freshOutputDir()) }
+        check(result is CompileResult.Ok) { "rotating compile failed at i=$i (${source.first().name}): $result" }
+        ms
+    }
+    System.gc()
+    Thread.sleep(200)
+    val memAfterD = usedHeapMb()
+    reportTimes(rotatingTimes)
+    println("  heap before: $memBeforeD MB")
+    println("  heap after : $memAfterD MB")
+    println("  heap delta : ${memAfterD - memBeforeD} MB")
+    val firstQuarterD = rotatingTimes.drop(1).take(rotatingN / 4).average()
+    val lastQuarterD = rotatingTimes.takeLast(rotatingN / 4).average()
+    println("  early warm avg : ${firstQuarterD.toLong()} ms")
+    println("  late  warm avg : ${lastQuarterD.toLong()} ms")
+    println("  drift (late - early): ${(lastQuarterD - firstQuarterD).toLong()} ms")
+
     val sharedWarm = sharedTimes.drop(1).average()
     val isoWarm = isoTimes.drop(1).average()
     val overhead = (isoWarm - sharedWarm).toLong()
@@ -55,12 +94,41 @@ fun main() {
     val driftGate = 500L
     val verdictC = if ((lastQuarter - firstQuarter) < driftGate && (memAfter - memBefore) < 200) "PASS" else "FAIL"
 
+    val rotatingWarm = rotatingTimes.drop(1).average()
+    // Gate D against C (same n=50, same shared loader, single hot file) so the ratio
+    // isolates the rotation effect. A (n=10 Hello.kt) is kept as info only — comparing
+    // rotating non-trivial fixtures to a trivial stub would measure fixture size, not
+    // shared-loader reuse under rotation.
+    val longWarm = longTimes.drop(1).average()
+    val rotatingRatio = rotatingWarm / longWarm
+    val rotatingRatioA = rotatingWarm / sharedWarm
+    // Signed drift: we only want to FAIL on late-window regressions (leak / fragmentation).
+    // A strongly negative drift means the JIT is still improving at iteration ~40, which
+    // is healthy — do not switch this to abs().
+    val rotatingDrift = (lastQuarterD - firstQuarterD)
+    val rotatingHeapDelta = memAfterD - memBeforeD
+    val rotatingRatioGate = 2.0
+    val rotatingDriftGate = 200L
+    val rotatingHeapGate = 50L
+    val verdictD = if (
+        rotatingRatio < rotatingRatioGate &&
+        rotatingDrift < rotatingDriftGate &&
+        rotatingHeapDelta < rotatingHeapGate
+    ) "PASS" else "FAIL"
+
     println()
     println("=== Verdict ===")
     println("Scenario A (shared warm avg): ${sharedWarm.toLong()} ms")
     println("Scenario B (isolated warm avg): ${isoWarm.toLong()} ms")
     println("Scenario B overhead: $overhead ms  ->  kill criterion < $gate ms  ->  $verdictB")
     println("Scenario C drift: ${(lastQuarter - firstQuarter).toLong()} ms, heap delta: ${memAfter - memBefore} MB  ->  $verdictC")
+    println("Scenario D (rotating warm avg): ${rotatingWarm.toLong()} ms")
+    println(
+        "Scenario D ratio vs C: ${"%.2f".format(rotatingRatio)}x (gate < ${rotatingRatioGate}x), " +
+            "drift: ${rotatingDrift.toLong()} ms (gate < $rotatingDriftGate ms), " +
+            "heap delta: $rotatingHeapDelta MB (gate < $rotatingHeapGate MB)  ->  $verdictD"
+    )
+    println("Scenario D ratio vs A (info only): ${"%.2f".format(rotatingRatioA)}x")
 }
 
 private fun usedHeapMb(): Long {


### PR DESCRIPTION
## Summary

- Adds Scenario D to `spike/compile-bench/`: compiles 10 distinct non-trivial fixtures on a shared URLClassLoader across 50 iterations
- 10 fixtures under `fixtures/rotating/` exercise data classes, sealed types, generics, operators, interfaces, enums, recursion — PSI caches cannot trivially hit across rotations
- Verdict gates per #88: warm avg within 2× of Scenario C (same n, isolates rotation), signed drift < 200 ms (late-window regression only), heap delta < 50 MB over 50 iterations

## Why

Follow-up spike from #14 Phase A (see #86 comment). Re-scoped in ADR 0016 §5 as a **regression-monitoring** tool — no longer gating any rollout since the daemon shipped default-on. Confirms shared-loader reuse holds under a realistic rotating workload, not only the hot-PSI single-file case in Scenario C.

## Result (local run)

```
Scenario A (Hello.kt n=10)      warm avg ~225 ms
Scenario C (Hello.kt n=50)      warm avg ~130 ms   PASS
Scenario D (rotating n=50)      warm avg ~256 ms
  ratio vs C (gated)            1.97x   (< 2.0x)   PASS
  ratio vs A (info only)        1.14x
  drift (late - early)          -266 ms (< 200 ms) PASS
  heap delta                    12 MB   (< 50 MB)  PASS
```

Signed drift is intentional — we fail only on late-window regressions. A strongly negative drift means the JIT is still improving, which is healthy.

## Review notes

One independent sub-agent review pass applied. Key gate-baseline change: ratio is compared against Scenario C (same n, same shared loader) rather than Scenario A (n=10), so the metric isolates rotation effect rather than measuring fixture-size differences. The 1.97x headroom to the 2.0x gate is tight — if this spike is ever promoted to a CI gate, the C-vs-D fixture-size delta should be revisited (e.g. by adding a non-rotating non-trivial baseline).

## Test plan

- [x] `./gradlew run` in `spike/compile-bench/` — all four scenarios execute, Scenario D reports PASS
- [x] Sub-agent code review (correctness, fixture quality, drift interpretation, gate baseline) — should-fix items applied