### PR TITLE
Dogfood fallout from B-2b: source dir expansion + self-heal loop defense (#117)

### DIFF
--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/SelfHealingIncrementalCompiler.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/SelfHealingIncrementalCompiler.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.mapBoth
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.Collections
 
 // Self-heal wrapper defined by ADR 0019 §7. On an `IcError.InternalError`
 // from the wrapped adapter it (a) deletes the per-project `workingDir`
@@ -60,12 +61,51 @@ class SelfHealingIncrementalCompiler(
     private val stderrWarn: (String) -> Unit = ::defaultStderrWarn,
 ) : IncrementalCompiler {
 
+    // Per-project latch: when the previous compile for a given
+    // `projectId` fired the self-heal retry path, we mark the project
+    // "just self-healed". The next `IcError.InternalError` for the
+    // same project skips the retry and surfaces the error directly
+    // instead of wiping + re-running. Issue #117 part 2: without this
+    // latch, a persistent client-side bug (e.g. the native client
+    // sending a directory where BTA expects a file) makes every
+    // incoming `Message.Compile` burn one wipe cycle with no chance
+    // of making progress. Any successful compile — or any non-
+    // InternalError failure — clears the latch for that project so a
+    // later transient corruption still gets a fresh self-heal chance.
+    //
+    // The set is synchronised because `DaemonServer` currently
+    // serialises compile traffic, but a future parallel dispatch
+    // would still want the read/modify/write to be atomic.
+    private val projectsJustSelfHealed: MutableSet<String> =
+        Collections.synchronizedSet(mutableSetOf())
+
     override fun compile(request: IcRequest): Result<IcResponse, IcError> {
         val first = delegate.compile(request)
         return first.mapBoth(
-            success = { first },
+            success = {
+                // Any successful compile clears the latch for this
+                // project — we just proved that whatever was wrong
+                // last time is either fixed or transient, so we
+                // should allow the next InternalError to self-heal
+                // normally.
+                projectsJustSelfHealed.remove(request.projectId)
+                first
+            },
             failure = { error ->
                 if (error is IcError.InternalError) {
+                    if (projectsJustSelfHealed.contains(request.projectId)) {
+                        // Consecutive InternalError for the same
+                        // project. The previous self-heal cycle
+                        // already wiped the workingDir and retried;
+                        // if a second wipe+retry would help, it would
+                        // have helped last time. Skip the retry, emit
+                        // an observability metric, and surface the
+                        // error directly so the user sees the real
+                        // kotlinc diagnostic faster.
+                        metrics.record(METRIC_SELF_HEAL_SKIPPED_CONSECUTIVE)
+                        return@mapBoth first
+                    }
+                    projectsJustSelfHealed.add(request.projectId)
                     metrics.record(METRIC_SELF_HEAL)
                     stderrWarn(
                         "kolt-compiler-daemon: self-heal fired for project working dir " +
@@ -106,6 +146,13 @@ class SelfHealingIncrementalCompiler(
                     }
                     delegate.compile(request)
                 } else {
+                    // Non-InternalError failure (CompilationFailed —
+                    // a user type error). Clear the latch so a later
+                    // InternalError on the same project still gets
+                    // a fresh self-heal chance; a failed compile
+                    // that is the user's fault is unrelated to
+                    // cache corruption.
+                    projectsJustSelfHealed.remove(request.projectId)
                     first
                 }
             },
@@ -115,6 +162,8 @@ class SelfHealingIncrementalCompiler(
     companion object {
         internal const val METRIC_SELF_HEAL: String = "ic.self_heal"
         internal const val METRIC_SELF_HEAL_WIPE_FAILED: String = "ic.self_heal_wipe_failed"
+        internal const val METRIC_SELF_HEAL_SKIPPED_CONSECUTIVE: String =
+            "ic.self_heal_skipped_consecutive"
 
         // Recursively delete the working-dir tree. `Files.walk` in post-order
         // lets us delete children before their parent, which is the only

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingIncrementalCompilerTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingIncrementalCompilerTest.kt
@@ -323,6 +323,165 @@ class SelfHealingIncrementalCompilerTest {
     }
 
     @Test
+    fun `consecutive InternalError on the same project skips the retry and emits skipped metric`() {
+        // Regression guard for issue #117 part 2: when the underlying
+        // bug is persistent (e.g. a client-side source-path mistake),
+        // every request to the same project should NOT burn a fresh
+        // wipe+retry cycle. The first request pays the self-heal; the
+        // second surfaces the error directly without touching the
+        // workingDir.
+        val metrics = RecordingMetricsSink()
+        val calls = AtomicInteger(0)
+        val wipeCalls = AtomicInteger(0)
+        val delegate = FakeCompiler { _ ->
+            calls.incrementAndGet()
+            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("persistent failure")))
+        }
+        val wrapper = SelfHealingIncrementalCompiler(
+            delegate = delegate,
+            wipe = { wipeCalls.incrementAndGet(); emptyList() },
+            metrics = metrics,
+            stderrWarn = { },
+        )
+        val req = request()
+
+        // Request 1: first failure fires a self-heal (wipe + retry).
+        wrapper.compile(req)
+        assertEquals(2, calls.get(), "first request: one initial attempt + one retry")
+        assertEquals(1, wipeCalls.get())
+        assertEquals(1, metrics.events.count { it.first == "ic.self_heal" })
+        assertEquals(0, metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" })
+
+        // Request 2: same project, same error. The latch is set from
+        // request 1, so no wipe, no retry, no ic.self_heal — just the
+        // skipped counter.
+        wrapper.compile(req)
+        assertEquals(3, calls.get(), "second request: one attempt, no retry")
+        assertEquals(1, wipeCalls.get(), "wipe must NOT fire on the consecutive failure")
+        assertEquals(1, metrics.events.count { it.first == "ic.self_heal" })
+        assertEquals(1, metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" })
+
+        // Request 3: same project, same error. Latch stays set, skip again.
+        wrapper.compile(req)
+        assertEquals(4, calls.get())
+        assertEquals(1, wipeCalls.get())
+        assertEquals(2, metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" })
+    }
+
+    @Test
+    fun `a successful compile clears the self-heal latch so a later InternalError still self-heals`() {
+        val metrics = RecordingMetricsSink()
+        val sequence = listOf<Result<IcResponse, IcError>>(
+            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt 1"))),
+            // retry of request 1 — succeeds
+            Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),
+            // request 2 — healthy
+            Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),
+            // request 3 — InternalError again; latch was cleared by
+            // the prior success so this one should self-heal again
+            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt 2"))),
+            // retry of request 3 — succeeds
+            Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),
+        )
+        val idx = AtomicInteger(0)
+        val delegate = FakeCompiler { _ -> sequence[idx.getAndIncrement()] }
+        val wrapper = SelfHealingIncrementalCompiler(
+            delegate = delegate,
+            wipe = { emptyList() },
+            metrics = metrics,
+            stderrWarn = { },
+        )
+        val req = request()
+
+        wrapper.compile(req)  // request 1 — self-heal fires
+        wrapper.compile(req)  // request 2 — success, clears latch
+        wrapper.compile(req)  // request 3 — self-heal fires again
+
+        assertEquals(2, metrics.events.count { it.first == "ic.self_heal" })
+        assertEquals(
+            0,
+            metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" },
+            "a successful compile between the two failures must reset the latch",
+        )
+    }
+
+    @Test
+    fun `CompilationFailed between two InternalErrors also clears the latch`() {
+        // User type errors are unrelated to cache corruption, so a
+        // CompilationFailed should not keep the latch set from a
+        // prior self-heal. Otherwise a developer who hits an
+        // InternalError, then a syntax error, then another
+        // InternalError (e.g. intermittent BTA bug) would lose the
+        // self-heal on the third request.
+        val metrics = RecordingMetricsSink()
+        val sequence = listOf<Result<IcResponse, IcError>>(
+            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt 1"))),
+            Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),  // retry succeeds
+            com.github.michaelbull.result.Err(IcError.CompilationFailed(listOf("Main.kt: error"))),
+            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt 2"))),
+            Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),  // retry succeeds
+        )
+        val idx = AtomicInteger(0)
+        val delegate = FakeCompiler { _ -> sequence[idx.getAndIncrement()] }
+        val wrapper = SelfHealingIncrementalCompiler(
+            delegate = delegate,
+            wipe = { emptyList() },
+            metrics = metrics,
+            stderrWarn = { },
+        )
+        val req = request()
+
+        wrapper.compile(req)  // InternalError → self-heal → SUCCESS
+        wrapper.compile(req)  // CompilationFailed — clears latch
+        wrapper.compile(req)  // InternalError → self-heal fires again
+
+        assertEquals(2, metrics.events.count { it.first == "ic.self_heal" })
+        assertEquals(
+            0,
+            metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" },
+        )
+    }
+
+    @Test
+    fun `different projects keep independent self-heal latches`() {
+        val metrics = RecordingMetricsSink()
+        val delegate = FakeCompiler { _ ->
+            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt")))
+        }
+        val wrapper = SelfHealingIncrementalCompiler(
+            delegate = delegate,
+            wipe = { emptyList() },
+            metrics = metrics,
+            stderrWarn = { },
+        )
+        val projectA = IcRequest(
+            projectId = "project-a",
+            projectRoot = tmpRoot,
+            sources = emptyList(),
+            classpath = emptyList(),
+            outputDir = tmpRoot.resolve("out-a"),
+            workingDir = workingDir,
+        )
+        val projectB = projectA.copy(projectId = "project-b")
+
+        wrapper.compile(projectA)  // A self-heals
+        wrapper.compile(projectB)  // B independently self-heals
+        wrapper.compile(projectA)  // A skipped
+        wrapper.compile(projectB)  // B skipped
+
+        assertEquals(
+            2,
+            metrics.events.count { it.first == "ic.self_heal" },
+            "each project gets exactly one self-heal on first InternalError",
+        )
+        assertEquals(
+            2,
+            metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" },
+            "consecutive failure on each project is skipped independently",
+        )
+    }
+
+    @Test
     fun `no self-heal events when the failure is a CompilationFailed`() {
         val metrics = RecordingMetricsSink()
         val delegate = FakeCompiler { _ ->

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -162,7 +162,21 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
         // is no longer needed, teach resolveDependencies to return List<String>
         // directly and delete this split.
         classpath = if (classpath.isNullOrEmpty()) emptyList() else classpath.split(":").filter { it.isNotEmpty() },
-        sources = config.sources.map { absolutise(it, cwd) },
+        // Expand directory entries in `config.sources` to their
+        // constituent .kt files before handing them to the backend.
+        // The Phase A kotlin-compiler-embeddable subprocess path
+        // tolerated directories via kotlinc's CLI, but Phase B's BTA
+        // requires individual files (`jvmCompilationOperationBuilder`
+        // reports `Is a directory` on the first directory entry). See
+        // issue #117 for the dogfood trace that surfaced this. The
+        // expansion runs on absolute paths so subsequent `absolutise`
+        // calls are a no-op; we do them inline with flatMap to keep
+        // the single-Result shape this block used before the fix.
+        sources = expandKotlinSources(config.sources.map { absolutise(it, cwd) })
+            .getOrElse { err ->
+                eprintln("error: could not list Kotlin sources under ${err.path}")
+                exitProcess(EXIT_BUILD_ERROR)
+            },
         outputPath = absolutise(CLASSES_DIR, cwd),
         moduleName = config.name,
         extraArgs = buildList {

--- a/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
+++ b/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
@@ -265,6 +265,38 @@ fun listKotlinFiles(directory: String): Result<List<String>, ListFilesFailed> {
     return Ok(files)
 }
 
+// Expand a caller-supplied source path list to a flat list of .kt files.
+// Directory entries are walked recursively via `collectKotlinFiles`;
+// individual .kt files are kept verbatim; anything else (non-.kt file, or a
+// path that does not exist) is kept as-is so the caller can still surface
+// a useful backend error.
+//
+// Motivation: Phase A (kotlin-compiler-embeddable) accepted directories on
+// the kotlinc command line and walked them implicitly. Phase B's BTA
+// (`jvmCompilationOperationBuilder(sources: List<Path>, ...)`) requires
+// individual file paths and reports `Is a directory` on the first entry
+// that happens to be a directory — which turns a typical
+// `sources = ["src"]` into a hard failure. Expanding here keeps both
+// backends happy with one call site. See issue #117.
+//
+// Order is stable: entries within each directory are sorted by
+// `listKotlinFiles`, and the overall order preserves the caller's
+// `sources` list position so kotlinc / BTA see the same module-boundary
+// order a hand-written CLI would produce.
+fun expandKotlinSources(sources: List<String>): Result<List<String>, ListFilesFailed> {
+    val expanded = mutableListOf<String>()
+    for (entry in sources) {
+        when {
+            isDirectory(entry) -> {
+                val found = listKotlinFiles(entry).getOrElse { err -> return Err(err) }
+                expanded.addAll(found)
+            }
+            else -> expanded.add(entry)
+        }
+    }
+    return Ok(expanded)
+}
+
 @OptIn(ExperimentalForeignApi::class)
 private fun collectKotlinFiles(directory: String, result: MutableList<String>): ListFilesFailed? {
     val dir = opendir(directory) ?: return ListFilesFailed(directory)

--- a/src/nativeTest/kotlin/kolt/infra/FileSystemTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/FileSystemTest.kt
@@ -280,6 +280,85 @@ class FileSystemTest {
     }
 
     @Test
+    fun expandKotlinSourcesWalksDirectoriesIntoKtFiles() {
+        // Regression guard for issue #117: the daemon compile path
+        // must receive individual .kt files, not directories, because
+        // BTA's jvmCompilationOperationBuilder rejects directory
+        // entries with `Is a directory`. Before this fix, a typical
+        // `sources = ["src"]` in kolt.toml silently crashed the
+        // daemon-backed compile under default-on B-2b rollout.
+        val root = "/tmp/kolt_expand_sources_walk"
+        val sub = "$root/sub"
+        platform.posix.mkdir(root, 0b111111101u)
+        platform.posix.mkdir(sub, 0b111111101u)
+        writeTestFile("$root/A.kt", "package p; fun a() = 0")
+        writeTestFile("$sub/B.kt", "package p.q; fun b() = 0")
+        writeTestFile("$root/notes.md", "ignored")
+        try {
+            val files = assertNotNull(expandKotlinSources(listOf(root)).get())
+            // Only .kt files; sorted; nested dir walked.
+            assertEquals(listOf("$root/A.kt", "$sub/B.kt"), files)
+        } finally {
+            remove("$root/A.kt")
+            remove("$sub/B.kt")
+            remove("$root/notes.md")
+            platform.posix.rmdir(sub)
+            platform.posix.rmdir(root)
+        }
+    }
+
+    @Test
+    fun expandKotlinSourcesKeepsIndividualFilesAsIs() {
+        val root = "/tmp/kolt_expand_sources_individual"
+        platform.posix.mkdir(root, 0b111111101u)
+        writeTestFile("$root/Main.kt", "fun main() {}")
+        try {
+            // A caller-supplied individual file must pass through
+            // verbatim — no flattening, no walk.
+            val files = assertNotNull(expandKotlinSources(listOf("$root/Main.kt")).get())
+            assertEquals(listOf("$root/Main.kt"), files)
+        } finally {
+            remove("$root/Main.kt")
+            platform.posix.rmdir(root)
+        }
+    }
+
+    @Test
+    fun expandKotlinSourcesMergesDirsAndFilesPreservingCallerOrder() {
+        val dir = "/tmp/kolt_expand_sources_merge_dir"
+        val loose = "/tmp/kolt_expand_sources_merge_loose.kt"
+        platform.posix.mkdir(dir, 0b111111101u)
+        writeTestFile("$dir/Inside.kt", "fun inside() {}")
+        writeTestFile(loose, "fun loose() {}")
+        try {
+            // Mixing a dir and a standalone file: the caller's
+            // positional order must be preserved so kotlinc / BTA see
+            // the same module-boundary order a hand-written CLI would
+            // produce.
+            val files = assertNotNull(expandKotlinSources(listOf(dir, loose)).get())
+            assertEquals(listOf("$dir/Inside.kt", loose), files)
+        } finally {
+            remove("$dir/Inside.kt")
+            platform.posix.rmdir(dir)
+            remove(loose)
+        }
+    }
+
+    @Test
+    fun expandKotlinSourcesPassesThroughNonExistentEntriesUnchanged() {
+        // A path that is neither an existing directory nor an existing
+        // file is treated as "caller's intent" and passed through
+        // verbatim. The backend (kotlinc / BTA) then surfaces a real
+        // "no such file" error, which is strictly more informative
+        // than a wrapped `ListFilesFailed` would be. The test pins
+        // this policy so a future rewrite does not silently drop
+        // missing entries.
+        val missing = "/tmp/kolt_expand_sources_missing_${platform.posix.getpid()}.kt"
+        val files = assertNotNull(expandKotlinSources(listOf(missing)).get())
+        assertEquals(listOf(missing), files)
+    }
+
+    @Test
     fun copyDirectoryContentsCopiesFilesToDest() {
         // Given: source dir with one file
         val src = "/tmp/kolt_copy_src_basic"


### PR DESCRIPTION
Two follow-up fixes surfaced while dogfooding #116 (B-2b) against
\`spike/bench-scaling/fixtures/jvm-10\`. Both were latent issues that
only became observable once B-2b landed the KotlinLogger diagnostic
capture and structured \`ic.*\` metrics.

## Part 1 — Native client sends source directories to the daemon

\`BuildCommands.kt:165\` built \`CompileRequest.sources\` via
\`config.sources.map { absolutise(it, cwd) }\`, forwarding every
\`kolt.toml\` source entry verbatim. Phase A's
kotlin-compiler-embeddable subprocess tolerated directory entries
because kotlinc's CLI walks them implicitly, so the bug stayed dormant.
Phase B's BTA \`jvmCompilationOperationBuilder(sources: List<Path>, ...)\`
is strict: the first directory entry produces an \`Is a directory\`
failure, and every \`kolt build --daemon\` against a typical
\`sources = ["src"]\` fell into \`IcError.InternalError\`, fired
self-heal, wiped the workingDir, retried, failed again, surfaced
"error: compilation failed with exit code 2".

**Fix** (\`a2e2639\`): new \`expandKotlinSources(List<String>)\` helper in
\`infra/FileSystem.kt\` that walks directory entries via the existing
\`listKotlinFiles\` helper and keeps individual file entries verbatim.
Applied in \`BuildCommands.kt\` before constructing \`CompileRequest\`.
Non-existent entries pass through verbatim so the backend's own
"no such file" error surfaces with more context than a wrapped
\`ListFilesFailed\` would.

## Part 2 — Self-heal fires on every request for a persistent client-side bug

ADR 0019 §7 specifies "retry once per request" on
\`IcError.InternalError\`. That is correct in isolation, but when the
failure is persistent (e.g. part 1 above — the native client keeps
sending a directory), every incoming request triggers a fresh
wipe+retry cycle with no chance of making progress. Observed during
dogfood: 4+ \`ic.self_heal\` events across 2 \`kolt build\` invocations
with identical outcomes.

**Fix** (\`7135800\`): per-project latch inside
\`SelfHealingIncrementalCompiler\`. When a request for project X fires a
self-heal retry (for any outcome), mark X as "just self-healed". On
the next request for X, if the delegate surfaces \`IcError.InternalError\`
again, skip the wipe+retry entirely, record the new
\`ic.self_heal_skipped_consecutive\` counter, and surface the initial
failure directly. Any successful compile clears the latch so a later
corruption still gets a fresh self-heal chance. A
\`CompilationFailed\` (user type error) also clears the latch, since
syntax errors are unrelated to cache corruption.

Per-project state is a synchronised \`Set<String>\` keyed by
\`IcRequest.projectId\`. Daemon core currently serialises compile
traffic, but the synchronised wrapper keeps read/modify/write atomic
for a future parallel dispatch.

## Why these surfaced now

Both bugs existed before B-2b. The reason B-2b made them visible is the
observability work that shipped in #116:

- KotlinLogger diagnostic capture (\`dde1f27\`) replaced the stub
  "kotlinc reported COMPILATION_ERROR" message with the real BTA
  error text, so \`Is a directory\` became user-visible for the first
  time.
- Structured \`ic.*\` metrics (\`0c5869d\`) made the per-request
  self-heal firing pattern legible in the daemon log, which is how
  the wipe+retry loop was spotted in the first place.

## Test plan

- [x] \`./gradlew :kolt-compiler-daemon:ic:test\` — 38 cases pass
  (4 new latch cases, 4 pre-existing still pass)
- [x] \`./gradlew :kolt-compiler-daemon:test\` — 12 cases pass
- [x] \`./gradlew linuxX64Test\` — 735 cases pass (4 new
  \`expandKotlinSources*\` cases, all pre-existing still pass)
- [x] \`./gradlew :kolt-compiler-daemon:build\` — full green
- [x] Dogfood against \`spike/bench-scaling/fixtures/jvm-10\` post-fix:
  - Cold \`kolt build --daemon\`: 7.0s, \`ic.success\` +
    \`ic.fallback_to_full\` fire
  - Warm build after 1-line source touch: 1.0s, only \`ic.success\`
    fires (no \`ic.fallback_to_full\`)
  - Matches spike #104's ~7× bimodal-win target

## Related

- #113 Phase B-2b (parent issue)
- #116 B-2b merge (surfaced these issues)
- #117 (this PR's parent issue)
- ADR 0019 §7 (self-heal contract this PR tightens)

Refs #3 #113 #117
Closes #117