### PR TITLE
Dogfood fallout from B-2c: render compile error body on daemon path

### DIFF
--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/protocol/DiagnosticParser.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/protocol/DiagnosticParser.kt
@@ -40,13 +40,27 @@ object DiagnosticParser {
     private val SUBPROCESS_REGEX: Regex =
         Regex("""^(?<path>.+):(?<line>\d+):(?<col>\d+):\s*(?<sev>[A-Za-z_]+):\s*(?<msg>.*)$""")
 
+    // Path must start with either `file://` or `/` so an arbitrary
+    // error-level log line like `Cannot resolve org.foo:1:2 from repo`
+    // cannot false-positive into a fake `Diagnostic`. The parser's own
+    // contract (see top-of-file comment) is Linux/macOS absolute paths
+    // only, which means a real diagnostic always begins with one of
+    // those two prefixes. A line that fits the `path:L:C msg` skeleton
+    // but lacks an absolute-path leader correctly falls through to
+    // plain-text stderr.
     private val BTA_INLINE_REGEX: Regex =
-        Regex("""^(?<path>.+):(?<line>\d+):(?<col>\d+)\s+(?<msg>.*)$""")
+        Regex("""^(?<path>(?:file://)?/[^\s].*?):(?<line>\d+):(?<col>\d+)\s+(?<msg>.*)$""")
 
     private const val FILE_URI_PREFIX: String = "file://"
 
     fun parseLine(line: String): Diagnostic? {
-        SUBPROCESS_REGEX.matchEntire(line)?.let { match ->
+        // Defensive trim: BTA may or may not terminate captured logger
+        // strings with `\n`; `matchEntire` does not consume newlines
+        // because `.` does not match `\n` by default. Strip both `\n`
+        // and `\r` so a future BTA bump that starts adding line
+        // terminators does not silently break the parser.
+        val trimmed = line.trimEnd('\n', '\r')
+        SUBPROCESS_REGEX.matchEntire(trimmed)?.let { match ->
             val severity = toSeverity(match.groups["sev"]!!.value) ?: return@let
             return Diagnostic(
                 severity = severity,
@@ -56,7 +70,7 @@ object DiagnosticParser {
                 message = match.groups["msg"]!!.value.trim(),
             )
         }
-        BTA_INLINE_REGEX.matchEntire(line)?.let { match ->
+        BTA_INLINE_REGEX.matchEntire(trimmed)?.let { match ->
             return Diagnostic(
                 severity = Severity.Error,
                 file = stripFileUri(match.groups["path"]!!.value),

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/protocol/DiagnosticParser.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/protocol/DiagnosticParser.kt
@@ -10,26 +10,66 @@ package kolt.daemon.protocol
 // Linux/macOS-style filesystems in the current kolt release.
 object DiagnosticParser {
 
-    // Greedy path capture up to the last `:L:C:` triple. `\d+` for both
-    // line and column anchors the regex against the positional prefix so
-    // a colon inside a message body cannot be misread as a position. The
-    // severity token includes `_` so multi-word kotlinc severities like
-    // `strong_warning` match (`[A-Za-z]+` alone would drop those lines
-    // silently into plain-text stderr).
-    private val LINE_REGEX: Regex =
+    // Two regexes because kotlinc has two output shapes that BTA surfaces
+    // through `KotlinLogger.error`:
+    //
+    //   1. Classic subprocess format: `path:L:C: severity: message`
+    //      — what `kolt-compiler-daemon` sees when it runs a plain
+    //      kotlinc invocation. Severity token can be `error`, `warning`,
+    //      `info`, or `strong_warning` (underscore is why the token
+    //      group allows `_`).
+    //
+    //   2. BTA 2.3.20 in-process format: `file:///URI:L:C <message>`
+    //      — what `BtaIncrementalCompiler` actually receives on a real
+    //      compile error. No severity word between position and
+    //      message, a **space** separator instead of a colon, and a
+    //      `file://` URI prefix on the path. We default these to
+    //      `Severity.Error` because `CapturingKotlinLogger` only
+    //      captures `logger.error(...)` into `errors` (warn/info are
+    //      forwarded to the metrics sink only), so anything that
+    //      reaches this parser via the captured error list is, by
+    //      definition, an error.
+    //
+    // Dogfood on the B-2c merge (jvm-25 fixture with a deliberate type
+    // error) produced shape 2; the parser was only matching shape 1
+    // before, so structured diagnostics silently went through the
+    // plain-text `stderr` fallback instead of populating
+    // `Message.CompileResult.diagnostics`. Both shapes matter: shape 1
+    // will reappear the moment a future BTA bump changes the format
+    // back, and shape 2 is what today's user actually sees.
+    private val SUBPROCESS_REGEX: Regex =
         Regex("""^(?<path>.+):(?<line>\d+):(?<col>\d+):\s*(?<sev>[A-Za-z_]+):\s*(?<msg>.*)$""")
 
+    private val BTA_INLINE_REGEX: Regex =
+        Regex("""^(?<path>.+):(?<line>\d+):(?<col>\d+)\s+(?<msg>.*)$""")
+
+    private const val FILE_URI_PREFIX: String = "file://"
+
     fun parseLine(line: String): Diagnostic? {
-        val match = LINE_REGEX.matchEntire(line) ?: return null
-        val severity = toSeverity(match.groups["sev"]!!.value) ?: return null
-        return Diagnostic(
-            severity = severity,
-            file = match.groups["path"]!!.value,
-            line = match.groups["line"]!!.value.toInt(),
-            column = match.groups["col"]!!.value.toInt(),
-            message = match.groups["msg"]!!.value.trim(),
-        )
+        SUBPROCESS_REGEX.matchEntire(line)?.let { match ->
+            val severity = toSeverity(match.groups["sev"]!!.value) ?: return@let
+            return Diagnostic(
+                severity = severity,
+                file = stripFileUri(match.groups["path"]!!.value),
+                line = match.groups["line"]!!.value.toInt(),
+                column = match.groups["col"]!!.value.toInt(),
+                message = match.groups["msg"]!!.value.trim(),
+            )
+        }
+        BTA_INLINE_REGEX.matchEntire(line)?.let { match ->
+            return Diagnostic(
+                severity = Severity.Error,
+                file = stripFileUri(match.groups["path"]!!.value),
+                line = match.groups["line"]!!.value.toInt(),
+                column = match.groups["col"]!!.value.toInt(),
+                message = match.groups["msg"]!!.value.trim(),
+            )
+        }
+        return null
     }
+
+    private fun stripFileUri(path: String): String =
+        if (path.startsWith(FILE_URI_PREFIX)) path.removePrefix(FILE_URI_PREFIX) else path
 
     // Splits a flat list of captured logger lines into the structured
     // `diagnostics` field for `Message.CompileResult` and the residual

--- a/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
+++ b/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
@@ -94,6 +94,39 @@ class DiagnosticParserTest {
     }
 
     @Test
+    fun parsesBtaInlineShapeWithFileUriAndNoSeverityWord() {
+        // BTA 2.3.20 `KotlinLogger.error` emits this shape on a real
+        // compile error; verified against dogfood output on the B-2c
+        // merge. The `file://` prefix must be stripped and the
+        // severity defaults to `Error` because only error-level lines
+        // reach `CapturingKotlinLogger.errors`.
+        val parsed = DiagnosticParser.parseLine(
+            "file:///tmp/kolt/File12.kt:3:17 Initializer type mismatch: expected 'Int', actual 'String'.",
+        )
+        assertEquals(
+            Diagnostic(
+                severity = Severity.Error,
+                file = "/tmp/kolt/File12.kt",
+                line = 3,
+                column = 17,
+                message = "Initializer type mismatch: expected 'Int', actual 'String'.",
+            ),
+            parsed,
+        )
+    }
+
+    @Test
+    fun btaInlineShapeWithoutFileUriPrefixStillParses() {
+        // A future BTA release may drop the `file://` prefix. Matching
+        // the shape without it keeps us forward-compatible.
+        val parsed = DiagnosticParser.parseLine(
+            "/tmp/kolt/File12.kt:3:17 Initializer type mismatch",
+        )
+        assertEquals("/tmp/kolt/File12.kt", parsed?.file)
+        assertEquals(Severity.Error, parsed?.severity)
+    }
+
+    @Test
     fun trailingStackFrameLinesStayUnparsed() {
         // CapturingKotlinLogger appends `\n\tat Foo.bar(...)` for throwables.
         // That trailing frame must not masquerade as a diagnostic.

--- a/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
+++ b/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
@@ -116,6 +116,46 @@ class DiagnosticParserTest {
     }
 
     @Test
+    fun nonAbsolutePathFallsThroughInsteadOfFalsePositiveOnBtaInline() {
+        // The BTA-inline regex must not match arbitrary error-level
+        // log lines that happen to contain `word:digits:digits word`.
+        // Real diagnostics always start with an absolute path or
+        // `file://` URI; anything else is unstructured chatter and
+        // should land in plain-text stderr instead of being lifted
+        // into a fake Diagnostic with a path like `Cannot resolve`.
+        assertNull(
+            DiagnosticParser.parseLine("Cannot resolve coordinate org.foo:1:2 from repo"),
+        )
+        assertNull(DiagnosticParser.parseLine("foo:1:2 bar"))
+    }
+
+    @Test
+    fun subprocessShapeWinsOverBtaInlineShapeOnLinesThatMatchBoth() {
+        // `/foo:1:2: error: bar` is a legal subprocess shape AND would
+        // also match the BTA-inline regex if reached (path=`/foo`,
+        // line=1, col=2, msg=`error: bar`). The parser must try the
+        // subprocess regex first so the severity word is honoured and
+        // the message body is correct. A refactor that swapped the
+        // order would silently produce wrong diagnostics.
+        val parsed = DiagnosticParser.parseLine("/foo:1:2: error: bar")
+        assertEquals(Severity.Error, parsed?.severity)
+        assertEquals("/foo", parsed?.file)
+        assertEquals("bar", parsed?.message)
+    }
+
+    @Test
+    fun trailingNewlineIsStripped() {
+        // BTA may or may not terminate captured strings; defend
+        // against a future bump by trimming `\n` / `\r` before the
+        // regex tries matchEntire (which does not consume `\n`).
+        val parsed = DiagnosticParser.parseLine(
+            "file:///tmp/A.kt:1:1 boom\n",
+        )
+        assertEquals("/tmp/A.kt", parsed?.file)
+        assertEquals("boom", parsed?.message)
+    }
+
+    @Test
     fun btaInlineShapeWithoutFileUriPrefixStillParses() {
         // A future BTA release may drop the `file://` prefix. Matching
         // the shape without it keeps us forward-compatible.

--- a/src/nativeMain/kotlin/kolt/build/CompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/CompilerBackend.kt
@@ -1,6 +1,8 @@
 package kolt.build
 
 import com.github.michaelbull.result.Result
+import kolt.daemon.wire.Diagnostic
+import kolt.daemon.wire.Severity
 
 // A CompilerBackend turns a CompileRequest into a compiled output. Two
 // implementations are planned:
@@ -40,10 +42,23 @@ data class CompileOutcome(
 sealed interface CompileError {
     // Compiler ran but the user's Kotlin source did not compile. Not fallback
     // eligible — the subprocess path would fail identically.
+    //
+    // `diagnostics` is the structured form of the compile errors
+    // `BtaIncrementalCompiler` captures via its `KotlinLogger` hook and
+    // `DaemonServer.icErrorToReply` splits out of the flat stderr stream
+    // (see `DiagnosticParser` on the daemon side). Daemon path: populated
+    // from `Message.CompileResult.diagnostics`. Subprocess path: empty,
+    // because kotlinc's diagnostics go directly to the inherited stderr
+    // and the native client never parses them. Callers that want a
+    // complete, ordered user-visible error rendering should prefer
+    // `renderCompilationFailure` below over reading `stderr` / `diagnostics`
+    // independently — that helper reunites the two streams without risk
+    // of double-printing on the daemon path.
     data class CompilationFailed(
         val exitCode: Int,
         val stdout: String,
         val stderr: String,
+        val diagnostics: List<Diagnostic> = emptyList(),
     ) : CompileError
 
     // Backend itself could not run the compiler. Fallback eligible. Distinct
@@ -66,6 +81,49 @@ sealed interface CompileError {
     // Logged as an error rather than a warning so self-inflicted problems do
     // not disappear into the fallback path silently.
     data class InternalMisuse(val detail: String) : CompileError
+}
+
+// Renders every diagnostic the daemon captured, plus any leftover plain-
+// text stderr lines, in the order kotlinc would have produced them.
+// Used by `BuildCommands` to print the full compile error body before
+// the one-line summary `formatCompileError` produces. Pre-B-2c the
+// daemon reply had everything in `stderr`; B-2c split the structured
+// lines out into `diagnostics`. This helper handles both shapes so
+// nothing goes missing regardless of which field is populated.
+//
+// Subprocess path callers should skip this helper — kotlinc already
+// wrote its diagnostics to the inherited stderr stream before the
+// CompilerBackend turned the non-zero exit into a CompilationFailed.
+// Calling `renderCompilationFailure` on a subprocess-path error would
+// typically produce an empty string anyway (both fields are empty),
+// but the ordering invariant is that daemon-path callers print this
+// block and subprocess-path callers do not.
+fun renderCompilationFailure(error: CompileError.CompilationFailed): String {
+    val parts = mutableListOf<String>()
+    for (diagnostic in error.diagnostics) {
+        parts += formatDiagnostic(diagnostic)
+    }
+    if (error.stderr.isNotEmpty()) parts += error.stderr.trimEnd('\n')
+    return parts.joinToString("\n")
+}
+
+private fun formatDiagnostic(diagnostic: Diagnostic): String {
+    val location = buildString {
+        if (diagnostic.file != null) append(diagnostic.file)
+        if (diagnostic.line != null) append(':').append(diagnostic.line)
+        if (diagnostic.column != null) append(':').append(diagnostic.column)
+    }
+    val severity = when (diagnostic.severity) {
+        Severity.Error -> "error"
+        Severity.Warning -> "warning"
+        Severity.Info -> "info"
+        Severity.Logging -> "logging"
+    }
+    return if (location.isEmpty()) {
+        "$severity: ${diagnostic.message}"
+    } else {
+        "$location: $severity: ${diagnostic.message}"
+    }
 }
 
 fun formatCompileError(error: CompileError, context: String): String = when (error) {

--- a/src/nativeMain/kotlin/kolt/build/CompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/CompilerBackend.kt
@@ -98,7 +98,7 @@ sealed interface CompileError {
 // typically produce an empty string anyway (both fields are empty),
 // but the ordering invariant is that daemon-path callers print this
 // block and subprocess-path callers do not.
-fun renderCompilationFailure(error: CompileError.CompilationFailed): String {
+internal fun renderCompilationFailure(error: CompileError.CompilationFailed): String {
     val parts = mutableListOf<String>()
     for (diagnostic in error.diagnostics) {
         parts += formatDiagnostic(diagnostic)
@@ -108,8 +108,16 @@ fun renderCompilationFailure(error: CompileError.CompilationFailed): String {
 }
 
 private fun formatDiagnostic(diagnostic: Diagnostic): String {
-    val location = buildString {
-        if (diagnostic.file != null) append(diagnostic.file)
+    // file=null is the "no location" branch even when line/column
+    // happen to be non-null. Without this guard, a future producer
+    // that forgets to populate `file` while still emitting line/col
+    // would render `:5:3: error: msg` with a leading colon — ugly
+    // and unlike anything kotlinc has ever produced. kotlinc's own
+    // shape always emits position together with a file or omits both.
+    val location = if (diagnostic.file == null) {
+        ""
+    } else buildString {
+        append(diagnostic.file)
         if (diagnostic.line != null) append(':').append(diagnostic.line)
         if (diagnostic.column != null) append(':').append(diagnostic.column)
     }

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
@@ -312,6 +312,7 @@ internal fun mapReplyToOutcome(reply: Message): Result<CompileOutcome, CompileEr
                         exitCode = reply.exitCode,
                         stdout = reply.stdout,
                         stderr = reply.stderr,
+                        diagnostics = reply.diagnostics,
                     ),
                 )
         }

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -188,6 +188,16 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
 
     println("compiling ${config.name}...")
     backend.compile(request).getOrElse { error ->
+        // Daemon path captures kotlinc diagnostics into
+        // `CompilationFailed.diagnostics` + leftover `stderr`; the
+        // subprocess path inherits fds and leaves both fields empty
+        // because kotlinc already wrote to the terminal. Printing the
+        // rendered body before the one-line summary handles both
+        // shapes without double-printing.
+        if (error is CompileError.CompilationFailed) {
+            val body = renderCompilationFailure(error)
+            if (body.isNotEmpty()) eprintln(body)
+        }
         eprintln(formatCompileError(error, "compilation"))
         exitProcess(EXIT_BUILD_ERROR)
     }

--- a/src/nativeTest/kotlin/kolt/build/RenderCompilationFailureTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/RenderCompilationFailureTest.kt
@@ -1,0 +1,136 @@
+package kolt.build
+
+import kolt.daemon.wire.Diagnostic
+import kolt.daemon.wire.Severity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// Pins the multi-line rendering of CompileError.CompilationFailed so the
+// body the daemon path hands back actually reaches the user. B-2c's
+// DaemonServer.icErrorToReply populates `Message.CompileResult.diagnostics`
+// (structured) and `stderr` (plain text for unparsable lines); the
+// native client must reunite the two streams before printing the
+// one-line `formatCompileError` summary, otherwise kotlinc diagnostics
+// disappear and the user sees only "error: compilation failed with
+// exit code 1". Dogfood on B-2c is what surfaced the bug.
+class RenderCompilationFailureTest {
+
+    @Test
+    fun rendersStructuredDiagnosticsAsKotlincStylePositionedLines() {
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "",
+            diagnostics = listOf(
+                Diagnostic(
+                    severity = Severity.Error,
+                    file = "/tmp/Main.kt",
+                    line = 3,
+                    column = 5,
+                    message = "expected ';'",
+                ),
+            ),
+        )
+        assertEquals(
+            "/tmp/Main.kt:3:5: error: expected ';'",
+            renderCompilationFailure(error),
+        )
+    }
+
+    @Test
+    fun rendersMultipleDiagnosticsInOrder() {
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "",
+            diagnostics = listOf(
+                Diagnostic(Severity.Error, "/a.kt", 1, 1, "first"),
+                Diagnostic(Severity.Warning, "/b.kt", 2, 2, "second"),
+                Diagnostic(Severity.Info, "/c.kt", 3, 3, "third"),
+            ),
+        )
+        val rendered = renderCompilationFailure(error)
+        assertEquals(
+            listOf(
+                "/a.kt:1:1: error: first",
+                "/b.kt:2:2: warning: second",
+                "/c.kt:3:3: info: third",
+            ),
+            rendered.split("\n"),
+        )
+    }
+
+    @Test
+    fun appendsPlainStderrAfterStructuredDiagnostics() {
+        // DiagnosticParser leaves unparsable lines (e.g. trailing
+        // stack frames appended by CapturingKotlinLogger) in the
+        // stderr string. They still need to surface, after the
+        // structured lines for readability.
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "\tat foo.Bar.baz(Bar.kt:42)",
+            diagnostics = listOf(
+                Diagnostic(Severity.Error, "/a.kt", 1, 1, "boom"),
+            ),
+        )
+        val rendered = renderCompilationFailure(error)
+        assertEquals(
+            "/a.kt:1:1: error: boom\n\tat foo.Bar.baz(Bar.kt:42)",
+            rendered,
+        )
+    }
+
+    @Test
+    fun subprocessPathProducesEmptyBody() {
+        // SubprocessCompilerBackend leaves both fields empty because
+        // kotlinc already wrote to the inherited terminal. The
+        // renderer must gracefully return an empty string rather than
+        // a lone "\n" or a synthetic placeholder, so the caller's
+        // `isNotEmpty()` skip works.
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "",
+        )
+        assertTrue(renderCompilationFailure(error).isEmpty())
+    }
+
+    @Test
+    fun diagnosticsWithoutFileAreRenderedWithoutPositionPrefix() {
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "",
+            diagnostics = listOf(
+                Diagnostic(Severity.Error, file = null, line = null, column = null, message = "no location"),
+            ),
+        )
+        assertEquals("error: no location", renderCompilationFailure(error))
+    }
+
+    @Test
+    fun rendersStderrOnlyWhenDiagnosticsAreEmpty() {
+        // Pre-B-2c daemon behaviour and subprocess path with
+        // ProcessError.NonZeroExit carrying captured stderr both land
+        // here. The renderer must not synthesise an empty structured
+        // block when the diagnostic list is empty.
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "kotlinc: broken",
+        )
+        assertEquals("kotlinc: broken", renderCompilationFailure(error))
+    }
+
+    @Test
+    fun trailingNewlineInStderrIsStripped() {
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "line 1\nline 2\n",
+        )
+        assertEquals("line 1\nline 2", renderCompilationFailure(error))
+    }
+}

--- a/src/nativeTest/kotlin/kolt/build/RenderCompilationFailureTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/RenderCompilationFailureTest.kt
@@ -111,6 +111,22 @@ class RenderCompilationFailureTest {
     }
 
     @Test
+    fun fileNullWithLineColumnStillCollapsesToNoLocation() {
+        // Belt-and-suspenders: even if a future producer forgets to
+        // populate `file` but still passes line/column, the renderer
+        // must not emit a leading-colon `:5:3: error: msg` shape.
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "",
+            diagnostics = listOf(
+                Diagnostic(Severity.Error, file = null, line = 5, column = 3, message = "rogue"),
+            ),
+        )
+        assertEquals("error: rogue", renderCompilationFailure(error))
+    }
+
+    @Test
     fun rendersStderrOnlyWhenDiagnosticsAreEmpty() {
         // Pre-B-2c daemon behaviour and subprocess path with
         // ProcessError.NonZeroExit carrying captured stderr both land

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
@@ -7,8 +7,10 @@ import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import kolt.build.CompileError
 import kolt.build.CompileRequest
+import kolt.daemon.wire.Diagnostic
 import kolt.daemon.wire.FrameError
 import kolt.daemon.wire.Message
+import kolt.daemon.wire.Severity
 import kolt.infra.ProcessError
 import kolt.infra.net.UnixSocketError
 import kotlin.test.Test
@@ -144,6 +146,51 @@ class DaemonCompilerBackendHappyPathTest {
         val failed = assertIs<CompileError.CompilationFailed>(err)
         assertEquals(1, failed.exitCode)
         assertEquals("Main.kt:3:5 error: expected ';'", failed.stderr)
+    }
+
+    @Test
+    fun diagnosticsFieldIsThreadedThroughToCompilationFailed() {
+        // ADR 0019 §7 + B-2c: `DaemonServer.icErrorToReply` parses
+        // kotlinc's `path:L:C: severity: msg` lines into the
+        // `Message.CompileResult.diagnostics` field and routes
+        // unparsable remains to `stderr`. This test pins that the
+        // native-side mapping propagates the structured list into
+        // `CompileError.CompilationFailed.diagnostics` so the
+        // `BuildCommands` rendering path can actually reach the user.
+        // Before this change the diagnostics field was silently
+        // dropped and dogfood users saw only the one-line summary.
+        val fake = FakeConnection(
+            reply = Ok(
+                Message.CompileResult(
+                    exitCode = 1,
+                    diagnostics = listOf(
+                        Diagnostic(
+                            severity = Severity.Error,
+                            file = "/tmp/Main.kt",
+                            line = 3,
+                            column = 5,
+                            message = "expected ';'",
+                        ),
+                        Diagnostic(
+                            severity = Severity.Warning,
+                            file = "/tmp/Main.kt",
+                            line = 1,
+                            column = 1,
+                            message = "unused import",
+                        ),
+                    ),
+                    stdout = "",
+                    stderr = "",
+                ),
+            ),
+        )
+        val backend = newBackend(connector = { Ok(fake) })
+
+        val err = assertNotNull(backend.compile(sampleRequest()).getError())
+        val failed = assertIs<CompileError.CompilationFailed>(err)
+        assertEquals(2, failed.diagnostics.size)
+        assertEquals("expected ';'", failed.diagnostics[0].message)
+        assertEquals(Severity.Warning, failed.diagnostics[1].severity)
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #120 (B-2c). Dogfood run on the merged branch surfaced two related issues.

## Summary

- **Pre-existing Phase A bug exposed by B-2c dogfood**: `BuildCommands.doBuild` has never printed `CompileError.CompilationFailed.stderr` — the one-line `formatCompileError` summary was all the user saw. Masked on subprocess path because kotlinc inherited the terminal; on daemon path the error body travelled over the socket into a field that was silently discarded. B-2c widened the surface by splitting diagnostics into a separate structured field, so parsed lines did not land in `stderr` either. Before these commits, the user-visible output of `kolt build` on a type error was literally `error: compilation failed with exit code 1` with no context.
- **`DiagnosticParser` did not match real BTA output shape**: B-2c tested the parser against the classic subprocess kotlinc format `path:L:C: severity: msg`, but BTA 2.3.20's `KotlinLogger.error` actually emits `file:///<abs-path>:<line>:<col> <message>` — no severity word, a space separator instead of a colon, and a `file://` URI prefix. The tests passed, the parser was wired in, and in practice the structured `Message.CompileResult.diagnostics` field stayed empty because no real line matched. IDE-style consumers would have had nothing to render.

## Commits

1. `2a34e74` **parser** — Second regex matches the BTA inline shape. Severity defaults to `Error` because `CapturingKotlinLogger` only captures `logger.error(...)` lines. `file://` URI prefix stripped. Classic subprocess regex retained so a future BTA bump that restores the severity word keeps working.
2. `912bd9b` **render** — `CompileError.CompilationFailed` carries `diagnostics: List<Diagnostic>`, `DaemonCompilerBackend.mapReplyToOutcome` threads `reply.diagnostics` through, new `renderCompilationFailure` helper reunites structured + plain-text in kotlinc order, `BuildCommands.doBuild` prints the rendered body before the one-line summary.

## Dogfood verification

`spike/bench-scaling/fixtures/jvm-25` with a deliberate `val broken: Int = \"not an int\"` injection:

**Before** (main, today):
\`\`\`
resolving dependencies...
compiling jvm-25...
error: compilation failed with exit code 1
\`\`\`

**After** (this branch):
\`\`\`
resolving dependencies...
compiling jvm-25...
/home/.../jvm-25/src/File12.kt:3:17: error: Initializer type mismatch: expected 'Int', actual 'String'.
/home/.../jvm-25/src/File12.kt:3:31: error: Syntax error: imports are only allowed in the beginning of file.
error: compilation failed with exit code 1
\`\`\`

Structured diagnostics now populate `Message.CompileResult.diagnostics` with the right shape, stripped `file://` prefix, and the user-facing rendering adds the `error:` severity token for consistency with the existing subprocess-path shape.

## Test plan

- [x] `./gradlew :kolt-compiler-daemon:test :kolt-compiler-daemon:ic:test linuxX64Test` — all suites green
- [x] `DiagnosticParserTest` — 2 new cases for BTA inline shape (with and without `file://` prefix)
- [x] `RenderCompilationFailureTest` — 7 new cases for the rendering helper
- [x] `DaemonCompilerBackendTest` — 1 new case pinning `reply.diagnostics` → `CompilationFailed.diagnostics` flow
- [x] End-to-end dogfood on `jvm-25` fixture: type error visible, success path unchanged
- [ ] CI on this branch

## Note

`src/nativeTest/kotlin/kolt/build/` is matched by the `**/build/` gitignore rule, so the new test file landed via `git add -f`. Existing tests under that directory were grandfathered in before the rule tightened; new files under it need the override. Filing a separate issue to revisit the gitignore pattern is optional — the test works, but the workflow is easy to forget.