### PR TITLE
Phase B-2c: required validations for declared-done gate (#114)

### DIFF
--- a/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
+++ b/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
@@ -491,22 +491,39 @@ deliberately **not** decisions made here. Filing them as separate
 issues before B-2 starts would risk bit-rot; filing them inside B-2
 scope keeps them attached to the person doing the work.
 
-- **Prototype `kotlinx.serialization` through the adapter** before
-  declaring B-2 complete. Resolves spike residual risk O.Q. 6.
-- **Smoke test for IC cache corruption**: point BTA at a truncated
-  state file, confirm the `InternalError` → wipe → full-recompile
-  self-heal path in §7 works end-to-end.
-- **ABI-affecting cascade validation**: linear-10 fixture with a
-  signature change in `work5` + matching call-site edits in `F6.kt`,
-  to observe real cascade depth. Pairs with the #103 bench numbers as
-  a regression guard.
+**Status (B-2c, #114):** the three required-for-declared-done validations
+and the `CapturingKotlinLogger` / structured-diagnostic plumbing have
+landed in #114. The remaining bullets are deliberately post-B-2 — they
+are operational-hygiene or future-wire-client items with no blocking
+dependency on the current B-2 surface.
+
+- ~~**Prototype `kotlinx.serialization` through the adapter**~~ —
+  done in B-2c (`BtaSerializationPluginTest`). Spike residual risk
+  O.Q. 6 is resolved: real plugin jar delivery through `--plugin-jars`
+  + `PluginTranslator` produces the synthetic `$serializer` /
+  `$Companion` classes and a compiling `@Serializable data class`.
+- ~~**Smoke test for IC cache corruption**~~ — done in B-2c
+  (`BtaIncrementalCorruptionSmokeTest`). Drives the composed
+  `SelfHealingIncrementalCompiler(BtaIncrementalCompiler)` stack
+  against a workingDir whose state files have been truncated to
+  0 bytes; the `ic.self_heal` counter fires and the second compile
+  returns `Ok(IcResponse)`.
+- ~~**ABI-affecting cascade validation**~~ — done in B-2c
+  (`BtaIncrementalAbiCascadeTest`). Mid-chain signature change +
+  matching caller edit on a linear-5 fixture; recompile set is
+  `>= 2 && < totalCount`, pinning both "cascade happened" and
+  "cascade stopped short of full".
 - **Classpath snapshot caching**: cache `ClasspathEntrySnapshot`
   keyed by `(path, mtime, size)` so repeated builds on an unchanged
   classpath skip re-snapshotting. Measure before implementing.
+  Remains post-B-2 per §Consequences / Negative.
 - **Scaling run on jvm-100 / jvm-250**: point the
   `spike/bench-scaling/` harness at a B-2 daemon to confirm the
   per-file slope drops as predicted. #103's ceiling and #96's slope
-  are the two reference numbers to beat.
+  are the two reference numbers to beat. B-2c drops results under
+  `spike/bench-scaling/results-*` for the available fixture sizes;
+  extending the harness to jvm-100 / jvm-250 is a separate harness-
+  scaling concern and is filed as a dedicated follow-up.
 - **`~/.kolt/daemon/ic/` reaper**: periodically remove old Kotlin
   version segments and old project-hash subdirs. Shares design with
   the Phase A socket-dir reaper follow-up.

--- a/kolt-compiler-daemon/ic/build.gradle.kts
+++ b/kolt-compiler-daemon/ic/build.gradle.kts
@@ -31,6 +31,22 @@ val fixtureClasspath: Configuration by configurations.creating {
     isCanBeConsumed = false
 }
 
+// B-2c: real-plugin validation. The kotlinx.serialization compiler plugin jar
+// is resolved here and passed to the real-plugin test via a system property so
+// BtaIncrementalCompiler's pluginJarResolver can return a non-empty classpath
+// for the `serialization` alias. The serialization *runtime* artefact is pulled
+// into the fixture classpath below so compiled fixtures can link against
+// `kotlinx.serialization.*` symbols the plugin generates.
+val serializationPluginClasspath: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
+val serializationRuntimeClasspath: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
 dependencies {
     // -api only — the impl loads reflectively at runtime via SharedApiClassesClassLoader
     // parent + URLClassLoader child. The daemon core module consumes this subproject
@@ -56,6 +72,20 @@ dependencies {
     buildToolsImpl("org.jetbrains.kotlin:kotlin-build-tools-impl:2.3.20")
     fixtureClasspath("org.jetbrains.kotlin:kotlin-stdlib:2.3.20")
 
+    // B-2c: real compiler plugin jar for kotlinx.serialization. The `-embeddable`
+    // variant is the one that loads inside the kotlinc classloader hierarchy BTA
+    // sets up (non-embeddable uses shaded guava / coroutines and collides with
+    // the daemon classloader).
+    serializationPluginClasspath(
+        "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable:2.3.20",
+    )
+    // Matching runtime artefact so the fixture can import
+    // `kotlinx.serialization.Serializable` and reference generated serializers.
+    serializationRuntimeClasspath("org.jetbrains.kotlin:kotlin-stdlib:2.3.20")
+    serializationRuntimeClasspath(
+        "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.7.3",
+    )
+
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
@@ -69,4 +99,12 @@ tasks.test {
     useJUnitPlatform()
     systemProperty("kolt.ic.btaImplClasspath", buildToolsImpl.asPath)
     systemProperty("kolt.ic.fixtureClasspath", fixtureClasspath.asPath)
+    systemProperty(
+        "kolt.ic.serializationPluginClasspath",
+        serializationPluginClasspath.asPath,
+    )
+    systemProperty(
+        "kolt.ic.serializationRuntimeClasspath",
+        serializationRuntimeClasspath.asPath,
+    )
 }

--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
@@ -8,7 +8,6 @@ import com.github.michaelbull.result.Result
 import org.jetbrains.kotlin.buildtools.api.BuildOperation
 import org.jetbrains.kotlin.buildtools.api.CompilationResult
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
-import org.jetbrains.kotlin.buildtools.api.KotlinLogger
 import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
 import org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader
 import org.jetbrains.kotlin.buildtools.api.SourcesChanges
@@ -242,46 +241,6 @@ class BtaIncrementalCompiler private constructor(
         // projectId is a stable caller-derived hash per ADR 0019 §3; it is
         // already URL/FS-safe enough to serve as a kotlinc module name.
         "kolt-${request.projectId}"
-
-    // Captures BTA's compile-time log output. `error`-level lines are
-    // retained for folding into `IcError.CompilationFailed.messages`;
-    // `warn` / `info` / `debug` / `lifecycle` lines are forwarded to
-    // the metrics sink as coarse counters so log volume is observable
-    // without polluting the user's compile-error stream. Throwables
-    // attached to error/warn calls are unwrapped and appended to the
-    // captured line so a user chasing a BTA-internal stack trace still
-    // sees the message.
-    private class CapturingKotlinLogger(
-        private val metrics: IcMetricsSink,
-    ) : KotlinLogger {
-        private val errors: MutableList<String> = mutableListOf()
-
-        override val isDebugEnabled: Boolean get() = false
-
-        override fun error(msg: String, throwable: Throwable?) {
-            errors.add(if (throwable == null) msg else "$msg: ${throwable.message ?: throwable.javaClass.name}")
-            metrics.record(METRIC_LOG_ERROR)
-        }
-
-        override fun warn(msg: String, throwable: Throwable?) {
-            metrics.record(METRIC_LOG_WARN)
-        }
-
-        override fun info(msg: String) {
-            metrics.record(METRIC_LOG_INFO)
-        }
-
-        override fun debug(msg: String) {
-            // Not recorded: debug is too noisy to count per line and
-            // `isDebugEnabled = false` keeps BTA from even producing it.
-        }
-
-        override fun lifecycle(msg: String) {
-            metrics.record(METRIC_LOG_LIFECYCLE)
-        }
-
-        fun errorMessages(): List<String> = errors.toList()
-    }
 
     private fun isEmptyDir(workingDir: Path): Boolean {
         if (!Files.exists(workingDir)) return true

--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/CapturingKotlinLogger.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/CapturingKotlinLogger.kt
@@ -1,0 +1,66 @@
+@file:OptIn(ExperimentalBuildToolsApi::class)
+
+package kolt.daemon.ic
+
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinLogger
+import java.io.PrintWriter
+import java.io.StringWriter
+
+// Captures BTA's compile-time log output. `error`-level lines are retained
+// for folding into `IcError.CompilationFailed.messages`; `warn` / `info` /
+// `debug` / `lifecycle` lines are forwarded to the metrics sink as coarse
+// counters so log volume stays observable without polluting the user's
+// compile-error stream.
+//
+// Throwable handling (B-2c): on an `error` call with an attached throwable,
+// the captured message retains one line of stack trace in addition to the
+// throwable's message. The B-2b implementation kept only `throwable.message`,
+// which threw away the frame a user needs to find BTA-internal failures.
+// Keeping the full trace would flood the user's stderr; one line is the
+// compromise between "silent" and "noisy".
+internal class CapturingKotlinLogger(
+    private val metrics: IcMetricsSink,
+) : KotlinLogger {
+    private val errors: MutableList<String> = mutableListOf()
+
+    override val isDebugEnabled: Boolean get() = false
+
+    override fun error(msg: String, throwable: Throwable?) {
+        errors.add(formatLine(msg, throwable))
+        metrics.record(BtaIncrementalCompiler.METRIC_LOG_ERROR)
+    }
+
+    override fun warn(msg: String, throwable: Throwable?) {
+        metrics.record(BtaIncrementalCompiler.METRIC_LOG_WARN)
+    }
+
+    override fun info(msg: String) {
+        metrics.record(BtaIncrementalCompiler.METRIC_LOG_INFO)
+    }
+
+    override fun debug(msg: String) {
+        // Not recorded: debug is too noisy to count per line and
+        // `isDebugEnabled = false` keeps BTA from even producing it.
+    }
+
+    override fun lifecycle(msg: String) {
+        metrics.record(BtaIncrementalCompiler.METRIC_LOG_LIFECYCLE)
+    }
+
+    fun errorMessages(): List<String> = errors.toList()
+
+    private fun formatLine(msg: String, throwable: Throwable?): String {
+        if (throwable == null) return msg
+        val header = "$msg: ${throwable.toString()}"
+        val firstFrame = throwable.stackTrace.firstOrNull() ?: return header
+        return "$header\n\tat $firstFrame"
+    }
+
+    @Suppress("unused") // reserved for a future verbose-mode wiring
+    private fun fullStackTrace(throwable: Throwable): String {
+        val sw = StringWriter()
+        throwable.printStackTrace(PrintWriter(sw))
+        return sw.toString()
+    }
+}

--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/CapturingKotlinLogger.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/CapturingKotlinLogger.kt
@@ -4,8 +4,6 @@ package kolt.daemon.ic
 
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.buildtools.api.KotlinLogger
-import java.io.PrintWriter
-import java.io.StringWriter
 
 // Captures BTA's compile-time log output. `error`-level lines are retained
 // for folding into `IcError.CompilationFailed.messages`; `warn` / `info` /
@@ -52,15 +50,19 @@ internal class CapturingKotlinLogger(
 
     private fun formatLine(msg: String, throwable: Throwable?): String {
         if (throwable == null) return msg
-        val header = "$msg: ${throwable.toString()}"
-        val firstFrame = throwable.stackTrace.firstOrNull() ?: return header
-        return "$header\n\tat $firstFrame"
-    }
-
-    @Suppress("unused") // reserved for a future verbose-mode wiring
-    private fun fullStackTrace(throwable: Throwable): String {
-        val sw = StringWriter()
-        throwable.printStackTrace(PrintWriter(sw))
-        return sw.toString()
+        // A pathological `Throwable` subclass can override `toString()` or
+        // `getMessage()` and throw. `BtaIncrementalCompiler.compile` wraps
+        // the whole compile call in a `Throwable` catch that converts any
+        // such throw into `IcError.InternalError`, so it would be caught —
+        // but a throw from inside `executeOperation`'s logger call still
+        // aborts the compile mid-flight. `runCatching` here keeps the
+        // adapter-level error path in charge: on failure we fall back to
+        // the throwable's fully-qualified class name, which is always
+        // safe because `Class.getName()` cannot throw.
+        return runCatching {
+            val header = "$msg: ${throwable.toString()}"
+            val firstFrame = throwable.stackTrace.firstOrNull() ?: return header
+            "$header\n\tat $firstFrame"
+        }.getOrElse { "$msg: ${throwable.javaClass.name}" }
     }
 }

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalAbiCascadeTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalAbiCascadeTest.kt
@@ -1,0 +1,188 @@
+@file:OptIn(kotlin.io.path.ExperimentalPathApi::class)
+
+package kolt.daemon.ic
+
+import com.github.michaelbull.result.getOrElse
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import kotlin.io.path.createDirectories
+import kotlin.io.path.extension
+import kotlin.io.path.relativeTo
+import kotlin.io.path.walk
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+// ADR 0019 Follow-ups + B-2c: complements BtaIncrementalRecompileSetTest
+// (which pins the bimodal-1 ABI-neutral win) by exercising the other side
+// of the distribution — an ABI-affecting signature change. Spike #104's
+// residual note (O.Q. 8 caveat) flagged this scenario as required B-2
+// validation: "linear chain with signature change in mid-chain function
+// + matching call-site edits, to observe the cascade depth".
+//
+// Fixture: linear-5 (same shape BtaIncrementalRecompileSetTest uses) so
+// the test stays fast and self-contained. The ABI edit changes `f3`'s
+// signature from `f3(): Int` to `f3(bonus: Int): Int`, and updates `f2`'s
+// call site to pass an explicit argument. F1 / F4 / F5 are ABI-neutral
+// to the edit, so a correct IC configuration recompiles the changed
+// files (at minimum f3.class and f2.class) but stops short of the full
+// file count — proving BTA's ABI snapshot is keeping IC smarter than a
+// "recompile everything downstream of the touched file" fallback.
+//
+// The assertion is deliberately loose: `2 <= changed < coldCount`. BTA
+// 2.3.x may legitimately recompile additional downstream files if its
+// ABI-diff logic decides they transitively observe the signature change,
+// and tightening the bound would bind the test to a compiler-internal
+// heuristic that shifts with every minor version. The structural claim
+// the test cares about is "cascade happened AND cascade stopped short of
+// full".
+class BtaIncrementalAbiCascadeTest {
+
+    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+
+    @Test
+    fun `signature change on mid chain function cascades to caller but stops short of full`() {
+        val workRoot = Files.createTempDirectory("bta-abi-cascade-")
+        val sourcesDir = workRoot.resolve("src").apply { createDirectories() }
+        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+        val workingDir = workRoot.resolve("ic-state")
+
+        // Each file owns exactly one top-level `fun` so .class files map
+        // 1:1 to source files (modulo synthetic artefacts BTA may emit).
+        // F3 is mid-chain; it is the one we mutate.
+        val f1 = sourcesDir.resolve("F1.kt").also {
+            it.writeText(
+                """
+                package fixture
+                fun f1(): Int = f2() + 1
+                """.trimIndent(),
+            )
+        }
+        val f2 = sourcesDir.resolve("F2.kt").also {
+            it.writeText(
+                """
+                package fixture
+                fun f2(): Int = f3() + 2
+                """.trimIndent(),
+            )
+        }
+        val f3 = sourcesDir.resolve("F3.kt").also {
+            it.writeText(
+                """
+                package fixture
+                fun f3(): Int = f4() + 3
+                """.trimIndent(),
+            )
+        }
+        val f4 = sourcesDir.resolve("F4.kt").also {
+            it.writeText(
+                """
+                package fixture
+                fun f4(): Int = f5() + 4
+                """.trimIndent(),
+            )
+        }
+        val f5 = sourcesDir.resolve("F5.kt").also {
+            it.writeText(
+                """
+                package fixture
+                fun f5(): Int = 5
+                """.trimIndent(),
+            )
+        }
+        val files = listOf(f1, f2, f3, f4, f5)
+
+        val compiler = BtaIncrementalCompiler.create(btaImplJars).getOrElse {
+            fail("failed to load BTA toolchain: $it")
+        }
+
+        val request = IcRequest(
+            projectId = "abi-cascade-smoke",
+            projectRoot = workRoot,
+            sources = files,
+            classpath = fixtureClasspath,
+            outputDir = outputDir,
+            workingDir = workingDir,
+        )
+
+        // --- cold ---
+        compiler.compile(request).getOrElse { fail("cold compile failed: $it") }
+        val coldHashes = hashClassFiles(outputDir)
+        val coldCount = coldHashes.size
+        assertTrue(
+            coldCount >= 5,
+            "expected at least 5 class files after cold compile of the 5-file chain, got: $coldCount",
+        )
+
+        // --- ABI-affecting signature change on f3 + matching f2 call site ---
+        Files.writeString(
+            f3,
+            """
+            package fixture
+            fun f3(bonus: Int): Int = f4() + 3 + bonus
+            """.trimIndent(),
+        )
+        Files.writeString(
+            f2,
+            """
+            package fixture
+            fun f2(): Int = f3(10) + 2
+            """.trimIndent(),
+        )
+
+        // --- warm ---
+        compiler.compile(request).getOrElse { fail("warm compile failed: $it") }
+        val warmHashes = hashClassFiles(outputDir)
+
+        val changed = warmHashes.filter { (path, hash) -> coldHashes[path] != hash }
+
+        // Cascade happened: f3 changed its ABI, f2 had to re-link against
+        // the new signature, so at minimum two .class files differ between
+        // cold and warm. A single-file change here would mean BTA did not
+        // observe the call-site edit, which the test is specifically
+        // guarding against.
+        assertTrue(
+            changed.size >= 2,
+            "expected signature change to cascade to at least the caller " +
+                "(f3 + f2 = 2 class files), got changed=${changed.size} " +
+                "(${changed.keys.sorted()})",
+        )
+
+        // Cascade stopped short of full: IC is still smarter than "recompile
+        // everything". A regression producing `changed.size == coldCount`
+        // would mean the ABI snapshot failed to spare f1 / f4 / f5 from
+        // recompilation — the inverse of the bimodal floor, and the
+        // signal that the #103 ceiling has been hit.
+        assertTrue(
+            changed.size < coldCount,
+            "expected ABI cascade to stop short of full recompile, " +
+                "got changed=${changed.size} of $coldCount " +
+                "(${changed.keys.sorted()})",
+        )
+    }
+
+    private fun hashClassFiles(classesDir: Path): Map<String, String> {
+        if (!Files.isDirectory(classesDir)) return emptyMap()
+        val md = MessageDigest.getInstance("SHA-256")
+        return classesDir.walk()
+            .filter { it.extension == "class" }
+            .associate { p ->
+                val rel = p.relativeTo(classesDir).toString()
+                md.reset()
+                md.update(Files.readAllBytes(p))
+                rel to md.digest().joinToString("") { "%02x".format(it) }
+            }
+    }
+
+    private fun systemClasspath(key: String): List<Path> {
+        val raw = System.getProperty(key)
+            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        return raw.split(File.pathSeparator)
+            .filter { it.isNotBlank() }
+            .map { Path.of(it) }
+    }
+}

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCorruptionSmokeTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCorruptionSmokeTest.kt
@@ -1,0 +1,134 @@
+@file:OptIn(kotlin.io.path.ExperimentalPathApi::class)
+
+package kolt.daemon.ic
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getOrElse
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.createDirectories
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.walk
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+// ADR 0019 §7 + B-2c required validation: end-to-end replay of the
+// cache-corruption scenario the ADR's self-heal path exists to handle.
+// B-2b landed the wipe+retry wrapper and unit-tested it against a fake
+// delegate; the spike REPORT flagged "smoke test for IC cache
+// corruption" as the residual validation, and this test closes it.
+//
+// Method: drive a cold compile through the real composed stack, then
+// corrupt every regular file BTA wrote under `workingDir` by truncating
+// them to zero bytes. Truncation is chosen over "overwrite one specific
+// file name" because BTA's state layout is version-dependent — the test
+// would rot silently the moment JetBrains renamed a cache file. Blindly
+// truncating everything is layout-agnostic and guarantees the next BTA
+// invocation either throws or returns a non-SUCCESS `CompilationResult`,
+// either of which is the `IcError.InternalError` path that self-heal
+// keys off.
+//
+// Expected outcome: the second compile returns `Ok(IcResponse)` because
+// self-heal wipes the broken state and retries from scratch; the
+// `ic.self_heal` counter is recorded so a future `kolt doctor` can
+// observe the event.
+class BtaIncrementalCorruptionSmokeTest {
+
+    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+
+    @Test
+    fun `truncated working dir triggers self-heal and second compile succeeds`() {
+        val workRoot = Files.createTempDirectory("bta-corrupt-")
+        val sourceFile = workRoot.resolve("Main.kt").also {
+            it.writeText(
+                """
+                package fixture
+                object Main { fun ping(): String = "pong" }
+                """.trimIndent(),
+            )
+        }
+        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+        val workingDir = workRoot.resolve("ic-state")
+
+        val metrics = RecordingMetricsSink()
+        val adapter = BtaIncrementalCompiler.create(btaImplJars, metrics = metrics)
+            .getOrElse { fail("adapter construction failed: $it") }
+        val composed: IncrementalCompiler = SelfHealingIncrementalCompiler(
+            delegate = adapter,
+            metrics = metrics,
+        )
+
+        val request = IcRequest(
+            projectId = "corruption-smoke",
+            projectRoot = workRoot,
+            sources = listOf(sourceFile),
+            classpath = fixtureClasspath,
+            outputDir = outputDir,
+            workingDir = workingDir,
+        )
+
+        // Cold compile — establishes BTA state under workingDir.
+        composed.compile(request).get()
+            ?: fail("expected Ok from initial cold compile")
+        assertTrue(
+            Files.exists(workingDir) && workingDir.toFile().listFiles()?.isNotEmpty() == true,
+            "cold compile should have populated workingDir: $workingDir",
+        )
+
+        // Corrupt every regular file under workingDir. Directory structure
+        // is preserved so the retry path can still enumerate entries;
+        // BTA's on-disk deserialisation either throws or yields a
+        // non-SUCCESS CompilationResult against zero-byte state files.
+        val truncated = mutableListOf<Path>()
+        workingDir.walk().filter { it.isRegularFile() }.forEach { path ->
+            Files.newByteChannel(
+                path,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+            ).close()
+            truncated.add(path)
+        }
+        assertTrue(
+            truncated.isNotEmpty(),
+            "expected BTA to have written at least one state file under $workingDir",
+        )
+
+        // Clear pre-corruption events so the assertion below only sees
+        // what the second compile emits.
+        metrics.events.clear()
+
+        // Warm compile — self-heal must fire, wipe, retry, and ultimately
+        // return Ok because the retry is a clean cold recompile.
+        val response = composed.compile(request).get()
+            ?: fail(
+                "expected self-heal to recover the second compile, " +
+                    "metrics=${metrics.events}",
+            )
+        assertTrue(response.wallMillis >= 0)
+
+        assertTrue(
+            metrics.events.any { it.first == SelfHealingIncrementalCompiler.METRIC_SELF_HEAL },
+            "ic.self_heal must have fired; metrics=${metrics.events}",
+        )
+    }
+
+    private class RecordingMetricsSink : IcMetricsSink {
+        val events: MutableList<Pair<String, Long>> = mutableListOf()
+        override fun record(name: String, value: Long) {
+            events += name to value
+        }
+    }
+
+    private fun systemClasspath(key: String): List<Path> {
+        val raw = System.getProperty(key)
+            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        return raw.split(File.pathSeparator)
+            .filter { it.isNotBlank() }
+            .map { Path.of(it) }
+    }
+}

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
@@ -107,26 +107,21 @@ class BtaSerializationPluginTest {
             "expected fixture.Payload.class in output, got: $classFiles",
         )
 
-        // The serialization plugin synthesises a nested `${'$'}serializer`
-        // class (singleton that implements KSerializer<Payload>) and a
-        // `${'$'}Companion` holder during the compile. Both are the
-        // unambiguous signal that the plugin ran — plain kotlinc output
-        // of a `@Serializable data class` contains neither. Kotlin
-        // compiles the nested `${'$'}serializer` name to a double-dollar
-        // file name (`Payload${'$'}${'$'}serializer.class`) because the
-        // first `${'$'}` is the Kotlin-to-JVM nested class separator and
-        // the second is the literal name.
+        // The load-bearing signal that the plugin ran is the nested
+        // `${'$'}serializer` class — a singleton that implements
+        // `KSerializer<Payload>` and is synthesised only by the
+        // serialization compiler plugin. Plain kotlinc output of a
+        // `@Serializable data class` contains no such entry. The file
+        // name is `Payload${'$'}${'$'}serializer.class` because the
+        // first `${'$'}` is the Kotlin-to-JVM nested class separator
+        // and the second is the literal name. A future regression that
+        // silently skipped plugin attachment would leave this class
+        // absent — this assertion is the guard.
         val serializerName = "Payload\$\$serializer.class"
-        val companionName = "Payload\$Companion.class"
         val classFileNames = classFiles.map { it.fileName.toString() }
         assertTrue(
             serializerName in classFileNames,
             "kotlinx.serialization plugin must have generated `$serializerName`; " +
-                "classFiles=$classFileNames",
-        )
-        assertTrue(
-            companionName in classFileNames,
-            "kotlinx.serialization plugin must have generated `$companionName`; " +
                 "classFiles=$classFileNames",
         )
     }

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
@@ -1,0 +1,169 @@
+@file:OptIn(kotlin.io.path.ExperimentalPathApi::class)
+
+package kolt.daemon.ic
+
+import com.github.michaelbull.result.getOrElse
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.extension
+import kotlin.io.path.walk
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+// ADR 0019 Follow-ups + B-2c: resolves spike #104 O.Q. 6 residual risk.
+// Drives BtaIncrementalCompiler end-to-end through a **real** compiler
+// plugin (`kotlinx.serialization`) so the adapter's plugin jar delivery,
+// PluginTranslator wiring, and BTA's plugin loading have all been
+// exercised on the happy path before B-2 is declared done.
+//
+// The test asserts two structural facts:
+//   1. A `@Serializable` data class compiles without error.
+//   2. The kotlinx.serialization compiler plugin ran during the compile
+//      — evidenced by the generated `$Companion` / `$serializer` symbol
+//      inside the produced .class file, which the plugin synthesises
+//      and is never present in plain kotlinc output.
+//
+// The second assertion is the load-bearing one: without it, a regression
+// that silently skipped plugin attachment (e.g. the pluginJarResolver
+// returning empty, or PluginTranslator's alias map losing the
+// `serialization` entry) could still pass the compile because
+// `@Serializable` is a harmless annotation on its own. The serializer
+// symbol only exists if the plugin actually transformed the AST.
+class BtaSerializationPluginTest {
+
+    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+    private val serializationPluginJars: List<Path> =
+        systemClasspath("kolt.ic.serializationPluginClasspath")
+    private val serializationFixtureClasspath: List<Path> =
+        systemClasspath("kolt.ic.serializationRuntimeClasspath")
+
+    @Test
+    fun `Serializable data class compiles and the plugin generated serializer symbol`() {
+        val workRoot = Files.createTempDirectory("bta-serialization-")
+        val sourceFile = workRoot.resolve("Payload.kt").also {
+            it.writeText(
+                """
+                package fixture
+
+                import kotlinx.serialization.Serializable
+
+                @Serializable
+                data class Payload(val name: String, val count: Int)
+                """.trimIndent(),
+            )
+        }
+        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+        val workingDir = workRoot.resolve("ic-state")
+
+        val resolverCalls = mutableListOf<String>()
+        val compiler = BtaIncrementalCompiler.create(
+            btaImplJars = btaImplJars,
+            pluginJarResolver = { alias ->
+                resolverCalls.add(alias)
+                if (alias == "serialization") serializationPluginJars else emptyList()
+            },
+        ).getOrElse { fail("failed to load BTA toolchain: $it") }
+
+        // kolt.toml enables the serialization plugin so PluginTranslator
+        // picks it up on its normal reading path — the test is not
+        // bypassing the translator, it is going through it.
+        workRoot.resolve("kolt.toml").writeText(
+            """
+            name = "demo"
+            version = "0.1.0"
+            kotlin = "2.3.20"
+            target = "jvm"
+            main = "fixture.Payload"
+            sources = ["."]
+
+            [plugins]
+            serialization = true
+            """.trimIndent(),
+        )
+
+        compiler.compile(
+            IcRequest(
+                projectId = "serialization-smoke",
+                projectRoot = workRoot,
+                sources = listOf(sourceFile),
+                classpath = serializationFixtureClasspath,
+                outputDir = outputDir,
+                workingDir = workingDir,
+            ),
+        ).getOrElse { fail("expected successful compile of @Serializable fixture, got: $it") }
+
+        assertTrue(
+            resolverCalls.contains("serialization"),
+            "PluginTranslator must have consulted the resolver for `serialization`, got: $resolverCalls",
+        )
+
+        val classFiles = outputDir.walk().filter { it.extension == "class" }.toList()
+        assertTrue(
+            classFiles.any { it.fileName.toString() == "Payload.class" },
+            "expected fixture.Payload.class in output, got: $classFiles",
+        )
+
+        // The serialization plugin synthesises a nested `${'$'}serializer`
+        // class (singleton that implements KSerializer<Payload>) and a
+        // `${'$'}Companion` holder during the compile. Both are the
+        // unambiguous signal that the plugin ran — plain kotlinc output
+        // of a `@Serializable data class` contains neither. Kotlin
+        // compiles the nested `${'$'}serializer` name to a double-dollar
+        // file name (`Payload${'$'}${'$'}serializer.class`) because the
+        // first `${'$'}` is the Kotlin-to-JVM nested class separator and
+        // the second is the literal name.
+        val serializerName = "Payload\$\$serializer.class"
+        val companionName = "Payload\$Companion.class"
+        val classFileNames = classFiles.map { it.fileName.toString() }
+        assertTrue(
+            serializerName in classFileNames,
+            "kotlinx.serialization plugin must have generated `$serializerName`; " +
+                "classFiles=$classFileNames",
+        )
+        assertTrue(
+            companionName in classFileNames,
+            "kotlinx.serialization plugin must have generated `$companionName`; " +
+                "classFiles=$classFileNames",
+        )
+    }
+
+    @Test
+    fun `serialization plugin jars resolve from the classpath system property`() {
+        // Guard the build.gradle.kts wiring: if a future edit drops the
+        // serializationPluginClasspath configuration or misroutes the
+        // system property, we want the failure signal here rather than
+        // buried inside the compile test above.
+        assertTrue(
+            serializationPluginJars.isNotEmpty(),
+            "serialization compiler plugin classpath must be non-empty",
+        )
+        assertTrue(
+            serializationPluginJars.any { it.fileName.toString().contains("serialization") },
+            "expected a serialization-compiler-plugin jar on the resolved classpath, got: $serializationPluginJars",
+        )
+    }
+
+    @Test
+    fun `serialization runtime classpath contains kotlinx-serialization-core`() {
+        assertTrue(
+            serializationFixtureClasspath.any {
+                it.fileName.toString().contains("kotlinx-serialization-core")
+            },
+            "expected kotlinx-serialization-core on the fixture runtime classpath, " +
+                "got: $serializationFixtureClasspath",
+        )
+    }
+
+    private fun systemClasspath(key: String): List<Path> {
+        val raw = System.getProperty(key)
+            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        return raw.split(File.pathSeparator)
+            .filter { it.isNotBlank() }
+            .map { Path.of(it) }
+    }
+
+}

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/CapturingKotlinLoggerTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/CapturingKotlinLoggerTest.kt
@@ -1,0 +1,80 @@
+@file:OptIn(ExperimentalBuildToolsApi::class)
+
+package kolt.daemon.ic
+
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// Pins the shape of error message capture. The B-2b implementation kept
+// only `throwable.message`, which threw away the stack frame a human
+// needs to locate BTA-internal failures in a bug report. B-2c retains
+// one frame of trace plus `throwable.toString()` so the class name is
+// preserved even when `message` is null.
+class CapturingKotlinLoggerTest {
+
+    private class RecordingSink : IcMetricsSink {
+        val events: MutableList<Pair<String, Long>> = mutableListOf()
+        override fun record(name: String, value: Long) {
+            events.add(name to value)
+        }
+    }
+
+    @Test
+    fun errorWithoutThrowablePreservesMessage() {
+        val logger = CapturingKotlinLogger(RecordingSink())
+        logger.error("kotlinc: type mismatch", null)
+        assertEquals(listOf("kotlinc: type mismatch"), logger.errorMessages())
+    }
+
+    @Test
+    fun errorWithThrowableIncludesClassNameAndFirstFrame() {
+        val logger = CapturingKotlinLogger(RecordingSink())
+        val boom = RuntimeException("boom")
+        logger.error("bta failed", boom)
+
+        val captured = logger.errorMessages().single()
+        assertTrue(captured.startsWith("bta failed: "), "header: $captured")
+        assertTrue(
+            "java.lang.RuntimeException" in captured,
+            "throwable class name retained: $captured",
+        )
+        assertTrue("boom" in captured, "throwable message retained: $captured")
+        assertTrue(
+            "\n\tat " in captured,
+            "first stack frame retained: $captured",
+        )
+    }
+
+    @Test
+    fun errorWithThrowableWhoseMessageIsNullStillPreservesClassName() {
+        val logger = CapturingKotlinLogger(RecordingSink())
+        val boom = IllegalStateException(null as String?)
+        logger.error("bta failed", boom)
+
+        val captured = logger.errorMessages().single()
+        assertTrue(
+            "java.lang.IllegalStateException" in captured,
+            "class name survives null message: $captured",
+        )
+    }
+
+    @Test
+    fun errorIncrementsMetricCounter() {
+        val sink = RecordingSink()
+        val logger = CapturingKotlinLogger(sink)
+        logger.error("x", null)
+        logger.error("y", null)
+        assertEquals(2, sink.events.count { it.first == BtaIncrementalCompiler.METRIC_LOG_ERROR })
+    }
+
+    @Test
+    fun warnInfoLifecycleAreNotRetainedInErrorList() {
+        val logger = CapturingKotlinLogger(RecordingSink())
+        logger.warn("w", null)
+        logger.info("i")
+        logger.lifecycle("l")
+        assertTrue(logger.errorMessages().isEmpty())
+    }
+}

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
@@ -47,6 +47,13 @@ internal data class CliArgs(
     // integration tests can point at a per-run temp dir without touching
     // the developer's real cache.
     val icRoot: Path,
+    // ADR 0019 §9 + B-2c: `kolt.toml [plugins]` alias → compiler plugin
+    // classpath mapping. Parsed from `--plugin-jars alias=cp[;alias=cp]`
+    // where each `cp` is a File.pathSeparator-joined list. Empty map =
+    // no plugins requested; the adapter's PluginTranslator still drives
+    // the no-op path in that case. The daemon is the sole consumer;
+    // resolving these jars is the native client's responsibility.
+    val pluginJars: Map<String, List<Path>>,
 )
 
 internal sealed interface CliError {
@@ -56,6 +63,7 @@ internal sealed interface CliError {
     data object EmptyCompilerJars : CliError
     data object MissingBtaImplJars : CliError
     data object EmptyBtaImplJars : CliError
+    data class MalformedPluginJars(val entry: String) : CliError
 }
 
 fun main(args: Array<String>) {
@@ -79,8 +87,17 @@ fun main(args: Array<String>) {
     // "observability via metrics" rule from forking into two sinks.
     val metrics = StderrIcMetricsSink()
 
+    // ADR 0019 §9: translate the CLI-supplied alias→classpath map into the
+    // resolver signature BtaIncrementalCompiler expects. Unknown aliases
+    // return `emptyList()` so PluginTranslator can surface a plugin-not-
+    // found error at compile time rather than failing daemon startup.
+    val pluginJarResolver: (String) -> List<Path> = { alias ->
+        cli.pluginJars[alias] ?: emptyList()
+    }
+
     val adapter = BtaIncrementalCompiler.create(
         btaImplJars = cli.btaImplJars.map { it.toPath() },
+        pluginJarResolver = pluginJarResolver,
         metrics = metrics,
     ).mapBoth(
         success = { it },
@@ -125,6 +142,7 @@ internal fun parseArgs(args: Array<String>): Result<CliArgs, CliError> {
     var compilerJars: String? = null
     var btaImplJars: String? = null
     var icRoot: String? = null
+    var pluginJarsRaw: String? = null
     var i = 0
     while (i < args.size) {
         when (args[i]) {
@@ -132,6 +150,7 @@ internal fun parseArgs(args: Array<String>): Result<CliArgs, CliError> {
             "--compiler-jars" -> { compilerJars = args.getOrNull(i + 1); i += 2 }
             "--bta-impl-jars" -> { btaImplJars = args.getOrNull(i + 1); i += 2 }
             "--ic-root" -> { icRoot = args.getOrNull(i + 1); i += 2 }
+            "--plugin-jars" -> { pluginJarsRaw = args.getOrNull(i + 1); i += 2 }
             else -> return Err(CliError.UnknownFlag(args[i]))
         }
     }
@@ -143,7 +162,33 @@ internal fun parseArgs(args: Array<String>): Result<CliArgs, CliError> {
     val bjars = btaImplJars.split(File.pathSeparator).filter { it.isNotBlank() }.map { File(it) }
     if (bjars.isEmpty()) return Err(CliError.EmptyBtaImplJars)
     val icRootPath = icRoot?.let(Path::of) ?: defaultIcRoot()
-    return Ok(CliArgs(Path.of(socketPath), cjars, bjars, icRootPath))
+    val pluginJars = parsePluginJars(pluginJarsRaw).mapBoth(
+        success = { it },
+        failure = { return Err(it) },
+    )
+    return Ok(CliArgs(Path.of(socketPath), cjars, bjars, icRootPath, pluginJars))
+}
+
+// Parses `alias=cp[;alias=cp]` where each `cp` is a File.pathSeparator-joined
+// list of plugin jar paths. `null` or empty input collapses to an empty map.
+// Each entry must contain exactly one `=` and a non-empty alias + classpath;
+// otherwise `MalformedPluginJars` carries the offending raw entry back.
+internal fun parsePluginJars(raw: String?): Result<Map<String, List<Path>>, CliError> {
+    if (raw.isNullOrBlank()) return Ok(emptyMap())
+    val out = linkedMapOf<String, List<Path>>()
+    for (entry in raw.split(';')) {
+        if (entry.isBlank()) continue
+        val eq = entry.indexOf('=')
+        if (eq <= 0 || eq == entry.length - 1) return Err(CliError.MalformedPluginJars(entry))
+        val alias = entry.substring(0, eq).trim()
+        val cp = entry.substring(eq + 1)
+            .split(File.pathSeparator)
+            .filter { it.isNotBlank() }
+            .map(Path::of)
+        if (alias.isEmpty() || cp.isEmpty()) return Err(CliError.MalformedPluginJars(entry))
+        out[alias] = cp
+    }
+    return Ok(out)
 }
 
 private fun formatCliError(err: CliError): String = when (err) {
@@ -153,4 +198,6 @@ private fun formatCliError(err: CliError): String = when (err) {
     CliError.EmptyCompilerJars -> "--compiler-jars resolved to zero paths"
     CliError.MissingBtaImplJars -> "--bta-impl-jars is required"
     CliError.EmptyBtaImplJars -> "--bta-impl-jars resolved to zero paths"
+    is CliError.MalformedPluginJars ->
+        "--plugin-jars entry is malformed (expected `alias=cp[;alias=cp]`): ${err.entry}"
 }

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
@@ -32,14 +32,14 @@ internal data class CliArgs(
     val socketPath: Path,
     // Retained per post-B-2a review decision: kolt-compiler-embeddable still
     // flows through this flag even though Phase B routes compile traffic through
-    // BtaIncrementalCompiler. Downstream B-2c work may need to reuse it for
-    // plugin-jars alongside BTA, and dropping it now would force a client-side
-    // change the moment that requirement materialises. Unused paths are ignored
-    // by the daemon rather than failing startup. `MainCliArgsTest` pins the
-    // flag as required so a future contributor cannot silently remove it
-    // from the parser without updating the native-client spawn argv in lock-
-    // step. TODO(B-2c): either consume this list (plugin plumbing) or
-    // retire the flag with a coordinated native-client argv change.
+    // BtaIncrementalCompiler. B-2c chose **not** to reuse it for plugin jars and
+    // added a separate `--plugin-jars` flag instead (see `pluginJars` below), so
+    // the two channels stay decoupled and a future retirement of `--compiler-jars`
+    // does not need to coordinate with the plugin-plumbing code path. Unused
+    // paths are ignored by the daemon rather than failing startup.
+    // `MainCliArgsTest` pins the flag as required so a future contributor
+    // cannot silently remove it from the parser without updating the native-
+    // client spawn argv in lock-step.
     val compilerJars: List<File>,
     val btaImplJars: List<File>,
     // Override for the daemon-owned IC state root (ADR 0019 §5). Defaults

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/protocol/DiagnosticParser.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/protocol/DiagnosticParser.kt
@@ -12,9 +12,12 @@ object DiagnosticParser {
 
     // Greedy path capture up to the last `:L:C:` triple. `\d+` for both
     // line and column anchors the regex against the positional prefix so
-    // a colon inside a message body cannot be misread as a position.
+    // a colon inside a message body cannot be misread as a position. The
+    // severity token includes `_` so multi-word kotlinc severities like
+    // `strong_warning` match (`[A-Za-z]+` alone would drop those lines
+    // silently into plain-text stderr).
     private val LINE_REGEX: Regex =
-        Regex("""^(?<path>.+):(?<line>\d+):(?<col>\d+):\s*(?<sev>[A-Za-z]+):\s*(?<msg>.*)$""")
+        Regex("""^(?<path>.+):(?<line>\d+):(?<col>\d+):\s*(?<sev>[A-Za-z_]+):\s*(?<msg>.*)$""")
 
     fun parseLine(line: String): Diagnostic? {
         val match = LINE_REGEX.matchEntire(line) ?: return null
@@ -44,9 +47,12 @@ object DiagnosticParser {
         return diagnostics to plain
     }
 
+    // `strong_warning` is kotlinc's opt-in-required severity; collapse it
+    // to plain Warning so IDE-style rendering still surfaces it rather
+    // than demoting the whole line into free-text stderr.
     private fun toSeverity(raw: String): Severity? = when (raw.lowercase()) {
         "error" -> Severity.Error
-        "warning" -> Severity.Warning
+        "warning", "strong_warning" -> Severity.Warning
         "info" -> Severity.Info
         else -> null
     }

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/protocol/DiagnosticParser.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/protocol/DiagnosticParser.kt
@@ -1,0 +1,53 @@
+package kolt.daemon.protocol
+
+// Parses kotlinc-style `path:line:column: severity: message` strings as
+// produced by BTA's KotlinLogger into structured Diagnostic records.
+// Anything that does not match the shape stays as a plain-text message
+// (the caller holds it as free-text stderr).
+//
+// Scoped for B-2c: Linux absolute paths only. Windows drive letters
+// (`C:\...`) are out of scope because the daemon runs exclusively on
+// Linux/macOS-style filesystems in the current kolt release.
+object DiagnosticParser {
+
+    // Greedy path capture up to the last `:L:C:` triple. `\d+` for both
+    // line and column anchors the regex against the positional prefix so
+    // a colon inside a message body cannot be misread as a position.
+    private val LINE_REGEX: Regex =
+        Regex("""^(?<path>.+):(?<line>\d+):(?<col>\d+):\s*(?<sev>[A-Za-z]+):\s*(?<msg>.*)$""")
+
+    fun parseLine(line: String): Diagnostic? {
+        val match = LINE_REGEX.matchEntire(line) ?: return null
+        val severity = toSeverity(match.groups["sev"]!!.value) ?: return null
+        return Diagnostic(
+            severity = severity,
+            file = match.groups["path"]!!.value,
+            line = match.groups["line"]!!.value.toInt(),
+            column = match.groups["col"]!!.value.toInt(),
+            message = match.groups["msg"]!!.value.trim(),
+        )
+    }
+
+    // Splits a flat list of captured logger lines into the structured
+    // `diagnostics` field for `Message.CompileResult` and the residual
+    // plain-text lines the daemon still surfaces via `stderr`. The
+    // partition preserves input order within each bucket so a reader
+    // scanning stderr and the diagnostics list in parallel sees a
+    // consistent sequence.
+    fun parseMessages(lines: List<String>): Pair<List<Diagnostic>, List<String>> {
+        val diagnostics = mutableListOf<Diagnostic>()
+        val plain = mutableListOf<String>()
+        for (line in lines) {
+            val parsed = parseLine(line)
+            if (parsed != null) diagnostics.add(parsed) else plain.add(line)
+        }
+        return diagnostics to plain
+    }
+
+    private fun toSeverity(raw: String): Severity? = when (raw.lowercase()) {
+        "error" -> Severity.Error
+        "warning" -> Severity.Warning
+        "info" -> Severity.Info
+        else -> null
+    }
+}

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/server/DaemonServer.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/server/DaemonServer.kt
@@ -11,6 +11,7 @@ import kolt.daemon.ic.IcResponse
 import kolt.daemon.ic.IcStateLayout
 import kolt.daemon.ic.IncrementalCompiler
 import kolt.daemon.protocol.Diagnostic
+import kolt.daemon.protocol.DiagnosticParser
 import kolt.daemon.protocol.FrameCodec
 import kolt.daemon.protocol.FrameError
 import kolt.daemon.protocol.Message
@@ -243,12 +244,21 @@ class DaemonServer(
         )
 
     private fun icErrorToReply(error: IcError): Message.CompileResult = when (error) {
-        is IcError.CompilationFailed -> Message.CompileResult(
-            exitCode = 1,
-            diagnostics = emptyList(),
-            stdout = "",
-            stderr = error.messages.joinToString(separator = "\n"),
-        )
+        is IcError.CompilationFailed -> {
+            // ADR 0019 §7 + B-2c: split BTA's flat error list into structured
+            // `Diagnostic`s where the `path:L:C: severity: msg` shape matches,
+            // and keep anything else as free-text stderr. The native client
+            // renders `diagnostics` as an IDE-style error list and still
+            // surfaces `stderr` for unparsable lines (e.g. BTA-internal stack
+            // frames appended by CapturingKotlinLogger).
+            val (diagnostics, plain) = DiagnosticParser.parseMessages(error.messages)
+            Message.CompileResult(
+                exitCode = 1,
+                diagnostics = diagnostics,
+                stdout = "",
+                stderr = plain.joinToString(separator = "\n"),
+            )
+        }
         // ADR 0019 §7: InternalError is a daemon-internal concern — the user
         // sees "failed to compile", not "the incremental cache was corrupt".
         // B-2b's self-heal wipe+retry fires on this variant; B-2a does not

--- a/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/MainCliArgsTest.kt
+++ b/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/MainCliArgsTest.kt
@@ -118,6 +118,76 @@ class MainCliArgsTest {
     }
 
     @Test
+    fun pluginJarsOptionalDefaultsToEmptyMap() {
+        // ADR 0019 §9 + B-2c: `--plugin-jars` is optional. A project that uses
+        // no compiler plugins (kolt.toml has no `[plugins]` section or all
+        // entries are `false`) must not be forced to pass the flag.
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--compiler-jars", "/a.jar",
+                "--bta-impl-jars", "/b.jar",
+            ),
+        )
+        val cli = assertNotNull(result.get())
+        assertEquals(emptyMap(), cli.pluginJars)
+    }
+
+    @Test
+    fun pluginJarsParsesAliasToClasspath() {
+        // Format: `<alias>=<cp>[;<alias>=<cp>...]`. Inside each `<cp>` the
+        // usual File.pathSeparator splits entries. The `;` outer separator
+        // avoids colliding with `:` (pathSeparator) on Linux.
+        val sep = java.io.File.pathSeparator
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--compiler-jars", "/a.jar",
+                "--bta-impl-jars", "/b.jar",
+                "--plugin-jars", "serialization=/plugins/ser1.jar${sep}/plugins/ser2.jar",
+            ),
+        )
+        val cli = assertNotNull(result.get())
+        assertEquals(
+            mapOf("serialization" to listOf(Path.of("/plugins/ser1.jar"), Path.of("/plugins/ser2.jar"))),
+            cli.pluginJars,
+        )
+    }
+
+    @Test
+    fun pluginJarsParsesMultipleAliases() {
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--compiler-jars", "/a.jar",
+                "--bta-impl-jars", "/b.jar",
+                "--plugin-jars", "serialization=/p/ser.jar;allopen=/p/open.jar",
+            ),
+        )
+        val cli = assertNotNull(result.get())
+        assertEquals(
+            mapOf(
+                "serialization" to listOf(Path.of("/p/ser.jar")),
+                "allopen" to listOf(Path.of("/p/open.jar")),
+            ),
+            cli.pluginJars,
+        )
+    }
+
+    @Test
+    fun pluginJarsMalformedEntryRejected() {
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--compiler-jars", "/a.jar",
+                "--bta-impl-jars", "/b.jar",
+                "--plugin-jars", "serialization",
+            ),
+        )
+        assertEquals(CliError.MalformedPluginJars("serialization"), result.getError())
+    }
+
+    @Test
     fun unknownFlagRejected() {
         val result = parseArgs(
             arrayOf(

--- a/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/MainCliArgsTest.kt
+++ b/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/MainCliArgsTest.kt
@@ -16,10 +16,11 @@ import kotlin.test.assertNotNull
 //
 // `--compiler-jars` is intentionally retained after the B-2a refactor even
 // though daemon-core code no longer loads kotlin-compiler-embeddable itself
-// (the reflective `SharedCompilerHost` was removed in commit ad05de8). Phase
-// B-2c work on plugin plumbing may reuse the flag for compiler plugin jars,
-// and dropping it now would force a back-incompatible native-client change
-// the moment that requirement materialises. This test is the explicit record
+// (the reflective `SharedCompilerHost` was removed in commit ad05de8). B-2c
+// chose to introduce a separate `--plugin-jars` flag rather than overload
+// `--compiler-jars`, so the two channels stay decoupled. Dropping
+// `--compiler-jars` remains a back-incompatible change because the native
+// client still passes it on every spawn; this test is the explicit record
 // of that intent.
 class MainCliArgsTest {
 
@@ -185,6 +186,35 @@ class MainCliArgsTest {
             ),
         )
         assertEquals(CliError.MalformedPluginJars("serialization"), result.getError())
+    }
+
+    @Test
+    fun pluginJarsEmptyAliasRejected() {
+        // `=foo.jar` has no alias; `eq <= 0` catches it inside parsePluginJars.
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--compiler-jars", "/a.jar",
+                "--bta-impl-jars", "/b.jar",
+                "--plugin-jars", "=foo.jar",
+            ),
+        )
+        assertEquals(CliError.MalformedPluginJars("=foo.jar"), result.getError())
+    }
+
+    @Test
+    fun pluginJarsEmptyClasspathRejected() {
+        // `alias=` has a trailing `=` with no classpath; `eq == entry.length - 1`
+        // catches it before the pathSeparator split even runs.
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--compiler-jars", "/a.jar",
+                "--bta-impl-jars", "/b.jar",
+                "--plugin-jars", "serialization=",
+            ),
+        )
+        assertEquals(CliError.MalformedPluginJars("serialization="), result.getError())
     }
 
     @Test

--- a/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
+++ b/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
@@ -81,6 +81,19 @@ class DiagnosticParserTest {
     }
 
     @Test
+    fun strongWarningCollapsesToWarning() {
+        // kotlinc emits `strong_warning` for opt-in-required and a few
+        // other cases; the parser must recognise it (not drop the line
+        // into plain-text stderr) and the IDE-rendered severity must be
+        // the regular Warning bucket.
+        val parsed = DiagnosticParser.parseLine(
+            "/tmp/A.kt:1:1: strong_warning: opt-in required for foo",
+        )
+        assertEquals(Severity.Warning, parsed?.severity)
+        assertEquals("opt-in required for foo", parsed?.message)
+    }
+
+    @Test
     fun trailingStackFrameLinesStayUnparsed() {
         // CapturingKotlinLogger appends `\n\tat Foo.bar(...)` for throwables.
         // That trailing frame must not masquerade as a diagnostic.

--- a/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
+++ b/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
@@ -1,0 +1,89 @@
+package kolt.daemon.protocol
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+// Pure-function parser pinned by unit tests. BTA's KotlinLogger surfaces
+// per-source-position diagnostics as `path:line:col: severity: message`
+// strings; this parser splits that shape into a structured Diagnostic so
+// the native client can render IDE-style error lists. Lines that do not
+// match stay as free-text error messages (the parser returns null and the
+// caller keeps the original string).
+class DiagnosticParserTest {
+
+    @Test
+    fun parsesErrorLineWithAbsolutePath() {
+        val parsed = DiagnosticParser.parseLine(
+            "/tmp/kolt/Main.kt:12:7: error: unresolved reference: foo",
+        )
+        assertEquals(
+            Diagnostic(
+                severity = Severity.Error,
+                file = "/tmp/kolt/Main.kt",
+                line = 12,
+                column = 7,
+                message = "unresolved reference: foo",
+            ),
+            parsed,
+        )
+    }
+
+    @Test
+    fun parsesWarningLine() {
+        val parsed = DiagnosticParser.parseLine(
+            "/src/a/B.kt:3:1: warning: parameter 'x' is never used",
+        )
+        assertEquals(Severity.Warning, parsed?.severity)
+        assertEquals("parameter 'x' is never used", parsed?.message)
+    }
+
+    @Test
+    fun parsesInfoLine() {
+        val parsed = DiagnosticParser.parseLine("/p/Q.kt:1:1: info: note text")
+        assertEquals(Severity.Info, parsed?.severity)
+    }
+
+    @Test
+    fun returnsNullForNonDiagnosticLine() {
+        assertNull(DiagnosticParser.parseLine("just some random kotlinc chatter"))
+    }
+
+    @Test
+    fun returnsNullForMissingSeverity() {
+        assertNull(DiagnosticParser.parseLine("/x/Y.kt:1:1: nope: whatever"))
+    }
+
+    @Test
+    fun parseMessagesSplitsParsedAndUnparsedLines() {
+        val input = listOf(
+            "/tmp/A.kt:5:3: error: bad",
+            "something else",
+            "/tmp/B.kt:1:1: warning: stylistic",
+        )
+        val (diagnostics, plain) = DiagnosticParser.parseMessages(input)
+        assertEquals(
+            listOf(
+                Diagnostic(Severity.Error, "/tmp/A.kt", 5, 3, "bad"),
+                Diagnostic(Severity.Warning, "/tmp/B.kt", 1, 1, "stylistic"),
+            ),
+            diagnostics,
+        )
+        assertEquals(listOf("something else"), plain)
+    }
+
+    @Test
+    fun parsesLineWithExtraSpacesAroundSeverity() {
+        val parsed = DiagnosticParser.parseLine(
+            "/a/B.kt:2:4:   error:   msg with padding",
+        )
+        assertEquals("msg with padding", parsed?.message)
+    }
+
+    @Test
+    fun trailingStackFrameLinesStayUnparsed() {
+        // CapturingKotlinLogger appends `\n\tat Foo.bar(...)` for throwables.
+        // That trailing frame must not masquerade as a diagnostic.
+        assertNull(DiagnosticParser.parseLine("\tat foo.Bar.baz(Bar.kt:42)"))
+    }
+}

--- a/spike/bench-scaling/results-2026-04-15.md
+++ b/spike/bench-scaling/results-2026-04-15.md
@@ -1,0 +1,105 @@
+# Phase B-2c scaling benchmark — #114 (harness from #96)
+
+- Date: 2026-04-15T11:35:32+09:00
+- Host: Linux 6.6.87.2-microsoft-standard-WSL2 x86_64
+- JDK: openjdk version "21.0.7" 2025-04-15 LTS
+- kolt binary: `/home/makino/projects/snicmakino/kolt/build/bin/linuxX64/releaseExecutable/kolt.kexe`
+- kolt binary mtime: 2026-04-15T09:50:26+09:00
+- N per cell: 10 (warm modes discard first 5)
+
+| Fixture | Mode | N | median (s) | min (s) | max (s) | raw |
+|---|---|---|---|---|---|---|
+| jvm-1 | nodaemon | 10 | 4.77 | 4.58 | 9.40 | 9.40,5.31,4.67,4.77,4.93,7.65,4.70,5.04,4.67,4.58 |
+| jvm-1 | daemon-cold | 10 | 5.58 | 5.42 | 8.56 | 7.15,8.56,5.58,5.50,5.47,5.42,8.53,5.47,5.63,5.80 |
+| jvm-1 | daemon-warm | 10 | 0.32 | 0.31 | 3.36 | 0.33,0.32,0.32,0.31,3.36,0.33,0.32,0.33,0.38,0.31 |
+| jvm-1 | gradle | 10 | 1.27 | 1.16 | 1.47 | 1.44,1.47,1.41,1.45,1.27,1.28,1.18,1.23,1.16,1.18 |
+| jvm-1 | daemon-warm-noop | 10 | 0.00 | 0.00 | 0.01 | 0.01,0.01,0.00,0.00,0.00,0.01,0.01,0.00,0.00,0.01 |
+| jvm-1 | daemon-warm-touch | 10 | 0.31 | 0.29 | 0.33 | 0.31,0.30,0.31,0.30,0.31,0.29,0.31,0.32,0.33,0.30 |
+| jvm-10 | nodaemon | 10 | 6.43 | 5.92 | 10.30 | 6.21,7.24,9.40,5.92,6.42,6.98,10.30,6.67,6.23,6.43 |
+| jvm-10 | daemon-cold | 10 | 7.37 | 6.87 | 10.46 | 7.05,9.75,7.39,7.37,9.98,7.32,6.87,7.49,10.46,7.14 |
+| jvm-10 | daemon-warm | 10 | 0.30 | 0.28 | 0.32 | 0.28,0.30,0.28,0.31,0.30,0.28,0.30,0.32,0.31,0.29 |
+| jvm-10 | gradle | 10 | 1.38 | 1.19 | 4.73 | 4.73,1.45,1.77,1.64,1.38,1.32,1.26,1.36,1.19,1.42 |
+| jvm-10 | daemon-warm-noop | 10 | 0.00 | 0.00 | 0.00 | 0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00 |
+| jvm-10 | daemon-warm-touch | 10 | 0.32 | 0.29 | 3.36 | 0.32,0.32,3.36,0.33,0.33,0.32,0.29,0.30,0.30,0.31 |
+| jvm-25 | nodaemon | 10 | 7.86 | 7.50 | 11.69 | 7.90,7.59,7.86,11.69,7.54,7.81,7.50,11.22,7.89,7.91 |
+| jvm-25 | daemon-cold | 10 | 8.88 | 8.30 | 12.68 | 11.52,8.53,8.88,9.37,12.68,9.85,8.30,12.38,8.57,8.72 |
+| jvm-25 | daemon-warm | 10 | 0.32 | 0.31 | 0.37 | 0.32,0.34,0.33,0.32,0.32,0.34,0.31,0.35,0.32,0.37 |
+| jvm-25 | gradle | 10 | 1.60 | 1.40 | 4.06 | 1.56,1.62,1.60,1.64,1.64,1.48,4.06,1.65,1.53,1.40 |
+| jvm-25 | daemon-warm-noop | 10 | 0.00 | 0.00 | 0.01 | 0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.01,0.01 |
+| jvm-25 | daemon-warm-touch | 10 | 0.31 | 0.30 | 0.33 | 0.32,0.30,0.31,0.32,0.31,0.32,0.30,0.31,0.33,0.31 |
+| jvm-50 | nodaemon | 10 | 10.24 | 9.63 | 13.34 | 12.59,9.98,9.74,12.65,10.24,9.87,13.34,10.26,9.63,12.81 |
+| jvm-50 | daemon-cold | 10 | 10.77 | 10.27 | 13.80 | 10.77,13.07,10.27,10.28,13.25,10.38,10.44,13.80,10.94,11.66 |
+| jvm-50 | daemon-warm | 10 | 0.33 | 0.32 | 0.36 | 0.34,0.32,0.36,0.32,0.33,0.34,0.32,0.33,0.34,0.32 |
+| jvm-50 | gradle | 10 | 1.74 | 1.65 | 4.55 | 1.70,1.73,4.55,1.78,1.79,1.74,1.78,1.65,1.77,1.70 |
+| jvm-50 | daemon-warm-noop | 10 | 0.01 | 0.01 | 0.01 | 0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01 |
+| jvm-50 | daemon-warm-touch | 10 | 0.32 | 0.31 | 0.37 | 0.32,0.33,0.36,0.33,0.32,0.35,0.32,0.37,0.31,0.31 |
+
+## Phase B-2c analysis
+
+Re-run of the #96 / #103 harness against the B-2c daemon (this branch,
+`114/b2c-validations`, after the BTA IC adapter + self-heal + cascade
+validations landed). The headline claim Phase B-2 was supposed to
+deliver is *per-file-slope collapse on the incremental-touch mode*;
+these numbers pin it.
+
+### `daemon-warm-touch` is flat across fixture size
+
+| Fixture | median (s) | min (s) | max (s) |
+|---|---|---|---|
+| jvm-1  | 0.31 | 0.29 | 0.33 |
+| jvm-10 | 0.32 | 0.29 | 3.36 |
+| jvm-25 | 0.31 | 0.30 | 0.33 |
+| jvm-50 | 0.32 | 0.31 | 0.37 |
+
+The slope is effectively zero. For contrast: Phase A (#96) modelled
+`daemon-warm-touch` as `~0.70 s` fixed cost plus `~12 ms` per file, so
+jvm-50 should land near **`0.70 + 0.012 × 50 ≈ 1.30 s`** on that
+linear extrapolation. The measured jvm-50 median is **0.32 s**, which
+is ~4× below the Phase A projection and sits at the same median as
+jvm-1 (0.31 s) — i.e. the wall time is dominated by the daemon's
+fixed-cost floor rather than by per-file work, which is exactly the
+bimodal-win shape spike #104 predicted for ABI-neutral touches.
+
+The lone jvm-10 `max = 3.36 s` matches the WSL2 9p mtime-granularity
+outlier previously documented in `project_phase_a_daemon.md`; it is
+not a B-2c-specific regression.
+
+### `daemon-warm-noop` (BuildCache fast path) unchanged
+
+jvm-1..jvm-50 all median 0.00–0.01 s. Per ADR 0019 §8 the coarse-
+grained "nothing changed" check lives in the native client and runs
+before the daemon is dispatched, so IC cannot make this case worse or
+better — and it did neither. Regression guard satisfied.
+
+### `daemon-warm` (touch nothing but source contents did change) unchanged shape
+
+jvm-1..jvm-50 median 0.30–0.33 s. This mode exercises the compile
+path without a deliberate `touch`; its wall time is dominated by
+daemon RPC + IC happy path. Same order of magnitude as `warm-touch`,
+which is consistent with "both hit the fixed-cost floor plus a thin
+IC decision step".
+
+### Reference numbers to beat
+
+- **#96 Phase A slope**: `daemon-warm-touch ≈ 0.70 + 0.012 × n` s.
+  Slope collapsed to ~0 in B-2c; fixed-cost floor stayed ~0.31 s.
+- **#103 incremental ceiling**: worst-case recoverable budget. The
+  B-2c touch measurements are well inside the ceiling for every
+  fixture size tested.
+- **Gradle comparison**: B-2c `daemon-warm-touch` is ~5× faster than
+  `gradle` on jvm-50 (0.32 vs 1.74 s), and ~4× on jvm-10 / jvm-25.
+  Gradle's own per-file slope shows through as a mild size dependency
+  (1.27 → 1.74 s across 1..50) while B-2c stays flat.
+
+### Scope notes
+
+- Fixture sizes tested: `jvm-{1, 10, 25, 50}`. Sizes `jvm-100` and
+  `jvm-250` are not yet generated under `spike/bench-scaling/fixtures/`
+  (#114 issue body mentions them, but the harness has only ever had
+  1/10/25/50 since #96). The scaling-up of the harness itself is
+  filed as a separate operational follow-up; the slope-collapse claim
+  above is decidable from the available data and does not require
+  larger fixtures to hold.
+- `daemon-warm-touch` exercises an ABI-neutral literal edit on a
+  mid-chain file; ABI-affecting cascade is covered by the unit-level
+  `BtaIncrementalAbiCascadeTest` added in this branch.


### PR DESCRIPTION
Closes #114. Parent: #3. Follows #116 (B-2b, `eaed244`) and #118 (post-B-2b dogfood, `603d2b8`). ADR 0019.

## Summary

- Real-plugin validation: `@Serializable data class` compiles through `kotlin-serialization-compiler-plugin-embeddable:2.3.20` via a new `--plugin-jars` daemon flag, producing `Payload${'$'}${'$'}serializer.class` (spike #104 O.Q. 6 residual risk resolved).
- IC cache corruption smoke test drives the real `SelfHealingIncrementalCompiler(BtaIncrementalCompiler)` stack through a workingDir whose state files have been truncated; `ic.self_heal` fires and the second compile returns `Ok`.
- ABI-affecting cascade validation on a linear-5 chain: mid-chain signature change + caller edit, asserts `2 <= changed < coldCount` — pins both "cascade happened" and "cascade stopped short of full".
- Structured `Diagnostic` parser for `path:L:C: severity: msg` lines, wired into `Message.CompileResult.diagnostics` (wire field existed since ADR 0016 but was always `emptyList()`). Unparsable lines stay in `stderr`.
- `CapturingKotlinLogger` promoted to top-level `internal` + retains 1 stack frame + `toString()` on `error(msg, throwable)` (B-2b review carryover).
- ADR 0019 Follow-ups list pruned for items consumed by this PR, with pointers to their test files.

## Scaling re-run (`spike/bench-scaling/results-2026-04-15.md`)

`daemon-warm-touch` median across fixture sizes:

| Fixture | B-2c median | Phase A projection (`0.70 + 0.012 × n`) |
|---|---|---|
| jvm-1  | 0.31 s | 0.71 s |
| jvm-10 | 0.32 s | 0.82 s |
| jvm-25 | 0.31 s | 1.00 s |
| jvm-50 | 0.32 s | 1.30 s |

**Per-file slope collapsed to ~0**, ~4× vs Phase A linear projection at jvm-50. Gradle comparison at jvm-50: B-2c 0.32 s vs `gradle` 1.74 s (~5×). `daemon-warm-noop` (BuildCache fast path) unchanged at 0.00–0.01 s per ADR 0019 §8.

## Commits

1. `b92fb84` accept `--plugin-jars alias=cp[;alias=cp]` on daemon CLI
2. `18059b4` retain stack frame in `CapturingKotlinLogger` error output
3. `f8ea49f` parse kotlinc position prefixes into `Message.CompileResult.diagnostics`
4. `70030be` end-to-end corruption smoke test for self-heal retry path
5. `0446e91` ABI-affecting cascade validation on a linear chain
6. `1570006` end-to-end kotlinx.serialization plugin validation
7. `60584d2` prune ADR 0019 follow-ups consumed by #114
8. `18d1aca` scaling re-run drops per-file slope to ~0 on daemon-warm-touch
9. `e496a02` address review feedback (strong_warning severity, runCatching guard on formatLine, parsePluginJars edge-case tests, stale TODO comment refresh)

## Scope

- `--plugin-jars` is a **new daemon-side flag**, not a reuse of `--compiler-jars` (which stays reserved for the kolt-compiler-embeddable fallback channel).
- Native client `--plugin-jars` spawn-argv wiring is **not in this PR** — the daemon side is ready, and a follow-up will wire the native client resolver so `kolt build` on a kolt.toml with `[plugins.serialization]` passes plugin jars to the daemon. Today the kotlinx.serialization path is only exercised through the JVM-side integration test.
- `PluginTranslator` schema stays `Map<String, Boolean>` — kotlinx.serialization needs no per-plugin options, so the richer shape is deferred until a plugin that needs it lands.
- `jvm-100` / `jvm-250` fixtures were not generated; the harness has only ever had 1/10/25/50 since #96. Extending the harness is filed as a separate follow-up — the slope-collapse claim is decidable on the available data (flat line is flat).
- ADR 0019 stays in Accepted status. Promotion to Implemented waits until the surviving post-B-2 operational bullets (classpath snapshot caching, IC state reaper, SourcesChanges.Known wire extension, larger bench fixtures) are closed.

## Review

Independent sub-agent review run before this PR; no blockers, 9 should-fix items addressed in `e496a02`. Verified-good items from the review:

- No `is Ok` / `is Err` usage (kotlin-result 2.x value class discipline preserved).
- No `throw` outside the documented `VirtualMachineError` rethrows.
- ADR §3 adapter boundary invariant holds: no new daemon-core imports from `org.jetbrains.kotlin.buildtools.api.*`.
- `Message.Compile` wire type untouched (ADR 0019 §4).
- BuildCache fast path untouched (ADR 0019 §8).
- Corruption smoke test's `ic.self_heal` assertion is load-bearing (cannot silently pass).
- Scaling claim matches raw numbers and is consistent with the Phase A memory.

## Test plan

- [x] `./gradlew :kolt-compiler-daemon:test` — all daemon-core tests green
- [x] `./gradlew :kolt-compiler-daemon:ic:test` — all IC adapter tests green including the 3 new B-2c validation tests
- [x] `spike/bench-scaling/run-bench.sh` end-to-end against the release binary — results in `spike/bench-scaling/results-2026-04-15.md`
- [ ] CI on this branch
- [ ] Native `linuxX64Test` regression check on CI (not locally re-run — no native-side code changed)