### PR TITLE
Wire native client --plugin-jars to the daemon (#65 slice)

### DIFF
--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/PluginTranslator.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/PluginTranslator.kt
@@ -29,15 +29,23 @@ object PluginTranslator {
 
     // Kotlin compiler plugin IDs are stable strings the compiler itself uses to
     // route -P options. `kotlinx-serialization` is the canonical ID for the
-    // serialization plugin across Kotlin 1.x/2.x; changing it would break every
-    // build that depends on it, so it is safe to hard-code.
+    // serialization plugin across Kotlin 1.x/2.x; the `allopen` / `noarg` IDs
+    // are read from `AllOpenPluginNames.PLUGIN_ID` / `NoArgPluginNames.PLUGIN_ID`
+    // in the Kotlin source tree (verified against v2.3.20). Changing any of
+    // these would break every build that depends on the plugin, so they are
+    // safe to hard-code.
     const val SERIALIZATION_PLUGIN_ID = "org.jetbrains.kotlinx.serialization"
+    const val ALLOPEN_PLUGIN_ID = "org.jetbrains.kotlin.allopen"
+    const val NOARG_PLUGIN_ID = "org.jetbrains.kotlin.noarg"
 
-    // Alias that kolt.toml users type. Multiple aliases can resolve to the same
-    // plugin id — for now only one is supported, and adding more is a pure
-    // lookup-table update.
+    // Alias that kolt.toml users type. Aliases mirror the native client's
+    // `PLUGIN_JAR_NAMES` map in `kolt.build.CompilerPlugin` so a project's
+    // `[plugins]` section means the same thing on both the daemon and the
+    // subprocess fallback path.
     private val aliasToPluginId: Map<String, String> = mapOf(
         "serialization" to SERIALIZATION_PLUGIN_ID,
+        "allopen" to ALLOPEN_PLUGIN_ID,
+        "noarg" to NOARG_PLUGIN_ID,
     )
 
     /**

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/PluginTranslatorTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/PluginTranslatorTest.kt
@@ -108,6 +108,64 @@ class PluginTranslatorTest {
         assertTrue(plugins.isEmpty())
     }
 
+    // #65 native client wiring: allopen / noarg join serialization in the
+    // alias map so the JVM build path can enable them via kolt.toml. The
+    // plugin IDs are the stock Kotlin compiler ones (`org.jetbrains.kotlin.
+    // allopen`, `org.jetbrains.kotlin.noarg`) — not vendor-renamed — so a
+    // future bump of the kolt-compiler-daemon kotlin version does not need
+    // to revisit this map.
+    @Test
+    fun `allopen plugin entry is translated to the stock allopen CompilerPlugin id`() {
+        val projectRoot = Files.createTempDirectory("plugin-translator-allopen-")
+        projectRoot.resolve("kolt.toml").writeText(
+            """
+            name = "demo"
+            version = "0.1.0"
+            kotlin = "2.3.20"
+            target = "jvm"
+            main = "demo.Main"
+            sources = ["src/main/kotlin"]
+
+            [plugins]
+            allopen = true
+            """.trimIndent(),
+        )
+        val fakeJar = Path.of("/fake/allopen-compiler-plugin.jar")
+        val plugins = PluginTranslator.translate(
+            projectRoot = projectRoot,
+            jarResolver = { name -> if (name == "allopen") listOf(fakeJar) else emptyList() },
+        )
+        assertEquals(1, plugins.size)
+        assertEquals(PluginTranslator.ALLOPEN_PLUGIN_ID, plugins.single().pluginId)
+        assertEquals(listOf(fakeJar), plugins.single().classpath)
+    }
+
+    @Test
+    fun `noarg plugin entry is translated to the stock noarg CompilerPlugin id`() {
+        val projectRoot = Files.createTempDirectory("plugin-translator-noarg-")
+        projectRoot.resolve("kolt.toml").writeText(
+            """
+            name = "demo"
+            version = "0.1.0"
+            kotlin = "2.3.20"
+            target = "jvm"
+            main = "demo.Main"
+            sources = ["src/main/kotlin"]
+
+            [plugins]
+            noarg = true
+            """.trimIndent(),
+        )
+        val fakeJar = Path.of("/fake/noarg-compiler-plugin.jar")
+        val plugins = PluginTranslator.translate(
+            projectRoot = projectRoot,
+            jarResolver = { name -> if (name == "noarg") listOf(fakeJar) else emptyList() },
+        )
+        assertEquals(1, plugins.size)
+        assertEquals(PluginTranslator.NOARG_PLUGIN_ID, plugins.single().pluginId)
+        assertEquals(listOf(fakeJar), plugins.single().classpath)
+    }
+
     @Test
     fun `unresolved plugin jar produces an empty classpath but still emits a CompilerPlugin`() {
         // An empty classpath from the resolver does not mean "skip this plugin":

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/protocol/DiagnosticParser.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/protocol/DiagnosticParser.kt
@@ -40,13 +40,27 @@ object DiagnosticParser {
     private val SUBPROCESS_REGEX: Regex =
         Regex("""^(?<path>.+):(?<line>\d+):(?<col>\d+):\s*(?<sev>[A-Za-z_]+):\s*(?<msg>.*)$""")
 
+    // Path must start with either `file://` or `/` so an arbitrary
+    // error-level log line like `Cannot resolve org.foo:1:2 from repo`
+    // cannot false-positive into a fake `Diagnostic`. The parser's own
+    // contract (see top-of-file comment) is Linux/macOS absolute paths
+    // only, which means a real diagnostic always begins with one of
+    // those two prefixes. A line that fits the `path:L:C msg` skeleton
+    // but lacks an absolute-path leader correctly falls through to
+    // plain-text stderr.
     private val BTA_INLINE_REGEX: Regex =
-        Regex("""^(?<path>.+):(?<line>\d+):(?<col>\d+)\s+(?<msg>.*)$""")
+        Regex("""^(?<path>(?:file://)?/[^\s].*?):(?<line>\d+):(?<col>\d+)\s+(?<msg>.*)$""")
 
     private const val FILE_URI_PREFIX: String = "file://"
 
     fun parseLine(line: String): Diagnostic? {
-        SUBPROCESS_REGEX.matchEntire(line)?.let { match ->
+        // Defensive trim: BTA may or may not terminate captured logger
+        // strings with `\n`; `matchEntire` does not consume newlines
+        // because `.` does not match `\n` by default. Strip both `\n`
+        // and `\r` so a future BTA bump that starts adding line
+        // terminators does not silently break the parser.
+        val trimmed = line.trimEnd('\n', '\r')
+        SUBPROCESS_REGEX.matchEntire(trimmed)?.let { match ->
             val severity = toSeverity(match.groups["sev"]!!.value) ?: return@let
             return Diagnostic(
                 severity = severity,
@@ -56,7 +70,7 @@ object DiagnosticParser {
                 message = match.groups["msg"]!!.value.trim(),
             )
         }
-        BTA_INLINE_REGEX.matchEntire(line)?.let { match ->
+        BTA_INLINE_REGEX.matchEntire(trimmed)?.let { match ->
             return Diagnostic(
                 severity = Severity.Error,
                 file = stripFileUri(match.groups["path"]!!.value),

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/protocol/DiagnosticParser.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/protocol/DiagnosticParser.kt
@@ -10,26 +10,66 @@ package kolt.daemon.protocol
 // Linux/macOS-style filesystems in the current kolt release.
 object DiagnosticParser {
 
-    // Greedy path capture up to the last `:L:C:` triple. `\d+` for both
-    // line and column anchors the regex against the positional prefix so
-    // a colon inside a message body cannot be misread as a position. The
-    // severity token includes `_` so multi-word kotlinc severities like
-    // `strong_warning` match (`[A-Za-z]+` alone would drop those lines
-    // silently into plain-text stderr).
-    private val LINE_REGEX: Regex =
+    // Two regexes because kotlinc has two output shapes that BTA surfaces
+    // through `KotlinLogger.error`:
+    //
+    //   1. Classic subprocess format: `path:L:C: severity: message`
+    //      — what `kolt-compiler-daemon` sees when it runs a plain
+    //      kotlinc invocation. Severity token can be `error`, `warning`,
+    //      `info`, or `strong_warning` (underscore is why the token
+    //      group allows `_`).
+    //
+    //   2. BTA 2.3.20 in-process format: `file:///URI:L:C <message>`
+    //      — what `BtaIncrementalCompiler` actually receives on a real
+    //      compile error. No severity word between position and
+    //      message, a **space** separator instead of a colon, and a
+    //      `file://` URI prefix on the path. We default these to
+    //      `Severity.Error` because `CapturingKotlinLogger` only
+    //      captures `logger.error(...)` into `errors` (warn/info are
+    //      forwarded to the metrics sink only), so anything that
+    //      reaches this parser via the captured error list is, by
+    //      definition, an error.
+    //
+    // Dogfood on the B-2c merge (jvm-25 fixture with a deliberate type
+    // error) produced shape 2; the parser was only matching shape 1
+    // before, so structured diagnostics silently went through the
+    // plain-text `stderr` fallback instead of populating
+    // `Message.CompileResult.diagnostics`. Both shapes matter: shape 1
+    // will reappear the moment a future BTA bump changes the format
+    // back, and shape 2 is what today's user actually sees.
+    private val SUBPROCESS_REGEX: Regex =
         Regex("""^(?<path>.+):(?<line>\d+):(?<col>\d+):\s*(?<sev>[A-Za-z_]+):\s*(?<msg>.*)$""")
 
+    private val BTA_INLINE_REGEX: Regex =
+        Regex("""^(?<path>.+):(?<line>\d+):(?<col>\d+)\s+(?<msg>.*)$""")
+
+    private const val FILE_URI_PREFIX: String = "file://"
+
     fun parseLine(line: String): Diagnostic? {
-        val match = LINE_REGEX.matchEntire(line) ?: return null
-        val severity = toSeverity(match.groups["sev"]!!.value) ?: return null
-        return Diagnostic(
-            severity = severity,
-            file = match.groups["path"]!!.value,
-            line = match.groups["line"]!!.value.toInt(),
-            column = match.groups["col"]!!.value.toInt(),
-            message = match.groups["msg"]!!.value.trim(),
-        )
+        SUBPROCESS_REGEX.matchEntire(line)?.let { match ->
+            val severity = toSeverity(match.groups["sev"]!!.value) ?: return@let
+            return Diagnostic(
+                severity = severity,
+                file = stripFileUri(match.groups["path"]!!.value),
+                line = match.groups["line"]!!.value.toInt(),
+                column = match.groups["col"]!!.value.toInt(),
+                message = match.groups["msg"]!!.value.trim(),
+            )
+        }
+        BTA_INLINE_REGEX.matchEntire(line)?.let { match ->
+            return Diagnostic(
+                severity = Severity.Error,
+                file = stripFileUri(match.groups["path"]!!.value),
+                line = match.groups["line"]!!.value.toInt(),
+                column = match.groups["col"]!!.value.toInt(),
+                message = match.groups["msg"]!!.value.trim(),
+            )
+        }
+        return null
     }
+
+    private fun stripFileUri(path: String): String =
+        if (path.startsWith(FILE_URI_PREFIX)) path.removePrefix(FILE_URI_PREFIX) else path
 
     // Splits a flat list of captured logger lines into the structured
     // `diagnostics` field for `Message.CompileResult` and the residual

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/server/DaemonServer.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/server/DaemonServer.kt
@@ -216,6 +216,21 @@ class DaemonServer(
         // held a `workingDir = projectRoot` placeholder here; B-2b retires
         // that by pointing workingDir at daemon-owned state under
         // `icRoot / kotlinVersion / sha256(projectRoot)`.
+        //
+        // ADR 0019 §9 + #65: `request.extraArgs` is intentionally NOT
+        // forwarded. The native client packs `-jvm-target N` and the
+        // legacy `-Xplugin=...` plugin args into `extraArgs` for the
+        // subprocess fallback path, which execs raw kotlinc and needs
+        // them. The daemon path uses structured channels instead:
+        // - plugins flow through `--plugin-jars` → `pluginJarResolver` →
+        //   `PluginTranslator` → `COMPILER_PLUGINS` (BTA's structured
+        //   plugin list).
+        // - jvm target is hard-coded by the daemon's BTA setup.
+        // Honouring `extraArgs` here would re-attach `-Xplugin=` as a
+        // free-text compiler arg on top of the structured `CompilerPlugin`
+        // list, double-loading the plugin classpath. If a future change
+        // wants to forward subset args, it MUST filter `-Xplugin=` first
+        // (or the native client must stop emitting it on the daemon path).
         return IcRequest(
             projectId = IcStateLayout.projectIdFor(projectRoot),
             projectRoot = projectRoot,

--- a/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
+++ b/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
@@ -94,6 +94,39 @@ class DiagnosticParserTest {
     }
 
     @Test
+    fun parsesBtaInlineShapeWithFileUriAndNoSeverityWord() {
+        // BTA 2.3.20 `KotlinLogger.error` emits this shape on a real
+        // compile error; verified against dogfood output on the B-2c
+        // merge. The `file://` prefix must be stripped and the
+        // severity defaults to `Error` because only error-level lines
+        // reach `CapturingKotlinLogger.errors`.
+        val parsed = DiagnosticParser.parseLine(
+            "file:///tmp/kolt/File12.kt:3:17 Initializer type mismatch: expected 'Int', actual 'String'.",
+        )
+        assertEquals(
+            Diagnostic(
+                severity = Severity.Error,
+                file = "/tmp/kolt/File12.kt",
+                line = 3,
+                column = 17,
+                message = "Initializer type mismatch: expected 'Int', actual 'String'.",
+            ),
+            parsed,
+        )
+    }
+
+    @Test
+    fun btaInlineShapeWithoutFileUriPrefixStillParses() {
+        // A future BTA release may drop the `file://` prefix. Matching
+        // the shape without it keeps us forward-compatible.
+        val parsed = DiagnosticParser.parseLine(
+            "/tmp/kolt/File12.kt:3:17 Initializer type mismatch",
+        )
+        assertEquals("/tmp/kolt/File12.kt", parsed?.file)
+        assertEquals(Severity.Error, parsed?.severity)
+    }
+
+    @Test
     fun trailingStackFrameLinesStayUnparsed() {
         // CapturingKotlinLogger appends `\n\tat Foo.bar(...)` for throwables.
         // That trailing frame must not masquerade as a diagnostic.

--- a/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
+++ b/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
@@ -116,6 +116,46 @@ class DiagnosticParserTest {
     }
 
     @Test
+    fun nonAbsolutePathFallsThroughInsteadOfFalsePositiveOnBtaInline() {
+        // The BTA-inline regex must not match arbitrary error-level
+        // log lines that happen to contain `word:digits:digits word`.
+        // Real diagnostics always start with an absolute path or
+        // `file://` URI; anything else is unstructured chatter and
+        // should land in plain-text stderr instead of being lifted
+        // into a fake Diagnostic with a path like `Cannot resolve`.
+        assertNull(
+            DiagnosticParser.parseLine("Cannot resolve coordinate org.foo:1:2 from repo"),
+        )
+        assertNull(DiagnosticParser.parseLine("foo:1:2 bar"))
+    }
+
+    @Test
+    fun subprocessShapeWinsOverBtaInlineShapeOnLinesThatMatchBoth() {
+        // `/foo:1:2: error: bar` is a legal subprocess shape AND would
+        // also match the BTA-inline regex if reached (path=`/foo`,
+        // line=1, col=2, msg=`error: bar`). The parser must try the
+        // subprocess regex first so the severity word is honoured and
+        // the message body is correct. A refactor that swapped the
+        // order would silently produce wrong diagnostics.
+        val parsed = DiagnosticParser.parseLine("/foo:1:2: error: bar")
+        assertEquals(Severity.Error, parsed?.severity)
+        assertEquals("/foo", parsed?.file)
+        assertEquals("bar", parsed?.message)
+    }
+
+    @Test
+    fun trailingNewlineIsStripped() {
+        // BTA may or may not terminate captured strings; defend
+        // against a future bump by trimming `\n` / `\r` before the
+        // regex tries matchEntire (which does not consume `\n`).
+        val parsed = DiagnosticParser.parseLine(
+            "file:///tmp/A.kt:1:1 boom\n",
+        )
+        assertEquals("/tmp/A.kt", parsed?.file)
+        assertEquals("boom", parsed?.message)
+    }
+
+    @Test
     fun btaInlineShapeWithoutFileUriPrefixStillParses() {
         // A future BTA release may drop the `file://` prefix. Matching
         // the shape without it keeps us forward-compatible.

--- a/src/nativeMain/kotlin/kolt/build/CompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/CompilerBackend.kt
@@ -1,6 +1,8 @@
 package kolt.build
 
 import com.github.michaelbull.result.Result
+import kolt.daemon.wire.Diagnostic
+import kolt.daemon.wire.Severity
 
 // A CompilerBackend turns a CompileRequest into a compiled output. Two
 // implementations are planned:
@@ -40,10 +42,23 @@ data class CompileOutcome(
 sealed interface CompileError {
     // Compiler ran but the user's Kotlin source did not compile. Not fallback
     // eligible — the subprocess path would fail identically.
+    //
+    // `diagnostics` is the structured form of the compile errors
+    // `BtaIncrementalCompiler` captures via its `KotlinLogger` hook and
+    // `DaemonServer.icErrorToReply` splits out of the flat stderr stream
+    // (see `DiagnosticParser` on the daemon side). Daemon path: populated
+    // from `Message.CompileResult.diagnostics`. Subprocess path: empty,
+    // because kotlinc's diagnostics go directly to the inherited stderr
+    // and the native client never parses them. Callers that want a
+    // complete, ordered user-visible error rendering should prefer
+    // `renderCompilationFailure` below over reading `stderr` / `diagnostics`
+    // independently — that helper reunites the two streams without risk
+    // of double-printing on the daemon path.
     data class CompilationFailed(
         val exitCode: Int,
         val stdout: String,
         val stderr: String,
+        val diagnostics: List<Diagnostic> = emptyList(),
     ) : CompileError
 
     // Backend itself could not run the compiler. Fallback eligible. Distinct
@@ -66,6 +81,49 @@ sealed interface CompileError {
     // Logged as an error rather than a warning so self-inflicted problems do
     // not disappear into the fallback path silently.
     data class InternalMisuse(val detail: String) : CompileError
+}
+
+// Renders every diagnostic the daemon captured, plus any leftover plain-
+// text stderr lines, in the order kotlinc would have produced them.
+// Used by `BuildCommands` to print the full compile error body before
+// the one-line summary `formatCompileError` produces. Pre-B-2c the
+// daemon reply had everything in `stderr`; B-2c split the structured
+// lines out into `diagnostics`. This helper handles both shapes so
+// nothing goes missing regardless of which field is populated.
+//
+// Subprocess path callers should skip this helper — kotlinc already
+// wrote its diagnostics to the inherited stderr stream before the
+// CompilerBackend turned the non-zero exit into a CompilationFailed.
+// Calling `renderCompilationFailure` on a subprocess-path error would
+// typically produce an empty string anyway (both fields are empty),
+// but the ordering invariant is that daemon-path callers print this
+// block and subprocess-path callers do not.
+fun renderCompilationFailure(error: CompileError.CompilationFailed): String {
+    val parts = mutableListOf<String>()
+    for (diagnostic in error.diagnostics) {
+        parts += formatDiagnostic(diagnostic)
+    }
+    if (error.stderr.isNotEmpty()) parts += error.stderr.trimEnd('\n')
+    return parts.joinToString("\n")
+}
+
+private fun formatDiagnostic(diagnostic: Diagnostic): String {
+    val location = buildString {
+        if (diagnostic.file != null) append(diagnostic.file)
+        if (diagnostic.line != null) append(':').append(diagnostic.line)
+        if (diagnostic.column != null) append(':').append(diagnostic.column)
+    }
+    val severity = when (diagnostic.severity) {
+        Severity.Error -> "error"
+        Severity.Warning -> "warning"
+        Severity.Info -> "info"
+        Severity.Logging -> "logging"
+    }
+    return if (location.isEmpty()) {
+        "$severity: ${diagnostic.message}"
+    } else {
+        "$location: $severity: ${diagnostic.message}"
+    }
 }
 
 fun formatCompileError(error: CompileError, context: String): String = when (error) {

--- a/src/nativeMain/kotlin/kolt/build/CompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/CompilerBackend.kt
@@ -98,7 +98,7 @@ sealed interface CompileError {
 // typically produce an empty string anyway (both fields are empty),
 // but the ordering invariant is that daemon-path callers print this
 // block and subprocess-path callers do not.
-fun renderCompilationFailure(error: CompileError.CompilationFailed): String {
+internal fun renderCompilationFailure(error: CompileError.CompilationFailed): String {
     val parts = mutableListOf<String>()
     for (diagnostic in error.diagnostics) {
         parts += formatDiagnostic(diagnostic)
@@ -108,8 +108,16 @@ fun renderCompilationFailure(error: CompileError.CompilationFailed): String {
 }
 
 private fun formatDiagnostic(diagnostic: Diagnostic): String {
-    val location = buildString {
-        if (diagnostic.file != null) append(diagnostic.file)
+    // file=null is the "no location" branch even when line/column
+    // happen to be non-null. Without this guard, a future producer
+    // that forgets to populate `file` while still emitting line/col
+    // would render `:5:3: error: msg` with a leading colon — ugly
+    // and unlike anything kotlinc has ever produced. kotlinc's own
+    // shape always emits position together with a file or omits both.
+    val location = if (diagnostic.file == null) {
+        ""
+    } else buildString {
+        append(diagnostic.file)
         if (diagnostic.line != null) append(':').append(diagnostic.line)
         if (diagnostic.column != null) append(':').append(diagnostic.column)
     }

--- a/src/nativeMain/kotlin/kolt/build/CompilerPlugin.kt
+++ b/src/nativeMain/kotlin/kolt/build/CompilerPlugin.kt
@@ -25,6 +25,27 @@ fun pluginArgs(
     return Ok(args)
 }
 
+// #65 daemon path: returns enabled aliases mapped to their resolved
+// plugin jar classpaths. The daemon's `--plugin-jars` flag expects this
+// shape (see Main.parsePluginJars), and `PluginTranslator` reads it as
+// alias → List<Path> when building BTA `CompilerPlugin` instances.
+// Today the lookup is the same kotlinc-sidecar `<lib>/<jar>.jar` mapping
+// pluginArgs uses; replacing this with a Maven fixed-coordinate fetcher
+// is the rest of #65 and only requires updating this function (the
+// daemon wiring is alias-shaped on both sides).
+fun pluginJarPaths(
+    plugins: Map<String, Boolean>,
+    kotlinHome: String,
+): Result<Map<String, List<String>>, UnknownPlugin> {
+    val out = linkedMapOf<String, List<String>>()
+    for ((name, enabled) in plugins) {
+        if (!enabled) continue
+        val jarName = PLUGIN_JAR_NAMES[name] ?: return Err(UnknownPlugin(name))
+        out[name] = listOf("$kotlinHome/lib/$jarName")
+    }
+    return Ok(out)
+}
+
 fun parseKotlinHome(kotlincPath: String): String {
     return kotlincPath.removeSuffix("/bin/kotlinc")
 }

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
@@ -87,6 +87,11 @@ class DaemonCompilerBackend internal constructor(
     private val btaImplJars: List<String>,
     private val socketPath: String,
     private val logPath: String? = null,
+    // ADR 0019 §9 + #65: enabled `kolt.toml [plugins]` alias → compiler
+    // plugin classpath. Serialised onto `--plugin-jars` when spawning the
+    // daemon (see Main.parsePluginJars). Empty map omits the flag entirely
+    // so the common no-plugin path stays trivial.
+    private val pluginJars: Map<String, List<String>> = emptyMap(),
     private val connector: DaemonConnector = defaultDaemonConnector,
     private val spawner: DaemonSpawner = defaultDaemonSpawner,
     private val clockMs: () -> Long = ::monotonicMs,
@@ -100,6 +105,7 @@ class DaemonCompilerBackend internal constructor(
         btaImplJars: List<String>,
         socketPath: String,
         logPath: String? = null,
+        pluginJars: Map<String, List<String>> = emptyMap(),
     ) : this(
         javaBin = javaBin,
         daemonJarPath = daemonJarPath,
@@ -107,6 +113,7 @@ class DaemonCompilerBackend internal constructor(
         btaImplJars = btaImplJars,
         socketPath = socketPath,
         logPath = logPath,
+        pluginJars = pluginJars,
         connector = defaultDaemonConnector,
         spawner = defaultDaemonSpawner,
     )
@@ -191,6 +198,14 @@ class DaemonCompilerBackend internal constructor(
         add(compilerJars.joinToString(":"))
         add("--bta-impl-jars")
         add(btaImplJars.joinToString(":"))
+        if (pluginJars.isNotEmpty()) {
+            add("--plugin-jars")
+            add(
+                pluginJars.entries.joinToString(";") { (alias, cp) ->
+                    "$alias=${cp.joinToString(":")}"
+                },
+            )
+        }
     }
 
     companion object {

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
@@ -312,6 +312,7 @@ internal fun mapReplyToOutcome(reply: Message): Result<CompileOutcome, CompileEr
                         exitCode = reply.exitCode,
                         stdout = reply.stdout,
                         stderr = reply.stderr,
+                        diagnostics = reply.diagnostics,
                     ),
                 )
         }

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -131,12 +131,20 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
     }
 
     val subprocessBackend = SubprocessCompilerBackend(kotlincBin = managedKotlincBin)
+    // #65 native client wiring: alias → plugin jar classpath fed to the
+    // daemon via `--plugin-jars`. The subprocess fallback still picks up
+    // plugins through `-Xplugin=...` in extraArgs (`pArgs`); the daemon
+    // ignores extraArgs entirely (DaemonServer.toIcRequest drops the
+    // field) and reads the plugin classpath from this map instead, so
+    // the two channels coexist without double-loading.
+    val pluginJarsForDaemon = resolvePluginJarsMap(config, managedKotlincBin)
     val backend: CompilerBackend = resolveCompilerBackend(
         config = config,
         paths = paths,
         subprocessBackend = subprocessBackend,
         useDaemon = useDaemon,
         absProjectPath = cwd,
+        pluginJars = pluginJarsForDaemon,
     )
     // Sources and outputPath are relative to the project root in
     // kolt.toml. The subprocess backend inherits cwd via fork+exec,
@@ -566,10 +574,17 @@ internal fun resolveCompilerBackend(
     subprocessBackend: CompilerBackend,
     useDaemon: Boolean,
     absProjectPath: String,
+    // #65 native client wiring: enabled `kolt.toml [plugins]` alias →
+    // compiler plugin jar classpath. The map is built by the caller
+    // (doBuild) so resolveCompilerBackend stays decoupled from the
+    // concrete jar lookup mechanism (kotlinc sidecar today, Maven fetch
+    // once the rest of #65 lands). An empty map means "no plugins" and
+    // collapses to spawnArgv omitting `--plugin-jars` entirely.
+    pluginJars: Map<String, List<String>> = emptyMap(),
     preconditionResolver: (KoltPaths, String, String) -> Result<DaemonSetup, DaemonPreconditionError> =
         { p, kotlincVersion, cwd -> resolveDaemonPreconditions(p, kotlincVersion, cwd) },
     daemonDirCreator: (String) -> Result<Unit, MkdirFailed> = ::ensureDirectoryRecursive,
-    daemonBackendFactory: (DaemonSetup) -> CompilerBackend = ::createDaemonBackend,
+    daemonBackendFactory: (DaemonSetup, Map<String, List<String>>) -> CompilerBackend = ::createDaemonBackend,
     warningSink: (String) -> Unit = ::eprintln,
 ): CompilerBackend {
     if (!useDaemon) return subprocessBackend
@@ -592,20 +607,74 @@ internal fun resolveCompilerBackend(
     }
 
     return FallbackCompilerBackend(
-        primary = daemonBackendFactory(setup),
+        primary = daemonBackendFactory(setup, pluginJars),
         fallback = subprocessBackend,
         onFallback = ::reportFallback,
     )
 }
 
-internal fun createDaemonBackend(setup: DaemonSetup): CompilerBackend = DaemonCompilerBackend(
-    javaBin = setup.javaBin,
-    daemonJarPath = setup.daemonJarPath,
-    compilerJars = setup.compilerJars,
-    btaImplJars = setup.btaImplJars,
-    socketPath = setup.socketPath,
-    logPath = setup.logPath,
-)
+internal fun createDaemonBackend(
+    setup: DaemonSetup,
+    pluginJars: Map<String, List<String>>,
+): CompilerBackend {
+    // #65 native client wiring: a daemon spawned with one plugin set keeps
+    // that set for its entire JVM lifetime (`--plugin-jars` is parsed once
+    // in `Main.parseArgs` and stored on `CliArgs.pluginJars`). If the user
+    // edits `kolt.toml [plugins]` between builds, naively reusing the same
+    // socket would attach the warm daemon's stale plugin classpath — for an
+    // alias that wasn't in the original spawn, `pluginJarResolver` returns
+    // `emptyList()` and `PluginTranslator` emits a `CompilerPlugin` with an
+    // empty classpath, which BTA either silently drops or fails on with a
+    // diagnostic unrelated to the user's source.
+    //
+    // Mixing a plugin-set fingerprint into the socket / log filename forces
+    // a different (and absent) socket on a plugin-set change, which in turn
+    // trips the ENOENT path in `connectOrSpawn` and spawns a fresh daemon
+    // with the new args. The old daemon stays running on its own socket
+    // until it idles out (or the next reaper sweep) — harmless: the
+    // ADR 0016 socket layout already isolates per-project state.
+    val fp = pluginsFingerprint(pluginJars)
+    val socketPath = applyPluginsFingerprintToFile(setup.socketPath, fp)
+    val logPath = applyPluginsFingerprintToFile(setup.logPath, fp)
+    return DaemonCompilerBackend(
+        javaBin = setup.javaBin,
+        daemonJarPath = setup.daemonJarPath,
+        compilerJars = setup.compilerJars,
+        btaImplJars = setup.btaImplJars,
+        socketPath = socketPath,
+        logPath = logPath,
+        pluginJars = pluginJars,
+    )
+}
+
+// Stable 8-hex SHA-256 prefix over the canonicalised plugin map. Sorting
+// the alias keys means iteration order does not affect the fingerprint;
+// the inner classpath order IS significant because BTA treats it as the
+// plugin's own classpath order. Empty input collapses to a fixed marker
+// so the no-plugin path keeps a single socket name.
+internal fun pluginsFingerprint(pluginJars: Map<String, List<String>>): String {
+    if (pluginJars.isEmpty()) return "noplugins"
+    val canonical = pluginJars.entries
+        .sortedBy { it.key }
+        .joinToString(";") { (alias, cp) -> "$alias=${cp.joinToString(":")}" }
+    return kolt.infra.sha256Hex(canonical.encodeToByteArray()).take(8)
+}
+
+// Inserts `-<fingerprint>` between the filename stem and its extension so
+// both `daemon.sock` and `daemon.log` become `daemon-<fp>.sock` /
+// `daemon-<fp>.log`. Confined to this helper so KoltPaths does not need
+// to learn about the plugin channel.
+internal fun applyPluginsFingerprintToFile(path: String, fingerprint: String): String {
+    val slash = path.lastIndexOf('/')
+    val dir = if (slash >= 0) path.substring(0, slash + 1) else ""
+    val name = if (slash >= 0) path.substring(slash + 1) else path
+    val dot = name.lastIndexOf('.')
+    return if (dot > 0) {
+        "$dir${name.substring(0, dot)}-$fingerprint${name.substring(dot)}"
+    } else {
+        "$dir$name-$fingerprint"
+    }
+}
 
 internal fun createResolverDeps() = object : ResolverDeps {
     override fun fileExists(path: String): Boolean = kolt.infra.fileExists(path)

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -188,6 +188,16 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
 
     println("compiling ${config.name}...")
     backend.compile(request).getOrElse { error ->
+        // Daemon path captures kotlinc diagnostics into
+        // `CompilationFailed.diagnostics` + leftover `stderr`; the
+        // subprocess path inherits fds and leaves both fields empty
+        // because kotlinc already wrote to the terminal. Printing the
+        // rendered body before the one-line summary handles both
+        // shapes without double-printing.
+        if (error is CompileError.CompilationFailed) {
+            val body = renderCompilationFailure(error)
+            if (body.isNotEmpty()) eprintln(body)
+        }
         eprintln(formatCompileError(error, "compilation"))
         exitProcess(EXIT_BUILD_ERROR)
     }

--- a/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
+++ b/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
@@ -3,6 +3,7 @@ package kolt.cli
 import com.github.michaelbull.result.getOrElse
 import kolt.build.parseKotlinHome
 import kolt.build.pluginArgs
+import kolt.build.pluginJarPaths
 import kolt.config.KoltConfig
 import kolt.infra.eprintln
 import kolt.infra.executeAndCapture
@@ -35,6 +36,27 @@ internal fun resolvePluginArgs(config: KoltConfig, managedKotlincBin: String? = 
         resolveKotlinHome()
     }
     return pluginArgs(config.plugins, kotlinHome).getOrElse { error ->
+        eprintln("error: unknown plugin '${error.name}'")
+        exitProcess(EXIT_CONFIG_ERROR)
+    }
+}
+
+// #65 daemon path: alias → resolved plugin jar classpath, ready to be
+// handed to `resolveCompilerBackend(pluginJars=...)` and serialised on
+// `--plugin-jars` by `DaemonCompilerBackend`. Returns an empty map when
+// no plugins are enabled so the no-plugin path is free for both the
+// daemon and the subprocess fallback. The kotlinc lookup is the same
+// sidecar path `resolvePluginArgs` uses today; future Maven fetcher
+// work (rest of #65) is a single-callsite swap.
+internal fun resolvePluginJarsMap(
+    config: KoltConfig,
+    managedKotlincBin: String,
+): Map<String, List<String>> {
+    // No early return on `config.plugins.isEmpty()`: `pluginJarPaths`
+    // already filters disabled entries and returns an empty map for an
+    // empty input, which is the same shape this helper would emit.
+    val kotlinHome = parseKotlinHome(managedKotlincBin)
+    return pluginJarPaths(config.plugins, kotlinHome).getOrElse { error ->
         eprintln("error: unknown plugin '${error.name}'")
         exitProcess(EXIT_CONFIG_ERROR)
     }

--- a/src/nativeTest/kotlin/kolt/build/CompilerPluginTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CompilerPluginTest.kt
@@ -117,6 +117,49 @@ class CompilerPluginTest {
         )
     }
 
+    // --- pluginJarPaths ---
+
+    // #65 daemon path: produces an alias → list-of-jar-paths map for
+    // `--plugin-jars`. Mirrors the existing pluginArgs lookup but emits
+    // structured paths instead of `-Xplugin=...` strings so the daemon's
+    // PluginTranslator can drive BTA's CompilerPlugin model.
+    @Test
+    fun pluginJarPathsSingleEnabledPluginReturnsAliasToJarList() {
+        val result = pluginJarPaths(mapOf("serialization" to true), kotlinHome)
+
+        val map = assertNotNull(result.get())
+        assertEquals(
+            mapOf("serialization" to listOf("/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar")),
+            map,
+        )
+    }
+
+    @Test
+    fun pluginJarPathsDisabledPluginsAreExcluded() {
+        val result = pluginJarPaths(
+            mapOf("serialization" to true, "allopen" to false, "noarg" to true),
+            kotlinHome,
+        )
+
+        val map = assertNotNull(result.get())
+        assertEquals(setOf("serialization", "noarg"), map.keys)
+    }
+
+    @Test
+    fun pluginJarPathsEmptyMapReturnsEmptyMap() {
+        val result = pluginJarPaths(emptyMap(), kotlinHome)
+        assertEquals(emptyMap(), assertNotNull(result.get()))
+    }
+
+    @Test
+    fun pluginJarPathsUnknownEnabledPluginReturnsError() {
+        val result = pluginJarPaths(mapOf("unknown-plugin" to true), kotlinHome)
+
+        assertNull(result.get())
+        val error = assertNotNull(result.getError())
+        assertEquals("unknown-plugin", error.name)
+    }
+
     // --- parseKotlinHome ---
 
     @Test

--- a/src/nativeTest/kotlin/kolt/build/RenderCompilationFailureTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/RenderCompilationFailureTest.kt
@@ -1,0 +1,136 @@
+package kolt.build
+
+import kolt.daemon.wire.Diagnostic
+import kolt.daemon.wire.Severity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// Pins the multi-line rendering of CompileError.CompilationFailed so the
+// body the daemon path hands back actually reaches the user. B-2c's
+// DaemonServer.icErrorToReply populates `Message.CompileResult.diagnostics`
+// (structured) and `stderr` (plain text for unparsable lines); the
+// native client must reunite the two streams before printing the
+// one-line `formatCompileError` summary, otherwise kotlinc diagnostics
+// disappear and the user sees only "error: compilation failed with
+// exit code 1". Dogfood on B-2c is what surfaced the bug.
+class RenderCompilationFailureTest {
+
+    @Test
+    fun rendersStructuredDiagnosticsAsKotlincStylePositionedLines() {
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "",
+            diagnostics = listOf(
+                Diagnostic(
+                    severity = Severity.Error,
+                    file = "/tmp/Main.kt",
+                    line = 3,
+                    column = 5,
+                    message = "expected ';'",
+                ),
+            ),
+        )
+        assertEquals(
+            "/tmp/Main.kt:3:5: error: expected ';'",
+            renderCompilationFailure(error),
+        )
+    }
+
+    @Test
+    fun rendersMultipleDiagnosticsInOrder() {
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "",
+            diagnostics = listOf(
+                Diagnostic(Severity.Error, "/a.kt", 1, 1, "first"),
+                Diagnostic(Severity.Warning, "/b.kt", 2, 2, "second"),
+                Diagnostic(Severity.Info, "/c.kt", 3, 3, "third"),
+            ),
+        )
+        val rendered = renderCompilationFailure(error)
+        assertEquals(
+            listOf(
+                "/a.kt:1:1: error: first",
+                "/b.kt:2:2: warning: second",
+                "/c.kt:3:3: info: third",
+            ),
+            rendered.split("\n"),
+        )
+    }
+
+    @Test
+    fun appendsPlainStderrAfterStructuredDiagnostics() {
+        // DiagnosticParser leaves unparsable lines (e.g. trailing
+        // stack frames appended by CapturingKotlinLogger) in the
+        // stderr string. They still need to surface, after the
+        // structured lines for readability.
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "\tat foo.Bar.baz(Bar.kt:42)",
+            diagnostics = listOf(
+                Diagnostic(Severity.Error, "/a.kt", 1, 1, "boom"),
+            ),
+        )
+        val rendered = renderCompilationFailure(error)
+        assertEquals(
+            "/a.kt:1:1: error: boom\n\tat foo.Bar.baz(Bar.kt:42)",
+            rendered,
+        )
+    }
+
+    @Test
+    fun subprocessPathProducesEmptyBody() {
+        // SubprocessCompilerBackend leaves both fields empty because
+        // kotlinc already wrote to the inherited terminal. The
+        // renderer must gracefully return an empty string rather than
+        // a lone "\n" or a synthetic placeholder, so the caller's
+        // `isNotEmpty()` skip works.
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "",
+        )
+        assertTrue(renderCompilationFailure(error).isEmpty())
+    }
+
+    @Test
+    fun diagnosticsWithoutFileAreRenderedWithoutPositionPrefix() {
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "",
+            diagnostics = listOf(
+                Diagnostic(Severity.Error, file = null, line = null, column = null, message = "no location"),
+            ),
+        )
+        assertEquals("error: no location", renderCompilationFailure(error))
+    }
+
+    @Test
+    fun rendersStderrOnlyWhenDiagnosticsAreEmpty() {
+        // Pre-B-2c daemon behaviour and subprocess path with
+        // ProcessError.NonZeroExit carrying captured stderr both land
+        // here. The renderer must not synthesise an empty structured
+        // block when the diagnostic list is empty.
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "kotlinc: broken",
+        )
+        assertEquals("kotlinc: broken", renderCompilationFailure(error))
+    }
+
+    @Test
+    fun trailingNewlineInStderrIsStripped() {
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "line 1\nline 2\n",
+        )
+        assertEquals("line 1\nline 2", renderCompilationFailure(error))
+    }
+}

--- a/src/nativeTest/kotlin/kolt/build/RenderCompilationFailureTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/RenderCompilationFailureTest.kt
@@ -111,6 +111,22 @@ class RenderCompilationFailureTest {
     }
 
     @Test
+    fun fileNullWithLineColumnStillCollapsesToNoLocation() {
+        // Belt-and-suspenders: even if a future producer forgets to
+        // populate `file` but still passes line/column, the renderer
+        // must not emit a leading-colon `:5:3: error: msg` shape.
+        val error = CompileError.CompilationFailed(
+            exitCode = 1,
+            stdout = "",
+            stderr = "",
+            diagnostics = listOf(
+                Diagnostic(Severity.Error, file = null, line = 5, column = 3, message = "rogue"),
+            ),
+        )
+        assertEquals("error: rogue", renderCompilationFailure(error))
+    }
+
+    @Test
     fun rendersStderrOnlyWhenDiagnosticsAreEmpty() {
         // Pre-B-2c daemon behaviour and subprocess path with
         // ProcessError.NonZeroExit carrying captured stderr both land

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
@@ -7,8 +7,10 @@ import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import kolt.build.CompileError
 import kolt.build.CompileRequest
+import kolt.daemon.wire.Diagnostic
 import kolt.daemon.wire.FrameError
 import kolt.daemon.wire.Message
+import kolt.daemon.wire.Severity
 import kolt.infra.ProcessError
 import kolt.infra.net.UnixSocketError
 import kotlin.test.Test
@@ -144,6 +146,51 @@ class DaemonCompilerBackendHappyPathTest {
         val failed = assertIs<CompileError.CompilationFailed>(err)
         assertEquals(1, failed.exitCode)
         assertEquals("Main.kt:3:5 error: expected ';'", failed.stderr)
+    }
+
+    @Test
+    fun diagnosticsFieldIsThreadedThroughToCompilationFailed() {
+        // ADR 0019 §7 + B-2c: `DaemonServer.icErrorToReply` parses
+        // kotlinc's `path:L:C: severity: msg` lines into the
+        // `Message.CompileResult.diagnostics` field and routes
+        // unparsable remains to `stderr`. This test pins that the
+        // native-side mapping propagates the structured list into
+        // `CompileError.CompilationFailed.diagnostics` so the
+        // `BuildCommands` rendering path can actually reach the user.
+        // Before this change the diagnostics field was silently
+        // dropped and dogfood users saw only the one-line summary.
+        val fake = FakeConnection(
+            reply = Ok(
+                Message.CompileResult(
+                    exitCode = 1,
+                    diagnostics = listOf(
+                        Diagnostic(
+                            severity = Severity.Error,
+                            file = "/tmp/Main.kt",
+                            line = 3,
+                            column = 5,
+                            message = "expected ';'",
+                        ),
+                        Diagnostic(
+                            severity = Severity.Warning,
+                            file = "/tmp/Main.kt",
+                            line = 1,
+                            column = 1,
+                            message = "unused import",
+                        ),
+                    ),
+                    stdout = "",
+                    stderr = "",
+                ),
+            ),
+        )
+        val backend = newBackend(connector = { Ok(fake) })
+
+        val err = assertNotNull(backend.compile(sampleRequest()).getError())
+        val failed = assertIs<CompileError.CompilationFailed>(err)
+        assertEquals(2, failed.diagnostics.size)
+        assertEquals("expected ';'", failed.diagnostics[0].message)
+        assertEquals(Severity.Warning, failed.diagnostics[1].severity)
     }
 
     @Test

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
@@ -69,6 +69,7 @@ private fun newBackend(
     connector: DaemonConnector,
     spawner: DaemonSpawner = { _, _ -> Ok(Unit) },
     clock: FakeClock = FakeClock(),
+    pluginJars: Map<String, List<String>> = emptyMap(),
 ): DaemonCompilerBackend = DaemonCompilerBackend(
     javaBin = "/opt/jdk/bin/java",
     daemonJarPath = "/opt/kolt/libexec/kolt-compiler-daemon-all.jar",
@@ -76,6 +77,7 @@ private fun newBackend(
     btaImplJars = listOf("/opt/kolt/libexec/kolt-bta-impl/kotlin-build-tools-impl.jar"),
     socketPath = "/tmp/kolt-daemon-test.sock",
     logPath = "/tmp/kolt-daemon-test.log",
+    pluginJars = pluginJars,
     connector = connector,
     spawner = spawner,
     clockMs = clock.clock,
@@ -293,6 +295,106 @@ class DaemonCompilerBackendConnectAndSpawnTest {
             argv[flagIdx + 1].contains("kotlin-build-tools-impl"),
             "--bta-impl-jars value must contain kotlin-build-tools-impl jar, got: ${argv[flagIdx + 1]}",
         )
+    }
+
+    // #65 native client wiring: when kolt.toml [plugins] is empty (or all
+    // disabled) the native client must NOT pass --plugin-jars to the daemon.
+    // The daemon parser collapses an absent flag to an empty map, so omitting
+    // the flag is the canonical "no plugins" wire shape and avoids any risk of
+    // a malformed entry in the common path.
+    @Test
+    fun spawnArgvOmitsPluginJarsFlagWhenEmpty() {
+        var captured: List<String>? = null
+        var attempt = 0
+        val connector: DaemonConnector = { path ->
+            attempt++
+            if (attempt == 1) {
+                Err(UnixSocketError.ConnectFailed(path, platform.posix.ENOENT, "No such file"))
+            } else {
+                Ok(FakeConnection())
+            }
+        }
+        val backend = newBackend(
+            connector = connector,
+            spawner = { argv, _ -> captured = argv; Ok(Unit) },
+            pluginJars = emptyMap(),
+        )
+
+        backend.compile(sampleRequest())
+
+        val argv = assertNotNull(captured)
+        assertFalse(
+            argv.contains("--plugin-jars"),
+            "spawnArgv must omit --plugin-jars when no plugins are enabled, got: $argv",
+        )
+    }
+
+    // #65 native client wiring: a single enabled plugin must be serialised as
+    // `alias=cp1:cp2` (':' on linuxX64 == File.pathSeparator on the daemon
+    // side, see Main.kt:160). Pinning the wire format in a unit test means
+    // a future contributor cannot silently desync the two sides without
+    // failing CI.
+    @Test
+    fun spawnArgvSerialisesSinglePluginWithColonSeparatedClasspath() {
+        var captured: List<String>? = null
+        var attempt = 0
+        val connector: DaemonConnector = { path ->
+            attempt++
+            if (attempt == 1) {
+                Err(UnixSocketError.ConnectFailed(path, platform.posix.ENOENT, "No such file"))
+            } else {
+                Ok(FakeConnection())
+            }
+        }
+        val backend = newBackend(
+            connector = connector,
+            spawner = { argv, _ -> captured = argv; Ok(Unit) },
+            pluginJars = mapOf("serialization" to listOf("/kt/lib/ser1.jar", "/kt/lib/ser2.jar")),
+        )
+
+        backend.compile(sampleRequest())
+
+        val argv = assertNotNull(captured)
+        val flagIdx = argv.indexOf("--plugin-jars")
+        assertTrue(flagIdx >= 0, "spawnArgv must include --plugin-jars, got: $argv")
+        assertEquals("serialization=/kt/lib/ser1.jar:/kt/lib/ser2.jar", argv[flagIdx + 1])
+    }
+
+    // #65 native client wiring: multiple aliases are joined with ';' so that
+    // the daemon's parsePluginJars can re-split them. The serialised order
+    // mirrors the input map's iteration order — `linkedMapOf` is used here
+    // and `resolvePluginJarsMap` returns a `LinkedHashMap` in production, so
+    // the assertion below pins the exact wire string. A future caller that
+    // hands `DaemonCompilerBackend` a non-LinkedHashMap would break this
+    // test, which is the point: that change would also break the
+    // pluginsFingerprint stability and the warm-daemon reuse story.
+    @Test
+    fun spawnArgvSerialisesMultiplePluginsSemicolonSeparated() {
+        var captured: List<String>? = null
+        var attempt = 0
+        val connector: DaemonConnector = { path ->
+            attempt++
+            if (attempt == 1) {
+                Err(UnixSocketError.ConnectFailed(path, platform.posix.ENOENT, "No such file"))
+            } else {
+                Ok(FakeConnection())
+            }
+        }
+        val backend = newBackend(
+            connector = connector,
+            spawner = { argv, _ -> captured = argv; Ok(Unit) },
+            pluginJars = linkedMapOf(
+                "serialization" to listOf("/p/ser.jar"),
+                "allopen" to listOf("/p/open.jar"),
+            ),
+        )
+
+        backend.compile(sampleRequest())
+
+        val argv = assertNotNull(captured)
+        val flagIdx = argv.indexOf("--plugin-jars")
+        assertTrue(flagIdx >= 0, "spawnArgv must include --plugin-jars, got: $argv")
+        assertEquals("serialization=/p/ser.jar;allopen=/p/open.jar", argv[flagIdx + 1])
     }
 
     @Test

--- a/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
@@ -57,7 +57,7 @@ class ResolveCompilerBackendTest {
             absProjectPath = absProject,
             preconditionResolver = { _, _, _ -> error("must not resolve preconditions when useDaemon=false") },
             daemonDirCreator = { error("must not create daemon dir when useDaemon=false") },
-            daemonBackendFactory = { error("must not construct daemon backend when useDaemon=false") },
+            daemonBackendFactory = { _, _ -> error("must not construct daemon backend when useDaemon=false") },
             warningSink = { warnings.add(it) },
         )
 
@@ -78,7 +78,7 @@ class ResolveCompilerBackendTest {
                 Err(DaemonPreconditionError.DaemonJarMissing)
             },
             daemonDirCreator = { error("must not create daemon dir after precondition failure") },
-            daemonBackendFactory = { error("must not construct daemon backend after precondition failure") },
+            daemonBackendFactory = { _, _ -> error("must not construct daemon backend after precondition failure") },
             warningSink = { warnings.add(it) },
         )
 
@@ -113,7 +113,7 @@ class ResolveCompilerBackendTest {
                 )
             },
             daemonDirCreator = { error("must not create daemon dir after precondition failure") },
-            daemonBackendFactory = { error("must not construct daemon backend after precondition failure") },
+            daemonBackendFactory = { _, _ -> error("must not construct daemon backend after precondition failure") },
             warningSink = { warnings.add(it) },
         )
 
@@ -145,12 +145,46 @@ class ResolveCompilerBackendTest {
             absProjectPath = absProject,
             preconditionResolver = { _, _, _ -> Ok(okSetup) },
             daemonDirCreator = { Err(MkdirFailed(okSetup.daemonDir)) },
-            daemonBackendFactory = { error("must not construct daemon backend after mkdir failure") },
+            daemonBackendFactory = { _, _ -> error("must not construct daemon backend after mkdir failure") },
             warningSink = { warnings.add(it) },
         )
 
         assertSame(subprocess, backend)
         assertEquals(listOf(WARNING_DAEMON_DIR_UNWRITABLE), warnings)
+    }
+
+    // #65 native client wiring: the `pluginJars` map flows through
+    // `resolveCompilerBackend` into `daemonBackendFactory` verbatim, so the
+    // daemon backend can serialise it onto `--plugin-jars` when it spawns
+    // the JVM. Pinning the pass-through here means a future contributor
+    // cannot silently drop the wiring between `doBuild` and the daemon
+    // spawn — the JVM build path's plugin support depends on it.
+    @Test
+    fun pluginJarsArgumentIsForwardedToDaemonBackendFactory() {
+        val warnings = mutableListOf<String>()
+        var capturedPluginJars: Map<String, List<String>>? = null
+        val pluginJars = mapOf(
+            "serialization" to listOf("/fake/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar"),
+        )
+        val backend = resolveCompilerBackend(
+            config = config,
+            paths = paths,
+            subprocessBackend = subprocess,
+            useDaemon = true,
+            absProjectPath = absProject,
+            pluginJars = pluginJars,
+            preconditionResolver = { _, _, _ -> Ok(okSetup) },
+            daemonDirCreator = { Ok(Unit) },
+            daemonBackendFactory = { _, jars ->
+                capturedPluginJars = jars
+                daemonSentinel
+            },
+            warningSink = { warnings.add(it) },
+        )
+
+        assertEquals(emptyList(), warnings)
+        assertNotNull(backend as? FallbackCompilerBackend)
+        assertEquals(pluginJars, capturedPluginJars)
     }
 
     @Test
@@ -172,7 +206,7 @@ class ResolveCompilerBackendTest {
                 assertEquals(okSetup.daemonDir, dir)
                 Ok(Unit)
             },
-            daemonBackendFactory = { setup ->
+            daemonBackendFactory = { setup, _ ->
                 createdFrom = setup
                 daemonSentinel
             },
@@ -188,6 +222,54 @@ class ResolveCompilerBackendTest {
         assertSame(daemonSentinel, fallback.primary)
         assertSame(subprocess, fallback.fallback)
         assertEquals(okSetup, createdFrom)
+    }
+
+    // #65 native client wiring: editing kolt.toml [plugins] between builds
+    // must NOT reuse a warm daemon spawned with a stale plugin set. The
+    // socket and log paths get a plugin-set fingerprint suffix so a
+    // different plugin set probes a different (absent) socket and trips
+    // the ENOENT spawn path in DaemonCompilerBackend.connectOrSpawn.
+    @Test
+    fun pluginsFingerprintIsStableForSamePluginMap() {
+        val a = pluginsFingerprint(mapOf("serialization" to listOf("/k/lib/ser.jar")))
+        val b = pluginsFingerprint(mapOf("serialization" to listOf("/k/lib/ser.jar")))
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun pluginsFingerprintIsOrderInsensitiveOnAliases() {
+        // Iteration order of a caller's map must not affect the fingerprint —
+        // otherwise a future caller swapping a `linkedMapOf` for a `mapOf`
+        // would orphan all warm daemons for no semantic change.
+        val a = pluginsFingerprint(linkedMapOf("a" to listOf("/x"), "b" to listOf("/y")))
+        val b = pluginsFingerprint(linkedMapOf("b" to listOf("/y"), "a" to listOf("/x")))
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun pluginsFingerprintChangesWhenAClasspathChanges() {
+        val a = pluginsFingerprint(mapOf("serialization" to listOf("/k/lib/ser-2.0.jar")))
+        val b = pluginsFingerprint(mapOf("serialization" to listOf("/k/lib/ser-2.1.jar")))
+        assertTrue(a != b, "version bump should change fingerprint, both=$a")
+    }
+
+    @Test
+    fun pluginsFingerprintEmptyMapHasFixedMarker() {
+        // The no-plugin path must collapse to a single, stable bucket so the
+        // common case keeps a single warm daemon across repeated builds.
+        assertEquals("noplugins", pluginsFingerprint(emptyMap()))
+    }
+
+    @Test
+    fun applyPluginsFingerprintInsertsBeforeExtension() {
+        assertEquals(
+            "/fake/daemon/dir/daemon-abcd1234.sock",
+            applyPluginsFingerprintToFile("/fake/daemon/dir/daemon.sock", "abcd1234"),
+        )
+        assertEquals(
+            "/fake/daemon/dir/daemon-abcd1234.log",
+            applyPluginsFingerprintToFile("/fake/daemon/dir/daemon.log", "abcd1234"),
+        )
     }
 
     private class SentinelBackend(val tag: String) : CompilerBackend {


### PR DESCRIPTION
## Summary

First slice of #65: the native client now passes `--plugin-jars` to the warm JVM compiler daemon, fixing a dead wire where JVM-path plugin support (`kolt.toml [plugins]`) silently produced un-pluginned output on the daemon path while the subprocess fallback worked. The kotlinc-sidecar lookup is preserved for now; the Maven fixed-coordinate fetcher and `ensureKotlincBin` removal from native build/test are follow-ups under the same issue.

- `DaemonCompilerBackend` gains a `pluginJars` constructor parameter and `spawnArgv` emits `--plugin-jars alias=p1:p2;alias=p` when non-empty.
- `pluginJarPaths` (sister to `pluginArgs`) returns the alias→jar-list map shape, threaded through `resolveCompilerBackend` / `createDaemonBackend` into the spawn.
- A plugin-set fingerprint is mixed into the daemon socket / log filenames so editing `kolt.toml [plugins]` between builds forces a fresh spawn instead of reusing a warm daemon with stale `pluginJarResolver` state.
- `PluginTranslator` alias map extended from `serialization` only to `serialization` / `allopen` / `noarg`. Plugin IDs verified against `JetBrains/kotlin@v2.3.20`.
- `DaemonServer.toIcRequest` documents the deliberate `extraArgs` drop as load-bearing for the plugin channel split — a future change that honours any subset of `extraArgs` must filter `-Xplugin=` first.

Subagent review (general-purpose) ran before push; review findings #1–#4 are addressed in this commit, the rest are deferred to the Maven-fetcher follow-up.

## Test plan

- [x] `./gradlew build` passes (linuxX64Test + kolt-compiler-daemon JVM tests + ic tests)
- [x] New unit tests:
  - `DaemonCompilerBackendTest`: `--plugin-jars` omit-when-empty, single-alias colon-joined classpath, multi-alias semicolon-separated
  - `CompilerPluginTest`: `pluginJarPaths` happy / disabled / empty / unknown
  - `ResolveCompilerBackendTest`: pluginJars forwarding + `pluginsFingerprint` stability / order-insensitivity / change-detection / empty-marker, `applyPluginsFingerprintToFile` insertion
  - `PluginTranslatorTest`: allopen / noarg alias translation
- [ ] Dogfood `kolt build` against a project with `[plugins] serialization = true` (manual, post-merge)

Refs #65