### PR TITLE
Add Phase B-1a scenario F to bench-scaling harness (#103)

### DIFF
--- a/spike/bench-scaling/results-2026-04-14-2.md
+++ b/spike/bench-scaling/results-2026-04-14-2.md
@@ -1,0 +1,48 @@
+# Phase A daemon scaling benchmark — #96 (SUPERSEDED)
+
+> **SUPERSEDED by `results-2026-04-14-3.md`.** This run's `daemon-warm-touch`
+> numbers are contaminated by a mtime-granularity bug in an earlier version
+> of `run-bench.sh`: a plain `touch` called within the same wall-clock second
+> as the previous build left the file mtime unchanged under WSL2 9p's 1-second
+> granularity, so `BuildCache` short-circuited to the up-to-date fast path
+> and the "touched → full recompile" signal was lost on jvm-1 entirely and
+> intermittently on jvm-10+. Kept as negative-result context for #103; do
+> not use these `daemon-warm-touch` numbers. The fix (monotonically-
+> increasing synthetic epoch via `touch -d "@${base+counter}"`) is applied
+> in run 3.
+
+# Phase A daemon scaling benchmark — #96
+
+- Date: 2026-04-14T22:59:26+09:00
+- Host: Linux 6.6.87.2-microsoft-standard-WSL2 x86_64
+- JDK: openjdk version "21.0.7" 2025-04-15 LTS
+- kolt binary: `/home/makino/projects/snicmakino/kolt/build/bin/linuxX64/releaseExecutable/kolt.kexe`
+- kolt binary mtime: 2026-04-14T18:16:31+09:00
+- N per cell: 10 (warm modes discard first 5)
+
+| Fixture | Mode | N | median (s) | min (s) | max (s) | raw |
+|---|---|---|---|---|---|---|
+| jvm-1 | nodaemon | 10 | 5.34 | 5.07 | 5.59 | 5.28,5.43,5.41,5.59,5.20,5.07,5.16,5.42,5.50,5.34 |
+| jvm-1 | daemon-cold | 10 | 5.04 | 4.78 | 5.37 | 5.19,5.37,4.88,5.29,5.04,4.78,5.07,4.95,5.25,4.89 |
+| jvm-1 | daemon-warm | 10 | 0.64 | 0.57 | 0.83 | 0.79,0.81,0.83,0.68,0.64,0.64,0.61,0.68,0.57,0.57 |
+| jvm-1 | gradle | 10 | 1.78 | 1.64 | 2.81 | 2.81,2.31,2.13,2.03,1.83,1.78,1.72,1.69,1.70,1.64 |
+| jvm-1 | daemon-warm-noop | 10 | 0.01 | 0.00 | 0.01 | 0.00,0.00,0.00,0.00,0.01,0.01,0.01,0.01,0.01,0.01 |
+| jvm-1 | daemon-warm-touch | 10 | 0.01 | 0.01 | 0.84 | 0.84,0.01,0.01,0.01,0.01,0.84,0.01,0.01,0.01,0.01 |
+| jvm-10 | nodaemon | 10 | 7.35 | 7.24 | 8.16 | 7.35,7.33,8.16,7.38,7.30,7.31,7.66,7.54,7.49,7.24 |
+| jvm-10 | daemon-cold | 10 | 7.33 | 7.11 | 7.84 | 7.61,7.23,7.11,7.22,7.34,7.24,7.84,7.33,7.57,7.58 |
+| jvm-10 | daemon-warm | 10 | 1.01 | 0.79 | 1.52 | 1.52,1.35,1.38,1.23,1.18,1.01,1.00,0.94,0.79,0.83 |
+| jvm-10 | gradle | 10 | 1.82 | 1.74 | 2.31 | 2.07,2.01,2.14,2.31,1.98,1.82,1.82,1.79,1.74,1.80 |
+| jvm-10 | daemon-warm-noop | 10 | 0.01 | 0.01 | 0.01 | 0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01 |
+| jvm-10 | daemon-warm-touch | 10 | 1.01 | 0.01 | 1.24 | 1.24,1.20,1.20,1.15,1.17,1.01,0.91,0.86,0.01,0.01 |
+| jvm-25 | nodaemon | 10 | 9.52 | 8.97 | 10.20 | 9.60,10.20,9.52,9.15,9.19,9.88,9.41,8.97,10.07,9.53 |
+| jvm-25 | daemon-cold | 10 | 9.44 | 9.28 | 9.70 | 9.28,9.70,9.28,9.59,9.65,9.68,9.34,9.49,9.31,9.44 |
+| jvm-25 | daemon-warm | 10 | 1.35 | 1.04 | 1.53 | 1.53,1.52,1.51,1.35,1.44,1.28,1.25,1.37,1.08,1.04 |
+| jvm-25 | gradle | 10 | 1.86 | 1.77 | 2.03 | 2.00,1.96,1.87,1.85,1.77,1.78,1.86,2.03,1.88,1.79 |
+| jvm-25 | daemon-warm-noop | 10 | 0.01 | 0.01 | 0.01 | 0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01 |
+| jvm-25 | daemon-warm-touch | 10 | 1.24 | 0.99 | 1.71 | 1.71,1.66,1.57,1.33,1.34,1.24,1.21,1.23,0.99,1.01 |
+| jvm-50 | nodaemon | 10 | 12.52 | 11.63 | 12.95 | 11.63,12.63,12.58,12.52,12.95,12.04,12.27,12.22,12.53,12.71 |
+| jvm-50 | daemon-cold | 10 | 12.35 | 11.83 | 12.83 | 12.62,12.35,12.30,12.67,12.11,12.83,12.39,12.31,12.83,11.83 |
+| jvm-50 | daemon-warm | 10 | 1.42 | 1.20 | 1.98 | 1.83,1.83,1.73,1.62,1.41,1.42,1.31,1.98,1.36,1.20 |
+| jvm-50 | gradle | 10 | 2.11 | 1.85 | 2.46 | 2.17,2.18,2.13,2.11,2.14,2.03,2.11,2.46,1.85,1.90 |
+| jvm-50 | daemon-warm-noop | 10 | 0.01 | 0.01 | 0.01 | 0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01 |
+| jvm-50 | daemon-warm-touch | 10 | 1.53 | 1.16 | 1.87 | 1.87,1.83,1.72,1.53,1.53,1.40,1.53,1.27,1.19,1.16 |

--- a/spike/bench-scaling/results-2026-04-14-3.md
+++ b/spike/bench-scaling/results-2026-04-14-3.md
@@ -1,0 +1,102 @@
+# Phase B-1a incremental ceiling measurement — #103
+
+> Also carries the #96 baseline modes (nodaemon / daemon-cold / daemon-warm
+> / gradle) since they share a harness and running them together keeps the
+> daemon / filesystem state consistent across all rows. Supersedes the
+> `daemon-warm-touch` column in `results-2026-04-14-2.md` (mtime-granularity
+> bug, see that file's header).
+
+## #103 interpretation (Phase B-1a: incremental ceiling)
+
+| Size | warm-noop (F1 floor) | warm-touch (F2 current) | daemon-warm full | naive ceiling (F2−F1) |
+|---|---|---|---|---|
+| jvm-1  | 0.00s | 0.69s | 0.68s | 0.69s |
+| jvm-10 | 0.01s | 0.91s | 0.90s | 0.90s |
+| jvm-25 | 0.01s | 1.16s | 1.17s | 1.15s |
+| jvm-50 | 0.01s | 1.40s | 1.40s | 1.39s |
+
+**Validation**: `daemon-warm-touch` median ≈ `daemon-warm` median at every
+size (within 0.01–0.02s). This confirms the measurement is clean — today's
+kolt recompiles everything on any source change, so touching 1 file costs
+the same as a rm-rf-rebuild with the warm daemon. The `daemon-warm-touch`
+column is the correct "Phase B target to beat".
+
+**The naive ceiling is misleading.** Subtracting the 0.00-0.01s noop floor
+from the full recompile cost is not the right budget for incremental,
+because no real incremental scheme can hit 0.01s for a 1-file-touch case:
+it must resolve dependencies (classpath check), call the daemon (fixed
+cost ~0.70s per ADR 0016 / run 3 of #96), and compile at least the
+touched file plus its downstream chain. The **realistic** floor is the
+warm daemon fixed cost, not the BuildCache fast path.
+
+**Realistic incremental budget** (assuming IC hits the daemon warm floor
+~0.70s and the per-file slope is the measured ~12 ms/file from #96):
+
+| Size | warm-touch (today) | realistic IC floor (~0.70s + 12ms/file recompiled) | max recoverable |
+|---|---|---|---|
+| jvm-1  | 0.69s | 0.70 + 12ms ≈ 0.71s  | ≈ 0 (below the daemon floor) |
+| jvm-10 | 0.91s | 0.70 + 12 × (10/2 + 1) ≈ 0.77s | ≈ 0.14s |
+| jvm-25 | 1.16s | 0.70 + 12 × (25/2 + 1) ≈ 0.86s | ≈ 0.30s |
+| jvm-50 | 1.40s | 0.70 + 12 × (25 + 1) ≈ 1.01s | ≈ 0.39s |
+
+The linear dependency chain in `gen.sh` (Main → File2 → ... → FileN via
+`work${i}(prev: M${i-1}): M${i}`) is **adversarial for incremental**:
+touching File_{n/2} forces recompilation of File_{n/2} + all downstream
+files + Main, i.e. (n/2 + 1) files. Only the upstream (n/2 − 1) files can
+be skipped. Real Kotlin codebases usually have tree-shaped or hub-and-spoke
+graphs where an interior node has fewer downstream dependents, which gives
+IC a larger window.
+
+**Takeaway for Phase B planning**:
+
+1. On this fixture family and with today's daemon, the incremental win is
+   bounded by **≲0.40s per build**, and it's effectively zero below ~10
+   files. The Phase A warm daemon already absorbs most of the latency a
+   user would notice.
+2. The interesting regime is **larger fixtures** (100–500 files), where
+   12ms/file slope stacks up and even a linear chain leaves more upstream
+   skippable. The current jvm-50 cap is too small to characterise this.
+3. Fixture shape matters as much as size. A tree-shaped fixture with
+   independent leaves would show a higher ceiling at the same file count.
+   Worth considering for the Phase B-1b spike (#104) when evaluating what
+   kotlin-build-tools-impl actually delivers.
+4. The `daemon-warm-noop` floor (0.00-0.01s, independent of N) is worth
+   remembering separately: it's kolt's true "nothing changed" cost, and
+   any IC scheme that makes this path *slower* would be a regression —
+   the BuildCache coarse-grained fast path must remain intact.
+
+# Phase A daemon scaling benchmark — #96
+
+- Date: 2026-04-14T23:20:57+09:00
+- Host: Linux 6.6.87.2-microsoft-standard-WSL2 x86_64
+- JDK: openjdk version "21.0.7" 2025-04-15 LTS
+- kolt binary: `/home/makino/projects/snicmakino/kolt/build/bin/linuxX64/releaseExecutable/kolt.kexe`
+- kolt binary mtime: 2026-04-14T18:16:31+09:00
+- N per cell: 10 (warm modes discard first 5)
+
+| Fixture | Mode | N | median (s) | min (s) | max (s) | raw |
+|---|---|---|---|---|---|---|
+| jvm-1 | nodaemon | 10 | 5.20 | 5.11 | 5.92 | 5.29,5.30,5.20,5.78,5.13,5.15,5.32,5.11,5.12,5.92 |
+| jvm-1 | daemon-cold | 10 | 5.42 | 5.24 | 5.98 | 5.26,5.24,5.33,5.49,5.98,5.42,5.53,5.43,5.38,5.65 |
+| jvm-1 | daemon-warm | 10 | 0.68 | 0.61 | 0.82 | 0.75,0.82,0.77,0.68,0.67,0.79,0.72,0.64,0.61,0.65 |
+| jvm-1 | gradle | 10 | 1.22 | 1.20 | 1.92 | 1.27,1.30,1.50,1.92,1.25,1.21,1.21,1.21,1.22,1.20 |
+| jvm-1 | daemon-warm-noop | 10 | 0.00 | 0.00 | 0.01 | 0.01,0.00,0.00,0.00,0.01,0.01,0.01,0.00,0.00,0.01 |
+| jvm-1 | daemon-warm-touch | 10 | 0.69 | 0.56 | 1.28 | 0.82,0.83,0.73,0.69,0.65,0.64,0.65,0.69,0.56,1.28 |
+| jvm-10 | nodaemon | 10 | 6.86 | 6.73 | 7.38 | 6.99,7.00,6.86,7.03,7.38,6.78,6.81,6.73,7.27,6.82 |
+| jvm-10 | daemon-cold | 10 | 7.05 | 6.76 | 7.94 | 7.14,7.02,7.94,7.19,7.24,6.88,7.36,6.89,6.76,7.05 |
+| jvm-10 | daemon-warm | 10 | 0.90 | 0.71 | 1.28 | 1.28,0.99,1.02,1.10,1.04,0.88,0.90,0.87,0.71,0.76 |
+| jvm-10 | gradle | 10 | 1.27 | 1.22 | 1.97 | 1.35,1.37,1.36,1.28,1.97,1.27,1.25,1.22,1.22,1.27 |
+| jvm-10 | daemon-warm-noop | 10 | 0.01 | 0.01 | 0.01 | 0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01 |
+| jvm-10 | daemon-warm-touch | 10 | 0.91 | 0.80 | 2.00 | 2.00,1.15,1.17,1.00,0.96,0.91,0.88,0.80,0.82,0.83 |
+| jvm-25 | nodaemon | 10 | 9.06 | 8.65 | 9.70 | 9.06,8.85,9.70,9.19,9.03,9.54,8.65,9.03,9.50,9.25 |
+| jvm-25 | daemon-cold | 10 | 9.17 | 8.97 | 9.84 | 9.01,9.49,9.84,9.58,8.97,9.73,9.08,9.05,9.74,9.17 |
+| jvm-25 | daemon-warm | 10 | 1.17 | 1.00 | 1.68 | 1.68,1.30,1.34,1.17,1.24,1.18,1.06,1.12,1.13,1.00 |
+| jvm-25 | gradle | 10 | 1.60 | 1.53 | 1.99 | 1.54,1.56,1.89,1.99,1.54,1.62,1.81,1.60,1.53,1.60 |
+| jvm-25 | daemon-warm-noop | 10 | 0.01 | 0.01 | 0.01 | 0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01 |
+| jvm-25 | daemon-warm-touch | 10 | 1.16 | 1.03 | 1.53 | 1.53,1.39,1.27,1.32,1.11,1.23,1.16,1.08,1.03,1.10 |
+| jvm-50 | nodaemon | 10 | 11.36 | 11.14 | 12.36 | 12.05,11.15,11.42,12.31,11.30,12.27,11.15,11.14,12.36,11.36 |
+| jvm-50 | daemon-cold | 10 | 11.64 | 11.01 | 12.97 | 11.20,12.12,11.22,11.93,11.64,11.01,11.82,11.32,12.97,11.72 |
+| jvm-50 | daemon-warm | 10 | 1.40 | 1.19 | 1.89 | 1.89,1.71,1.85,1.43,1.55,1.38,1.40,1.23,1.34,1.19 |
+| jvm-50 | gradle | 10 | 1.77 | 1.70 | 1.98 | 1.85,1.86,1.79,1.75,1.91,1.98,1.70,1.76,1.77,1.74 |
+| jvm-50 | daemon-warm-noop | 10 | 0.01 | 0.01 | 0.01 | 0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01 |
+| jvm-50 | daemon-warm-touch | 10 | 1.40 | 1.28 | 2.58 | 1.91,2.58,1.81,1.40,1.47,1.31,1.32,1.52,1.31,1.28 |

--- a/spike/bench-scaling/run-bench.sh
+++ b/spike/bench-scaling/run-bench.sh
@@ -1,13 +1,29 @@
 #!/usr/bin/env bash
-# Scaling benchmark harness for issue #96.
+# Scaling benchmark harness for issues #96 and #103.
 #
 # Measures `kolt build` wall-clock wall time across
-#   (fixture size × mode) ∈ ({1,10,25,50} × {nodaemon, daemon-cold, daemon-warm, gradle})
-# using the release kolt binary. N=7 per cell, median/min/max reported;
-# daemon-warm and gradle modes discard the first 2 runs as JIT warmup.
+#   (fixture size × mode) ∈ ({1,10,25,50} × {nodaemon, daemon-cold,
+#     daemon-warm, gradle, daemon-warm-noop, daemon-warm-touch})
+# using the release kolt binary. N=10 per cell, median/min/max reported;
+# warm-family modes discard the first 5 runs as JIT warmup.
+#
+# Issue #103's "Scenario F" is implemented as a pair of modes rather than a
+# single cell. Splitting it keeps the harness shape uniform (one mode per
+# run_cell call, one row per mode in the output table) and lets the noop
+# number be reused as a fixed-cost reference by other analyses later.
+# The two warm-* scenarios added for #103 frame the incremental-build ceiling:
+#   - daemon-warm-noop: warm daemon, build/ preserved, no source change.
+#     Measures the fixed-cost floor (binary startup + dep resolve + kolt's
+#     coarse BuildCache up-to-date check + exit). No correct incremental
+#     scheme can go below this.
+#   - daemon-warm-touch: warm daemon, build/ preserved, touch one designated
+#     mid-graph file before each measured build. Today kolt has no real IC,
+#     so this exercises the full-recompile path with a warm daemon. The gap
+#     (touch − noop) is the incremental ceiling: the maximum wall time a
+#     Phase B implementation could ever hope to recover.
 #
 # Output: raw per-run table appended into results-YYYY-MM-DD.md next to this
-# script.  Does not modify kolt source or ADRs.
+# script. Does not modify kolt source or ADRs.
 
 set -euo pipefail
 
@@ -46,6 +62,19 @@ fi
 # our own shell invocations that merely mention the daemon in their cmdline).
 DAEMON_PATTERN='java.*kolt-compiler-daemon-all\.jar'
 
+# Relative path (from the fixture root) of the source file to touch in the
+# daemon-warm-touch scenario. Picks a mid-graph file so the downstream chain
+# of `work${i+1}` references into `work${i}` is exercised — not a leaf.
+# See gen.sh: files form a linear chain Main → File2 → ... → FileN.
+designated_touch_file() {
+  local n="$1"
+  if (( n == 1 )); then
+    echo "src/Main.kt"
+  else
+    echo "src/File$((n / 2)).kt"
+  fi
+}
+
 kill_daemon() {
   pkill -f "$DAEMON_PATTERN" 2>/dev/null || true
   for _ in 1 2 3 4 5 6 7 8 9 10; do
@@ -83,6 +112,7 @@ median_minmax() {
 run_cell() {
   local fixture_dir="$1" mode="$2"
   local label="$3"
+  local fixture_size="$4"
   local samples=()
   local prime=0
   local total_runs="$N_RUNS"
@@ -114,6 +144,64 @@ run_cell() {
         if (( i > prime )); then
           samples+=("$t")
         fi
+      done
+      ;;
+    daemon-warm-noop)
+      # Fixed-cost floor (#103). Warm daemon, build/ populated once, then
+      # N measured builds with no source change. BuildCache sees the state
+      # file matches and takes the up-to-date fast path (BuildCommands.kt
+      # doBuild: up-to-date return happens before resolveDependencies).
+      # We are timing: binary startup + config parse + toolchain resolve +
+      # mtime scan + short-circuit exit. resolveDependencies and the daemon
+      # round-trip are NOT exercised on this path. This is the absolute
+      # lower bound any kolt build invocation can hit today.
+      prime="$WARM_DISCARD"
+      kill_daemon
+      rm -rf "$fixture_dir/build" "$HOME/.kolt/daemon"
+      for i in $(seq 1 "$prime"); do
+        (cd "$fixture_dir" && "$KOLT_BIN" build >/dev/null 2>&1)
+      done
+      for i in $(seq 1 "$total_runs"); do
+        local t; t=$(cd "$fixture_dir" && measure "$KOLT_BIN" build)
+        samples+=("$t")
+      done
+      ;;
+    daemon-warm-touch)
+      # Incremental ceiling baseline (#103). Warm daemon, build/ populated,
+      # but each iteration touches one designated mid-graph source file
+      # before building. Today's kolt has no file-level incremental, so
+      # this is a full recompile on the warm daemon path. Phase B's target
+      # is to push this number toward daemon-warm-noop.
+      prime="$WARM_DISCARD"
+      kill_daemon
+      rm -rf "$fixture_dir/build" "$HOME/.kolt/daemon"
+      local touch_rel
+      touch_rel=$(designated_touch_file "$fixture_size")
+      if [[ ! -f "$fixture_dir/$touch_rel" ]]; then
+        echo "designated touch file missing: $fixture_dir/$touch_rel" >&2
+        return 1
+      fi
+      # Force the touched file's mtime strictly forward each iteration.
+      # WSL2 9p (and several other filesystems) expose 1-second mtime
+      # granularity, so a plain `touch` run within the same wall-clock
+      # second as the previous build's cached sourcesNewestMtime leaves
+      # the mtime value unchanged, BuildCache short-circuits to the
+      # up-to-date fast path, and the "touch → full recompile" signal
+      # we are trying to measure is lost. A monotonically-increasing
+      # synthetic epoch sidesteps the clock entirely.
+      local bump_counter=0
+      local bump_base
+      bump_base=$(( $(date +%s) + 10 ))
+      for i in $(seq 1 "$prime"); do
+        bump_counter=$(( bump_counter + 1 ))
+        (cd "$fixture_dir" && touch -d "@$((bump_base + bump_counter))" "$touch_rel")
+        (cd "$fixture_dir" && "$KOLT_BIN" build >/dev/null 2>&1)
+      done
+      for i in $(seq 1 "$total_runs"); do
+        bump_counter=$(( bump_counter + 1 ))
+        (cd "$fixture_dir" && touch -d "@$((bump_base + bump_counter))" "$touch_rel")
+        local t; t=$(cd "$fixture_dir" && measure "$KOLT_BIN" build)
+        samples+=("$t")
       done
       ;;
     gradle)
@@ -163,10 +251,12 @@ for n in "${SIZES[@]}"; do
   fix="$FIX_DIR/jvm-${n}"
   [[ -d "$fix" ]] || { echo "missing fixture $fix — run gen.sh first" >&2; exit 1; }
   echo "==> jvm-${n}"
-  run_cell "$fix" nodaemon     "jvm-${n}"
-  run_cell "$fix" daemon-cold  "jvm-${n}"
-  run_cell "$fix" daemon-warm  "jvm-${n}"
-  run_cell "$fix" gradle       "jvm-${n}"
+  run_cell "$fix" nodaemon          "jvm-${n}" "$n"
+  run_cell "$fix" daemon-cold       "jvm-${n}" "$n"
+  run_cell "$fix" daemon-warm       "jvm-${n}" "$n"
+  run_cell "$fix" gradle            "jvm-${n}" "$n"
+  run_cell "$fix" daemon-warm-noop  "jvm-${n}" "$n"
+  run_cell "$fix" daemon-warm-touch "jvm-${n}" "$n"
 done
 
 echo


### PR DESCRIPTION
## Summary

- Add `daemon-warm-noop` and `daemon-warm-touch` modes to `spike/bench-scaling/run-bench.sh` to measure the Phase B incremental-build ceiling.
- Use a monotonically-increasing synthetic epoch (`touch -d "@${base+i}"`) so WSL2 9p's 1 s mtime granularity cannot silently defeat cache invalidation.
- Commit run 3 results (`results-2026-04-14-3.md`) and keep run 2 (`-2.md`) with a superseded header as negative-result context for the mtime-granularity bug.

Closes #103. Full analysis in [the #103 comment](https://github.com/snicmakino/kolt/issues/103#issuecomment-4244776081).

### Headline numbers (medians in s)

| Size | warm-noop (floor) | warm-touch (current full recompile) | daemon-warm | gradle |
|---|---|---|---|---|
| jvm-1  | 0.00 | 0.69 | 0.68 | 1.22 |
| jvm-10 | 0.01 | 0.91 | 0.90 | 1.27 |
| jvm-25 | 0.01 | 1.16 | 1.17 | 1.60 |
| jvm-50 | 0.01 | 1.40 | 1.40 | 1.77 |

`warm-touch ≈ daemon-warm` at every size (Δ ≤ 0.02s) validates the scenario: today's kolt has no file-level incremental, so touching 1 file costs a full recompile on the warm daemon path.

### Realistic recoverable budget

The naive `F2 − F1` ceiling is misleading because an IC implementation cannot hit the 0.00-0.01s BuildCache fast path for a real 1-file-touch: it must resolve deps, call the daemon, and recompile the touched file plus its downstream chain. Using the daemon warm fixed cost (~0.70s per #96 run 3) plus 12 ms/file slope as the realistic floor:

| Size | warm-touch today | realistic IC floor | max recoverable |
|---|---|---|---|
| jvm-1  | 0.69s | ≈ 0.71s | ≈ 0 |
| jvm-10 | 0.91s | ≈ 0.77s | ≈ 0.14s |
| jvm-25 | 1.16s | ≈ 0.86s | ≈ 0.30s |
| jvm-50 | 1.40s | ≈ 1.01s | ≈ 0.39s |

### Implications for Phase B planning

1. Phase B incremental win is bounded by ≲0.40s on this fixture family, effectively zero below ~10 files. Phase A's warm daemon already absorbs most of the latency.
2. The linear dependency chain is adversarial for IC (mid-graph touch forces recompile of half the files). A tree-shaped fixture would show a larger ceiling at the same file count — flag for #104 spike evaluation.
3. The `daemon-warm-noop` 0.00-0.01s fast path must remain intact under any future IC implementation — it is the "nothing changed" regression guardrail.

## Test plan

- [x] `bash -n run-bench.sh` parses cleanly
- [x] Smoke test on jvm-10 confirms `warm-noop` hits the BuildCache fast path (`"up to date (0.0s)"`) and `warm-touch` triggers a full rebuild
- [x] Full sweep (run 3) produces clean numbers: `daemon-warm-touch` median matches `daemon-warm` median within 0.02s at every size
- [x] Sub-agent review of the patch (Critical 0, Should-fix 1 applied, Should-fix 2 + Nit declined with rationale)
- [x] No changes to kolt source or ADRs, harness-only