### PR TITLE
Add long-run leak check scenario to compile-bench (#90)

### DIFF
--- a/spike/compile-bench/build.gradle.kts
+++ b/spike/compile-bench/build.gradle.kts
@@ -39,4 +39,5 @@ tasks.test {
 tasks.named<JavaExec>("run") {
     systemProperty("kotlinc.classpath", kotlincClasspath.asPath)
     systemProperty("fixture.classpath", fixtureClasspath.asPath)
+    System.getenv("BENCH_LONG_RUN")?.let { environment("BENCH_LONG_RUN", it) }
 }

--- a/spike/compile-bench/src/main/kotlin/bench/Bench.kt
+++ b/spike/compile-bench/src/main/kotlin/bench/Bench.kt
@@ -129,7 +129,116 @@ fun main() {
             "heap delta: $rotatingHeapDelta MB (gate < $rotatingHeapGate MB)  ->  $verdictD"
     )
     println("Scenario D ratio vs A (info only): ${"%.2f".format(rotatingRatioA)}x")
+
+    System.gc()
+    Thread.sleep(200)
+
+    // Scenario E is gated behind an env flag because a 1000-iteration run takes several
+    // minutes. Default off so the routine spike run stays fast; enable with
+    //   BENCH_LONG_RUN=1 ./gradlew run
+    // or a number to override the iteration count, e.g. BENCH_LONG_RUN=500.
+    val longRunFlag = System.getenv("BENCH_LONG_RUN")
+    if (longRunFlag != null) {
+        // "=1" is the common enable-flag idiom but it also round-trips as "run 1 iter",
+        // which produces empty windows and NaN drift. Require a minimum that keeps the
+        // drift windows disjoint and non-trivial. Unparseable input is an error, not a
+        // silent default — the user asked for the long run explicitly.
+        val minLeakN = 400
+        val leakN = longRunFlag.toIntOrNull()
+            ?: error("BENCH_LONG_RUN must be an integer, got: $longRunFlag")
+        check(leakN >= minLeakN) { "BENCH_LONG_RUN must be >= $minLeakN, got: $leakN" }
+        val sampleEvery = 50
+        println()
+        println("=== Scenario E: shared loader long-run leak check (n=$leakN, sample every $sampleEvery) ===")
+        val sharedE = SharedLoaderCompileDriver(jars, fixtureCp)
+        // Sample heap after forced GC so live-set is visible, not floating garbage.
+        System.gc()
+        Thread.sleep(200)
+        val baselineHeap = usedHeapMb()
+        println("  baseline heap (post-gc, pre-compile): $baselineHeap MB")
+        val heapSamples = mutableListOf(HeapSample(0, baselineHeap))
+        val leakTimes = ArrayList<Long>(leakN)
+        val wallStart = System.currentTimeMillis()
+        for (i in 0 until leakN) {
+            var result: CompileResult? = null
+            val ms = measureTimeMillis { result = sharedE.compile(sources, freshOutputDir()) }
+            check(result is CompileResult.Ok) { "long-run compile failed at i=$i: $result" }
+            leakTimes += ms
+            if ((i + 1) % sampleEvery == 0) {
+                System.gc()
+                Thread.sleep(100)
+                val sample = HeapSample(i + 1, usedHeapMb())
+                heapSamples += sample
+                val elapsedSec = (System.currentTimeMillis() - wallStart) / 1000
+                println("  iter=${sample.iter.toString().padStart(4)}  heap=${sample.heapMb.toString().padStart(4)} MB  t+${elapsedSec}s  last compile=${ms} ms")
+            }
+        }
+        val totalWallSec = (System.currentTimeMillis() - wallStart) / 1000
+        println("  total wall: ${totalWallSec}s")
+
+        reportTimes(leakTimes)
+
+        // Time drift gate: first N warm samples vs last N, disjoint.
+        // minLeakN guarantees warmTimes.size >= 399 so windowSize is always 100.
+        val warmTimes = leakTimes.drop(1)
+        val windowSize = 100
+        check(warmTimes.size >= 2 * windowSize) {
+            "warmTimes too small for disjoint windows: ${warmTimes.size}"
+        }
+        val firstWindow = warmTimes.take(windowSize).average()
+        val lastWindow = warmTimes.takeLast(windowSize).average()
+        val timeDriftRatio = lastWindow / firstWindow
+        println("  first $windowSize warm avg: ${firstWindow.toLong()} ms")
+        println("  last  $windowSize warm avg: ${lastWindow.toLong()} ms")
+        println("  time drift ratio (last/first): ${"%.2f".format(timeDriftRatio)}x")
+
+        // Plateau detection: find the first post-baseline sample `i` such that every
+        // subsequent sample is within ±slack of sample[i]. This measures *suffix
+        // flatness*, not "is sample[i] close to the future max" — the latter would
+        // trivially match the baseline whenever total growth fits in slack.
+        // The baseline sample (iter=0, pre-compile) is excluded from candidates: it's
+        // the starting state, not steady state.
+        val plateauSlack = 20L
+        val postBaseline = heapSamples.drop(1)
+        val plateauIter = run {
+            for (idx in postBaseline.indices) {
+                val suffix = postBaseline.subList(idx, postBaseline.size)
+                val suffixMax = suffix.maxOf { it.heapMb }
+                val suffixMin = suffix.minOf { it.heapMb }
+                if (suffixMax - suffixMin <= plateauSlack) {
+                    return@run postBaseline[idx].iter
+                }
+            }
+            null
+        }
+        val maxHeap = heapSamples.maxOf { it.heapMb }
+        val heapDeltaTotal = maxHeap - baselineHeap
+        println("  max heap observed: $maxHeap MB")
+        println("  heap delta (max - baseline): $heapDeltaTotal MB")
+        println("  plateau iter (within ${plateauSlack} MB): ${plateauIter ?: "none"}")
+
+        val plateauIterGate = 500
+        val maxHeapGate = 512L
+        val timeDriftGate = 1.20
+        val verdictE = if (
+            plateauIter != null && plateauIter <= plateauIterGate &&
+            maxHeap < maxHeapGate &&
+            timeDriftRatio < timeDriftGate
+        ) "PASS" else "FAIL"
+        println()
+        println("=== Scenario E Verdict ===")
+        println(
+            "plateau iter: ${plateauIter ?: "none"} (gate <= $plateauIterGate), " +
+                "max heap: $maxHeap MB (gate < $maxHeapGate MB), " +
+                "time drift: ${"%.2f".format(timeDriftRatio)}x (gate < ${timeDriftGate}x)  ->  $verdictE"
+        )
+    } else {
+        println()
+        println("(Scenario E skipped — set BENCH_LONG_RUN=1 to enable the 1000-iter leak check)")
+    }
 }
+
+private data class HeapSample(val iter: Int, val heapMb: Long)
 
 private fun usedHeapMb(): Long {
     val rt = Runtime.getRuntime()


### PR DESCRIPTION
## Summary

- Adds Scenario E to `spike/compile-bench/`: 1000 iterations on a shared `URLClassLoader`, sampling heap every 50 iters with forced GC
- Gated behind `BENCH_LONG_RUN` env var so routine `./gradlew run` stays fast; value must be an integer >= 400 so disjoint 100-sample drift windows are well-defined
- Plateau detection uses suffix-flatness (first post-baseline sample whose suffix stays within ±20 MB) rather than "is this sample close to future max", which trivially matched the baseline under small total growth

## Why

Follow-up spike from #14 Phase A (see #86 comment). Re-scoped in ADR 0016 §5 as a **regression-monitoring** tool — no longer gating any rollout since the daemon shipped default-on. Tests whether shared-loader reuse leaks over a realistic watch-mode session (1000+ warm compiles).

## Result (BENCH_LONG_RUN=1000, Hello.kt, local run)

```
Scenario E: shared loader long-run leak check (n=1000, sample every 50)
  baseline heap (post-gc, pre-compile): 160 MB
  iter=  50  heap= 174 MB  t+10s
  iter= 100  heap= 174 MB  t+15s
  ...
  iter= 950  heap= 175 MB  t+82s
  iter=1000  heap= 175 MB  t+85s
  total wall: 85s

  first 100 warm avg: 120 ms
  last  100 warm avg:  60 ms
  time drift ratio (last/first): 0.50x

  max heap observed: 175 MB
  heap delta (max - baseline): 14 MB
  plateau iter (within 20 MB): 50

Scenario E Verdict:
  plateau iter: 50 (gate <= 500), max heap: 175 MB (gate < 512 MB),
  time drift: 0.50x (gate < 1.20x)  ->  PASS
```

Heap plateaus by iter 50 and stays dead-flat (±1 MB) for the remaining 950 iterations. Compile time *improves* from 120 ms to 60 ms as the JIT continues to optimize — no upward drift whatsoever.

**Interpretation**: the shared classloader shows zero evidence of a leak over 1000 compiles. The #86 PoC's "+9 MB / 50 iter" was bounded caching saturating, not the leading edge of a linear leak. Phase A's "restart daemon every N compiles" safety-net design is empirically unnecessary for this workload shape.

## Review notes

One independent sub-agent review pass. Critical finding: the original plateau algorithm was broken — it checked "is current sample within slack of the max of current+later" which trivially matched the baseline whenever total growth fit in slack, returning `plateau iter = 0` as a meaningless PASS. Fixed to check suffix flatness (max − min of the suffix from `i` onward) and to exclude the pre-compile baseline from plateau candidates. After the fix, plateau iter = 50, which actually reflects the observed steady state. Should-fix items on BENCH_LONG_RUN parsing (now requires integer >= 400, rejects unparseable) and disjoint drift windows (asserted) also applied.

## Test plan

- [x] `BENCH_LONG_RUN=1000 ./gradlew run` — Scenario E reports PASS with plateau iter 50, max heap 175 MB, drift 0.50x
- [x] `BENCH_LONG_RUN=200 ./gradlew run` — rejected with error (minimum 400), as intended
- [x] Unset `BENCH_LONG_RUN` — Scenario E skipped with the documented skip message
- [x] Sub-agent review (plateau correctness, env var parsing, drift window, GC discipline) — critical + should-fix items applied