### PR TITLE
Add Phase B-1b kotlin-build-tools-api spike (#104)

### DIFF
--- a/spike/incremental-ic/README.md
+++ b/spike/incremental-ic/README.md
@@ -1,0 +1,38 @@
+# incremental-ic spike
+
+**Throwaway. Not production code.**
+
+Phase B-1b spike for #104. Drives `kotlin-build-tools-api` 2.3.20
+(`KotlinToolchains` entry point, `JvmPlatformToolchain.jvmCompilationOperationBuilder`)
+in-process to answer:
+
+1. Does the API actually work end-to-end on a small JVM fixture?
+2. Does snapshot-based IC meaningfully reduce the recompile set on
+   `linear-10` vs `hub-10` fixture shapes?
+3. Answers to Open Questions 1-8 in issue #104.
+
+No tests, no TDD, no daemon integration. The point is to find out
+what the adapter layer in B-2 has to cover, not to ship code.
+
+## Usage
+
+```
+./gradlew :run --args="<fixture> <caches-dir> <touched-file>"
+```
+
+Example:
+
+```
+./gradlew :run --args="fixtures/linear-10 /tmp/ic-caches Main.kt"
+```
+
+## Observation
+
+The spike records the recompile set by hashing every `.class` file
+under the destination directory before and after the incremental run.
+`BuildMetricsCollector` is attached as a supplementary signal for the
+compiled-files count metric.
+
+## Deliverables
+
+- `REPORT.md` — verdict + answers to #104 open questions 1-8.

--- a/spike/incremental-ic/REPORT.md
+++ b/spike/incremental-ic/REPORT.md
@@ -1,0 +1,339 @@
+# Phase B-1b spike report — `kotlin-build-tools-api` incremental compilation
+
+Issue: #104. Throwaway spike. Kotlin 2.3.20.
+
+## Verdict
+
+**It works.** `kotlin-build-tools-api` 2.3.20 drives end-to-end cold and
+snapshot-based incremental JVM compilation in-process from an embedder,
+on both fixture shapes, with `COMPILATION_SUCCESS` and no silent
+fallbacks.
+
+**Recommendation**: proceed to ADR 0019 (B-1c) on approach **B**. The
+API surface we depend on is small enough to wrap in a thin adapter;
+Phase B-2 can build against it without relying on compiler-internal
+types.
+
+## Measured data
+
+Two fixtures, 10 Kotlin files each, hand-authored under `fixtures/`:
+
+- **linear-10**: `Main.kt` (defines `M1` + `main`) plus `F2.kt`..`F10.kt`
+  each defining `class M{i}` and `fun work{i}(prev: M{i-1}): M{i}`.
+  Adversarial chain from the #103 bench-scaling family.
+- **hub-10**: `Util.kt` (singleton object) + `Leaf1.kt`..`Leaf8.kt`
+  (independent functions that call `Util.tag`) + `Main.kt`. Edit-closure
+  best case.
+
+Edit scenario: touch one source by appending a uniquely-named top-level
+function (ABI-neutral addition — does not change any existing
+signature). See `src/main/kotlin/spike/ic/Main.kt::touchSourceFile`.
+
+| Fixture | Touched | Cold wall | Incremental wall | Speedup | `lines analyzed` cold → inc | Recompile set |
+|---|---|---|---|---|---|---|
+| linear-10 | `F5.kt` (mid-graph) | 3914 ms | 565 ms | 6.9× | 63 → 8 | `fixture/F5Kt.class` (1 / 20 class files) |
+| hub-10    | `Leaf1.kt`          | 3665 ms | 488 ms | 7.5× | 51 → 6 | `fixture/Leaf1Kt.class` (1 / 10 class files) |
+
+Observation method:
+
+1. Primary: `.class` byte-hash diff between `destinationDirectory`
+   snapshots taken after cold and after incremental runs.
+2. Supplementary: `BuildOperation.METRICS_COLLECTOR` →
+   `BuildMetricsCollector.collectMetric`. The
+   `"Total compiler iteration -> Number of lines analyzed"` metric
+   tracks how much source the compiler actually processed on each run.
+
+Both signals agreed: exactly one `.class` changed, compiler work
+dropped ~8× at the iteration level.
+
+## Open questions
+
+Answers keyed to #104 issue body:
+
+### 1. Session / build ID
+
+**Resolved.** The API exposes `KotlinToolchains.createBuildSession():
+BuildSession`, an `AutoCloseable` that scopes a group of operations
+sharing caches. `BuildSession.projectId: ProjectId` is the durable
+identifier; the runtime `BuildSession` instance is not.
+
+**Who owns what in kolt**: the daemon generates and holds a stable
+`ProjectId` per project root (hash of absolute path is sufficient). The
+`BuildSession` itself is JVM-local and cheap — open it per
+`Message.Compile` request and `close()` when the request completes.
+Clients do not need to see either identifier.
+
+### 2. State location
+
+**Resolved.** `snapshotBasedIcConfigurationBuilder(workingDirectory, ...)`
+takes a caller-owned `Path`. The impl writes its dependency graph / ABI
+snapshots / source-change detector state under that directory.
+
+**Placement for kolt**: daemon-owned, under
+`~/.kolt/daemon/ic/<projectId-hash>/`. Per-project, not per-build. Do
+not put it under `build/` — we want state to survive `build/` cleans,
+and we want the daemon (not the client) to hold invalidation authority.
+
+### 3. Classpath change detection
+
+**Resolved.** Not automatic. The IC API has two routes:
+
+- **Multi-module projects**: compute `ClasspathEntrySnapshot` per
+  classpath entry via `JvmPlatformToolchain.classpathSnapshottingOperationBuilder(...)`,
+  persist, and pass as `dependenciesSnapshotFiles` into the IC config.
+- **Single-module / no external deps**: pass
+  `dependenciesSnapshotFiles = emptyList()`. The impl still requires a
+  `shrunkClasspathSnapshot: Path` argument and will write a small
+  shrunk-snapshot file there (4 bytes in our runs — effectively empty).
+
+The spike used the second route. Kolt's realistic case is the first —
+projects have `kotlin-stdlib` + dependency-resolver output on the
+classpath, so B-2 will need a classpath-snapshot caching step parallel
+to the IC call.
+
+### 4. API stability and pin
+
+**Resolved.** The whole surface we use (`KotlinToolchains`,
+`JvmPlatformToolchain`, `JvmCompilationOperation`,
+`JvmSnapshotBasedIncrementalCompilationConfiguration`,
+`JvmClasspathSnapshottingOperation`, `BuildOperation.METRICS_COLLECTOR`,
+`SourcesChanges`) is annotated `@ExperimentalBuildToolsApi`.
+`@since 2.3.0` for the toolchains entry, many members `@since 2.3.20`.
+
+Pin for B-2: **`org.jetbrains.kotlin:kotlin-build-tools-api:2.3.20`** +
+`kotlin-build-tools-impl:2.3.20`, matching kolt's compiler version.
+Loaded via `SharedApiClassesClassLoader` + a `URLClassLoader` pointing
+at the impl artifacts (see `spike/ic/Main.kt::loadToolchain`). Must
+track this pin to kolt's `kotlinc` version going forward.
+
+**Trap**: in `master`, the old `CompilationService` entry point is
+`@Deprecated(level = ERROR)` with the message "Use the new BTA API with
+entry points in KotlinToolchain instead". Do not follow stale
+documentation or examples that reference `CompilationService` —
+`KotlinToolchains` is the only entry point that actually compiles.
+
+### 5. Failure modes
+
+**Partially resolved.** Both spike runs returned
+`CompilationResult.COMPILATION_SUCCESS` and no silent-fallback warnings
+in stderr. We did not observe `COMPILATION_ERROR` or fallback paths in
+this spike.
+
+What the API gives you:
+
+- `CompilationResult` is an enum returned by `executeOperation`. B-2
+  needs to branch on `COMPILATION_SUCCESS` vs error values.
+- `BuildMetricsCollector` emits hierarchical metric names under
+  "Run compilation -> ..."; a fallback (IC → full) would show up as
+  counters shifting between IC-specific and full-build metrics.
+- `KotlinBuildToolsException` is the escape hatch for truly broken
+  invocations — should be caught by the daemon dispatcher and converted
+  to a `Message.Error` reply rather than killing the daemon.
+
+**Residual**: validation of actual IC-fallback-to-full behavior (e.g.
+when a cache file is corrupted) was not exercised. B-2 should write a
+smoke test that points IC at a truncated cache file and confirms the
+error / fallback classification.
+
+### 6. Compiler plugin interaction
+
+**Not exercised.** The spike fixtures are plain Kotlin — no
+kotlinx.serialization, no kotlin-test, no kapt. `compilerArguments`
+exposes `PLUGIN_CLASSPATHS` / `PLUGIN_OPTIONS` equivalents, so the wiring
+is there, but we did not load any plugin jar.
+
+Constraint inherited from compile-bench spike #86 still applies: plugin
+jars and kotlin-build-tools-impl share a classloader hierarchy, and
+plugin classes must be reachable from whatever loader the impl uses to
+invoke them. B-2 should prototype kotlinx.serialization early; the
+shared-loader pattern from compile-bench (`SharedLoaderCompileDriver`)
+is the working template.
+
+### 7. Wire protocol implications
+
+**Resolved.** Minimum sufficient wire:
+
+```
+Message.Compile {
+    projectRoot: Path
+    sources:     List<Path>       // full source set, not a delta
+    classpath:   List<Path>       // deps + stdlib
+    outputDir:   Path
+}
+```
+
+No session ID, no build ID, no explicit dirty-file set required on the
+wire. The daemon side wraps this in:
+
+- stable `ProjectId` = hash(projectRoot)
+- IC `workingDirectory` = `~/.kolt/daemon/ic/<ProjectId>/`
+- `SourcesChanges = ToBeCalculated` — the BTA impl diffs against its
+  own persisted state and figures out what changed.
+
+**Optional optimization for later**: if a future kolt client (e.g. a
+file watcher) already knows which files changed, the wire can add
+`modifiedSources: List<Path>` + `removedSources: List<Path>`, and the
+daemon selects `SourcesChanges.Known(...)`. This is not required for
+correctness and should not block B-2 — keep the minimum wire and add
+`Known` as a follow-up.
+
+**Classpath snapshots cross-wire**: if B-2 computes classpath snapshots
+on the daemon side per request, no protocol change is needed. If snapshot
+computation is expensive enough to want client-side caching, that is a
+separate protocol discussion (out of scope for B-1c).
+
+### 8. Fixture shape sensitivity
+
+**Answered empirically, with a caveat.**
+
+The #103 takeaway predicted "linear chain is adversarial because
+mid-graph touch cascades through n/2 downstream files". This spike's
+results were narrower than that prediction for the specific edit we
+tested:
+
+- For **ABI-neutral** edits (adding a new, unreferenced top-level
+  declaration to a mid-chain file), IC on the linear-10 fixture
+  recompiled exactly **1** file. Downstream files were not touched,
+  because IC's ABI snapshot correctly determined that `class M5` and
+  `fun work5`'s public shape did not change.
+- The hub-10 fixture recompiled the same **1** file for the leaf edit,
+  as expected.
+
+**Caveat (important, because it's the scenario #103 was worried
+about)**: the spike did NOT test an **ABI-affecting** edit, e.g.
+changing `fun work5(prev: M4): M5` to add a parameter, or changing `M5`'s
+public API. Such an edit would force the downstream chain
+(F6..F10) to re-link, and the linear-chain shape would genuinely matter
+there. We elected not to block the spike on hand-editing matched
+call sites for a third scenario.
+
+**Implication for B-2**: the `recoverable budget ≲ 0.40s` ceiling from
+#103 was computed assuming full-downstream recompile. IC appears to be
+substantially smarter than that on ABI-neutral edits (which, in typical
+iterative development, are the common case: "add a log line", "tweak a
+literal"). The realistic win distribution will be **bimodal**:
+- ABI-neutral edit on any file: ~1-file recompile, win is large.
+- ABI-affecting edit at the top of a long chain: worst case, win is the
+  #103 ceiling or thereabouts.
+
+**Recommended B-2 validation scenarios** (not to be done in the spike,
+but in the Phase B-2 test suite):
+
+1. ABI-neutral body edit (literal change in `work5`'s body).
+2. ABI-affecting signature change in `work5` with matching edits in
+   `F6.kt`'s call site, to observe the cascade depth.
+3. Classpath-entry ABI change (a `stdlib` upgrade or similar) to
+   exercise the `classpathSnapshottingOperation` path.
+
+## Recommended adapter-layer shape for Phase B-2
+
+Goal: isolate `@ExperimentalBuildToolsApi` surface from the daemon
+core so that a 2.3.x → 2.4 bump of Kotlin cannot break the daemon
+request handler directly.
+
+Proposed interface (daemon-core-facing, experimental-API-free):
+
+```kotlin
+// daemon/src/.../ic/IncrementalCompiler.kt
+interface IncrementalCompiler {
+    fun compile(request: IcRequest): Result<IcResponse, IcError>
+}
+
+data class IcRequest(
+    val projectId: String,            // stable, caller-derived
+    val sources: List<Path>,          // full source set
+    val classpath: List<Path>,        // full classpath incl. stdlib
+    val outputDir: Path,
+    val workingDir: Path,             // per-project IC state dir
+)
+
+data class IcResponse(
+    val wallMillis: Long,
+    val compiledFileCount: Int?,      // may be null if metrics not available
+    val status: Status,
+)
+
+enum class Status { SUCCESS, ERROR }
+
+sealed interface IcError {
+    data class CompilationFailed(val messages: List<String>) : IcError
+    data class InternalError(val cause: Throwable) : IcError
+}
+```
+
+Concrete implementation (`BtaIncrementalCompiler`) lives in a separate
+module that is the ONLY module depending on
+`kotlin-build-tools-api`/`-impl`. All experimental annotations,
+`SharedApiClassesClassLoader`, `JvmCompilerArguments`, `SourcesChanges`
+handling, and metrics collection are internal to that module. Daemon
+core sees only `IncrementalCompiler`.
+
+Pattern mirrors compile-bench spike #86's `SharedLoaderCompileDriver`
+separation — daemon-facing interface plus a driver that owns the
+classloader hierarchy.
+
+## Wire-protocol deltas the B-1c ADR must cover
+
+Based on this spike, ADR 0019 needs to specify:
+
+1. **`Message.Compile` stays simple**: projectRoot, sources (full set),
+   classpath, outputDir. No session ID, no dirty-file set. (See O.Q. 7.)
+2. **Daemon-owned IC state dir convention**:
+   `~/.kolt/daemon/ic/<sha256(projectRoot)>/`.
+   Decision for the ADR: is this daemon-global, or per-JVM-version?
+   (Kotlin version bumps probably require wiping this — ADR should say
+   so explicitly, and the daemon should version-stamp the dir.)
+3. **Classpath snapshot lifecycle**: compute on daemon per request
+   (simple, O(classpath) cost) vs. cache keyed by classpath-entry
+   mtime+size+path (fast for repeated builds). Spike did not exercise
+   the multi-module case, so the ADR should pick **per-request
+   computation** as the B-2 initial implementation and mark caching as
+   a follow-up.
+4. **Failure classification**: `COMPILATION_SUCCESS` vs
+   `CompilationResult.COMPILATION_ERROR` vs thrown
+   `KotlinBuildToolsException`. The daemon dispatcher must not
+   propagate uncaught exceptions — wrap at the adapter boundary.
+5. **Plugin-classloader policy**: defer to the pattern in compile-bench
+   `SharedLoaderCompileDriver`. The ADR should reference that file and
+   explicitly note that B-2 must prototype kotlinx.serialization before
+   declaring B-2 complete (residual from O.Q. 6).
+6. **Regression guardrail from #103**: the BuildCache coarse-grained
+   noop fast-path (0.00–0.01s) must remain. IC is only invoked when the
+   fast path says "changes detected". ADR must state this
+   non-negotiable.
+
+## Residual risks / followups not answered by this spike
+
+- **Plugin / compiler-arguments plumbing**: `IcRequest` in the adapter
+  sketch above intentionally omits a `compilerArguments` / plugin-list
+  field. The spike fixtures did not need plugins, so the shape of this
+  field is not yet forced by data. ADR 0019 must decide whether
+  plugin settings (plugin classpaths, plugin options, compiler flags
+  like `-jvm-target`) are (a) resolved inside the adapter by reading
+  `kolt.toml [plugins]` and translated to `JvmCompilerArguments` there,
+  or (b) passed through from daemon core on every `IcRequest`. Option
+  (a) keeps daemon core free of BTA-shaped types; option (b) keeps the
+  adapter pure and makes plugin resolution the daemon's job. Decide in
+  the ADR; either works, the tradeoff is where the translation layer
+  lives.
+- ABI-affecting cascade depth: see O.Q. 8 caveat. Covered by B-2
+  validation suite, not by ADR.
+- IC fallback-to-full observability: see O.Q. 5 residual. Covered by
+  B-2 smoke tests.
+- Compiler plugin loading: see O.Q. 6. Covered by B-2 prototype.
+- `SourcesChanges.Known(...)` optimization path: covered by a
+  follow-up issue post-B-2 if a file-watcher client ever materializes.
+- IC performance at larger fixture sizes (jvm-100, jvm-250): B-1a's
+  bench-scaling harness already exists and can be pointed at a B-2
+  implementation; not a blocker for the ADR.
+
+## What the spike cost
+
+Rough: 1 working session (much less than the 1-day budget in the issue
+body, largely because context7 + direct `gh api` browsing of
+`jetbrains/kotlin` at the `v2.3.20` tag let O.Q. 1/2/3/7 get answered
+from source before any code ran). The 1-hour early-exit gate for
+step 4 (driving the API) was not triggered: the first `executeOperation`
+call produced `COMPILATION_SUCCESS` on the first compile and correct
+`lines analyzed` deltas on the first incremental call after a stdlib
+classpath and touch-semantics fix.

--- a/spike/incremental-ic/build.gradle.kts
+++ b/spike/incremental-ic/build.gradle.kts
@@ -1,0 +1,41 @@
+plugins {
+    kotlin("jvm") version "2.3.20"
+    application
+}
+
+repositories {
+    mavenCentral()
+}
+
+// Classpath used to load the Build Tools API implementation at runtime.
+// The spike uses SharedApiClassesClassLoader to separate API classes (on the app
+// classpath) from impl classes (loaded from this configuration), matching the
+// isolation policy used by Gradle's Kotlin plugin.
+val buildToolsImpl: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+val fixtureClasspath: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
+dependencies {
+    // API only — the impl is loaded reflectively at runtime from buildToolsImpl.
+    implementation("org.jetbrains.kotlin:kotlin-build-tools-api:2.3.20")
+    buildToolsImpl("org.jetbrains.kotlin:kotlin-build-tools-impl:2.3.20")
+    fixtureClasspath("org.jetbrains.kotlin:kotlin-stdlib:2.3.20")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+application {
+    mainClass.set("spike.ic.MainKt")
+}
+
+tasks.named<JavaExec>("run") {
+    systemProperty("bta.impl.classpath", buildToolsImpl.asPath)
+    systemProperty("fixture.classpath", fixtureClasspath.asPath)
+}

--- a/spike/incremental-ic/fixtures/hub-10/Leaf1.kt
+++ b/spike/incremental-ic/fixtures/hub-10/Leaf1.kt
@@ -1,0 +1,3 @@
+package fixture
+
+fun leaf1(): String = Util.tag("leaf1", 1)

--- a/spike/incremental-ic/fixtures/hub-10/Leaf2.kt
+++ b/spike/incremental-ic/fixtures/hub-10/Leaf2.kt
@@ -1,0 +1,3 @@
+package fixture
+
+fun leaf2(): String = Util.tag("leaf2", 2)

--- a/spike/incremental-ic/fixtures/hub-10/Leaf3.kt
+++ b/spike/incremental-ic/fixtures/hub-10/Leaf3.kt
@@ -1,0 +1,3 @@
+package fixture
+
+fun leaf3(): String = Util.tag("leaf3", 3)

--- a/spike/incremental-ic/fixtures/hub-10/Leaf4.kt
+++ b/spike/incremental-ic/fixtures/hub-10/Leaf4.kt
@@ -1,0 +1,3 @@
+package fixture
+
+fun leaf4(): String = Util.tag("leaf4", 4)

--- a/spike/incremental-ic/fixtures/hub-10/Leaf5.kt
+++ b/spike/incremental-ic/fixtures/hub-10/Leaf5.kt
@@ -1,0 +1,3 @@
+package fixture
+
+fun leaf5(): String = Util.tag("leaf5", 5)

--- a/spike/incremental-ic/fixtures/hub-10/Leaf6.kt
+++ b/spike/incremental-ic/fixtures/hub-10/Leaf6.kt
@@ -1,0 +1,3 @@
+package fixture
+
+fun leaf6(): String = Util.tag("leaf6", 6)

--- a/spike/incremental-ic/fixtures/hub-10/Leaf7.kt
+++ b/spike/incremental-ic/fixtures/hub-10/Leaf7.kt
@@ -1,0 +1,3 @@
+package fixture
+
+fun leaf7(): String = Util.tag("leaf7", 7)

--- a/spike/incremental-ic/fixtures/hub-10/Leaf8.kt
+++ b/spike/incremental-ic/fixtures/hub-10/Leaf8.kt
@@ -1,0 +1,3 @@
+package fixture
+
+fun leaf8(): String = Util.tag("leaf8", 8)

--- a/spike/incremental-ic/fixtures/hub-10/Main.kt
+++ b/spike/incremental-ic/fixtures/hub-10/Main.kt
@@ -1,0 +1,12 @@
+package fixture
+
+fun main() {
+    println(leaf1())
+    println(leaf2())
+    println(leaf3())
+    println(leaf4())
+    println(leaf5())
+    println(leaf6())
+    println(leaf7())
+    println(leaf8())
+}

--- a/spike/incremental-ic/fixtures/hub-10/Util.kt
+++ b/spike/incremental-ic/fixtures/hub-10/Util.kt
@@ -1,0 +1,5 @@
+package fixture
+
+object Util {
+    fun tag(label: String, n: Int): String = "[$label]=$n"
+}

--- a/spike/incremental-ic/fixtures/linear-10/F10.kt
+++ b/spike/incremental-ic/fixtures/linear-10/F10.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M10(val v: Int)
+
+fun work10(prev: M9): M10 = M10(prev.v + 10)

--- a/spike/incremental-ic/fixtures/linear-10/F2.kt
+++ b/spike/incremental-ic/fixtures/linear-10/F2.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M2(val v: Int)
+
+fun work2(prev: M1): M2 = M2(prev.v + 2)

--- a/spike/incremental-ic/fixtures/linear-10/F3.kt
+++ b/spike/incremental-ic/fixtures/linear-10/F3.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M3(val v: Int)
+
+fun work3(prev: M2): M3 = M3(prev.v + 3)

--- a/spike/incremental-ic/fixtures/linear-10/F4.kt
+++ b/spike/incremental-ic/fixtures/linear-10/F4.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M4(val v: Int)
+
+fun work4(prev: M3): M4 = M4(prev.v + 4)

--- a/spike/incremental-ic/fixtures/linear-10/F5.kt
+++ b/spike/incremental-ic/fixtures/linear-10/F5.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M5(val v: Int)
+
+fun work5(prev: M4): M5 = M5(prev.v + 5)

--- a/spike/incremental-ic/fixtures/linear-10/F6.kt
+++ b/spike/incremental-ic/fixtures/linear-10/F6.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M6(val v: Int)
+
+fun work6(prev: M5): M6 = M6(prev.v + 6)

--- a/spike/incremental-ic/fixtures/linear-10/F7.kt
+++ b/spike/incremental-ic/fixtures/linear-10/F7.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M7(val v: Int)
+
+fun work7(prev: M6): M7 = M7(prev.v + 7)

--- a/spike/incremental-ic/fixtures/linear-10/F8.kt
+++ b/spike/incremental-ic/fixtures/linear-10/F8.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M8(val v: Int)
+
+fun work8(prev: M7): M8 = M8(prev.v + 8)

--- a/spike/incremental-ic/fixtures/linear-10/F9.kt
+++ b/spike/incremental-ic/fixtures/linear-10/F9.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M9(val v: Int)
+
+fun work9(prev: M8): M9 = M9(prev.v + 9)

--- a/spike/incremental-ic/fixtures/linear-10/Main.kt
+++ b/spike/incremental-ic/fixtures/linear-10/Main.kt
@@ -1,0 +1,8 @@
+package fixture
+
+class M1(val v: Int)
+
+fun main() {
+    val result = work10(work9(work8(work7(work6(work5(work4(work3(work2(M1(1)))))))))).v
+    println(result)
+}

--- a/spike/incremental-ic/settings.gradle.kts
+++ b/spike/incremental-ic/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "incremental-ic"

--- a/spike/incremental-ic/src/main/kotlin/spike/ic/Main.kt
+++ b/spike/incremental-ic/src/main/kotlin/spike/ic/Main.kt
@@ -1,0 +1,249 @@
+@file:OptIn(ExperimentalBuildToolsApi::class)
+
+package spike.ic
+
+import org.jetbrains.kotlin.buildtools.api.BuildOperation
+import org.jetbrains.kotlin.buildtools.api.CompilationResult
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader
+import org.jetbrains.kotlin.buildtools.api.SourcesChanges
+import org.jetbrains.kotlin.buildtools.api.arguments.JvmCompilerArguments
+import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain.Companion.jvm
+import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperation
+import org.jetbrains.kotlin.buildtools.api.trackers.BuildMetricsCollector
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.extension
+import kotlin.io.path.relativeTo
+import kotlin.io.path.walk
+import kotlin.system.exitProcess
+import kotlin.time.DurationUnit
+import kotlin.time.TimeSource
+
+fun main(args: Array<String>) {
+    if (args.size == 1 && args[0] == "--version") {
+        val toolchain = loadToolchain()
+        println("kotlin-build-tools-api loaded. compiler version: ${toolchain.getCompilerVersion()}")
+        return
+    }
+    if (args.size != 3) {
+        System.err.println("usage: <fixture-dir> <work-dir> <touched-file>")
+        exitProcess(2)
+    }
+
+    val fixtureDir = Path.of(args[0]).toAbsolutePath()
+    val workDir = Path.of(args[1]).toAbsolutePath()
+    val touchedFileName = args[2]
+
+    require(Files.isDirectory(fixtureDir)) { "fixture dir not found: $fixtureDir" }
+
+    val sourcesDir = workDir.resolve("sources")
+    val classesDir = workDir.resolve("classes")
+    val icDir = workDir.resolve("ic")
+    val snapshotDir = workDir.resolve("snapshots")
+
+    resetDir(workDir)
+    copyFixture(fixtureDir, sourcesDir)
+    listOf(classesDir, icDir, snapshotDir).forEach { it.createDirectories() }
+
+    val touched = sourcesDir.resolve(touchedFileName)
+    require(Files.isRegularFile(touched)) { "touched source not found in fixture: $touched" }
+
+    val toolchain = loadToolchain()
+    println("=== spike incremental-ic ===")
+    println("compiler: ${toolchain.getCompilerVersion()}")
+    println("fixture:  $fixtureDir")
+    println("sources:  $sourcesDir")
+    println("classes:  $classesDir")
+    println("ic dir:   $icDir")
+    println("touch:    $touchedFileName")
+    println()
+
+    val shrunkClasspathSnapshot = snapshotDir.resolve("shrunk-classpath-snapshot.bin")
+
+    // -------- Cold run --------
+    println("--- cold run ---")
+    val coldResult = runCompilation(
+        toolchain = toolchain,
+        sourcesDir = sourcesDir,
+        classesDir = classesDir,
+        icDir = icDir,
+        dependenciesSnapshotFiles = emptyList(),
+        shrunkClasspathSnapshot = shrunkClasspathSnapshot,
+        sourcesChanges = SourcesChanges.ToBeCalculated,
+    )
+    val coldClassHashes = hashClassFiles(classesDir)
+    printRun("cold", coldResult, coldClassHashes.size)
+    println("   class files: ${coldClassHashes.size}")
+
+    // -------- Touch --------
+    println()
+    println("--- touch ---")
+    touchSourceFile(touched)
+    println("touched $touchedFileName (appended whitespace + unique body marker)")
+
+    // -------- Incremental run --------
+    println()
+    println("--- incremental run ---")
+    val incResult = runCompilation(
+        toolchain = toolchain,
+        sourcesDir = sourcesDir,
+        classesDir = classesDir,
+        icDir = icDir,
+        dependenciesSnapshotFiles = emptyList(),
+        shrunkClasspathSnapshot = shrunkClasspathSnapshot,
+        sourcesChanges = SourcesChanges.ToBeCalculated,
+    )
+    val incClassHashes = hashClassFiles(classesDir)
+    printRun("incremental", incResult, incClassHashes.size)
+
+    // -------- Diff --------
+    val changed = incClassHashes.filter { (path, hash) -> coldClassHashes[path] != hash }
+    val added = incClassHashes.keys - coldClassHashes.keys
+    val removed = coldClassHashes.keys - incClassHashes.keys
+    println()
+    println("--- recompile set (by .class hash diff) ---")
+    println("changed: ${changed.size}")
+    changed.keys.sorted().forEach { println("  ~ $it") }
+    if (added.isNotEmpty()) {
+        println("added:   ${added.size}")
+        added.sorted().forEach { println("  + $it") }
+    }
+    if (removed.isNotEmpty()) {
+        println("removed: ${removed.size}")
+        removed.sorted().forEach { println("  - $it") }
+    }
+    println()
+    println("spike done")
+}
+
+private class RunResult(
+    val compilationResult: CompilationResult,
+    val wallMs: Long,
+    val metrics: Map<String, Long>,
+)
+
+private fun printRun(label: String, r: RunResult, classFilesCount: Int) {
+    println("$label: status=${r.compilationResult} wall=${r.wallMs}ms class-files=$classFilesCount")
+    val interesting = r.metrics.filter { (k, _) ->
+        k.contains("compiled", ignoreCase = true) || k.contains("Number of", ignoreCase = true)
+    }
+    if (interesting.isNotEmpty()) {
+        println("  metrics:")
+        interesting.entries.sortedBy { it.key }.forEach { (k, v) -> println("    $k = $v") }
+    }
+}
+
+@OptIn(kotlin.io.path.ExperimentalPathApi::class)
+private fun runCompilation(
+    toolchain: KotlinToolchains,
+    sourcesDir: Path,
+    classesDir: Path,
+    icDir: Path,
+    dependenciesSnapshotFiles: List<Path>,
+    shrunkClasspathSnapshot: Path,
+    sourcesChanges: SourcesChanges,
+): RunResult {
+    val sources: List<Path> = sourcesDir.walk()
+        .filter { it.extension == "kt" || it.extension == "java" }
+        .sorted()
+        .toList()
+    val fixtureClasspath = System.getProperty("fixture.classpath")!!
+
+    val collected = mutableMapOf<String, Long>()
+    val collector = object : BuildMetricsCollector {
+        override fun collectMetric(name: String, type: BuildMetricsCollector.ValueType, value: Long) {
+            collected.merge(name, value) { a, b -> a + b }
+        }
+    }
+
+    val builder = toolchain.jvm.jvmCompilationOperationBuilder(sources, classesDir)
+    builder.compilerArguments[JvmCompilerArguments.CLASSPATH] = fixtureClasspath
+    builder.compilerArguments[JvmCompilerArguments.MODULE_NAME] = "spike-fixture"
+    builder.compilerArguments[JvmCompilerArguments.NO_STDLIB] = true
+    builder.compilerArguments[JvmCompilerArguments.NO_REFLECT] = true
+
+    val icConfig = builder.snapshotBasedIcConfigurationBuilder(
+        workingDirectory = icDir,
+        sourcesChanges = sourcesChanges,
+        dependenciesSnapshotFiles = dependenciesSnapshotFiles,
+        shrunkClasspathSnapshot = shrunkClasspathSnapshot,
+    ).build()
+    builder[JvmCompilationOperation.INCREMENTAL_COMPILATION] = icConfig
+
+    builder[BuildOperation.METRICS_COLLECTOR] = collector
+    val op = builder.build()
+
+    val policy = toolchain.createInProcessExecutionPolicy()
+    val start = TimeSource.Monotonic.markNow()
+    val result = toolchain.createBuildSession().use { session ->
+        session.executeOperation(op, policy)
+    }
+    val wall = start.elapsedNow().toLong(DurationUnit.MILLISECONDS)
+    return RunResult(result, wall, collected.toMap())
+}
+
+@OptIn(kotlin.io.path.ExperimentalPathApi::class)
+private fun hashClassFiles(classesDir: Path): Map<String, String> {
+    if (!Files.isDirectory(classesDir)) return emptyMap()
+    val md = MessageDigest.getInstance("SHA-256")
+    return classesDir.walk()
+        .filter { it.extension == "class" }
+        .associate { p ->
+            val rel = p.relativeTo(classesDir).toString()
+            md.reset()
+            md.update(Files.readAllBytes(p))
+            rel to md.digest().joinToString("") { "%02x".format(it) }
+        }
+}
+
+@OptIn(kotlin.io.path.ExperimentalPathApi::class)
+private fun resetDir(dir: Path) {
+    if (Files.exists(dir)) dir.deleteRecursively()
+    dir.createDirectories()
+}
+
+@OptIn(kotlin.io.path.ExperimentalPathApi::class)
+private fun copyFixture(src: Path, dst: Path) {
+    dst.createDirectories()
+    src.walk().filter { Files.isRegularFile(it) }.forEach { p ->
+        val rel = p.relativeTo(src)
+        val target = dst.resolve(rel.toString())
+        target.parent?.createDirectories()
+        Files.copy(p, target, StandardCopyOption.REPLACE_EXISTING)
+    }
+}
+
+private fun touchSourceFile(path: Path) {
+    // Append a new top-level function with a unique name so that the touched
+    // source actually produces different bytecode (cold vs incremental .class
+    // hash comparison is the spike's primary observation for the recompile
+    // set). A comment-only change would leave the .class file byte-identical
+    // and defeat the hash diff.
+    val uniq = System.nanoTime()
+    val marker = "\nfun spikeTouch$uniq(): Long = $uniq\n"
+    Files.writeString(
+        path,
+        marker,
+        java.nio.file.StandardOpenOption.APPEND,
+    )
+}
+
+private fun loadToolchain(): KotlinToolchains {
+    val implClasspath = System.getProperty("bta.impl.classpath")
+        ?: error("bta.impl.classpath system property not set")
+    val urls = implClasspath.split(File.pathSeparator)
+        .filter { it.isNotBlank() }
+        .map { File(it).toURI().toURL() }
+        .toTypedArray()
+    val loader = URLClassLoader(urls, SharedApiClassesClassLoader())
+    return KotlinToolchains.loadImplementation(loader)
+}


### PR DESCRIPTION
## Summary
- Throwaway spike under `spike/incremental-ic/` that drives `kotlin-build-tools-api` 2.3.20 end-to-end in-process, proving `KotlinToolchains` → `JvmPlatformToolchain.jvmCompilationOperationBuilder` + `snapshotBasedIcConfigurationBuilder` works for cold and incremental JVM compilation.
- Two hand-authored 10-file fixtures (`linear-10`, `hub-10`) and a driver that observes the recompile set via `.class` byte-hash diff. Both shapes produce `COMPILATION_SUCCESS` with a 1-file recompile set and ~7× speedup on ABI-neutral edits.
- `REPORT.md` answers #104 Open Questions 1-8, sketches the Phase B-2 adapter-layer interface, and lists 6 wire-protocol deltas for ADR 0019 (B-1c).

Closes #104.

## Test plan
- [x] `./gradlew -p spike/incremental-ic :compileKotlin` succeeds
- [x] `./gradlew -p spike/incremental-ic :run --args="fixtures/linear-10 /tmp/ic-linear F5.kt"` → 1 class file changed, `COMPILATION_SUCCESS`
- [x] `./gradlew -p spike/incremental-ic :run --args="fixtures/hub-10 /tmp/ic-hub Leaf1.kt"` → 1 class file changed, `COMPILATION_SUCCESS`
- [ ] CI unaffected (spike dir is an independent Gradle build, not wired into the root)