### PR TITLE
Reap stale IC state under ~/.kolt/daemon/ic/ (#125)

### DIFF
--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
@@ -18,8 +18,13 @@ import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperatio
 import org.jetbrains.kotlin.buildtools.api.trackers.BuildMetricsCollector
 import java.io.File
 import java.net.URLClassLoader
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.channels.OverlappingFileLockException
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
 
@@ -62,6 +67,22 @@ class BtaIncrementalCompiler private constructor(
     private val metrics: IcMetricsSink,
 ) : IncrementalCompiler {
 
+    // Advisory `flock` held on `<workingDir>/LOCK` for the daemon
+    // process lifetime, keyed by `workingDir`. The IC reaper probes
+    // `tryLock` on the same file; a held entry here means "this dir is
+    // in use" and the reaper will skip it.
+    //
+    // Each entry caches both the `FileLock` and the backing
+    // `FileChannel`. When `SelfHealingIncrementalCompiler` wipes
+    // `workingDir` after a corruption, the LOCK file on disk is also
+    // deleted — the cached entry then points at a dead inode and the
+    // next compile must close the stale channel and re-acquire the
+    // lock against the freshly-created file. A naive "cache by
+    // containsKey" short-circuit would leave the daemon holding a dead
+    // lock for the rest of its lifetime.
+    private class HeldLock(val channel: FileChannel, val lock: FileLock)
+    private val heldLocks: MutableMap<Path, HeldLock> = ConcurrentHashMap()
+
     override fun compile(request: IcRequest): Result<IcResponse, IcError> =
         try {
             executeCompile(request)
@@ -84,8 +105,35 @@ class BtaIncrementalCompiler private constructor(
         // not learn which project is compiling until the first request
         // arrives. `createDirectories` is a no-op if the tree already
         // exists, which is the common case for every non-initial request.
-        val wasEmptyBeforeCompile = isEmptyDir(request.workingDir)
         Files.createDirectories(request.workingDir)
+        val btaWorkingDir = request.workingDir.resolve(BTA_SUBDIR)
+        val wasEmptyBeforeCompile = isEmptyDir(btaWorkingDir)
+        Files.createDirectories(btaWorkingDir)
+
+        // ADR 0019 §Negative follow-up (IC reaper): drop a `project.path`
+        // breadcrumb next to BTA state so the reaper can decide whether
+        // this projectId's source tree still exists. Idempotent on every
+        // compile — overwrite is cheap and resilient to a truncation by
+        // the self-heal path. Failure to write is logged as a reaper
+        // concern and does not fail the compile.
+        // ADR 0019 §Negative follow-up (IC reaper): drop a `project.path`
+        // breadcrumb next to the BTA subdir so the reaper can decide
+        // whether this projectId's source tree still exists. Kept
+        // above `btaWorkingDir` because BTA clears its workingDirectory
+        // on cold-path startup; a breadcrumb sitting inside BTA state
+        // would be swept away on every first compile.
+        runCatching {
+            Files.writeString(
+                request.workingDir.resolve(PROJECT_PATH_BREADCRUMB),
+                request.projectRoot.toString(),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+            )
+        }.onFailure { metrics.record(METRIC_REAPER_BREADCRUMB_FAILED) }
+
+        runCatching { ensureLock(request.workingDir) }
+            .onFailure { metrics.record(METRIC_REAPER_LOCK_FAILED) }
 
         val builder = toolchain.jvm.jvmCompilationOperationBuilder(request.sources, request.outputDir)
         if (request.classpath.isNotEmpty()) {
@@ -122,9 +170,9 @@ class BtaIncrementalCompiler private constructor(
         // `SHRUNK_CLASSPATH_SNAPSHOT` constant so the post-B-2 reaper (and
         // any future debugging session that wonders why this file
         // occasionally does not exist) can recognise it.
-        val shrunkClasspathSnapshot = request.workingDir.resolve(SHRUNK_CLASSPATH_SNAPSHOT)
+        val shrunkClasspathSnapshot = btaWorkingDir.resolve(SHRUNK_CLASSPATH_SNAPSHOT)
         val icConfig = builder.snapshotBasedIcConfigurationBuilder(
-            workingDirectory = request.workingDir,
+            workingDirectory = btaWorkingDir,
             sourcesChanges = SourcesChanges.ToBeCalculated,
             dependenciesSnapshotFiles = emptyList(),
             shrunkClasspathSnapshot = shrunkClasspathSnapshot,
@@ -242,6 +290,39 @@ class BtaIncrementalCompiler private constructor(
         // already URL/FS-safe enough to serve as a kotlinc module name.
         "kolt-${request.projectId}"
 
+    private fun ensureLock(workingDir: Path) {
+        val lockPath = workingDir.resolve(LOCK_FILE)
+        val cached = heldLocks[workingDir]
+        if (cached != null && cached.lock.isValid && Files.isRegularFile(lockPath)) {
+            return
+        }
+        if (cached != null) {
+            // Stale cache entry: either the lock was released or
+            // `SelfHealingIncrementalCompiler` wiped the LOCK file when
+            // it cleaned `workingDir`. Close the dead channel and drop
+            // the entry so the next block re-acquires cleanly.
+            runCatching { cached.channel.close() }
+            heldLocks.remove(workingDir)
+        }
+        val channel = FileChannel.open(
+            lockPath,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.READ,
+            StandardOpenOption.WRITE,
+        )
+        val lock: FileLock? = try {
+            channel.tryLock()
+        } catch (_: OverlappingFileLockException) {
+            null
+        }
+        if (lock == null) {
+            channel.close()
+            metrics.record(METRIC_REAPER_LOCK_CONFLICT)
+            return
+        }
+        heldLocks[workingDir] = HeldLock(channel, lock)
+    }
+
     private fun isEmptyDir(workingDir: Path): Boolean {
         if (!Files.exists(workingDir)) return true
         if (!Files.isDirectory(workingDir)) return false
@@ -277,6 +358,16 @@ class BtaIncrementalCompiler private constructor(
         internal const val METRIC_LOG_WARN: String = "ic.log.warn"
         internal const val METRIC_LOG_INFO: String = "ic.log.info"
         internal const val METRIC_LOG_LIFECYCLE: String = "ic.log.lifecycle"
+
+        internal const val METRIC_REAPER_BREADCRUMB_FAILED: String = "reaper.breadcrumb_failed"
+        internal const val METRIC_REAPER_LOCK_FAILED: String = "reaper.lock_failed"
+        internal const val METRIC_REAPER_LOCK_CONFLICT: String = "reaper.lock_conflict"
+
+        // Layout constants are mirrored from `IcStateLayout` for call-
+        // site terseness. The authoritative definition is there.
+        private const val PROJECT_PATH_BREADCRUMB: String = IcStateLayout.BREADCRUMB_FILE
+        private const val LOCK_FILE: String = IcStateLayout.LOCK_FILE
+        private const val BTA_SUBDIR: String = IcStateLayout.BTA_SUBDIR
 
 
         // Loads kotlin-build-tools-impl from [btaImplJars] through a URLClassLoader

--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/IcStateLayout.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/IcStateLayout.kt
@@ -28,6 +28,16 @@ import java.security.MessageDigest
 // future reaper (ADR §Negative) to clean up.
 object IcStateLayout {
 
+    // On-disk names under `<icRoot>/<kotlinVersion>/<projectId>/`.
+    // `BtaIncrementalCompiler` writes these and `IcReaper` reads them;
+    // collecting the constants here keeps the layout contract in one
+    // file. BTA's own state lives one level deeper under `BTA_SUBDIR`
+    // so the reaper-facing metadata is not swept away by BTA's
+    // cold-path housekeeping of its `workingDirectory`.
+    const val BREADCRUMB_FILE: String = "project.path"
+    const val LOCK_FILE: String = "LOCK"
+    const val BTA_SUBDIR: String = "bta"
+
     fun projectIdFor(projectRoot: Path): String {
         val md = MessageDigest.getInstance("SHA-256")
         val digest = md.digest(projectRoot.toString().toByteArray(Charsets.UTF_8))

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
@@ -9,7 +9,9 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
 import kotlin.io.path.extension
+import kotlin.io.path.readText
 import kotlin.io.path.walk
 import kotlin.io.path.writeText
 import kotlin.test.Test
@@ -68,6 +70,15 @@ class BtaIncrementalCompilerColdPathTest {
         val classFiles = outputDir.walk().filter { it.extension == "class" }.toList()
         assertTrue(classFiles.isNotEmpty(), "expected at least one .class under $outputDir")
         assertTrue(classFiles.any { it.fileName.toString() == "Main.class" }, "expected fixture.Main.class in output: $classFiles")
+
+        // ADR 0019 §Negative follow-up — IC reaper coordination: the
+        // cold path must drop a `project.path` breadcrumb inside
+        // workingDir pointing at the request's projectRoot, so the
+        // reaper can distinguish live projectId dirs from stale ones
+        // after a project is moved or deleted.
+        val breadcrumb = workingDir.resolve("project.path")
+        assertTrue(breadcrumb.exists(), "expected project.path breadcrumb at $breadcrumb")
+        assertEquals(workRoot.toString(), breadcrumb.readText().trim())
     }
 
     // A user type error is the only BTA outcome that maps to CompilationFailed.

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
@@ -7,6 +7,7 @@ import com.github.michaelbull.result.mapBoth
 import kolt.daemon.ic.BtaIncrementalCompiler
 import kolt.daemon.ic.SelfHealingIncrementalCompiler
 import kolt.daemon.ic.StderrIcMetricsSink
+import kolt.daemon.reaper.IcReaper
 import kolt.daemon.server.DaemonConfig
 import kolt.daemon.server.DaemonServer
 import java.io.File
@@ -119,12 +120,20 @@ fun main(args: Array<String>) {
         metrics = metrics,
     )
 
+    // ADR 0019 §Negative follow-up (#125): fire the IC reaper on a
+    // detached thread right after the daemon has bound its socket but
+    // before it starts serving compiles. Cleanup never blocks the
+    // first compile; a reaper failure is logged via `metrics` and
+    // swallowed by DaemonServer's `runCatching` around `preServeHook`.
     val server = DaemonServer(
         socketPath = cli.socketPath,
         compiler = compiler,
         icRoot = cli.icRoot,
         kotlinVersion = KOLT_DAEMON_KOTLIN_VERSION,
         config = DaemonConfig(),
+        preServeHook = {
+            IcReaper.runDetached(cli.icRoot, KOLT_DAEMON_KOTLIN_VERSION, metrics)
+        },
     )
     val reason = server.serve().mapBoth(
         success = { it },

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/reaper/IcReaper.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/reaper/IcReaper.kt
@@ -1,0 +1,209 @@
+package kolt.daemon.reaper
+
+import kolt.daemon.ic.IcMetricsSink
+import kolt.daemon.ic.IcStateLayout
+import java.io.IOException
+import java.io.UncheckedIOException
+import java.nio.channels.FileChannel
+import java.nio.channels.OverlappingFileLockException
+import java.nio.file.Files
+import java.nio.file.InvalidPathException
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+// ADR 0019 §5 / §Negative follow-up: prune stale state under
+// `~/.kolt/daemon/ic/`. The layout written by IcStateLayout is
+// `<icRoot>/<kotlinVersion>/<projectIdHash>/…`. Two leak sources are
+// handled:
+//
+//  A. Whole `<kotlinVersion>` segments other than the daemon's current
+//     pin, left behind when `KOLT_DAEMON_KOTLIN_VERSION` moved forward.
+//     ADR 0019 §5 explicitly defers this cleanup to a future reaper.
+//
+//  B. `<projectIdHash>` directories inside the current-version segment
+//     whose source project has been moved or deleted. Since
+//     `IcStateLayout.projectIdFor` is a one-way SHA-256, we cannot
+//     recover the project path from the hash — so the adapter drops a
+//     `project.path` breadcrumb at cold path and the reaper reads it
+//     back. No breadcrumb → keep (legacy state from before this reaper
+//     shipped is preserved, not nuked).
+//
+// Exclusion: an advisory `tryLock` probe on `<projectIdDir>/LOCK`.
+// `BtaIncrementalCompiler` holds this lock for the daemon's lifetime,
+// so a dir whose LOCK is held cannot be the current daemon's active
+// working directory — even across hash collisions. Rules A+B are
+// already safe by construction (A never touches the current version;
+// B only removes dangling projectRoots that a live daemon cannot have
+// spawned from), so the lock probe is belt-and-suspenders insurance.
+object IcReaper {
+
+    data class Report(
+        val scanned: Int,
+        val removed: Int,
+        val skippedLocked: Int,
+        val skippedMissingBreadcrumb: Int,
+        val errors: List<String>,
+    )
+
+    fun run(icRoot: Path, currentKotlinVersion: String, metrics: IcMetricsSink): Report {
+        if (!Files.isDirectory(icRoot)) return EMPTY_REPORT
+
+        var scanned = 0
+        var removed = 0
+        var skippedLocked = 0
+        var skippedMissingBreadcrumb = 0
+        val errors = mutableListOf<String>()
+
+        directoryChildren(icRoot).forEach { versionDir ->
+            try {
+                if (versionDir.fileName.toString() != currentKotlinVersion) {
+                    directoryChildren(versionDir).forEach { projectIdDir ->
+                        scanned++
+                        when (val outcome = tryDelete(projectIdDir)) {
+                            DeleteOutcome.Removed -> removed++
+                            DeleteOutcome.Locked -> skippedLocked++
+                            is DeleteOutcome.Failed -> errors += outcome.message
+                        }
+                    }
+                    // Best-effort removal of the now-empty version segment.
+                    runCatching { Files.deleteIfExists(versionDir) }
+                } else {
+                    directoryChildren(versionDir).forEach { projectIdDir ->
+                        scanned++
+                        val breadcrumb = projectIdDir.resolve(BREADCRUMB)
+                        if (!Files.isRegularFile(breadcrumb)) {
+                            skippedMissingBreadcrumb++
+                            return@forEach
+                        }
+                        val projectRoot = runCatching { Files.readString(breadcrumb).trim() }.getOrNull()
+                        if (projectRoot.isNullOrEmpty()) {
+                            skippedMissingBreadcrumb++
+                            return@forEach
+                        }
+                        // A corrupt breadcrumb (mid-write crash, garbage
+                        // bytes, encoding mismatch) must not crash the
+                        // reaper. Treat the dir as if no breadcrumb were
+                        // present so it is preserved, not deleted.
+                        val resolvedProjectRoot = try {
+                            Path.of(projectRoot)
+                        } catch (_: InvalidPathException) {
+                            skippedMissingBreadcrumb++
+                            return@forEach
+                        }
+                        if (Files.exists(resolvedProjectRoot)) return@forEach
+                        when (val outcome = tryDelete(projectIdDir)) {
+                            DeleteOutcome.Removed -> removed++
+                            DeleteOutcome.Locked -> skippedLocked++
+                            is DeleteOutcome.Failed -> errors += outcome.message
+                        }
+                    }
+                }
+            } catch (e: IOException) {
+                errors += "scan $versionDir: ${e.message}"
+            } catch (e: UncheckedIOException) {
+                errors += "scan $versionDir: ${e.message}"
+            }
+        }
+
+        metrics.record("reaper.scanned", scanned.toLong())
+        metrics.record("reaper.removed", removed.toLong())
+        metrics.record("reaper.skipped_locked", skippedLocked.toLong())
+        metrics.record("reaper.skipped_missing_breadcrumb", skippedMissingBreadcrumb.toLong())
+        if (errors.isNotEmpty()) metrics.record("reaper.error", errors.size.toLong())
+
+        return Report(scanned, removed, skippedLocked, skippedMissingBreadcrumb, errors.toList())
+    }
+
+    fun runDetached(
+        icRoot: Path,
+        currentKotlinVersion: String,
+        metrics: IcMetricsSink,
+    ): Thread =
+        Thread({
+            runCatching { run(icRoot, currentKotlinVersion, metrics) }
+                .onFailure { metrics.record("reaper.error") }
+        }, "ic-reaper").apply {
+            isDaemon = true
+            start()
+        }
+
+    private fun tryDelete(dir: Path): DeleteOutcome {
+        val lockPath = dir.resolve(LOCK_FILE)
+        if (Files.isRegularFile(lockPath)) {
+            val probe = runCatching {
+                FileChannel.open(
+                    lockPath,
+                    StandardOpenOption.READ,
+                    StandardOpenOption.WRITE,
+                )
+            }.getOrElse { return DeleteOutcome.Failed("open LOCK for ${dir}: ${it.message}") }
+            probe.use { channel ->
+                // `tryLock` returns `null` when another JVM holds the lock
+                // and throws `OverlappingFileLockException` when the same
+                // JVM already holds an overlapping lock through a
+                // different `FileChannel`. Both outcomes mean "someone
+                // else is using this dir" as far as the reaper is
+                // concerned.
+                val lock = try {
+                    channel.tryLock()
+                } catch (_: OverlappingFileLockException) {
+                    return DeleteOutcome.Locked
+                } catch (e: IOException) {
+                    return DeleteOutcome.Failed("tryLock LOCK for ${dir}: ${e.message}")
+                }
+                if (lock == null) return DeleteOutcome.Locked
+                lock.release()
+            }
+        }
+        return try {
+            deletePostOrder(dir)
+            DeleteOutcome.Removed
+        } catch (e: IOException) {
+            DeleteOutcome.Failed("delete $dir: ${e.message}")
+        } catch (e: UncheckedIOException) {
+            // `Files.walk(...).forEach { ... }` wraps IO failures from
+            // inside the stream pipeline. Catch both shapes so a
+            // directory mutated mid-walk by another actor cannot crash
+            // the reaper.
+            DeleteOutcome.Failed("delete $dir: ${e.message}")
+        }
+    }
+
+    // Post-order walk: children before parents. Mirrors the shape used
+    // by `SelfHealingIncrementalCompiler.defaultWipe` — reverse-sorted
+    // `Files.walk` works because lexicographic order over paths places
+    // every descendant after its parent string, so reversing visits
+    // deepest entries first.
+    private fun deletePostOrder(root: Path) {
+        if (!Files.exists(root)) return
+        Files.walk(root).use { stream ->
+            stream.sorted(Comparator.reverseOrder()).forEach { path ->
+                Files.deleteIfExists(path)
+            }
+        }
+    }
+
+    private fun directoryChildren(dir: Path): List<Path> {
+        if (!Files.isDirectory(dir)) return emptyList()
+        return Files.newDirectoryStream(dir).use { stream ->
+            stream.filter { Files.isDirectory(it) }.sortedBy { it.fileName.toString() }
+        }
+    }
+
+    private sealed interface DeleteOutcome {
+        data object Removed : DeleteOutcome
+        data object Locked : DeleteOutcome
+        data class Failed(val message: String) : DeleteOutcome
+    }
+
+    private val EMPTY_REPORT = Report(
+        scanned = 0,
+        removed = 0,
+        skippedLocked = 0,
+        skippedMissingBreadcrumb = 0,
+        errors = emptyList(),
+    )
+
+    private const val BREADCRUMB: String = IcStateLayout.BREADCRUMB_FILE
+    private const val LOCK_FILE: String = IcStateLayout.LOCK_FILE
+}

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/server/DaemonServer.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/server/DaemonServer.kt
@@ -60,6 +60,14 @@ class DaemonServer(
     // the single source of truth.
     private val kotlinVersion: String,
     private val config: DaemonConfig = DaemonConfig(),
+    // Fires once in `serve()` after the socket is bound and before the
+    // accept loop starts, on the server thread. Main.kt uses this to
+    // kick the IC reaper (ADR 0019 §Negative follow-up) on a detached
+    // background thread so the initial compile is never blocked on
+    // cleanup. Defaults to a no-op so tests that do not care can stay
+    // terse. Any throwable out of the hook is swallowed so a reaper
+    // failure cannot abort daemon startup.
+    private val preServeHook: () -> Unit = {},
 ) {
     private val stopRequested = AtomicBoolean(false)
     private val compilesServed = AtomicInteger(0)
@@ -91,6 +99,7 @@ class DaemonServer(
         }
 
         serverChannel = server
+        runCatching { preServeHook() }
         val watchdog = startWatchdog()
         try {
             server.use {

--- a/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/reaper/IcReaperTest.kt
+++ b/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/reaper/IcReaperTest.kt
@@ -1,0 +1,195 @@
+package kolt.daemon.reaper
+
+import kolt.daemon.ic.IcMetricsSink
+import java.nio.channels.FileChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class IcReaperTest {
+
+    private lateinit var icRoot: Path
+    private lateinit var otherTmp: Path
+    private lateinit var metrics: RecordingMetricsSink
+
+    @BeforeTest
+    fun setUp() {
+        icRoot = Files.createTempDirectory("kolt-ic-reaper-root-")
+        otherTmp = Files.createTempDirectory("kolt-ic-reaper-project-")
+        metrics = RecordingMetricsSink()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        runCatching { icRoot.toFile().deleteRecursively() }
+        runCatching { otherTmp.toFile().deleteRecursively() }
+    }
+
+    @Test
+    fun `empty icRoot returns an empty report`() {
+        val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+        assertEquals(0, report.scanned)
+        assertEquals(0, report.removed)
+        assertEquals(0, report.skippedLocked)
+        assertEquals(0, report.skippedMissingBreadcrumb)
+        assertTrue(report.errors.isEmpty())
+    }
+
+    @Test
+    fun `missing icRoot returns an empty report`() {
+        val nonexistent = icRoot.resolve("does-not-exist")
+        val report = IcReaper.run(nonexistent, "2.3.20", metrics)
+
+        assertEquals(0, report.scanned)
+        assertEquals(0, report.removed)
+    }
+
+    @Test
+    fun `Rule A removes stale version segments wholesale`() {
+        val stale = icRoot.resolve("2.3.19").resolve("aaaaaaaaaaaaaaaa").createDirectories()
+        stale.resolve("state.bin").writeText("garbage")
+        val current = icRoot.resolve("2.3.20").resolve("bbbbbbbbbbbbbbbb").createDirectories()
+        current.resolve("project.path").writeText(otherTmp.toString())
+
+        val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+        assertFalse(Files.exists(icRoot.resolve("2.3.19")), "stale version segment must be gone")
+        assertTrue(Files.exists(current), "current-version projectId dir must survive")
+        assertEquals(1, report.removed)
+    }
+
+    @Test
+    fun `Rule B removes projectId when breadcrumb points to a missing path`() {
+        val missing = otherTmp.resolve("deleted-project")
+        val projectId = icRoot.resolve("2.3.20").resolve("cccccccccccccccc").createDirectories()
+        projectId.resolve("project.path").writeText(missing.toString())
+        projectId.resolve("state.bin").writeText("garbage")
+
+        val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+        assertFalse(Files.exists(projectId), "projectId with dangling breadcrumb must be removed")
+        assertEquals(1, report.removed)
+    }
+
+    @Test
+    fun `Rule B keeps projectId when breadcrumb points to an existing path`() {
+        val projectId = icRoot.resolve("2.3.20").resolve("dddddddddddddddd").createDirectories()
+        projectId.resolve("project.path").writeText(otherTmp.toString())
+
+        val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+        assertTrue(Files.exists(projectId), "projectId with live breadcrumb must survive")
+        assertEquals(0, report.removed)
+    }
+
+    @Test
+    fun `Rule B keeps projectId without breadcrumb and counts it as skipped`() {
+        val legacy = icRoot.resolve("2.3.20").resolve("eeeeeeeeeeeeeeee").createDirectories()
+        legacy.resolve("state.bin").writeText("legacy")
+
+        val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+        assertTrue(Files.exists(legacy), "legacy state without breadcrumb must survive")
+        assertEquals(1, report.skippedMissingBreadcrumb)
+        assertEquals(0, report.removed)
+    }
+
+    @Test
+    fun `Rule B skips projectId when LOCK is held by another channel`() {
+        val missing = otherTmp.resolve("deleted-project")
+        val projectId = icRoot.resolve("2.3.20").resolve("ffffffffffffffff").createDirectories()
+        projectId.resolve("project.path").writeText(missing.toString())
+        val lockPath = projectId.resolve("LOCK")
+        Files.createFile(lockPath)
+
+        val channel = FileChannel.open(
+            lockPath,
+            StandardOpenOption.READ,
+            StandardOpenOption.WRITE,
+        )
+        val lock = channel.tryLock() ?: error("test could not acquire LOCK on $lockPath")
+        try {
+            val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+            assertTrue(Files.exists(projectId), "locked projectId must not be removed")
+            assertEquals(1, report.skippedLocked)
+            assertEquals(0, report.removed)
+        } finally {
+            lock.release()
+            channel.close()
+        }
+    }
+
+    @Test
+    fun `regular files directly under icRoot are ignored without crashing the scan`() {
+        Files.writeString(icRoot.resolve("README.txt"), "accidentally placed here")
+        icRoot.resolve("2.3.20").resolve("aaaaaaaaaaaaaaaa").createDirectories()
+            .resolve("project.path").writeText(otherTmp.toString())
+
+        val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+        assertTrue(Files.exists(icRoot.resolve("README.txt")), "stray file must survive")
+        assertEquals(1, report.scanned)
+        assertEquals(0, report.removed)
+    }
+
+    @Test
+    fun `run emits all counter names through the metrics sink on a mixed fixture`() {
+        val stale = icRoot.resolve("2.3.19").resolve("1111111111111111").createDirectories()
+        stale.resolve("state.bin").writeText("x")
+
+        val keep = icRoot.resolve("2.3.20").resolve("2222222222222222").createDirectories()
+        keep.resolve("project.path").writeText(otherTmp.toString())
+
+        val drop = icRoot.resolve("2.3.20").resolve("3333333333333333").createDirectories()
+        drop.resolve("project.path").writeText(otherTmp.resolve("gone").toString())
+
+        val legacy = icRoot.resolve("2.3.20").resolve("4444444444444444").createDirectories()
+        legacy.resolve("state.bin").writeText("legacy")
+
+        val lockedDangling = icRoot.resolve("2.3.20").resolve("5555555555555555").createDirectories()
+        lockedDangling.resolve("project.path").writeText(otherTmp.resolve("also-gone").toString())
+        val lockedFile = lockedDangling.resolve("LOCK")
+        Files.createFile(lockedFile)
+        val lockChannel = FileChannel.open(lockedFile, StandardOpenOption.READ, StandardOpenOption.WRITE)
+        val heldLock = lockChannel.tryLock() ?: error("test setup: failed to hold LOCK on $lockedFile")
+        try {
+            val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+            assertEquals(2, report.removed, "stale version + dangling breadcrumb")
+            assertEquals(1, report.skippedLocked, "locked dangling projectId must stay")
+            assertEquals(1, report.skippedMissingBreadcrumb)
+            assertTrue(Files.exists(keep))
+            assertTrue(Files.exists(legacy))
+            assertTrue(Files.exists(lockedDangling), "locked projectId must not be removed even when breadcrumb is stale")
+            assertFalse(Files.exists(stale.parent))
+
+            assertTrue(metrics.records.any { it.name == "reaper.scanned" })
+            assertTrue(metrics.records.any { it.name == "reaper.removed" && it.value == 2L })
+            assertTrue(metrics.records.any { it.name == "reaper.skipped_locked" && it.value == 1L })
+            assertTrue(metrics.records.any {
+                it.name == "reaper.skipped_missing_breadcrumb" && it.value == 1L
+            })
+        } finally {
+            heldLock.release()
+            lockChannel.close()
+        }
+    }
+
+    private class RecordingMetricsSink : IcMetricsSink {
+        data class Record(val name: String, val value: Long)
+        val records = mutableListOf<Record>()
+        override fun record(name: String, value: Long) {
+            records += Record(name, value)
+        }
+    }
+}

--- a/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/server/DaemonLifecycleTest.kt
+++ b/kolt-compiler-daemon/src/test/kotlin/kolt/daemon/server/DaemonLifecycleTest.kt
@@ -15,6 +15,7 @@ import java.nio.channels.Channels
 import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -22,6 +23,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class DaemonLifecycleTest {
 
@@ -111,6 +113,82 @@ class DaemonLifecycleTest {
 
         serverThread.join(5_000)
         assertEquals(false, serverThread.isAlive, "server should have exited after idle timeout")
+    }
+
+    @Test
+    fun `preServeHook fires exactly once after bind and before accept loop`() {
+        val hookCalls = AtomicInteger(0)
+        server = DaemonServer(
+            socketPath = socketPath,
+            compiler = alwaysSuccess(),
+            icRoot = icRoot,
+            kotlinVersion = "2.3.20",
+            config = DaemonConfig(
+                idleTimeoutMillis = 500,
+                maxCompiles = Int.MAX_VALUE,
+                heapWatermarkBytes = Long.MAX_VALUE,
+            ),
+            preServeHook = {
+                // Socket must already exist when the hook fires — this
+                // is the ordering ADR 0019 §Negative relies on so that
+                // the IC reaper never races with a client connection
+                // attempt.
+                assertTrue(Files.exists(socketPath), "socket must be bound before hook fires")
+                hookCalls.incrementAndGet()
+            },
+        )
+        serverThread = Thread({ server.serve() }, "daemon-pre-serve-hook").apply {
+            isDaemon = true
+            start()
+        }
+        waitForSocket()
+        // Hook must fire synchronously between bind and accept loop, so
+        // the socket existing already proves the hook ran exactly once.
+        // Asserting here (before idle-driven shutdown) keeps the test
+        // independent of watchdog timing.
+        assertEquals(1, hookCalls.get(), "preServeHook must fire exactly once per serve()")
+    }
+
+    @Test
+    fun `serve swallows preServeHook failures and keeps serving`() {
+        val compiler = alwaysSuccess()
+        server = DaemonServer(
+            socketPath = socketPath,
+            compiler = compiler,
+            icRoot = icRoot,
+            kotlinVersion = "2.3.20",
+            config = DaemonConfig(
+                idleTimeoutMillis = 60_000,
+                maxCompiles = 1,
+                heapWatermarkBytes = Long.MAX_VALUE,
+            ),
+            preServeHook = { throw RuntimeException("reaper blew up") },
+        )
+        serverThread = Thread({ server.serve() }, "daemon-hook-failure").apply {
+            isDaemon = true
+            start()
+        }
+        waitForSocket()
+
+        SocketChannel.open(StandardProtocolFamily.UNIX).use { ch ->
+            ch.connect(UnixDomainSocketAddress.of(socketPath))
+            val input = Channels.newInputStream(ch)
+            val output = Channels.newOutputStream(ch)
+            FrameCodec.writeFrame(
+                output,
+                Message.Compile(
+                    workingDir = "/w",
+                    classpath = emptyList(),
+                    sources = listOf("A.kt"),
+                    outputPath = "build/classes",
+                    moduleName = "m",
+                ),
+            )
+            FrameCodec.readFrame(input)
+        }
+
+        serverThread.join(2_000)
+        assertFalse(serverThread.isAlive, "server should have served the compile despite hook failure")
     }
 
     @Test


### PR DESCRIPTION
Closes #125.

Reaper fires once per daemon boot from a detached thread wired into a new `DaemonServer.preServeHook` — right after bind, before the accept loop. Two deterministic rules: stale `<kotlinVersion>` segments go wholesale (Rule A), current-version projectId dirs go only when their `project.path` breadcrumb points to a filesystem path that no longer exists (Rule B). Legacy dirs with no breadcrumb are preserved.

## Where to look carefully

**`BtaIncrementalCompiler` layout pivot.** BTA's state now lives under `<workingDir>/bta/` instead of `<workingDir>/` directly. This was forced: experimentally, BTA clears its `workingDirectory` on cold-path startup, so a breadcrumb or LOCK file sitting next to BTA state is deleted on every first compile. The reaper-facing metadata now lives one level above `bta/` where BTA cannot touch it. Please sanity-check that nothing outside the adapter reaches into `<workingDir>/` expecting BTA state directly — `SelfHealingIncrementalCompiler.defaultWipe` still walks the parent (intentional: wipe everything on corruption), and the existing corruption smoke test still passes with the new layout.

**`heldLocks` refresh on self-heal wipe.** First draft cached a `FileLock` keyed by `workingDir` and used `containsKey` as the short-circuit. After review caught it, that would leak a dead lock after `SelfHealingIncrementalCompiler` wipes the LOCK file mid-daemon: the cache still says \"held\" but the inode is gone. `ensureLock` now validates `FileLock.isValid && Files.isRegularFile(lockPath)` on every compile and closes the stale `FileChannel` if either check fails, then re-acquires. Worth a second look at the close/reopen sequence and whether the `ConcurrentHashMap` interactions are racy across the two daemon threads that could hit it (in practice a single-project daemon serialises compiles, but the map type reflects defensive coding).

**Rule A safety vs legacy daemons.** Rule A skips the current kotlinVersion entirely but still probes `LOCK` in each stale-version projectId dir before deleting. Pre-#125 daemons did not write LOCK files, so a still-running pre-#125 daemon pinned to an older compiler would have its active state wiped from under it during a version migration. Gated as an acceptable one-time migration hazard — noted as S4 in the review. If a smoother migration is wanted, let me know and I can make Rule A only proceed when a LOCK file is present or when the segment is older than some mtime threshold.

**`IcStateLayout` as the constants home.** The on-disk layout constants (`BREADCRUMB_FILE`, `LOCK_FILE`, `BTA_SUBDIR`) moved here so `BtaIncrementalCompiler` and `IcReaper` read from one source of truth. `IcStateLayout` was the natural spot — it already owns `projectIdFor` / `workingDirFor`.

## Verification

`:kolt-compiler-daemon:test` (2 new reaper lifecycle tests, 1 new regular-file edge case, 1 new lock-held assertion in the mixed fixture) + `:kolt-compiler-daemon:ic:test` (existing BTA suite under the `bta/` subdir layout, plus a breadcrumb assertion on the cold-path test) + full `./gradlew build` all green.

End-to-end: spawned `kolt-compiler-daemon-all.jar --ic-root /tmp/dogfood-ic ...` against a fixture seeded with all four cases (stale `2.2.99/`, dangling breadcrumb, live breadcrumb, legacy-no-breadcrumb). Reaper emitted `scanned=4 removed=2 skipped_missing_breadcrumb=1 skipped_locked=0` and the on-disk state after matched expectations exactly: stale version segment gone, dangling dir gone, legacy and live dirs preserved.

## Out of scope

- Runtime-dir reaper (#106) — separate issue, separate PR. No shared abstraction extracted yet; the two reapers can be unified when #106 lands.
- LRU / size-cap retention, `kolt gc` CLI, classpath snapshot caching — other ADR 0019 §Negative follow-ups, each tracked separately.