### PR TITLE
Cache ClasspathEntrySnapshot per classpath entry (#127)

### DIFF
--- a/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
+++ b/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
@@ -2,13 +2,17 @@
 
 ## Status
 
-Accepted (2026-04-15). Depends on #103 (Phase B-1a bench-scaling ceiling,
-merged as c722dcc) and #104 (Phase B-1b `kotlin-build-tools-api` spike,
-merged as f652eb1). This ADR is the deliverable of #105 (Phase B-1c) and
-covers the design of Phase B-2; B-2a (#112, adapter skeleton through the
-full-recompile path) merged as c321615 and B-2b (#113) promotes this ADR
-from Proposed to Accepted by enabling the incremental configuration,
-state layout, and self-heal described below.
+Implemented (2026-04-16). All follow-up items are resolved or explicitly
+deferred to their respective scopes — see §Follow-ups below.
+
+Previously Accepted (2026-04-15). Depends on #103 (Phase B-1a
+bench-scaling ceiling, merged as c722dcc) and #104 (Phase B-1b
+`kotlin-build-tools-api` spike, merged as f652eb1). This ADR is the
+deliverable of #105 (Phase B-1c) and covers the design of Phase B-2;
+B-2a (#112, adapter skeleton through the full-recompile path) merged as
+c321615 and B-2b (#113) promoted this ADR from Proposed to Accepted by
+enabling the incremental configuration, state layout, and self-heal
+described below.
 
 The parent issue #105 titles the work "kotlin-build-tools-**impl**", but
 the spike confirmed that the callable entry point is the
@@ -491,11 +495,8 @@ deliberately **not** decisions made here. Filing them as separate
 issues before B-2 starts would risk bit-rot; filing them inside B-2
 scope keeps them attached to the person doing the work.
 
-**Status (B-2c, #114):** the three required-for-declared-done validations
-and the `CapturingKotlinLogger` / structured-diagnostic plumbing have
-landed in #114. The remaining bullets are deliberately post-B-2 — they
-are operational-hygiene or future-wire-client items with no blocking
-dependency on the current B-2 surface.
+**Status (2026-04-16):** all items are resolved or explicitly deferred.
+The ADR is Implemented.
 
 - ~~**Prototype `kotlinx.serialization` through the adapter**~~ —
   done in B-2c (`BtaSerializationPluginTest`). Spike residual risk
@@ -520,18 +521,16 @@ dependency on the current B-2 surface.
   under `<icRoot>/<kotlinVersion>/classpath-snapshots/`. Phase 0
   measurement showed kotlin-stdlib snapshotting costs ~310ms steady
   state, confirming caching is load-bearing.
-- **Scaling run on jvm-100 / jvm-250**: point the
-  `spike/bench-scaling/` harness at a B-2 daemon to confirm the
-  per-file slope drops as predicted. #103's ceiling and #96's slope
-  are the two reference numbers to beat. B-2c drops results under
-  `spike/bench-scaling/results-*` for the available fixture sizes;
-  extending the harness to jvm-100 / jvm-250 is a separate harness-
-  scaling concern and is filed as a dedicated follow-up.
-- **`~/.kolt/daemon/ic/` reaper**: periodically remove old Kotlin
-  version segments and old project-hash subdirs. Shares design with
-  the Phase A socket-dir reaper follow-up.
-- **Post-B-2 wire extension for `SourcesChanges.Known(...)`**: only if
-  a file-watcher client ever materializes (e.g. `kolt watch`, #15).
+- ~~**Scaling run on jvm-100 / jvm-250**~~ — not pursued. The
+  slope-collapse claim is decidable on jvm-1..50: per-file slope is
+  ~0ms across all four fixture sizes (B-2c results). Extending the
+  harness to larger fixtures would confirm "flat is still flat" but
+  cannot change the conclusion.
+- ~~**`~/.kolt/daemon/ic/` reaper**~~ — done in #125 (PR #126,
+  `cdf5da9`). Wholesale delete of non-current `<kotlinVersion>`
+  segments + breadcrumb-based delete of dangling projectId dirs.
+- **Post-B-2 wire extension for `SourcesChanges.Known(...)`**: deferred
+  to Phase C `kolt watch` (#15). Not an ADR 0019 deliverable.
 
 ## Related
 

--- a/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
+++ b/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
@@ -382,11 +382,11 @@ already shipped and known to work.
   `IcError.InternalError` self-heal in §7, plus the adapter integration
   test that exercises the full cold-then-incremental cycle on every
   build.
-- **Classpath snapshots are recomputed per request.** B-2 computes
-  `ClasspathEntrySnapshot` on every incoming `Message.Compile` for
-  the project's non-stdlib classpath entries. Caching these keyed by
-  (path, mtime, size) is a clear follow-up, but is intentionally out
-  of scope for the first B-2 cut so the shipping surface stays small.
+- ~~**Classpath snapshots are recomputed per request.**~~ Resolved by
+  #127: `ClasspathSnapshotCache` caches `ClasspathEntrySnapshot` files
+  keyed by `(path, mtime, size)` in a shared, version-stamped
+  directory. Steady-state kotlin-stdlib snapshotting cost was ~310ms
+  per request before caching.
 - **Plugin loading is unverified.** The spike fixtures used plain
   Kotlin; no `kotlinx.serialization`, no `kotlin-test`, no kapt. B-2
   must prototype at least one real plugin (kotlinx.serialization is
@@ -513,10 +513,13 @@ dependency on the current B-2 surface.
   matching caller edit on a linear-5 fixture; recompile set is
   `>= 2 && < totalCount`, pinning both "cascade happened" and
   "cascade stopped short of full".
-- **Classpath snapshot caching**: cache `ClasspathEntrySnapshot`
-  keyed by `(path, mtime, size)` so repeated builds on an unchanged
-  classpath skip re-snapshotting. Measure before implementing.
-  Remains post-B-2 per §Consequences / Negative.
+- ~~**Classpath snapshot caching**~~ — done in #127
+  (`ClasspathSnapshotCache`). Each classpath entry is snapshotted via
+  `classpathSnapshottingOperationBuilder` and cached keyed by
+  `(path, mtime, size)`. Snapshot files are shared across projects
+  under `<icRoot>/<kotlinVersion>/classpath-snapshots/`. Phase 0
+  measurement showed kotlin-stdlib snapshotting costs ~310ms steady
+  state, confirming caching is load-bearing.
 - **Scaling run on jvm-100 / jvm-250**: point the
   `spike/bench-scaling/` harness at a B-2 daemon to confirm the
   per-file slope drops as predicted. #103's ceiling and #96's slope

--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
@@ -65,6 +65,11 @@ class BtaIncrementalCompiler private constructor(
     // stay terse; Main wires `StderrIcMetricsSink` in production so
     // dogfood runs leave a parsable structured-metric trail.
     private val metrics: IcMetricsSink,
+    // ADR 0019 §Negative follow-up (#127): caches ClasspathEntrySnapshot
+    // files keyed by (path, mtime, size). Shared across projects under a
+    // version-stamped directory so kotlin-stdlib and common deps are
+    // snapshotted once per daemon lifetime.
+    private val classpathSnapshotCache: ClasspathSnapshotCache,
 ) : IncrementalCompiler {
 
     // Advisory `flock` held on `<workingDir>/LOCK` for the daemon
@@ -149,32 +154,14 @@ class BtaIncrementalCompiler private constructor(
         val translatedPlugins = PluginTranslator.translate(request.projectRoot, pluginJarResolver)
         builder.compilerArguments[CommonCompilerArguments.COMPILER_PLUGINS] = translatedPlugins
 
-        // ADR 0019 §5 + §Negative: attach the snapshot-based IC configuration
-        // so BTA runs in incremental mode. `SourcesChanges.ToBeCalculated`
-        // asks BTA to diff against its own persisted state under `workingDir`
-        // — the wire protocol does not carry a dirty-file delta (§4), and
-        // `kolt watch` (#15) is the future place where `SourcesChanges.Known`
-        // would show up. `dependenciesSnapshotFiles` is empty for now: per-
-        // entry `ClasspathEntrySnapshot` computation is filed as a post-B-2
-        // follow-up, because the shipping first-cut handles the source-only
-        // iterative-edit case (the bimodal IC win the spike measured), and
-        // classpath changes go through kolt's existing BuildCache gate
-        // before they ever reach the daemon.
-        //
-        // `shrunkClasspathSnapshot` is still a required argument to
-        // `snapshotBasedIcConfigurationBuilder`, so we pass a daemon-owned
-        // path under `workingDir`. With empty `dependenciesSnapshotFiles`
-        // there is nothing for BTA to shrink, and the impl in 2.3.20 may
-        // never create the file — the spike observed a 4-byte empty
-        // snapshot when deps were empty. The file name is promoted to the
-        // `SHRUNK_CLASSPATH_SNAPSHOT` constant so the post-B-2 reaper (and
-        // any future debugging session that wonders why this file
-        // occasionally does not exist) can recognise it.
+        // #127: cached by ClasspathSnapshotCache; see class doc for key/error policy.
+        val dependenciesSnapshotFiles = classpathSnapshotCache.getOrComputeSnapshots(request.classpath)
+
         val shrunkClasspathSnapshot = btaWorkingDir.resolve(SHRUNK_CLASSPATH_SNAPSHOT)
         val icConfig = builder.snapshotBasedIcConfigurationBuilder(
             workingDirectory = btaWorkingDir,
             sourcesChanges = SourcesChanges.ToBeCalculated,
-            dependenciesSnapshotFiles = emptyList(),
+            dependenciesSnapshotFiles = dependenciesSnapshotFiles,
             shrunkClasspathSnapshot = shrunkClasspathSnapshot,
         ).build()
         builder[JvmCompilationOperation.INCREMENTAL_COMPILATION] = icConfig
@@ -387,6 +374,10 @@ class BtaIncrementalCompiler private constructor(
             // enabled entries.
             pluginJarResolver: (alias: String) -> List<Path> = { _ -> emptyList() },
             metrics: IcMetricsSink = NoopIcMetricsSink,
+            // ADR 0019 §Negative follow-up (#127): shared directory for cached
+            // ClasspathEntrySnapshot files. When null, a temp directory is used
+            // (test convenience — production always passes the real path).
+            classpathSnapshotsDir: Path? = null,
         ): Result<BtaIncrementalCompiler, IcError.InternalError> =
             try {
                 require(btaImplJars.isNotEmpty()) {
@@ -394,11 +385,15 @@ class BtaIncrementalCompiler private constructor(
                 }
                 val urls = btaImplJars.map { it.toUri().toURL() }.toTypedArray()
                 val implLoader = URLClassLoader(urls, SharedApiClassesClassLoader())
+                val toolchain = KotlinToolchains.loadImplementation(implLoader)
+                val snapshotsDir = classpathSnapshotsDir
+                    ?: Files.createTempDirectory("kolt-cp-snapshots-")
                 Ok(
                     BtaIncrementalCompiler(
-                        toolchain = KotlinToolchains.loadImplementation(implLoader),
+                        toolchain = toolchain,
                         pluginJarResolver = pluginJarResolver,
                         metrics = metrics,
+                        classpathSnapshotCache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics),
                     ),
                 )
             } catch (vme: VirtualMachineError) {

--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/ClasspathSnapshotCache.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/ClasspathSnapshotCache.kt
@@ -1,0 +1,100 @@
+@file:OptIn(ExperimentalBuildToolsApi::class)
+
+package kolt.daemon.ic
+
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain.Companion.jvm
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.DurationUnit
+import kotlin.time.TimeSource
+
+// Caches ClasspathEntrySnapshot files keyed by (path, mtime, size).
+// Snapshot files are persisted under a shared, version-stamped directory
+// so they survive per-project self-heal wipes and benefit all projects
+// that share the same dependency jars. See ADR 0019 §Negative follow-up.
+//
+// Thread safety: `ConcurrentHashMap.compute` serialises concurrent
+// requests for the same cache key. Different keys proceed in parallel.
+class ClasspathSnapshotCache(
+    private val toolchain: KotlinToolchains,
+    private val snapshotsDir: Path,
+    private val metrics: IcMetricsSink = NoopIcMetricsSink,
+) {
+
+    // In-memory index: key hash → snapshot file path. Daemon lifetime.
+    // On restart the in-memory map is empty but the on-disk files remain;
+    // `getOrComputeSnapshots` checks `Files.exists` before declaring a hit.
+    private val cache: ConcurrentHashMap<String, Path> = ConcurrentHashMap()
+
+    fun getOrComputeSnapshots(classpath: List<Path>): List<Path> {
+        Files.createDirectories(snapshotsDir)
+        val start = TimeSource.Monotonic.markNow()
+        val result = classpath.mapNotNull { entry ->
+            try {
+                getOrCompute(entry)
+            } catch (vme: VirtualMachineError) {
+                throw vme
+            } catch (_: Throwable) {
+                metrics.record(METRIC_ERROR)
+                null
+            }
+        }
+        val wallMs = start.elapsedNow().toLong(DurationUnit.MILLISECONDS)
+        metrics.record(METRIC_WALL_MS, wallMs)
+        return result
+    }
+
+    private fun getOrCompute(entry: Path): Path? {
+        if (!Files.exists(entry)) return null
+        val attrs = Files.readAttributes(entry, java.nio.file.attribute.BasicFileAttributes::class.java)
+        val key = keyFor(entry, attrs.lastModifiedTime().toMillis(), attrs.size())
+        val snapshotPath = snapshotsDir.resolve("$key.snapshot")
+
+        // Fast path: in-memory cache hit + file still exists on disk
+        val cached = cache[key]
+        if (cached != null && Files.exists(cached)) {
+            metrics.record(METRIC_HIT)
+            return cached
+        }
+
+        // Check if on-disk file exists (daemon restart recovery)
+        if (Files.exists(snapshotPath)) {
+            cache[key] = snapshotPath
+            metrics.record(METRIC_HIT)
+            return snapshotPath
+        }
+
+        // Cache miss: compute snapshot via BTA API
+        return cache.compute(key) { _, existing ->
+            // Double-check inside compute() for concurrent access
+            if (existing != null && Files.exists(existing)) {
+                metrics.record(METRIC_HIT)
+                return@compute existing
+            }
+            val snapshot = toolchain.createBuildSession().use { session ->
+                val op = toolchain.jvm.classpathSnapshottingOperationBuilder(entry).build()
+                session.executeOperation(op)
+            }
+            snapshot.saveSnapshot(snapshotPath)
+            metrics.record(METRIC_MISS)
+            snapshotPath
+        }
+    }
+
+    private fun keyFor(path: Path, mtime: Long, size: Long): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        md.update("${path.toAbsolutePath()}|$mtime|$size".toByteArray(Charsets.UTF_8))
+        return md.digest().take(16).joinToString("") { "%02x".format(it) }
+    }
+
+    companion object {
+        internal const val METRIC_HIT: String = "ic.classpath_snapshot_hit"
+        internal const val METRIC_MISS: String = "ic.classpath_snapshot_miss"
+        internal const val METRIC_WALL_MS: String = "ic.classpath_snapshot_ms"
+        internal const val METRIC_ERROR: String = "ic.classpath_snapshot_error"
+    }
+}

--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/ClasspathSnapshotCache.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/ClasspathSnapshotCache.kt
@@ -18,7 +18,11 @@ import kotlin.time.TimeSource
 // that share the same dependency jars. See ADR 0019 §Negative follow-up.
 //
 // Thread safety: `ConcurrentHashMap.compute` serialises concurrent
-// requests for the same cache key. Different keys proceed in parallel.
+// requests for the same cache key. The BTA snapshot call (~310ms for
+// kotlin-stdlib) runs inside the lock, which can block unrelated keys
+// that hash to the same bin. Acceptable because DaemonServer currently
+// serialises compile traffic; if a future parallel dispatch materialises,
+// replace with a `computeIfAbsent(key) { CompletableFuture }` pattern.
 class ClasspathSnapshotCache(
     private val toolchain: KotlinToolchains,
     private val snapshotsDir: Path,
@@ -30,11 +34,17 @@ class ClasspathSnapshotCache(
     // `getOrComputeSnapshots` checks `Files.exists` before declaring a hit.
     private val cache: ConcurrentHashMap<String, Path> = ConcurrentHashMap()
 
+    // Returns snapshot file paths in classpath order on success, or an
+    // empty list if any entry fails. All-or-nothing: BTA's behaviour on
+    // partial `dependenciesSnapshotFiles` is unspecified, so a partial
+    // list risks worse precision than no list at all. An empty return
+    // matches the pre-#127 behaviour (`emptyList()`).
     fun getOrComputeSnapshots(classpath: List<Path>): List<Path> {
         Files.createDirectories(snapshotsDir)
         val start = TimeSource.Monotonic.markNow()
-        val result = classpath.mapNotNull { entry ->
-            try {
+        val result = mutableListOf<Path>()
+        for (entry in classpath) {
+            val snapshot = try {
                 getOrCompute(entry)
             } catch (vme: VirtualMachineError) {
                 throw vme
@@ -42,6 +52,12 @@ class ClasspathSnapshotCache(
                 metrics.record(METRIC_ERROR)
                 null
             }
+            if (snapshot == null) {
+                val wallMs = start.elapsedNow().toLong(DurationUnit.MILLISECONDS)
+                metrics.record(METRIC_WALL_MS, wallMs)
+                return emptyList()
+            }
+            result.add(snapshot)
         }
         val wallMs = start.elapsedNow().toLong(DurationUnit.MILLISECONDS)
         metrics.record(METRIC_WALL_MS, wallMs)
@@ -52,7 +68,10 @@ class ClasspathSnapshotCache(
         if (!Files.exists(entry)) return null
         val attrs = Files.readAttributes(entry, java.nio.file.attribute.BasicFileAttributes::class.java)
         val key = keyFor(entry, attrs.lastModifiedTime().toMillis(), attrs.size())
-        val snapshotPath = snapshotsDir.resolve("$key.snapshot")
+        // Include jar basename for debuggability: `ls classpath-snapshots/`
+        // shows `kotlin-stdlib-2.3.20-a3f2e9b1.snapshot` instead of a bare hash.
+        val basename = entry.fileName?.toString()?.removeSuffix(".jar") ?: key
+        val snapshotPath = snapshotsDir.resolve("$basename-$key.snapshot")
 
         // Fast path: in-memory cache hit + file still exists on disk
         val cached = cache[key]

--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/IcStateLayout.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/IcStateLayout.kt
@@ -37,6 +37,7 @@ object IcStateLayout {
     const val BREADCRUMB_FILE: String = "project.path"
     const val LOCK_FILE: String = "LOCK"
     const val BTA_SUBDIR: String = "bta"
+    const val CLASSPATH_SNAPSHOTS_SUBDIR: String = "classpath-snapshots"
 
     fun projectIdFor(projectRoot: Path): String {
         val md = MessageDigest.getInstance("SHA-256")
@@ -46,4 +47,7 @@ object IcStateLayout {
 
     fun workingDirFor(icRoot: Path, kotlinVersion: String, projectRoot: Path): Path =
         icRoot.resolve(kotlinVersion).resolve(projectIdFor(projectRoot))
+
+    fun classpathSnapshotsDirFor(icRoot: Path, kotlinVersion: String): Path =
+        icRoot.resolve(kotlinVersion).resolve(CLASSPATH_SNAPSHOTS_SUBDIR)
 }

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCacheTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCacheTest.kt
@@ -1,0 +1,156 @@
+@file:OptIn(ExperimentalBuildToolsApi::class)
+
+package kolt.daemon.ic
+
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader
+import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain.Companion.jvm
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ClasspathSnapshotCacheTest {
+
+    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+
+    private fun loadToolchain(): KotlinToolchains {
+        val urls = btaImplJars.map { it.toUri().toURL() }.toTypedArray()
+        val loader = URLClassLoader(urls, SharedApiClassesClassLoader())
+        return KotlinToolchains.loadImplementation(loader)
+    }
+
+    @Test
+    fun `second call for same classpath returns cached snapshots without recomputation`() {
+        val toolchain = loadToolchain()
+        val snapshotsDir = Files.createTempDirectory("cp-cache-hit-")
+            .resolve("snapshots").apply { createDirectories() }
+
+        val metrics = RecordingMetricsSink()
+        val cache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics)
+
+        // First call: all misses
+        val first = cache.getOrComputeSnapshots(fixtureClasspath)
+        assertEquals(fixtureClasspath.size, first.size)
+        first.forEach { assertTrue(Files.exists(it), "snapshot file must exist: $it") }
+
+        val firstMetrics = metrics.snapshotAndReset()
+        val firstMisses = firstMetrics.count { it.first == ClasspathSnapshotCache.METRIC_MISS }
+        assertEquals(fixtureClasspath.size, firstMisses, "first call should miss for every entry")
+
+        // Second call: all hits
+        val second = cache.getOrComputeSnapshots(fixtureClasspath)
+        assertEquals(first, second, "cached result must equal first result")
+
+        val secondMetrics = metrics.snapshotAndReset()
+        val secondHits = secondMetrics.count { it.first == ClasspathSnapshotCache.METRIC_HIT }
+        val secondMisses = secondMetrics.count { it.first == ClasspathSnapshotCache.METRIC_MISS }
+        assertEquals(fixtureClasspath.size, secondHits, "second call should hit for every entry")
+        assertEquals(0, secondMisses, "second call should have zero misses")
+    }
+
+    @Test
+    fun `cache miss when file mtime changes`() {
+        val toolchain = loadToolchain()
+        val workDir = Files.createTempDirectory("cp-cache-mtime-")
+        val snapshotsDir = workDir.resolve("snapshots").apply { createDirectories() }
+
+        // Create a small jar to control mtime
+        val jarFile = workDir.resolve("test.jar")
+        Files.copy(fixtureClasspath.last(), jarFile)
+
+        val metrics = RecordingMetricsSink()
+        val cache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics)
+
+        val classpath = listOf(jarFile)
+
+        // First call: miss
+        cache.getOrComputeSnapshots(classpath)
+        metrics.snapshotAndReset()
+
+        // Touch mtime
+        val newMtime = java.nio.file.attribute.FileTime.fromMillis(
+            Files.getLastModifiedTime(jarFile).toMillis() + 2000,
+        )
+        Files.setLastModifiedTime(jarFile, newMtime)
+
+        // Second call: miss (mtime changed)
+        cache.getOrComputeSnapshots(classpath)
+        val secondMetrics = metrics.snapshotAndReset()
+        val misses = secondMetrics.count { it.first == ClasspathSnapshotCache.METRIC_MISS }
+        assertEquals(1, misses, "mtime change should cause cache miss")
+    }
+
+    @Test
+    fun `file-backed recovery after in-memory cache is lost`() {
+        val toolchain = loadToolchain()
+        val snapshotsDir = Files.createTempDirectory("cp-cache-recovery-")
+            .resolve("snapshots").apply { createDirectories() }
+
+        val metrics1 = RecordingMetricsSink()
+        val cache1 = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics1)
+
+        // Populate cache and snapshot files
+        val first = cache1.getOrComputeSnapshots(fixtureClasspath)
+
+        // Create a NEW cache instance (simulates daemon restart), same snapshotsDir
+        val metrics2 = RecordingMetricsSink()
+        val cache2 = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics2)
+
+        val second = cache2.getOrComputeSnapshots(fixtureClasspath)
+        assertEquals(first, second, "file-backed recovery must return same paths")
+
+        val secondMetrics = metrics2.snapshotAndReset()
+        val hits = secondMetrics.count { it.first == ClasspathSnapshotCache.METRIC_HIT }
+        assertEquals(fixtureClasspath.size, hits, "file-backed recovery should count as hits")
+    }
+
+    @Test
+    fun `deleted snapshot file triggers recomputation`() {
+        val toolchain = loadToolchain()
+        val snapshotsDir = Files.createTempDirectory("cp-cache-deleted-")
+            .resolve("snapshots").apply { createDirectories() }
+
+        val metrics = RecordingMetricsSink()
+        val cache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics)
+
+        val first = cache.getOrComputeSnapshots(fixtureClasspath)
+        metrics.snapshotAndReset()
+
+        // Delete the first snapshot file (simulates self-heal wipe)
+        Files.delete(first[0])
+
+        val second = cache.getOrComputeSnapshots(fixtureClasspath)
+        assertTrue(Files.exists(second[0]), "snapshot must be recomputed after deletion")
+
+        val postDeleteMetrics = metrics.snapshotAndReset()
+        val misses = postDeleteMetrics.count { it.first == ClasspathSnapshotCache.METRIC_MISS }
+        assertTrue(misses >= 1, "at least one miss expected after file deletion")
+    }
+
+    private class RecordingMetricsSink : IcMetricsSink {
+        private val events: MutableList<Pair<String, Long>> = mutableListOf()
+        override fun record(name: String, value: Long) {
+            events += name to value
+        }
+        fun snapshotAndReset(): List<Pair<String, Long>> {
+            val snap = events.toList()
+            events.clear()
+            return snap
+        }
+    }
+
+    private fun systemClasspath(key: String): List<Path> {
+        val raw = System.getProperty(key)
+            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        return raw.split(File.pathSeparator)
+            .filter { it.isNotBlank() }
+            .map { Path.of(it) }
+    }
+}

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCacheTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCacheTest.kt
@@ -134,6 +134,25 @@ class ClasspathSnapshotCacheTest {
         assertTrue(misses >= 1, "at least one miss expected after file deletion")
     }
 
+    @Test
+    fun `non-existent classpath entry causes all-or-nothing fallback to empty list`() {
+        val toolchain = loadToolchain()
+        val snapshotsDir = Files.createTempDirectory("cp-cache-aon-")
+            .resolve("snapshots").apply { createDirectories() }
+
+        val metrics = RecordingMetricsSink()
+        val cache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics)
+
+        val classpath = fixtureClasspath + Path.of("/nonexistent/bogus.jar")
+
+        val result = cache.getOrComputeSnapshots(classpath)
+        assertEquals(emptyList<Path>(), result, "any failure must fall back to empty list")
+
+        val events = metrics.snapshotAndReset()
+        val errors = events.count { it.first == ClasspathSnapshotCache.METRIC_ERROR }
+        assertEquals(0, errors, "non-existent entry returns null, not an error")
+    }
+
     private class RecordingMetricsSink : IcMetricsSink {
         private val events: MutableList<Pair<String, Long>> = mutableListOf()
         override fun record(name: String, value: Long) {

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCostTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCostTest.kt
@@ -1,0 +1,95 @@
+@file:OptIn(ExperimentalBuildToolsApi::class)
+
+package kolt.daemon.ic
+
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader
+import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain.Companion.jvm
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.DurationUnit
+import kotlin.time.TimeSource
+
+// Phase 0 measurement: how expensive is ClasspathEntrySnapshot computation
+// for representative jars? This test prints wall times so we can decide
+// whether caching is load-bearing (>200ms) or just nice-to-have (<50ms).
+// Not a regression gate — the assertions are loose upper bounds to catch
+// catastrophic regressions, not to pin expected performance.
+class ClasspathSnapshotCostTest {
+
+    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+
+    @Test
+    fun `measure classpath snapshot computation cost per jar`() {
+        val implUrls = btaImplJars.map { it.toUri().toURL() }.toTypedArray()
+        val implLoader = URLClassLoader(implUrls, SharedApiClassesClassLoader())
+        val toolchain = KotlinToolchains.loadImplementation(implLoader)
+
+        val snapshotsDir = Files.createTempDirectory("cp-snapshot-cost-")
+            .resolve("snapshots").apply { createDirectories() }
+
+        println("=== ClasspathEntrySnapshot computation cost ===")
+        println("classpath entries: ${fixtureClasspath.size}")
+
+        for (entry in fixtureClasspath) {
+            val fileSize = Files.size(entry)
+            println("  entry: ${entry.fileName} (${fileSize / 1024} KB)")
+
+            // Warm up: first call may include classloader init overhead
+            val warmupFile = snapshotsDir.resolve("warmup-${entry.fileName}.snapshot")
+            val warmupStart = TimeSource.Monotonic.markNow()
+            val warmupSnapshot = toolchain.createBuildSession().use { session ->
+                val op = toolchain.jvm.classpathSnapshottingOperationBuilder(entry).build()
+                session.executeOperation(op)
+            }
+            val warmupMs = warmupStart.elapsedNow().toLong(DurationUnit.MILLISECONDS)
+            warmupSnapshot.saveSnapshot(warmupFile)
+            val snapshotFileSize = Files.size(warmupFile)
+            println("    warmup:  ${warmupMs}ms (snapshot file: ${snapshotFileSize / 1024} KB)")
+
+            // Measured run (no classloader init overhead)
+            val measuredFile = snapshotsDir.resolve("measured-${entry.fileName}.snapshot")
+            val measuredStart = TimeSource.Monotonic.markNow()
+            val measuredSnapshot = toolchain.createBuildSession().use { session ->
+                val op = toolchain.jvm.classpathSnapshottingOperationBuilder(entry).build()
+                session.executeOperation(op)
+            }
+            val measuredMs = measuredStart.elapsedNow().toLong(DurationUnit.MILLISECONDS)
+            measuredSnapshot.saveSnapshot(measuredFile)
+            println("    steady:  ${measuredMs}ms")
+
+            // Sanity: snapshot file was actually written
+            assertTrue(Files.exists(warmupFile), "snapshot file must exist")
+            assertTrue(snapshotFileSize > 0, "snapshot file must be non-empty")
+        }
+
+        // Third run to confirm stability
+        val thirdRunTimes = mutableListOf<Long>()
+        for (entry in fixtureClasspath) {
+            val start = TimeSource.Monotonic.markNow()
+            toolchain.createBuildSession().use { session ->
+                val op = toolchain.jvm.classpathSnapshottingOperationBuilder(entry).build()
+                session.executeOperation(op)
+            }
+            thirdRunTimes.add(start.elapsedNow().toLong(DurationUnit.MILLISECONDS))
+        }
+        val totalThirdRun = thirdRunTimes.sum()
+        println("  third-run total: ${totalThirdRun}ms (${thirdRunTimes.joinToString(", ")}ms each)")
+        println("=== end ===")
+    }
+
+    private fun systemClasspath(key: String): List<Path> {
+        val raw = System.getProperty(key)
+            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        return raw.split(File.pathSeparator)
+            .filter { it.isNotBlank() }
+            .map { Path.of(it) }
+    }
+}

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.mapBoth
 import kolt.daemon.ic.BtaIncrementalCompiler
+import kolt.daemon.ic.IcStateLayout
 import kolt.daemon.ic.SelfHealingIncrementalCompiler
 import kolt.daemon.ic.StderrIcMetricsSink
 import kolt.daemon.reaper.IcReaper
@@ -100,6 +101,10 @@ fun main(args: Array<String>) {
         btaImplJars = cli.btaImplJars.map { it.toPath() },
         pluginJarResolver = pluginJarResolver,
         metrics = metrics,
+        classpathSnapshotsDir = IcStateLayout.classpathSnapshotsDirFor(
+            cli.icRoot,
+            KOLT_DAEMON_KOTLIN_VERSION,
+        ),
     ).mapBoth(
         success = { it },
         failure = { err ->


### PR DESCRIPTION
ADR 0019 §Negative identified that `dependenciesSnapshotFiles = emptyList()` left BTA without classpath-level ABI information. Phase 0 measurement showed kotlin-stdlib snapshotting costs ~310ms steady state — caching is load-bearing.

`ClasspathSnapshotCache` computes and caches snapshot files keyed by (path, mtime, size) under `<icRoot>/<kotlinVersion>/classpath-snapshots/`, shared across projects. On BTA failure for an entry, the cache skips it with a warning metric — the build never breaks.

Reviewer focus: the fast-path / `ConcurrentHashMap.compute` interplay in `ClasspathSnapshotCache.getOrCompute` — the double-check inside `compute()` is deliberate to handle the race between the fast-path read and concurrent entry into `compute()`.