### PR TITLE
Prune redundant comments across the codebase (#123)

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -6,11 +6,7 @@ import kolt.config.KoltConfig
 internal const val BUILD_DIR = "build"
 internal const val CLASSES_DIR = "$BUILD_DIR/classes"
 
-// Kotlin/Native target triple. Currently linux_x64 is the only supported
-// target (see #61 non-goals). Passed explicitly on every konanc and cinterop
-// invocation so a future cross-build (e.g. running kolt on macOS targeting
-// linux_x64) cannot silently fall back to the host default and produce a
-// wrong-architecture klib. Mirrors what the Kotlin Gradle plugin does.
+// Passed explicitly so a cross-build cannot silently fall back to host default.
 internal const val NATIVE_TARGET = "linux_x64"
 
 internal fun outputJarPath(config: KoltConfig): String = "$BUILD_DIR/${config.name}.jar"
@@ -19,8 +15,6 @@ internal fun outputKexePath(config: KoltConfig): String = "$BUILD_DIR/${config.n
 
 internal fun outputNativeTestKexePath(config: KoltConfig): String = "$BUILD_DIR/${config.name}-test.kexe"
 
-// Stage 1 output: the unpacked klib directory produced by `konanc -p library -nopack`.
-// Using a `-klib` suffix keeps it distinct from the sibling `<name>.kexe` file.
 internal fun outputNativeKlibPath(config: KoltConfig): String = "$BUILD_DIR/${config.name}-klib"
 
 internal fun outputNativeTestKlibPath(config: KoltConfig): String = "$BUILD_DIR/${config.name}-test-klib"
@@ -47,13 +41,8 @@ fun checkCommand(
     addAll(pluginArgs)
 }
 
-// Native builds run in two stages because konanc silently no-ops compiler
-// plugins (e.g. kotlinx.serialization) on a single-step `-p program` invocation.
-// Stage 1 compiles sources into an unpacked klib with the plugin applied; Stage
-// 2 links that klib into a program binary. This matches what the Kotlin Gradle
-// plugin does: compileKotlinLinuxX64 produces a klib, linkDebugExecutableLinuxX64
-// produces the executable.
-
+// Two-stage build: konanc silently no-ops compiler plugins on single-step
+// `-p program`, so Stage 1 compiles into a klib (plugin applied), Stage 2 links.
 fun nativeLibraryCommand(
     config: KoltConfig,
     pluginArgs: List<String> = emptyList(),
@@ -80,14 +69,6 @@ fun nativeLibraryCommand(
     return BuildCommand(args = args, outputPath = outputBase)
 }
 
-// Stage 2 consumes the klib produced by nativeLibraryCommand via -Xinclude,
-// which pulls the klib's IR (including the main() function) into the final
-// program. The plugin flag is not needed here — the IR is already transformed.
-//
-// -e points konanc at the entry function. config.main holds the Kotlin
-// function FQN verbatim, so we forward it as-is. Without this, konanc looks
-// for a function named `main` in the root package and fails when main lives
-// in a named package (e.g. `kolt.cli.main`).
 fun nativeLinkCommand(
     config: KoltConfig,
     konancPath: String? = null,
@@ -115,9 +96,6 @@ fun nativeLinkCommand(
     return BuildCommand(args = args, outputPath = outputPath)
 }
 
-// Test Stage 1: compile main + test sources together into a klib. Kotlin/Native
-// test discovery needs the @Test classes to live in a klib so the runner can
-// synthesize a main() that iterates them in Stage 2.
 fun nativeTestLibraryCommand(
     config: KoltConfig,
     pluginArgs: List<String> = emptyList(),
@@ -145,8 +123,6 @@ fun nativeTestLibraryCommand(
     return BuildCommand(args = args, outputPath = outputBase)
 }
 
-// Test Stage 2: -generate-test-runner asks the compiler to synthesize a main()
-// that discovers and runs @Test functions pulled in via -Xinclude from the klib.
 fun nativeTestLinkCommand(
     config: KoltConfig,
     konancPath: String? = null,
@@ -173,7 +149,7 @@ fun nativeTestLinkCommand(
     return BuildCommand(args = args, outputPath = outputPath)
 }
 
-// cinterop appends .klib to the -o path, so outputPath is without the extension.
+// cinterop appends .klib to the -o path, so outputPath omits the extension.
 fun cinteropCommand(
     entry: CinteropConfig,
     cinteropPath: String? = null,
@@ -199,23 +175,10 @@ fun cinteropCommand(
 fun cinteropOutputKlibPath(entry: CinteropConfig, outputDir: String = BUILD_DIR): String =
     "$outputDir/${entry.name}.klib"
 
-// Path of the sidecar stamp file written next to a cinterop klib. The stamp
-// records a canonical serialization of every CinteropConfig field plus the
-// .def file's mtime. runCinterop reads it to decide whether a previously
-// generated klib can be reused without re-invoking the cinterop tool.
 fun cinteropStampPath(entry: CinteropConfig, outputDir: String = BUILD_DIR): String =
     "$outputDir/${entry.name}.klib.stamp"
 
-// Canonical freshness stamp for a cinterop entry. Two stamps compare equal
-// iff a re-run of cinterop would produce an equivalent klib for cache purposes.
-// We observe:
-//   - name / def path / package — rename or relocation must invalidate
-//   - the .def file's mtime — the usual "contents changed" signal; since
-//     compilerOpts / linkerOpts live inside the .def file, editing them
-//     bumps mtime and invalidates the cache for free
-//   - the Kotlin/Native version — bumping `kotlin = "..."` in kolt.toml
-//     switches the cinterop/konanc toolchain, and the klib format is not
-//     guaranteed to be compatible across Kotlin versions
+// Includes kotlinVersion because klib format is not guaranteed compatible across versions.
 fun cinteropStamp(entry: CinteropConfig, defMtime: Long, kotlinVersion: String): String = buildString {
     append("kotlinVersion=").append(kotlinVersion).append('\n')
     append("name=").append(entry.name).append('\n')

--- a/src/nativeMain/kotlin/kolt/build/CompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/CompilerBackend.kt
@@ -4,23 +4,11 @@ import com.github.michaelbull.result.Result
 import kolt.daemon.wire.Diagnostic
 import kolt.daemon.wire.Severity
 
-// A CompilerBackend turns a CompileRequest into a compiled output. Two
-// implementations are planned:
-//   - SubprocessCompilerBackend: invokes kotlinc via fork+exec (legacy path).
-//   - DaemonCompilerBackend: sends Message.Compile over a Unix domain socket
-//     to a warm kolt-compiler-daemon process (#14 Phase A).
-//
-// The interface exists so doBuild() can swap backends without knowing which
-// one runs the compiler, and so the fallback policy can live in a composition
-// (FallbackCompilerBackend) rather than inside either backend.
 interface CompilerBackend {
     fun compile(request: CompileRequest): Result<CompileOutcome, CompileError>
 }
 
-// Mirrors kolt.daemon.protocol.Message.Compile (JVM-side wire type). Field
-// order is kept identical to Message.Compile so DaemonCompilerBackend can
-// translate positionally without a lossy adapter. Future divergence should be
-// absorbed inside DaemonCompilerBackend, not here.
+// Field order kept identical to Message.Compile — divergence goes in DaemonCompilerBackend.
 data class CompileRequest(
     val workingDir: String,
     val classpath: List<String>,
@@ -35,25 +23,10 @@ data class CompileOutcome(
     val stderr: String,
 )
 
-// CompileError variants carry enough discriminators to reproduce the exact
-// user-facing wording formatProcessError used before the CompilerBackend seam
-// was extracted (see formatCompileError). Keeping wording parity is what makes
-// the S1 refactor behaviour-preserving from the user's point of view.
 sealed interface CompileError {
-    // Compiler ran but the user's Kotlin source did not compile. Not fallback
-    // eligible — the subprocess path would fail identically.
-    //
-    // `diagnostics` is the structured form of the compile errors
-    // `BtaIncrementalCompiler` captures via its `KotlinLogger` hook and
-    // `DaemonServer.icErrorToReply` splits out of the flat stderr stream
-    // (see `DiagnosticParser` on the daemon side). Daemon path: populated
-    // from `Message.CompileResult.diagnostics`. Subprocess path: empty,
-    // because kotlinc's diagnostics go directly to the inherited stderr
-    // and the native client never parses them. Callers that want a
-    // complete, ordered user-visible error rendering should prefer
-    // `renderCompilationFailure` below over reading `stderr` / `diagnostics`
-    // independently — that helper reunites the two streams without risk
-    // of double-printing on the daemon path.
+    // Daemon path: diagnostics populated from Message.CompileResult.diagnostics.
+    // Subprocess path: empty (kotlinc writes to inherited stderr directly).
+    // Use renderCompilationFailure() to reunite both streams without double-printing.
     data class CompilationFailed(
         val exitCode: Int,
         val stdout: String,
@@ -61,9 +34,6 @@ sealed interface CompileError {
         val diagnostics: List<Diagnostic> = emptyList(),
     ) : CompileError
 
-    // Backend itself could not run the compiler. Fallback eligible. Distinct
-    // variants preserve the legacy per-ProcessError wording; Other is reserved
-    // for daemon-only failures (socket closed, protocol error etc.).
     sealed interface BackendUnavailable : CompileError {
         data object ForkFailed : BackendUnavailable
         data object WaitFailed : BackendUnavailable
@@ -72,32 +42,13 @@ sealed interface CompileError {
         data class Other(val detail: String) : BackendUnavailable
     }
 
-    // Empty argv / no command to execute. Kept as its own case because the
-    // legacy wording "error: no command to execute" does not embed the context
-    // string, unlike every other variant.
     data object NoCommand : CompileError
 
-    // kolt's own bug (e.g. daemon exit code 64 without a clearer signal).
-    // Logged as an error rather than a warning so self-inflicted problems do
-    // not disappear into the fallback path silently.
     data class InternalMisuse(val detail: String) : CompileError
 }
 
-// Renders every diagnostic the daemon captured, plus any leftover plain-
-// text stderr lines, in the order kotlinc would have produced them.
-// Used by `BuildCommands` to print the full compile error body before
-// the one-line summary `formatCompileError` produces. Pre-B-2c the
-// daemon reply had everything in `stderr`; B-2c split the structured
-// lines out into `diagnostics`. This helper handles both shapes so
-// nothing goes missing regardless of which field is populated.
-//
-// Subprocess path callers should skip this helper — kotlinc already
-// wrote its diagnostics to the inherited stderr stream before the
-// CompilerBackend turned the non-zero exit into a CompilationFailed.
-// Calling `renderCompilationFailure` on a subprocess-path error would
-// typically produce an empty string anyway (both fields are empty),
-// but the ordering invariant is that daemon-path callers print this
-// block and subprocess-path callers do not.
+// Daemon-path only: reunites structured diagnostics and leftover stderr.
+// Subprocess-path callers skip this — kotlinc already wrote to inherited stderr.
 internal fun renderCompilationFailure(error: CompileError.CompilationFailed): String {
     val parts = mutableListOf<String>()
     for (diagnostic in error.diagnostics) {
@@ -108,12 +59,6 @@ internal fun renderCompilationFailure(error: CompileError.CompilationFailed): St
 }
 
 private fun formatDiagnostic(diagnostic: Diagnostic): String {
-    // file=null is the "no location" branch even when line/column
-    // happen to be non-null. Without this guard, a future producer
-    // that forgets to populate `file` while still emitting line/col
-    // would render `:5:3: error: msg` with a leading colon — ugly
-    // and unlike anything kotlinc has ever produced. kotlinc's own
-    // shape always emits position together with a file or omits both.
     val location = if (diagnostic.file == null) {
         ""
     } else buildString {

--- a/src/nativeMain/kotlin/kolt/build/FallbackCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/FallbackCompilerBackend.kt
@@ -4,31 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
 
-/**
- * Composes two [CompilerBackend]s so that a failure from [primary]
- * which the policy classifies as recoverable is transparently retried
- * against [fallback]. This is the seam that lets `kolt build` default
- * to the warm JVM daemon (primary) while still honouring the ADR 0016
- * invariant that "the daemon is never load-bearing for correctness":
- * every daemon-level failure surfaces as a [CompileError] variant that
- * [isFallbackEligible] maps to `true`, and the subprocess path runs in
- * its place.
- *
- * Failures that represent real user-code problems
- * ([CompileError.CompilationFailed]) or kolt wiring mistakes that
- * cannot be papered over ([CompileError.NoCommand]) are returned as-is
- * — retrying would produce the same result, and hiding them behind a
- * silent fallback would be user-hostile.
- *
- * [onFallback] is a per-fallback observer hook. It is invoked exactly
- * once per compile, only on the path where the fallback actually
- * runs, and receives the *primary* error so the caller can decide how
- * loudly to surface it (warning for [CompileError.BackendUnavailable],
- * error log for [CompileError.InternalMisuse] — see ADR 0016 §3). It
- * defaults to a no-op so tests can construct instances without
- * plumbing logging infrastructure; production wiring (S7) supplies a
- * real reporter via `doBuild()`.
- */
+// ADR 0016: daemon is never load-bearing for correctness.
 class FallbackCompilerBackend(
     internal val primary: CompilerBackend,
     internal val fallback: CompilerBackend,
@@ -44,26 +20,6 @@ class FallbackCompilerBackend(
     }
 }
 
-/**
- * Classifies a [CompileError] by whether retrying the compile against
- * a different backend could plausibly succeed.
- *
- * - [CompileError.BackendUnavailable] — the backend itself failed to
- *   run the compiler (fork failed, daemon unreachable, protocol
- *   error). The subprocess path has a real chance of succeeding.
- * - [CompileError.InternalMisuse] — kolt produced a bad argument for
- *   the backend (e.g. a path too long for `sockaddr_un`). Fallback is
- *   still worthwhile because the subprocess path takes different
- *   arguments, but the caller should log loudly: ADR 0016 §3 treats
- *   exit 64 / internal misuse as a kolt bug that must not be silently
- *   swallowed.
- * - [CompileError.CompilationFailed] — kotlinc ran and the user's
- *   Kotlin source did not compile. A subprocess kotlinc would report
- *   the same failure.
- * - [CompileError.NoCommand] — an empty argv reached the backend.
- *   This is a kolt wiring mistake with no user-visible workaround; a
- *   subprocess retry would hit the same guard.
- */
 fun isFallbackEligible(error: CompileError): Boolean = when (error) {
     is CompileError.BackendUnavailable -> true
     is CompileError.InternalMisuse -> true

--- a/src/nativeMain/kotlin/kolt/build/FallbackReporter.kt
+++ b/src/nativeMain/kotlin/kolt/build/FallbackReporter.kt
@@ -2,40 +2,8 @@ package kolt.build
 
 import kolt.infra.eprintln
 
-/**
- * Turns a primary-backend [CompileError] into a one-line stderr line
- * and hands it to [sink]. This is the production hook wired into
- * [FallbackCompilerBackend] via `onFallback` and is kept as a
- * top-level function so the severity policy (ADR 0016 §3) can be
- * exercised without standing up a real doBuild pipeline.
- *
- * Severity mapping:
- *  - [CompileError.BackendUnavailable] — daemon spawn/connect/reply
- *    failed. Expected transient class; surface as a warning so the
- *    user sees it once but the build does not look broken.
- *  - [CompileError.InternalMisuse] — kolt produced a bad argument
- *    for the backend (e.g. a sockaddr_un path that overflowed, or a
- *    daemon that exited with "usage error"). This is a kolt bug that
- *    must not disappear into a silent fallback; ADR 0016 §3 requires
- *    an error log so the dogfooding feedback loop catches it.
- *  - [CompileError.CompilationFailed] / [CompileError.NoCommand] —
- *    not fallback-eligible; [isFallbackEligible] returns `false` for
- *    both so `FallbackCompilerBackend` never invokes the observer
- *    with them. The no-op branch here is a defensive fallthrough so
- *    that adding a new `false`-classified variant in the future does
- *    not force a hasty wording decision here.
- */
+// ADR 0016 §3: BackendUnavailable => warning, InternalMisuse => error.
 fun reportFallback(err: CompileError, sink: (String) -> Unit = ::eprintln) {
-    // Note on variant reachability: in the current production wiring
-    // (daemon primary + subprocess fallback) only
-    // `BackendUnavailable.Other` and `InternalMisuse` can arrive here
-    // — `DaemonCompilerBackend` wraps every spawn/connect/frame
-    // failure into one of those two. The four named `BackendUnavailable`
-    // variants below are emitted only by `SubprocessCompilerBackend`
-    // and are therefore dead in the current composition; they are
-    // kept (and tested) so a future composition that puts the
-    // subprocess backend as the primary — with a different secondary
-    // — does not silently lose severity wording.
     when (err) {
         is CompileError.BackendUnavailable.ForkFailed,
         is CompileError.BackendUnavailable.WaitFailed,
@@ -46,10 +14,6 @@ fun reportFallback(err: CompileError, sink: (String) -> Unit = ::eprintln) {
             sink("warning: compiler daemon unavailable (${err.detail}), falling back to subprocess compile")
         is CompileError.InternalMisuse ->
             sink("error: compiler daemon hit an internal kolt bug (${err.detail}); falling back to subprocess compile — please report this")
-        is CompileError.CompilationFailed, CompileError.NoCommand -> {
-            // isFallbackEligible returns false for both; FallbackCompilerBackend
-            // never reaches the onFallback hook with these. Kept as a no-op so
-            // the when remains exhaustive.
-        }
+        is CompileError.CompilationFailed, CompileError.NoCommand -> {}
     }
 }

--- a/src/nativeMain/kotlin/kolt/build/Runner.kt
+++ b/src/nativeMain/kotlin/kolt/build/Runner.kt
@@ -24,9 +24,6 @@ fun nativeRunCommand(
     appArgs: List<String> = emptyList()
 ): RunCommand = RunCommand(args = listOf(outputKexePath(config)) + appArgs)
 
-// Invokes the test kexe produced by nativeTestBuildCommand. testArgs are passed
-// through verbatim so users can supply kotlin.native test flags such as
-// --ktest_filter, --ktest_logger, --ktest_negative_filter.
 fun nativeTestRunCommand(
     config: KoltConfig,
     testArgs: List<String> = emptyList()

--- a/src/nativeMain/kotlin/kolt/build/SubprocessCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/SubprocessCompilerBackend.kt
@@ -7,9 +7,6 @@ import com.github.michaelbull.result.getOrElse
 import kolt.infra.ProcessError
 import kolt.infra.executeCommand
 
-// Legacy path: fork+exec a managed kotlinc and let it write class files directly.
-// This is what kolt has been doing since day one; S1 only wraps it behind the
-// CompilerBackend seam so S5+ can slot a daemon-backed implementation beside it.
 class SubprocessCompilerBackend(
     private val kotlincBin: String,
 ) : CompilerBackend {
@@ -19,20 +16,11 @@ class SubprocessCompilerBackend(
         executeCommand(argv).getOrElse { err ->
             return Err(mapProcessErrorToCompileError(err))
         }
-        // kotlinc prints diagnostics directly to the inherited stdout/stderr,
-        // so we have nothing to capture at this layer. DaemonCompilerBackend
-        // will populate these from Message.CompileResult. Structured
-        // diagnostics for both paths are deferred per ADR 0016.
         return Ok(CompileOutcome(stdout = "", stderr = ""))
     }
 }
 
-// Pure argv construction, factored out so BuilderTest-style unit tests can
-// cross-check it against the legacy buildCommand() output without spawning a
-// process. moduleName is intentionally not forwarded to kotlinc: the legacy
-// path never set -module-name, and matching that exactly is what makes S1 a
-// behaviour-preserving refactor. DaemonCompilerBackend uses moduleName for
-// Message.Compile.moduleName, which is a separate concern.
+// moduleName intentionally not forwarded — subprocess path never set -module-name.
 internal fun subprocessArgv(kotlincBin: String, request: CompileRequest): List<String> = buildList {
     add(kotlincBin)
     if (request.classpath.isNotEmpty()) {
@@ -50,10 +38,6 @@ internal fun mapProcessErrorToCompileError(error: ProcessError): CompileError = 
     is ProcessError.ForkFailed -> CompileError.BackendUnavailable.ForkFailed
     is ProcessError.WaitFailed -> CompileError.BackendUnavailable.WaitFailed
     is ProcessError.PopenFailed -> CompileError.BackendUnavailable.PopenFailed
-    // execvp() failure in the child surfaces as _exit(127), which arrives here
-    // as NonZeroExit(127) — indistinguishable from a kotlinc that legitimately
-    // exited with 127. We treat the whole NonZeroExit family as a user-level
-    // compilation failure, matching the legacy formatProcessError() behaviour.
     is ProcessError.NonZeroExit -> CompileError.CompilationFailed(
         exitCode = error.exitCode,
         stdout = "",

--- a/src/nativeMain/kotlin/kolt/build/TestDeps.kt
+++ b/src/nativeMain/kotlin/kolt/build/TestDeps.kt
@@ -2,19 +2,11 @@ package kolt.build
 
 import kolt.config.KoltConfig
 
-/**
- * Returns test dependencies that kolt auto-injects based on the target platform.
- * For JVM, injects kotlin-test-junit5 matching the project's Kotlin version.
- * Users can override the version via [test-dependencies] in kolt.toml.
- */
 fun autoInjectedTestDeps(config: KoltConfig): Map<String, String> {
     if (config.target != "jvm") return emptyMap()
     return mapOf("org.jetbrains.kotlin:kotlin-test-junit5" to config.kotlin)
 }
 
-/**
- * Merges auto-injected test deps, main deps, and user test deps.
- * Priority (right-hand side wins): auto-injected < main deps < user test deps.
- */
+// Priority (right wins): auto-injected < main deps < user test deps.
 fun mergeAllDeps(config: KoltConfig): Map<String, String> =
     autoInjectedTestDeps(config) + config.dependencies + config.testDependencies

--- a/src/nativeMain/kotlin/kolt/build/Workspace.kt
+++ b/src/nativeMain/kotlin/kolt/build/Workspace.kt
@@ -10,10 +10,6 @@ private val prettyJson = Json {
     prettyPrintIndent = "  "
 }
 
-/**
- * Generate workspace.json content for Kotlin/kotlin-lsp.
- * Pure function: no I/O, no side effects.
- */
 fun generateWorkspaceJson(
     config: KoltConfig,
     resolvedDeps: List<ResolvedDep>
@@ -41,10 +37,6 @@ fun generateWorkspaceJson(
     return prettyJson.encodeToString(JsonObject.serializer(), json)
 }
 
-/**
- * Generate kls-classpath content for fwcd/kotlin-language-server.
- * Returns colon-separated JAR paths.
- */
 fun generateKlsClasspath(resolvedDeps: List<ResolvedDep>): String =
     resolvedDeps.joinToString(":") { it.cachePath }
 
@@ -164,7 +156,7 @@ private fun buildKotlinSettings(config: KoltConfig): JsonObject =
         put("isHmppEnabled", true)
         putJsonArray("pureKotlinSourceFolders") {}
         put("kind", "default")
-        // kotlin-lsp uses "J" prefix to indicate JSON-encoded compiler arguments
+        // kotlin-lsp requires "J" prefix for JSON-encoded compiler arguments.
         put("compilerArguments", "J{\"jvmTarget\":\"${config.jvmTarget}\",\"pluginOptions\":[],\"pluginClasspaths\":[]}")
         put("additionalArguments", JsonNull)
         put("scriptTemplates", JsonNull)

--- a/src/nativeMain/kotlin/kolt/build/daemon/BootstrapJdk.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/BootstrapJdk.kt
@@ -10,80 +10,20 @@ import kolt.infra.fileExists
 import kolt.tool.ToolchainError
 import kolt.tool.installJdkToolchain
 
-// Version of the JDK kolt uses for running the compiler daemon.
-//
-// Pinned deliberately: the daemon is a kolt internal, independent of
-// whatever JDK the user has chosen for their project (kolt.toml
-// [build] jdk). A project that pins JDK 11 must still be able to run
-// the daemon, so the daemon has its own toolchain slot. Bumping this
-// value is a kolt release decision — see ADR 0017 for the trade-offs
-// around pinning, reproducibility, and upgrade cadence.
-//
-// The string is an Adoptium `latest/<feature>` key. Moving to a fully
-// qualified version (`21.0.5+11`) requires hitting a different
-// endpoint on the Adoptium API, which is follow-up work tracked in
-// ADR 0017.
+// Independent of the project's JDK — see ADR 0017.
 const val BOOTSTRAP_JDK_VERSION: String = "21"
 
-// Why bootstrap JDK provisioning failed for this build. The install
-// dir is carried so the warning can name the exact path kolt tried to
-// populate; [cause] is the underlying toolchain failure (download,
-// checksum, extract, …) already wrapped into a single user-facing
-// message by `ToolchainManager`. A single flat variant is enough —
-// nothing downstream classifies these; the daemon precondition path
-// just surfaces them in a one-line fallback warning. ADR 0016 §5
-// guarantees this is never load-bearing for correctness.
 internal data class BootstrapJdkError(
     val jdkInstallDir: String,
     val cause: ToolchainError,
 )
 
-/**
- * Read-only lookup for the bootstrap JDK's `java` binary. Returns
- * `null` if the JDK is not already installed under
- * `~/.kolt/toolchains/jdk/<version>/bin/java`.
- *
- * Kept alongside [ensureBootstrapJavaBin] for tests and diagnostic
- * callers that want to probe state without triggering a download.
- * The daemon bring-up path in production goes through
- * [ensureBootstrapJavaBin] (see ADR 0017 §Decision, revised once
- * `installJdkToolchain` became `Result`-returning) so a missing
- * bootstrap JDK is auto-provisioned on first use and the daemon
- * activates immediately instead of requiring a separate install step.
- */
 internal fun resolveBootstrapJavaBin(paths: KoltPaths): String? {
     val javaBin = paths.javaBin(BOOTSTRAP_JDK_VERSION)
     return if (fileExists(javaBin)) javaBin else null
 }
 
-/**
- * Resolves the bootstrap JDK's `java` binary, downloading and
- * installing the pinned version under `~/.kolt/toolchains/jdk/` on
- * first use. Returns `Ok(javaBin)` if the JDK is already installed
- * or becomes installed as a side effect, or
- * `Err(BootstrapJdkError)` if the download / checksum / extract
- * pipeline fails.
- *
- * On failure, the caller (daemon precondition resolver) must treat
- * this as a fallback signal — **never** as a build failure — because
- * the daemon is not load-bearing for correctness (ADR 0016 §5).
- * Specifically, an offline first run surfaces here as an `Err` and
- * the build silently drops back to the subprocess compile path; the
- * next online run will install the JDK and the daemon takes over.
- *
- * Progress output (`downloading jdk 21…` etc.) is routed through
- * `eprintln` rather than `println` because the auto-install fires
- * implicitly inside `doBuild` — it would otherwise interleave with
- * build stdout the user cares about. Explicit `kolt toolchain install`
- * still goes to stdout via the default `::println` progress sink on
- * [installJdkToolchain].
- *
- * Seams:
- * - [resolve] maps to [resolveBootstrapJavaBin] in production so a
- *   test can skip the download path by returning a ready-made bin.
- * - [install] maps to [installJdkToolchain] so a test can inject a
- *   fake install pipeline (success, hard failure, partial install).
- */
+// Progress goes to stderr so it does not interleave with build stdout.
 internal fun ensureBootstrapJavaBin(
     paths: KoltPaths,
     resolve: (KoltPaths) -> String? = ::resolveBootstrapJavaBin,
@@ -97,15 +37,6 @@ internal fun ensureBootstrapJavaBin(
         return Err(BootstrapJdkError(installDir, err))
     }
 
-    // Post-install re-check: running `resolve` again here
-    // guarantees the returned path observes the same "bin/java
-    // exists" invariant as the fast path above. Any mismatch means
-    // the [install] lambda lied about success — either a
-    // ToolchainManager bug, or a test-injected seam returning
-    // `Ok(Unit)` without populating the filesystem. Either way we
-    // surface it as an `Err` so the daemon path degrades
-    // gracefully instead of handing back a path the JVM launcher
-    // cannot exec.
     val javaBin = resolve(paths)
         ?: return Err(
             BootstrapJdkError(

--- a/src/nativeMain/kotlin/kolt/build/daemon/BtaImplJarResolver.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/BtaImplJarResolver.kt
@@ -6,10 +6,6 @@ import kolt.infra.readSelfExe
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
 
-// Result of locating the kotlin-build-tools-impl jars the Phase B daemon
-// expects via its `--bta-impl-jars` CLI flag. Carries the probed directory
-// on the NotFound branch so the warning tells the user the exact path kolt
-// looked at, mirroring the shape of `DaemonPreconditionError.CompilerJarsMissing`.
 sealed interface BtaImplJarsResolution {
     data class Resolved(val jars: List<String>, val source: Source) : BtaImplJarsResolution
     data class NotFound(val probedDir: String) : BtaImplJarsResolution
@@ -17,39 +13,11 @@ sealed interface BtaImplJarsResolution {
     enum class Source { Env, Libexec, DevFallback }
 }
 
-// KOLT_BTA_IMPL_JARS_DIR is the explicit override for the -impl jar directory.
-// Found => taken verbatim, the path must contain at least one .jar. Parallel
-// to KOLT_DAEMON_JAR for the daemon fat jar itself — one env var per resource
-// keeps the override contract obvious to users writing scripts.
 internal const val KOLT_BTA_IMPL_JARS_DIR_ENV = "KOLT_BTA_IMPL_JARS_DIR"
 
-// Directory name used under both the installed layout and the dev fallback.
-// Kept as a shared constant so a future rename (e.g. for a second Kotlin
-// version segment) touches exactly one place.
 internal const val BTA_IMPL_DIR_NAME = "kolt-bta-impl"
 
-/**
- * Pure resolution entry point for kotlin-build-tools-impl jars. The probe
- * order mirrors [resolveDaemonJarPure]:
- *
- *   1. `[envDirValue]` — early-return override pointed at a directory.
- *      If the env var is set but the directory is empty or unreadable,
- *      return NotFound with the env-supplied path so the user's
- *      mis-setting surfaces as the warning.
- *   2. Installed layout: `<dirname(dirname(selfExe))>/libexec/kolt-bta-impl/`.
- *      Jars end up here when kolt is shipped as a packaged distribution
- *      with a staged copy of `kotlin-build-tools-impl` alongside the
- *      daemon fat jar. The libexec layout is the same one
- *      [resolveDaemonJarPure] uses for `kolt-compiler-daemon-all.jar`.
- *   3. Dev fallback: `<repo>/kolt-compiler-daemon/build/bta-impl-jars/`,
- *      populated by the `stageBtaImplJars` Gradle task. Identical
- *      five-parents-up walk from `build/bin/linuxX64/<variant>/kolt.kexe`
- *      to the repo root as [resolveDaemonJarPure].
- *
- * `NotFound` carries the last probed directory so the caller can surface
- * a warning with an actionable path (either the env override, the libexec
- * layout, or the dev fallback, in that priority order).
- */
+// Probe order: env override -> libexec -> dev fallback (same as resolveDaemonJarPure).
 fun resolveBtaImplJarsPure(
     envDirValue: String?,
     selfExePath: String?,
@@ -60,16 +28,10 @@ fun resolveBtaImplJarsPure(
         return if (!jars.isNullOrEmpty()) {
             BtaImplJarsResolution.Resolved(jars, BtaImplJarsResolution.Source.Env)
         } else {
-            // Env override is user-asserted; empty or unreadable is a
-            // mis-setting we surface rather than falling through, so the
-            // user doesn't get a libexec path in the warning when they
-            // clearly set the env var.
             BtaImplJarsResolution.NotFound(envDirValue)
         }
     }
 
-    // Probed directories are collected so the NotFound branch can name the
-    // last-probed path without re-deriving it.
     var lastProbed = "<no selfExe>"
 
     if (selfExePath != null) {
@@ -84,7 +46,6 @@ fun resolveBtaImplJarsPure(
             }
         }
 
-        // Dev fallback: walk five parents up from the test/debug binary.
         var repoRoot: String? = selfExePath
         repeat(5) { repoRoot = repoRoot?.let { parentDir(it) } }
         if (repoRoot != null) {

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
@@ -27,70 +27,15 @@ import platform.posix.clock_gettime
 import platform.posix.timespec
 import platform.posix.usleep
 
-/**
- * Warm JVM daemon path for compilation (see ADR 0016, issue #14).
- *
- * The first `compile()` call after a cold boot connects to (or spawns
- * and then connects to) a long-lived helper JVM that keeps the Kotlin
- * compiler's classloader warm. Subsequent compiles reuse the same
- * daemon and pay microseconds of IPC instead of seconds of JVM startup.
- *
- * This backend is **not** load-bearing for correctness. Every failure
- * mode — daemon spawn fails, daemon crashes mid-compile, socket path
- * is unreachable, reply is malformed — is mapped to a [CompileError]
- * that `FallbackCompilerBackend` is free to translate into a
- * subprocess fallback (S6/S7). The only error that is returned as
- * "don't fall back" is [CompileError.CompilationFailed]: that means
- * the daemon ran kotlinc and the user's Kotlin source did not
- * compile, and retrying with a subprocess kotlinc would produce the
- * same failure.
- *
- * ### Connect / spawn / retry policy
- *
- * 1. One optimistic `connect()`. If it succeeds, the daemon was
- *    already running — send the frame and return.
- * 2. If `connect()` fails with `ENOENT` (socket file absent) or
- *    `ECONNREFUSED` (no listener yet), the daemon is assumed to be
- *    down. Call [spawner] and enter the retry loop.
- * 3. If `connect()` fails with any other errno, the failure is fatal
- *    for this build — `EACCES`, `ENAMETOOLONG`, `EADDRNOTAVAIL` etc.
- *    all indicate environment or path problems that more retries
- *    will not resolve. [UnixSocketError.InvalidArgument] from path
- *    length validation is mapped to [CompileError.InternalMisuse]
- *    because it means kolt itself built a bad path.
- * 4. The retry loop uses exponential backoff (10 / 20 / 40 / ... ms,
- *    capped at 200 ms per iteration) inside a fixed total budget of
- *    [connectTotalBudgetMs] ms. The budget is wall-clock, not
- *    attempt-counted, so a laggy spawn does not burn the budget in
- *    one iteration and a fast spawn is not limited by a minimum
- *    retry count.
- *
- * ### Seams
- *
- * The constructor takes a [connector] and a [spawner] as defaulted
- * function parameters. In production both default to real
- * implementations ([UnixSocket.connect] wrapped in a
- * [SocketDaemonConnection] and [spawnDetached]); in tests they are
- * substituted with fakes so retry policy, spawn behaviour, and reply
- * mapping can be exercised without bringing up a real JVM daemon.
- * The same seam lets a future integration test swap in a real daemon
- * as a second configuration without duplicating the compile pipeline.
- */
+// ADR 0016, #14. Not load-bearing for correctness — all failures are fallback-eligible
+// except CompilationFailed. Retry policy: exponential backoff (10..200ms) within 3s budget.
 class DaemonCompilerBackend internal constructor(
     private val javaBin: String,
     private val daemonJarPath: String,
     private val compilerJars: List<String>,
-    // kotlin-build-tools-impl classpath shipped separately from the fat jar
-    // per ADR 0019 §3. Passed verbatim on `--bta-impl-jars` when spawning
-    // the daemon; the daemon loads these through a URLClassLoader parented
-    // by `SharedApiClassesClassLoader`.
     private val btaImplJars: List<String>,
     private val socketPath: String,
     private val logPath: String? = null,
-    // ADR 0019 §9 + #65: enabled `kolt.toml [plugins]` alias → compiler
-    // plugin classpath. Serialised onto `--plugin-jars` when spawning the
-    // daemon (see Main.parsePluginJars). Empty map omits the flag entirely
-    // so the common no-plugin path stays trivial.
     private val pluginJars: Map<String, List<String>> = emptyMap(),
     private val connector: DaemonConnector = defaultDaemonConnector,
     private val spawner: DaemonSpawner = defaultDaemonSpawner,
@@ -135,7 +80,6 @@ class DaemonCompilerBackend internal constructor(
     }
 
     private fun connectOrSpawn(): Result<DaemonConnection, CompileError> {
-        // Fast path: a daemon is already listening from a previous build.
         val first = connector(socketPath)
         first.getError()?.let { err ->
             if (!isRetryableConnectError(err)) {
@@ -143,10 +87,6 @@ class DaemonCompilerBackend internal constructor(
             }
         } ?: return Ok(first.get()!!)
 
-        // Daemon is (probably) not up — double-fork-exec and then
-        // wait for it to `bind()` the socket. [spawnDetached] returns
-        // as soon as the intermediate child exits, so we still need
-        // the retry loop before the first real connect succeeds.
         val spawnErr = spawner(
             spawnArgv(),
             logPath,
@@ -192,9 +132,6 @@ class DaemonCompilerBackend internal constructor(
         add("--socket")
         add(socketPath)
         add("--compiler-jars")
-        // JVM `kolt-compiler-daemon` CLI splits this on `File.pathSeparator`,
-        // which on Linux is ':'. Hard-code rather than pull in a platform
-        // detect: kolt is linuxX64-only today (see CLAUDE.md non-goals).
         add(compilerJars.joinToString(":"))
         add("--bta-impl-jars")
         add(btaImplJars.joinToString(":"))
@@ -215,12 +152,6 @@ class DaemonCompilerBackend internal constructor(
     }
 }
 
-/**
- * Frame-level daemon endpoint. Extracted as an internal seam so tests
- * can replace real socket I/O with a fake that returns pre-canned
- * [Message] responses, and so the compile pipeline does not need to
- * know about [UnixSocket] directly.
- */
 internal interface DaemonConnection : AutoCloseable {
     fun sendRequest(message: Message): Result<Unit, FrameError>
     fun receiveReply(): Result<Message, FrameError>
@@ -251,10 +182,6 @@ internal val defaultDaemonSpawner: DaemonSpawner = { argv, logPath -> spawnDetac
 
 internal val defaultSleeper: (Int) -> Unit = { ms -> usleep((ms * 1000).toUInt()) }
 
-// Monotonic milliseconds, used as the retry-budget clock. TimeSource
-// would have required a captured TimeMark and could not be swapped in
-// tests without an extra indirection; clock_gettime returns an
-// absolute monotonic value that is trivial to fake.
 @OptIn(ExperimentalForeignApi::class)
 internal fun monotonicMs(): Long = memScoped {
     val ts = alloc<timespec>()
@@ -262,11 +189,7 @@ internal fun monotonicMs(): Long = memScoped {
     ts.tv_sec * 1000L + ts.tv_nsec / 1_000_000L
 }
 
-// ENOENT: socket file does not exist yet (daemon has not bound).
-// ECONNREFUSED: socket file exists but nobody is listening (daemon is
-// shutting down mid-bind, or crashed between cleanup and rebind). Both
-// are expected transients in the spawn window; all other errnos are
-// treated as environment failures and short-circuit.
+// ENOENT / ECONNREFUSED are expected transients in the spawn window.
 internal fun isRetryableConnectError(err: UnixSocketError): Boolean {
     if (err !is UnixSocketError.ConnectFailed) return false
     return err.errno == ENOENT || err.errno == ECONNREFUSED
@@ -278,10 +201,6 @@ internal fun mapFatalConnectError(err: UnixSocketError): CompileError = when (er
         CompileError.BackendUnavailable.Other(
             "connect(${err.path}) failed: errno=${err.errno} ${err.message}",
         )
-    // Non-connect variants cannot reach this path (connector returns
-    // only ConnectFailed / InvalidArgument today), but the exhaustive
-    // when keeps the compiler honest if a future UnixSocketError
-    // variant is added without updating this mapping.
     is UnixSocketError.SendFailed,
     is UnixSocketError.RecvFailed,
     is UnixSocketError.UnexpectedEof,
@@ -309,17 +228,6 @@ internal fun mapReplyToOutcome(reply: Message): Result<CompileOutcome, CompileEr
             reply.exitCode == 0 ->
                 Ok(CompileOutcome(stdout = reply.stdout, stderr = reply.stderr))
             isDaemonProtocolError(reply) ->
-                // The JVM daemon's `writeProtocolError` wire contract
-                // (ADR 0016 §3, `DaemonServer.writeProtocolError`)
-                // emits exactly this shape on host-level failures:
-                // exitCode=2, empty diagnostics, empty stdout, and a
-                // stderr prefixed with "protocol error: ". Route it
-                // to BackendUnavailable so FallbackCompilerBackend can
-                // drop to subprocess compile instead of surfacing a
-                // confusing "compilation failed: protocol error" to
-                // the user. Narrow enough to not false-positive on a
-                // real kotlinc internal-error exitCode=2, because the
-                // stderr prefix is unique to the daemon contract.
                 Err(CompileError.BackendUnavailable.Other("daemon protocol error: ${reply.stderr}"))
             else ->
                 Err(
@@ -350,10 +258,6 @@ private fun isDaemonProtocolError(reply: Message.CompileResult): Boolean =
         reply.stdout.isEmpty() &&
         reply.stderr.startsWith(DAEMON_PROTOCOL_ERROR_PREFIX)
 
-// Wire contract: the fields of Message.Compile must stay aligned with
-// CompileRequest so the native client and the JVM server can talk
-// through FrameCodec without a lossy adapter. See ADR 0016 §3 and
-// the note on CompileRequest in kolt.build.CompilerBackend.kt.
 internal fun CompileRequest.toWireMessage(): Message.Compile = Message.Compile(
     workingDir = workingDir,
     classpath = classpath,

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonJarResolver.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonJarResolver.kt
@@ -6,10 +6,6 @@ import kolt.infra.readSelfExe
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
 
-// Result of resolving where the kolt-compiler-daemon fat jar lives on
-// disk. The [source] tag is preserved so a future `kolt doctor` command
-// (or a verbose log line) can tell a user which fallback actually fired
-// without re-running the resolution.
 sealed interface DaemonJarResolution {
     data class Resolved(val path: String, val source: Source) : DaemonJarResolution
     data object NotFound : DaemonJarResolution
@@ -17,38 +13,10 @@ sealed interface DaemonJarResolution {
     enum class Source { Env, Libexec, DevFallback }
 }
 
-// Fixed filename of the Shadow-built fat jar produced by
-// kolt-compiler-daemon/build.gradle.kts (see S2, commit ad4199f).
 internal const val DAEMON_JAR_FILENAME = "kolt-compiler-daemon-all.jar"
-
-// KOLT_DAEMON_JAR is the explicit override documented in the
-// DaemonCompilerBackend contract. Found => taken verbatim, other
-// candidates are not inspected and the path is not existence-checked —
-// that matches the intent of an override (user takes responsibility).
 internal const val KOLT_DAEMON_JAR_ENV = "KOLT_DAEMON_JAR"
 
-/**
- * Pure resolution entry point, split out so the fallback chain can be
- * exercised with fake inputs — the real I/O wrapper [resolveDaemonJar]
- * below fills the holes from `getenv` + [readSelfExe] + [fileExists].
- *
- * Priority:
- *   1. [envValue] — early-return override, no existence check.
- *   2. Installed layout: `<dirname(dirname(selfExe))>/libexec/kolt-compiler-daemon-all.jar`.
- *      A `kolt` binary at `<prefix>/bin/kolt` and a jar at
- *      `<prefix>/libexec/kolt-compiler-daemon-all.jar` is the layout we
- *      will ship when packaging gets cut (intentionally left unbuilt in
- *      S2 — see memory/project_phase_a_daemon.md).
- *   3. Dev fallback: the jar produced by `./gradlew :kolt-compiler-daemon:shadowJar`
- *      at `<repo>/kolt-compiler-daemon/build/libs/kolt-compiler-daemon-all.jar`.
- *      The native test binary lives at
- *      `<repo>/build/bin/linuxX64/debugTest/test.kexe`
- *      and the dev binary at
- *      `<repo>/build/bin/linuxX64/debugExecutable/kolt.kexe`,
- *      so the jar is five levels up from the binary file and then
- *      `kolt-compiler-daemon/build/libs/...`. This keeps dev usable
- *      without any installed layout at all.
- */
+// Probe order: env override -> libexec -> dev fallback.
 fun resolveDaemonJarPure(
     envValue: String?,
     selfExePath: String?,
@@ -67,9 +35,6 @@ fun resolveDaemonJarPure(
         return DaemonJarResolution.Resolved(libexec, DaemonJarResolution.Source.Libexec)
     }
 
-    // From <repo>/build/bin/linuxX64/<variant>/kolt.kexe the repo root
-    // is five parents up. Any other binary layout simply won't match
-    // and falls through to NotFound.
     var repoRoot: String? = selfExePath
     repeat(5) { repoRoot = repoRoot?.let { parentDir(it) } }
     if (repoRoot != null) {
@@ -82,11 +47,6 @@ fun resolveDaemonJarPure(
     return DaemonJarResolution.NotFound
 }
 
-// Impure entry point: wires [resolveDaemonJarPure] up to getenv + the
-// real /proc/self/exe + on-disk file existence. DaemonCompilerBackend
-// calls this at compile() time, not at construction, so a user who
-// installs a daemon jar between builds gets picked up on the next run
-// without restarting kolt.
 @OptIn(ExperimentalForeignApi::class)
 fun resolveDaemonJar(): DaemonJarResolution {
     val env = platform.posix.getenv(KOLT_DAEMON_JAR_ENV)?.toKString()
@@ -98,8 +58,6 @@ fun resolveDaemonJar(): DaemonJarResolution {
     )
 }
 
-// Extract the parent directory component of a POSIX-style path. Returns
-// null if the path has no separator (e.g. "kolt"), or is exactly "/".
 internal fun parentDir(path: String): String? {
     if (path.isEmpty()) return null
     if (path == "/") return null

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
@@ -8,93 +8,30 @@ import kolt.config.KoltPaths
 import kolt.infra.listJarFiles
 
 
-// Everything `DaemonCompilerBackend` needs to try to talk to a warm
-// daemon. Collected into one value so doBuild() can decide in a single
-// branch whether the daemon path is reachable for this build.
-//
-// [daemonDir] is the per-project state directory that holds the socket
-// file and the daemon log. It is carried alongside [socketPath] so
-// wiring code does not have to re-derive the directory by string
-// slicing the socket path — a fragile inverse of `KoltPaths.daemonDir`
-// / `daemonSocketPath`.
 internal data class DaemonSetup(
     val javaBin: String,
     val daemonJarPath: String,
     val compilerJars: List<String>,
-    // kotlin-build-tools-impl jars shipped alongside the daemon. Required by the
-    // Phase B incremental compile path (ADR 0019 §3): the daemon spawns with
-    // these on the `--bta-impl-jars` CLI flag and loads them reflectively
-    // through a child URLClassLoader parented by `SharedApiClassesClassLoader`,
-    // keeping daemon-core classes free of @ExperimentalBuildToolsApi types.
-    // Existence is checked at precondition time, but jar *content* is not —
-    // a corrupted or version-mismatched -impl jar is a daemon-side failure
-    // surfaced through `IcError.InternalError` and retried via
-    // `FallbackCompilerBackend` per ADR 0016 §5.
     val btaImplJars: List<String>,
     val daemonDir: String,
     val socketPath: String,
     val logPath: String,
 )
 
-// Reasons the daemon path is not reachable for this build. Each
-// variant maps to a one-line warning the user sees once, after which
-// the build falls back to the subprocess compile path. None of these
-// are build failures — ADR 0016 §5 guarantees the daemon is never
-// load-bearing for correctness.
+// None of these are build failures — ADR 0016 §5.
 internal sealed interface DaemonPreconditionError {
-    // Auto-install of the bootstrap JDK failed (download, checksum,
-    // extract, or a leftover partial install under the probed
-    // directory). Carries the probed directory so the warning can
-    // name the exact path kolt tried to populate, plus the underlying
-    // cause message so the warning tells the user *why* it failed
-    // (HTTP status, offline, disk full, …) rather than just "missing".
-    // ADR 0017 §Decision (revised) describes this auto-install path.
     data class BootstrapJdkInstallFailed(
         val jdkInstallDir: String,
         val cause: String,
     ) : DaemonPreconditionError
 
-    // The `kolt-compiler-daemon-all.jar` was not found in any of the
-    // locations [resolveDaemonJar] probes (env override, libexec
-    // co-location, dev fallback). Not a user misconfig: it means
-    // kolt itself was not installed with a daemon jar beside it.
     data object DaemonJarMissing : DaemonPreconditionError
 
-    // The kotlinc lib directory either does not exist or contains no
-    // .jar files, so there is nothing to load into the daemon's
-    // compiler classloader. Includes the directory so the warning can
-    // point at the exact path the user needs to repair.
     data class CompilerJarsMissing(val kotlincLibDir: String) : DaemonPreconditionError
 
-    // kotlin-build-tools-impl jars could not be located. The Phase B
-    // incremental compile path needs them on disk so the daemon can
-    // load them through a URLClassLoader (ADR 0019 §3). Ships via
-    // `libexec/kolt-bta-impl/` at install time, or the dev-fallback
-    // directory `<repo>/kolt-compiler-daemon/build/bta-impl-jars/`
-    // populated by the `stageBtaImplJars` Gradle task. Includes the
-    // probed directory so the warning points at the exact path to
-    // repair — identical shape to CompilerJarsMissing.
     data class BtaImplJarsMissing(val probedDir: String) : DaemonPreconditionError
 }
 
-/**
- * Collects the inputs [DaemonCompilerBackend] needs and hands back
- * either a complete [DaemonSetup] or the first missing piece. This is
- * the single point where the daemon path is either "available" or
- * "not available for this build" — doBuild() branches on the result
- * and picks [kolt.build.FallbackCompilerBackend] or a plain
- * [kolt.build.SubprocessCompilerBackend] accordingly.
- *
- * Seams ([ensureJavaBin], [resolveDaemonJar], [listCompilerJars]) are
- * parameterised so unit tests can drive every variant of
- * [DaemonPreconditionError] without touching the real filesystem.
- * Defaults wire up the production helpers; production callers pass
- * only [paths], [kotlincVersion], and [absProjectPath]. [ensureJavaBin]
- * is the auto-installing [ensureBootstrapJavaBin] — on a clean first
- * run it downloads the pinned JDK synchronously before returning; on
- * failure the daemon path degrades to the subprocess backend per
- * ADR 0016 §5, never killing the build.
- */
 internal fun resolveDaemonPreconditions(
     paths: KoltPaths,
     kotlincVersion: String,
@@ -144,15 +81,6 @@ internal fun resolveDaemonPreconditions(
     )
 }
 
-/**
- * One-line stderr warning for a precondition failure. Kept next to
- * the error enum so every new variant is forced to supply wording at
- * the same time. For [DaemonPreconditionError.BootstrapJdkInstallFailed]
- * the wording now includes the underlying cause (HTTP status, offline,
- * disk full, …) so a user staring at "slow builds" knows whether to
- * retry online, free up disk, or investigate a proxy. ADR 0017
- * §Decision (revised) made the auto-install path default-on.
- */
 internal fun formatDaemonPreconditionWarning(err: DaemonPreconditionError): String = when (err) {
     is DaemonPreconditionError.BootstrapJdkInstallFailed ->
         "warning: could not install bootstrap JDK at ${err.jdkInstallDir} (${err.cause}) — falling back to subprocess compile"

--- a/src/nativeMain/kotlin/kolt/build/daemon/ProjectHash.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/ProjectHash.kt
@@ -2,11 +2,6 @@ package kolt.build.daemon
 
 import kolt.infra.sha256Hex
 
-// Opaque key for the per-project daemon working directory. Stability
-// across kolt runs is required (so the same project reuses one daemon);
-// cryptographic strength is not — this is a directory name, not a
-// security primitive. Truncating SHA-256 to 16 hex chars (64 bits) keeps
-// the directory name short while collision probability stays negligible
-// for any realistic number of projects on one machine.
+// Truncated to 16 hex chars — collision probability negligible for realistic project counts.
 fun projectHashOf(absProjectPath: String): String =
     sha256Hex(absProjectPath.encodeToByteArray()).take(16)

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -44,9 +44,7 @@ internal fun loadProjectConfig(): KoltConfig {
 internal fun doCheck(useDaemon: Boolean = true) {
     val startMark = TimeSource.Monotonic.markNow()
     val config = loadProjectConfig()
-    // For native target, check is equivalent to a full build (konanc has no
-    // syntax-only mode). Delegate to doBuild and discard its BuildResult —
-    // check has no further use for it.
+    // konanc has no syntax-only mode; a full build is the only option.
     if (config.target == "native") {
         doBuild(useDaemon = useDaemon)
         return
@@ -104,32 +102,13 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
     if (isBuildUpToDate(current = currentState, cached = cachedState)) {
         val elapsed = startMark.elapsedNow()
         println("${config.name} is up to date (${formatDuration(elapsed)})")
-        // #65 review finding #2: the up-to-date path deliberately does
-        // NOT resolve plugin jars, and (as of the second review pass)
-        // does NOT provision the kotlinc toolchain either. Plugin jar
-        // resolution re-hashes every cached jar against its stamp (TOFU
-        // self-heal, see PluginJarFetcher) and falls through to re-
-        // download on corruption, which would hard-exit an offline
-        // build that otherwise would have succeeded. kotlinc is only
-        // needed for the subprocess-fallback compile path (below), so
-        // deferring both keeps this branch a pure mtime compare, which
-        // is the invariant dogfood offline builds depend on. `doTest`
-        // resolves plugin args on its own for test compilation, so
-        // nothing downstream of `BuildResult` needs them here.
+        // Invariant: the up-to-date path must stay a pure mtime compare —
+        // no plugin jar resolution or toolchain provisioning — so offline
+        // cached builds don't hard-exit on a failed fetch.
         return BuildResult(config, cachedState!!.classpath, managedJavaBin)
     }
-    // Only provisioned when we actually need to run a compile. Matches
-    // the `ensureKonancBin` ordering in `doNativeBuild`, which has had
-    // the same "provision after the cache check" shape since it
-    // landed.
     val managedKotlincBin = ensureKotlincBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
     val classpath = resolveDependencies(config)
-    // #65 review finding #1: resolve enabled plugin jars once per
-    // rebuild and derive both the subprocess `-Xplugin=` form and the
-    // daemon `--plugin-jars` alias map from the same map. The previous
-    // version called `resolvePluginArgs` + `resolvePluginJarsMap` back
-    // to back and paid the file-exists + re-hash cost per enabled plugin
-    // twice on every warm-cache rebuild.
     val pluginJarPathsByAlias = resolveEnabledPluginJarPaths(config, paths, EXIT_BUILD_ERROR)
     val pArgs = pluginJarPathsByAlias.values.map { "-Xplugin=$it" }
     val pluginJarsForDaemon = pluginJarPathsByAlias.mapValues { (_, path) -> listOf(path) }
@@ -138,29 +117,12 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
         exitProcess(EXIT_BUILD_ERROR)
     }
 
-    // Resolve cwd once, up front. Both the daemon path (which keys
-    // per-project state on the absolute project path) and the
-    // absolutise pass below need it, and there is no sensible
-    // recovery if kolt itself cannot read its own cwd: any relative
-    // path in config.sources or CLASSES_DIR would resolve
-    // inconsistently from that point on. Hard-exit is the honest
-    // behaviour — this is not a "fall back to the daemon-less path"
-    // failure mode, it is "kolt cannot function" — and it unifies
-    // the failure policy with resolveCompilerBackend, which no
-    // longer needs a cwd seam of its own.
     val cwd = currentWorkingDirectory() ?: run {
         eprintln("error: could not determine current working directory")
         exitProcess(EXIT_BUILD_ERROR)
     }
 
     val subprocessBackend = SubprocessCompilerBackend(kotlincBin = managedKotlincBin)
-    // #65 native client wiring: `pluginJarsForDaemon` (built just above
-    // from `resolveEnabledPluginJarPaths`) is fed to the daemon via
-    // `--plugin-jars`. The subprocess fallback still picks up plugins
-    // through `-Xplugin=...` in extraArgs (`pArgs`); the daemon ignores
-    // extraArgs entirely (DaemonServer.toIcRequest drops the field) and
-    // reads the plugin classpath from this map instead, so the two
-    // channels coexist without double-loading.
     val backend: CompilerBackend = resolveCompilerBackend(
         config = config,
         paths = paths,
@@ -169,40 +131,14 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
         absProjectPath = cwd,
         pluginJars = pluginJarsForDaemon,
     )
-    // Sources and outputPath are relative to the project root in
-    // kolt.toml. The subprocess backend inherits cwd via fork+exec,
-    // but the daemon JVM persists across builds and ignores
-    // `CompileRequest.workingDir` (SharedCompilerHost.buildArgs does
-    // not consult it — ADR 0016 §3 leaves the daemon's cwd
-    // unspecified on purpose). Absolutise every path the backend
-    // receives so the result is identical regardless of whether the
-    // daemon or the subprocess backend serves the compile, and so a
-    // future daemon-side change (e.g. chdir or relative resolution)
-    // cannot silently desynchronise the two paths.
+    // Absolutise all paths: the daemon JVM persists across builds and
+    // does not honour CompileRequest.workingDir (ADR 0016 §3).
     val request = CompileRequest(
-        // TODO(#14): `workingDir` is populated with the project root
-        // as a forward-compatible anchor, but no backend reads it
-        // today — the native subprocess path inherits cwd via
-        // fork+exec and the JVM SharedCompilerHost.buildArgs ignores
-        // the field. Kept in the wire so a future daemon-side
-        // chdir-per-compile can honour it without a wire migration.
         workingDir = cwd,
-        // TODO(#14 S5+): resolveDependencies currently returns a ':'-joined
-        // String for legacy reasons, so we split it here to hand the backend a
-        // List<String>. When the daemon path lands and the legacy string form
-        // is no longer needed, teach resolveDependencies to return List<String>
+        // TODO(#14 S5+): teach resolveDependencies to return List<String>
         // directly and delete this split.
         classpath = if (classpath.isNullOrEmpty()) emptyList() else classpath.split(":").filter { it.isNotEmpty() },
-        // Expand directory entries in `config.sources` to their
-        // constituent .kt files before handing them to the backend.
-        // The Phase A kotlin-compiler-embeddable subprocess path
-        // tolerated directories via kotlinc's CLI, but Phase B's BTA
-        // requires individual files (`jvmCompilationOperationBuilder`
-        // reports `Is a directory` on the first directory entry). See
-        // issue #117 for the dogfood trace that surfaced this. The
-        // expansion runs on absolute paths so subsequent `absolutise`
-        // calls are a no-op; we do them inline with flatMap to keep
-        // the single-Result shape this block used before the fix.
+        // BTA requires individual .kt files, not directories (#117).
         sources = expandKotlinSources(config.sources.map { absolutise(it, cwd) })
             .getOrElse { err ->
                 eprintln("error: could not list Kotlin sources under ${err.path}")
@@ -219,12 +155,6 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
 
     println("compiling ${config.name}...")
     backend.compile(request).getOrElse { error ->
-        // Daemon path captures kotlinc diagnostics into
-        // `CompilationFailed.diagnostics` + leftover `stderr`; the
-        // subprocess path inherits fds and leaves both fields empty
-        // because kotlinc already wrote to the terminal. Printing the
-        // rendered body before the one-line summary handles both
-        // shapes without double-printing.
         if (error is CompileError.CompilationFailed) {
             val body = renderCompilationFailure(error)
             if (body.isNotEmpty()) eprintln(body)
@@ -288,12 +218,6 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
         return BuildResult(config, classpath = null, javaPath = null)
     }
 
-    // Resolved only on a real rebuild so cached builds don't hit Maven
-    // Central for the plugin jar fetch. Per #65: native builds no longer
-    // provision the full kotlinc sidecar just to borrow plugin jars —
-    // `resolvePluginArgs` pulls the shaded compiler-plugin jars directly
-    // from Maven Central into `~/.kolt/cache` and feeds `-Xplugin=...`
-    // to konanc from there.
     val nativePluginArgs = resolvePluginArgs(config, paths, EXIT_BUILD_ERROR)
 
     ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
@@ -333,23 +257,12 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
     return BuildResult(config, classpath = null, javaPath = null)
 }
 
-/** Returns the newest mtime among all .def files declared in cinterop entries, or null if none. */
 private fun newestDefMtime(config: KoltConfig): Long? {
     if (config.cinterop.isEmpty()) return null
     val mtimes = config.cinterop.mapNotNull { fileMtime(it.def) }
     return if (mtimes.isEmpty()) null else mtimes.max()
 }
 
-/**
- * Runs `cinterop` for each [[cinterop]] entry in the config.
- *
- * Per-entry freshness check: if the previously generated klib and its sidecar
- * `.klib.stamp` file both exist and the stamp matches the stamp that would be
- * produced by the current entry + its .def mtime, the cinterop invocation is
- * skipped and the cached klib is reused.
- *
- * Returns the list of generated .klib paths to pass to konanc via -l.
- */
 private fun runCinterop(config: KoltConfig, paths: KoltPaths): List<String> {
     if (config.cinterop.isEmpty()) return emptyList()
     val managedCinteropBin = paths.cinteropBin(config.kotlin)
@@ -374,8 +287,6 @@ private fun runCinterop(config: KoltConfig, paths: KoltPaths): List<String> {
         }
         if (currentStamp != null) {
             writeFileAsString(stampPath, currentStamp).getOrElse { error ->
-                // Stamp write failure is non-fatal: the next build will simply
-                // re-run cinterop instead of reusing the cached klib.
                 eprintln("warning: failed to write cinterop stamp ${error.path}")
             }
         }
@@ -383,11 +294,6 @@ private fun runCinterop(config: KoltConfig, paths: KoltPaths): List<String> {
     }
 }
 
-/**
- * Resolves direct + transitive Kotlin/Native dependencies and returns their
- * on-disk `.klib` paths. Unlike [resolveDependencies] for jvm, this does not
- * read or write `kolt.lock` (lockfile support for native lands later).
- */
 internal fun resolveNativeDependencies(config: KoltConfig, paths: KoltPaths): List<String> {
     if (config.dependencies.isEmpty()) return emptyList()
 
@@ -415,7 +321,6 @@ internal fun doRun(config: KoltConfig, classpath: String?, appArgs: List<String>
         }
         return
     }
-
     if (!fileExists(CLASSES_DIR)) {
         eprintln("error: $CLASSES_DIR not found. Run 'kolt build' first.")
         exitProcess(EXIT_BUILD_ERROR)
@@ -431,10 +336,6 @@ internal fun doRun(config: KoltConfig, classpath: String?, appArgs: List<String>
 }
 
 internal fun doTest(testArgs: List<String> = emptyList(), useDaemon: Boolean = true) {
-    // Load the config once up front so we can dispatch on target before doing
-    // any compilation work. The native path compiles main + test in a single
-    // konanc invocation and therefore bypasses doBuild() entirely, unlike the
-    // jvm path which reuses the build artifacts from doBuild().
     val config = loadProjectConfig()
     if (config.target == "native") {
         doNativeTest(config, testArgs)
@@ -454,12 +355,6 @@ internal fun doTest(testArgs: List<String> = emptyList(), useDaemon: Boolean = t
     val consoleLauncherPath = ensureTool(paths, CONSOLE_LAUNCHER_SPEC, EXIT_TEST_ERROR)
     val managedKotlincBin = ensureKotlincBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_TEST_ERROR) }
 
-    // #65 review finding #2: resolve plugin args at test time, not via
-    // `BuildResult.pluginArgs` threaded through `doBuild`. The up-to-
-    // date compile path deliberately skips plugin resolution so that an
-    // offline cached build stays offline; test compilation always runs
-    // a kotlinc subprocess, so the fetch is both unavoidable and
-    // bounded to test runs.
     val pArgs = resolvePluginArgs(config, paths, EXIT_TEST_ERROR)
 
     val testConfig = config.copy(testSources = existingTestSources)
@@ -559,63 +454,22 @@ internal fun ensureJdkBinsFromConfig(config: KoltConfig, paths: KoltPaths): JdkB
     return ensureJdkBins(version, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
 }
 
-/**
- * Single sink that maps a [ToolchainError] to an `eprintln` + exit.
- * Every CLI entry point that unwraps a toolchain `Result` funnels
- * through here so the pre-daemon UX (one line of "error: …" on
- * stderr, then exit with the step-appropriate exit code) is
- * preserved verbatim. Callers in `ToolchainCommands`,
- * `PluginSupport`, and `BuildCommands` all share this helper.
- */
 internal fun exitWithToolchainError(err: ToolchainError, exitCode: Int): Nothing {
     eprintln("error: ${err.message}")
     exitProcess(exitCode)
 }
 
-// Warning wording pinned as a constant so unit tests can assert on
-// the exact string without hard-coding it a second time in each
-// branch's test. Kept internal so the tests in the same module can
-// reference it without exposing it on the public API.
 internal const val WARNING_DAEMON_DIR_UNWRITABLE =
     "warning: could not create daemon state directory — falling back to subprocess compile"
 
-/**
- * Picks the backend [doBuild] will hand the compile request to. If
- * [useDaemon] is false (user passed `--no-daemon`), the subprocess
- * backend is returned directly — no fallback wrapper, no precondition
- * probing, so the code path is exactly the pre-daemon one. Otherwise
- * the daemon preconditions are checked; on success we return a
- * [FallbackCompilerBackend] wrapping a freshly-constructed
- * [DaemonCompilerBackend] with [subprocessBackend] as the fallback and
- * [reportFallback] as the observer. On any precondition or wiring
- * failure we print a one-line warning via [warningSink] and degrade
- * to the subprocess backend — daemon is never load-bearing for
- * correctness (ADR 0016 §5).
- *
- * [absProjectPath] is **required** and must be the current absolute
- * cwd. It is passed in by [doBuild] after that routine has already
- * decided a failure to read cwd is a kolt-cannot-function condition
- * and hard-exited the process; [resolveCompilerBackend] therefore
- * does not need a separate cwd-unavailable branch of its own.
- *
- * Seams ([preconditionResolver], [daemonDirCreator],
- * [daemonBackendFactory], [warningSink]) are defaulted to production
- * helpers so callers pass only the first five arguments. Unit tests
- * substitute fakes to drive each degradation branch without touching
- * the filesystem or bringing up a real daemon.
- */
+// Daemon is never load-bearing for correctness (ADR 0016 §5): any
+// precondition or wiring failure degrades to the subprocess backend.
 internal fun resolveCompilerBackend(
     config: KoltConfig,
     paths: KoltPaths,
     subprocessBackend: CompilerBackend,
     useDaemon: Boolean,
     absProjectPath: String,
-    // #65 native client wiring: enabled `kolt.toml [plugins]` alias →
-    // compiler plugin jar classpath. The map is built by the caller
-    // (doBuild) so resolveCompilerBackend stays decoupled from the
-    // concrete jar lookup mechanism (kotlinc sidecar today, Maven fetch
-    // once the rest of #65 lands). An empty map means "no plugins" and
-    // collapses to spawnArgv omitting `--plugin-jars` entirely.
     pluginJars: Map<String, List<String>> = emptyMap(),
     preconditionResolver: (KoltPaths, String, String) -> Result<DaemonSetup, DaemonPreconditionError> =
         { p, kotlincVersion, cwd -> resolveDaemonPreconditions(p, kotlincVersion, cwd) },
@@ -630,13 +484,8 @@ internal fun resolveCompilerBackend(
         return subprocessBackend
     }
 
-    // spawnDetached opens the log path with O_CREAT but not the
-    // intermediate directory — if ~/.kolt/daemon/<projectHash>/ is
-    // missing the log file is silently dropped and the daemon's
-    // stderr lands in /dev/null. The JVM side already creates the
-    // directory for the socket bind (ADR 0016 §Socket path
-    // lifecycle), but that happens after the client has already
-    // tried to open the log, so we create it eagerly here.
+    // spawnDetached opens the log with O_CREAT but not the parent dir;
+    // create it before the daemon tries to bind the socket.
     if (daemonDirCreator(setup.daemonDir).getError() != null) {
         warningSink(WARNING_DAEMON_DIR_UNWRITABLE)
         return subprocessBackend
@@ -653,22 +502,8 @@ internal fun createDaemonBackend(
     setup: DaemonSetup,
     pluginJars: Map<String, List<String>>,
 ): CompilerBackend {
-    // #65 native client wiring: a daemon spawned with one plugin set keeps
-    // that set for its entire JVM lifetime (`--plugin-jars` is parsed once
-    // in `Main.parseArgs` and stored on `CliArgs.pluginJars`). If the user
-    // edits `kolt.toml [plugins]` between builds, naively reusing the same
-    // socket would attach the warm daemon's stale plugin classpath — for an
-    // alias that wasn't in the original spawn, `pluginJarResolver` returns
-    // `emptyList()` and `PluginTranslator` emits a `CompilerPlugin` with an
-    // empty classpath, which BTA either silently drops or fails on with a
-    // diagnostic unrelated to the user's source.
-    //
-    // Mixing a plugin-set fingerprint into the socket / log filename forces
-    // a different (and absent) socket on a plugin-set change, which in turn
-    // trips the ENOENT path in `connectOrSpawn` and spawns a fresh daemon
-    // with the new args. The old daemon stays running on its own socket
-    // until it idles out (or the next reaper sweep) — harmless: the
-    // ADR 0016 socket layout already isolates per-project state.
+    // Plugin jars are baked into the daemon at spawn time. A fingerprint
+    // in the socket name forces a new daemon when the plugin set changes.
     val fp = pluginsFingerprint(pluginJars)
     val socketPath = applyPluginsFingerprintToFile(setup.socketPath, fp)
     val logPath = applyPluginsFingerprintToFile(setup.logPath, fp)
@@ -683,11 +518,7 @@ internal fun createDaemonBackend(
     )
 }
 
-// Stable 8-hex SHA-256 prefix over the canonicalised plugin map. Sorting
-// the alias keys means iteration order does not affect the fingerprint;
-// the inner classpath order IS significant because BTA treats it as the
-// plugin's own classpath order. Empty input collapses to a fixed marker
-// so the no-plugin path keeps a single socket name.
+// Inner classpath order is significant (BTA plugin classpath order).
 internal fun pluginsFingerprint(pluginJars: Map<String, List<String>>): String {
     if (pluginJars.isEmpty()) return "noplugins"
     val canonical = pluginJars.entries
@@ -696,10 +527,6 @@ internal fun pluginsFingerprint(pluginJars: Map<String, List<String>>): String {
     return kolt.infra.sha256Hex(canonical.encodeToByteArray()).take(8)
 }
 
-// Inserts `-<fingerprint>` between the filename stem and its extension so
-// both `daemon.sock` and `daemon.log` become `daemon-<fp>.sock` /
-// `daemon-<fp>.log`. Confined to this helper so KoltPaths does not need
-// to learn about the plugin channel.
 internal fun applyPluginsFingerprintToFile(path: String, fingerprint: String): String {
     val slash = path.lastIndexOf('/')
     val dir = if (slash >= 0) path.substring(0, slash + 1) else ""

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -212,10 +212,6 @@ internal fun doUpdate() {
 internal fun doTree() {
     val config = loadProjectConfig()
 
-    // For JVM, `autoInjectedTestDeps` unconditionally injects kotlin-test-junit5
-    // so `kolt tree` has something to show even when the user declared no test
-    // deps. For native, that function returns empty (konanc bundles kotlin.test),
-    // so we gate on user-declared deps only.
     val hasAnyDeps = config.dependencies.isNotEmpty() ||
         config.testDependencies.isNotEmpty() ||
         autoInjectedTestDeps(config).isNotEmpty()
@@ -227,9 +223,6 @@ internal fun doTree() {
     val paths = resolveKoltPaths(EXIT_DEPENDENCY_ERROR)
 
     if (config.target == "native") {
-        // Native target: walk Gradle Module Metadata, not POMs. The rendered
-        // graph mirrors what NativeResolver actually links (redirected
-        // -linuxx64 names, kotlin-stdlib skipped per ADR 0011).
         val nativeLookup = createNativeLookup(
             config.repositories.values.toList(),
             paths.cacheBase,

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -10,11 +10,6 @@ fun main(args: Array<String>) {
         return
     }
 
-    // Kolt-level flags (consumed here, never forwarded to subcommands
-    // or to the user program via `--`). Only `--no-daemon` lives at
-    // this layer today. The flag is only recognised *before* the `--`
-    // passthrough sentinel so a user program that accepts `--no-daemon`
-    // itself (e.g. `kolt run -- --no-daemon`) still receives it intact.
     val argList = args.toList()
     val passthroughStart = argList.indexOf("--")
     val koltLevel = if (passthroughStart >= 0) argList.subList(0, passthroughStart) else argList

--- a/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
+++ b/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
@@ -15,10 +15,6 @@ import kolt.resolve.PluginFetcherDeps
 import kolt.resolve.fetchEnabledPluginJars
 import kotlin.system.exitProcess
 
-// Production wiring for the plugin jar fetcher's I/O seam. Every method
-// is a passthrough to the matching `kolt.infra` helper — isolated in one
-// place so unit tests can substitute a fake, and so the fetcher has a
-// single "production" construction site.
 private fun defaultPluginFetcherDeps(): PluginFetcherDeps = object : PluginFetcherDeps {
     override fun fileExists(path: String): Boolean = kolt.infra.fileExists(path)
     override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> =
@@ -34,16 +30,6 @@ private fun defaultPluginFetcherDeps(): PluginFetcherDeps = object : PluginFetch
     override fun warn(message: String) = eprintln("warning: $message")
 }
 
-// Resolve every enabled `kolt.toml [plugins]` entry to its cached jar
-// path as a flat `alias → path` map. Callers that need the derived
-// shapes (`-Xplugin=…` strings or the daemon-shaped
-// `alias → List<path>`) should call this once and map the result so a
-// rebuild does not pay the file-exists + re-hash cost per enabled
-// plugin twice. Errors: an unknown alias is a user config bug
-// (`EXIT_CONFIG_ERROR`); any other failure (download, mkdir, hash,
-// stamp write) is an operational error pinned to the caller-provided
-// [operationalExitCode] so `build` and `test` paths can distinguish
-// their own exit statuses.
 internal fun resolveEnabledPluginJarPaths(
     config: KoltConfig,
     paths: KoltPaths,
@@ -67,25 +53,7 @@ private fun resolveEnabledPluginJarsOrExit(
     }
 }
 
-// #65 review findings #3 + #8: the error-to-exit translation is a pure
-// function so every branch (including the HTTP 404 → EXIT_CONFIG_ERROR
-// special case) is unit-testable without process exit. The wrapper
-// above handles the eprintln + exitProcess side effects; every test
-// that wants to pin the mapping calls this function directly.
-//
-// Mapping rules:
-// - UnknownPlugin → config bug (EXIT_CONFIG_ERROR). User mistyped an
-//   alias in `kolt.toml [plugins]`.
-// - DownloadFailed / HttpFailed 404 → config bug. A 404 on a stable
-//   `org.jetbrains.kotlin:kotlin-*-compiler-plugin:<ver>` coordinate
-//   effectively always means the `kotlin = "<ver>"` pin in `kolt.toml`
-//   is wrong (or a rare JetBrains un-publish, which is indistinguishable
-//   from the user's perspective and still requires a config edit).
-// - DownloadFailed / other → operational. Network / write / TLS errors
-//   are not the user's fault and should propagate as the caller's
-//   operational exit code (build vs test).
-// - Cache dir / hash / stamp failures → operational. Local filesystem
-//   failures bubble up the same way the resolver treats them.
+// 404 on a plugin jar → EXIT_CONFIG_ERROR (bad kotlin version in kolt.toml).
 internal data class PluginFetchExit(val exitCode: Int, val message: String)
 
 internal fun mapPluginFetchErrorToExit(
@@ -124,9 +92,6 @@ private fun formatDownloadError(err: DownloadError): String = when (err) {
     is DownloadError.WriteFailed -> "write failed to ${err.path}"
 }
 
-// #65: derive `-Xplugin=<jar>` arguments for kotlinc / konanc subprocess
-// calls. Used by the JVM subprocess fallback path and the native konanc
-// build / test paths — none of which talk to the warm daemon.
 internal fun resolvePluginArgs(
     config: KoltConfig,
     paths: KoltPaths,
@@ -134,11 +99,6 @@ internal fun resolvePluginArgs(
 ): List<String> =
     resolveEnabledPluginJarsOrExit(config, paths, exitCode).values.map { "-Xplugin=$it" }
 
-// #65 daemon path: alias → jar classpath (single-element list per alias
-// today, since plugin jars are shaded singletons). Consumed by
-// `resolveCompilerBackend(pluginJars=…)` → `DaemonCompilerBackend`'s
-// `--plugin-jars` argv builder. The list shape is forward-compatible
-// with a future plugin that ships multiple jars.
 internal fun resolvePluginJarsMap(
     config: KoltConfig,
     paths: KoltPaths,

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -59,7 +59,7 @@ fun parseConfig(tomlString: String): Result<KoltConfig, ConfigError> {
             ))
         }
         validateMainFqn(config.main).getError()?.let { return Err(it) }
-        // ktoml preserves quotes in map keys; strip them
+        // ktoml preserves quotes in map keys; strip them.
         val cleanedDeps = config.dependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }
         val cleanedTestDeps = config.testDependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }
         val cleanedRepos = config.repositories

--- a/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
+++ b/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
@@ -11,11 +11,6 @@ internal data class KoltPaths(val home: String) {
     val toolchainsDir: String = "$home/.kolt/toolchains"
     val daemonBaseDir: String = "$home/.kolt/daemon"
 
-    // Per-project daemon working directory. The hash is an opaque key
-    // derived from the absolute project path (see projectHashOf); it
-    // only has to be stable within a single kolt install. Daemon state
-    // (socket file + stderr log) is confined here so a daemon crash of
-    // project A cannot step on project B.
     fun daemonDir(projectHash: String): String = "$daemonBaseDir/$projectHash"
     fun daemonSocketPath(projectHash: String): String = "${daemonDir(projectHash)}/daemon.sock"
     fun daemonLogPath(projectHash: String): String = "${daemonDir(projectHash)}/daemon.log"

--- a/src/nativeMain/kotlin/kolt/config/Main.kt
+++ b/src/nativeMain/kotlin/kolt/config/Main.kt
@@ -4,26 +4,12 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 
-// kolt.toml's `main` field holds a Kotlin top-level function FQN. The bare
-// name "main" refers to `fun main()` in the root package; "com.example.main"
-// refers to `fun main()` in `com.example`.
-//
-// For target = "native", konanc consumes the FQN directly as its `-e` flag.
-// For target = "jvm", we derive the JVM facade class name assuming the file
-// is named `Main.kt`, which is the init template's convention and the only
-// shape kolt supports without `@JvmName`. A future `jvm_main_class` override
-// is noted as YAGNI in the PR that introduced this scheme.
+// Derives the JVM facade class from a Kotlin FQN, assuming the file is Main.kt.
 fun jvmMainClass(main: String): String {
     val prefix = main.substringBeforeLast("main")
     return "${prefix}MainKt"
 }
 
-// Validates that [main] is a Kotlin top-level function FQN. Either the bare
-// literal "main", or a dotted package followed by ".main".
-//
-// Rejects JVM-style class names (anything ending in "Kt") with a migration
-// hint showing the equivalent function FQN the user likely meant. Other
-// malformed values get a generic error.
 fun validateMainFqn(main: String): Result<Unit, ConfigError.ParseFailed> {
     if (main.endsWith("Kt")) {
         return Err(ConfigError.ParseFailed(
@@ -40,10 +26,6 @@ fun validateMainFqn(main: String): Result<Unit, ConfigError.ParseFailed> {
     return Ok(Unit)
 }
 
-// Best-effort suggestion when the user supplied a JVM facade class name:
-// drop the trailing "Kt" and replace the last segment with "main".
-// "MainKt" → "main"; "com.example.MainKt" → "com.example.main";
-// "com.example.AppKt" → "com.example.main".
 private fun jvmClassToFqnHint(main: String): String {
     val withoutKt = main.removeSuffix("Kt")
     val dot = withoutKt.lastIndexOf('.')

--- a/src/nativeMain/kotlin/kolt/daemon/wire/FrameCodec.kt
+++ b/src/nativeMain/kotlin/kolt/daemon/wire/FrameCodec.kt
@@ -16,22 +16,7 @@ sealed interface FrameError {
     data class Transport(val cause: UnixSocketError) : FrameError
 }
 
-/**
- * Length-prefix + JSON framing over a [UnixSocket] stream.
- *
- * Wire contract (see ADR 0016 §3 — the native and JVM sides must stay
- * in lockstep or the daemon breaks):
- *
- * - 4-byte big-endian unsigned length prefix, counting body bytes only.
- * - UTF-8 JSON body produced by `kotlinx.serialization` with
- *   `classDiscriminator = "type"`; sealed variants are identified by
- *   their `@SerialName`.
- * - Frames larger than [MAX_BODY_BYTES] are rejected symmetrically on
- *   both the write and read paths.
- *
- * All fallible paths return a [FrameError] — consistent with ADR 0001,
- * no exception ever escapes.
- */
+// Wire format: ADR 0016 §3. Native and JVM sides must stay in lockstep.
 object FrameCodec {
 
     const val MAX_BODY_BYTES: Int = 64 * 1024 * 1024
@@ -91,9 +76,6 @@ object FrameCodec {
         }
     }
 
-    // A clean EOF at the very start of a frame (zero bytes before the
-    // header arrives) is a normal shutdown; a partial header is a
-    // truncated frame. Everything else is a transport-level failure.
     private fun headerTransportError(err: UnixSocketError): FrameError = when (err) {
         is UnixSocketError.UnexpectedEof ->
             if (err.received == 0) FrameError.Eof

--- a/src/nativeMain/kotlin/kolt/daemon/wire/Message.kt
+++ b/src/nativeMain/kotlin/kolt/daemon/wire/Message.kt
@@ -3,18 +3,8 @@ package kolt.daemon.wire
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/**
- * Native mirror of `kolt.daemon.protocol.Message` from the JVM
- * `kolt-compiler-daemon` subproject. Field names and serial names are
- * load-bearing — the JSON wire format documented in ADR 0016 is the
- * contract shared between the two sides, and drift in either file
- * breaks the daemon.
- *
- * This file is deliberately duplicated rather than shared via a
- * commonMain source set: kolt today only speaks this protocol from one
- * native client and one JVM server, so a shared module would trade
- * straight-line readability for generic build plumbing we do not need.
- */
+// Mirror of JVM kolt.daemon.protocol.Message. Field/serial names are
+// load-bearing wire contract (ADR 0016) — drift breaks the daemon.
 @Serializable
 sealed interface Message {
 

--- a/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
+++ b/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
@@ -124,14 +124,6 @@ fun isDirectory(path: String): Boolean {
     }
 }
 
-/**
- * Returns `true` iff [path] resolves (via `stat(2)`, following
- * symlinks) to a regular file. Distinct from a naive "not a
- * directory" test because symlinks, FIFOs, sockets, and device
- * nodes are also not directories but are not regular files either.
- * Used by [listJarFiles] to filter out anything a caller cannot
- * hand to a JVM URL classloader as a jar.
- */
 @OptIn(ExperimentalForeignApi::class)
 fun isRegularFile(path: String): Boolean {
     memScoped {
@@ -150,7 +142,6 @@ fun fileMtime(path: String): Long? {
     }
 }
 
-/** Return the newest mtime among all .kt files in the given directories. 0 if no files found. */
 fun newestMtime(directories: List<String>): Long {
     var newest = 0L
     for (dir in directories) {
@@ -201,17 +192,6 @@ private fun collectAllFileMtimes(directory: String, onFile: (Long) -> Unit) {
     }
 }
 
-/**
- * Non-recursively lists entries in [path] whose name ends with `.jar`
- * **and** which resolve (via `stat(2)`) to regular files, returned
- * as absolute paths (`$path/$name`) in lexicographic order. Symlinks
- * are followed, so a symlink pointing at a real jar is admitted and
- * a symlink pointing at a directory named `foo.jar` is filtered out.
- * Returns [ListFilesFailed] if the directory cannot be opened. An
- * empty successful result is distinct from the error case, so a
- * caller can treat "directory missing" (Err) and "directory exists
- * but has no jars" (empty Ok) differently.
- */
 @OptIn(ExperimentalForeignApi::class)
 fun listJarFiles(path: String): Result<List<String>, ListFilesFailed> {
     val dir = opendir(path) ?: return Err(ListFilesFailed(path))
@@ -265,24 +245,8 @@ fun listKotlinFiles(directory: String): Result<List<String>, ListFilesFailed> {
     return Ok(files)
 }
 
-// Expand a caller-supplied source path list to a flat list of .kt files.
-// Directory entries are walked recursively via `collectKotlinFiles`;
-// individual .kt files are kept verbatim; anything else (non-.kt file, or a
-// path that does not exist) is kept as-is so the caller can still surface
-// a useful backend error.
-//
-// Motivation: Phase A (kotlin-compiler-embeddable) accepted directories on
-// the kotlinc command line and walked them implicitly. Phase B's BTA
-// (`jvmCompilationOperationBuilder(sources: List<Path>, ...)`) requires
-// individual file paths and reports `Is a directory` on the first entry
-// that happens to be a directory — which turns a typical
-// `sources = ["src"]` into a hard failure. Expanding here keeps both
-// backends happy with one call site. See issue #117.
-//
-// Order is stable: entries within each directory are sorted by
-// `listKotlinFiles`, and the overall order preserves the caller's
-// `sources` list position so kotlinc / BTA see the same module-boundary
-// order a hand-written CLI would produce.
+// BTA requires individual file paths, not directories (issue #117).
+// Non-.kt / non-existent entries are kept as-is for backend error reporting.
 fun expandKotlinSources(sources: List<String>): Result<List<String>, ListFilesFailed> {
     val expanded = mutableListOf<String>()
     for (entry in sources) {
@@ -384,28 +348,13 @@ fun homeDirectory(): Result<String, HomeNotFound> {
     }
 }
 
-/**
- * Returns the absolute path of the current working directory, or
- * `null` if `getcwd(3)` fails. Distinct from [homeDirectory] so
- * callers can use a cwd they just entered without re-reading `$HOME`.
- */
 @OptIn(ExperimentalForeignApi::class)
 fun currentWorkingDirectory(): String? = memScoped {
     val buf = allocArray<ByteVar>(PATH_MAX)
     getcwd(buf, PATH_MAX.toULong())?.toKString()
 }
 
-/**
- * If [path] starts with `/`, returns it unchanged. Otherwise returns
- * `"$cwd/$path"` (with any trailing slash on [cwd] collapsed so the
- * result never contains `//`). This is deliberately not a
- * path-canonicalising helper — it does **not** resolve `..`, `.`,
- * or symlinks. It exists so [doBuild] can hand absolute source /
- * output paths to any backend without relying on the backend
- * inheriting the kolt process's cwd, which is a load-bearing
- * assumption today for the daemon path (see ADR 0016 §3 and the
- * note on `CompileRequest.workingDir`).
- */
+// Does not resolve `..`, `.`, or symlinks — purely prepends cwd.
 fun absolutise(path: String, cwd: String): String {
     if (path.startsWith('/')) return path
     val base = if (cwd.endsWith('/')) cwd.dropLast(1) else cwd

--- a/src/nativeMain/kotlin/kolt/infra/Process.kt
+++ b/src/nativeMain/kotlin/kolt/infra/Process.kt
@@ -15,12 +15,6 @@ sealed class ProcessError {
     data object PopenFailed : ProcessError()
 }
 
-// Formats a [ProcessError] into a short, lowercase, prefix-free
-// message. Callers are responsible for prepending their own
-// "error:" / "warning:" tag at the output site — keeping the
-// prefix out here lets the same message round-trip through
-// [ToolchainError] (which re-prepends "error:" at eprintln time)
-// without a fragile `.removePrefix("error: ")`.
 fun formatProcessError(error: ProcessError, context: String): String = when (error) {
     is ProcessError.NonZeroExit -> "$context failed with exit code ${error.exitCode}"
     is ProcessError.EmptyArgs -> "no command to execute"
@@ -39,7 +33,6 @@ fun executeCommand(args: List<String>): Result<Int, ProcessError> {
         return Err(ProcessError.ForkFailed)
     }
     if (pid == 0) {
-        // child process
         memScoped {
             val argv = allocArray<CPointerVar<ByteVar>>(args.size + 1)
             for (i in args.indices) {
@@ -47,18 +40,15 @@ fun executeCommand(args: List<String>): Result<Int, ProcessError> {
             }
             argv[args.size] = null
             execvp(args[0], argv)
-            // execvp only returns on error
             _exit(127)
         }
     }
-    // parent process
     memScoped {
         val status = alloc<IntVar>()
         while (waitpid(pid, status.ptr, 0) == -1) {
             if (errno != EINTR) return Err(ProcessError.WaitFailed)
         }
         val raw = status.value
-        // WIFEXITED: (status & 0x7F) == 0
         return if ((raw and 0x7F) == 0) {
             val exitCode = (raw shr 8) and 0xFF
             if (exitCode == 0) Ok(0) else Err(ProcessError.NonZeroExit(exitCode))
@@ -68,37 +58,8 @@ fun executeCommand(args: List<String>): Result<Int, ProcessError> {
     }
 }
 
-// Spawn a child that keeps running after the parent exits. Used by
-// DaemonCompilerBackend to start the warm compiler JVM: the kolt
-// process that initiates the spawn is short-lived, but the daemon it
-// creates must survive across builds.
-//
-// Double-fork idiom: fork → setsid → fork → exec. The intermediate
-// child calls setsid() to become the leader of a new session with no
-// controlling terminal, then forks a grandchild. The intermediate
-// child immediately _exit(0), leaving the grandchild reparented to
-// PID 1 (so our original parent never has to reap it) and detached
-// from the session it inherited. [logPath], if non-null, receives the
-// grandchild's stdout and stderr (append mode) — stdin is always
-// redirected away from the parent's terminal. The intermediate child
-// is reaped synchronously so the caller observes no zombie.
-//
-// **`Ok(Unit)` does not mean `execvp` succeeded.** It means the
-// fork/setsid/fork/intermediate-reap chain completed; the grandchild
-// has started running but may `_exit(127)` when `execvp` fails on a
-// missing or non-executable target (for example, the daemon jar is
-// the wrong path). Callers that care (DaemonCompilerBackend does)
-// must observe spawn success indirectly by polling the socket: if
-// the grandchild died before binding, the retry loop hits the budget
-// and returns `BackendUnavailable`. We deliberately do not pass the
-// grandchild's pid back — reaping the intermediate already means the
-// grandchild is reparented to init, so waitpid() from the kolt parent
-// would return ECHILD regardless.
-//
-// This is separate from [executeCommand] because reusing fork+execvp
-// from there would entangle the managed-subprocess path (parent waits
-// for completion) with the detached-daemon path (parent must not
-// wait).
+// Double-fork detach. Ok(Unit) means the fork chain completed, not
+// that execvp succeeded — callers must poll the socket to confirm.
 @OptIn(ExperimentalForeignApi::class)
 fun spawnDetached(args: List<String>, logPath: String? = null): Result<Unit, ProcessError> {
     if (args.isEmpty()) return Err(ProcessError.EmptyArgs)
@@ -107,11 +68,6 @@ fun spawnDetached(args: List<String>, logPath: String? = null): Result<Unit, Pro
     if (pid1 < 0) return Err(ProcessError.ForkFailed)
 
     if (pid1 == 0) {
-        // Intermediate child. `setsid` fails only if we are already a
-        // session leader, which should not happen post-fork; when it
-        // does, the grandchild still inherits the parent's process
-        // group and controlling terminal, which is acceptable for a
-        // daemon that never reads a tty, so we log rather than abort.
         if (setsid() < 0) {
             fputs("spawnDetached: setsid() failed, errno=$errno\n", stderr)
         }
@@ -119,16 +75,6 @@ fun spawnDetached(args: List<String>, logPath: String? = null): Result<Unit, Pro
         if (pid2 < 0) _exit(127)
         if (pid2 > 0) _exit(0)
 
-        // Grandchild. Redirect fds 0/1/2 before execvp so the daemon
-        // never inherits our terminal. If /dev/null is unavailable or
-        // the log file cannot be opened, fall through to whichever
-        // descriptor did open — we never leave stdin pointing at the
-        // caller's terminal.
-        //
-        // open() is variadic in C (the mode argument is only
-        // consulted when O_CREAT is set); K/N exposes the third slot
-        // as `vararg Any?`, so we pass the mode as an Int value and
-        // let the vararg plumbing box it.
         val devNull = open("/dev/null", O_RDWR)
         val logFd = if (logPath != null) {
             val mode = S_IRUSR or S_IWUSR
@@ -141,9 +87,6 @@ fun spawnDetached(args: List<String>, logPath: String? = null): Result<Unit, Pro
         if (stdinFd >= 0) {
             dup2(stdinFd, STDIN_FILENO)
         } else {
-            // Neither /dev/null nor the log file opened. Close fd 0
-            // explicitly so the daemon cannot accidentally read from
-            // whatever descriptor the caller had on stdin.
             platform.posix.close(STDIN_FILENO)
         }
         if (outFd >= 0) {
@@ -164,9 +107,6 @@ fun spawnDetached(args: List<String>, logPath: String? = null): Result<Unit, Pro
         }
     }
 
-    // Parent: reap the intermediate child. The grandchild has already
-    // been reparented to PID 1 by the time the intermediate exits, so
-    // this wait completes as soon as _exit(0) runs above.
     memScoped {
         val status = alloc<IntVar>()
         while (waitpid(pid1, status.ptr, 0) == -1) {
@@ -188,7 +128,6 @@ fun executeAndCapture(command: String): Result<String, ProcessError> {
         }
     }
     val status = pclose(fp)
-    // WIFEXITED check
     val exitCode = if ((status and 0x7F) == 0) {
         (status shr 8) and 0xFF
     } else {

--- a/src/nativeMain/kotlin/kolt/infra/SelfExe.kt
+++ b/src/nativeMain/kotlin/kolt/infra/SelfExe.kt
@@ -18,14 +18,7 @@ import platform.posix.strerror
 
 data class SelfExeError(val errno: Int, val message: String)
 
-// Resolves the absolute path of the running kolt binary via the Linux
-// /proc/self/exe magic symlink. Used by DaemonCompilerBackend's jar
-// fallback chain to locate the sibling libexec/ directory in installed
-// layouts and the sibling build/libs/ jar in dev layouts.
-//
-// PATH_MAX is the accepted upper bound for a Linux filesystem path.
-// readlink does not write a trailing NUL, so we reserve one byte and
-// terminate the buffer explicitly before decoding.
+// readlink does not NUL-terminate; we reserve one byte and add it.
 @OptIn(ExperimentalForeignApi::class)
 fun readSelfExe(): Result<String, SelfExeError> {
     return memScoped {

--- a/src/nativeMain/kotlin/kolt/infra/Sha256.kt
+++ b/src/nativeMain/kotlin/kolt/infra/Sha256.kt
@@ -9,9 +9,6 @@ import platform.posix.*
 
 data class Sha256Error(val path: String)
 
-// In-memory SHA-256 hex digest. Callers that need only a byte-array hash
-// (e.g. hashing a project path for the daemon socket directory name) use
-// this instead of dragging bytes through a temporary file.
 fun sha256Hex(bytes: ByteArray): String {
     val digest = SHA256()
     digest.update(bytes)

--- a/src/nativeMain/kotlin/kolt/infra/net/SockaddrUn.kt
+++ b/src/nativeMain/kotlin/kolt/infra/net/SockaddrUn.kt
@@ -11,24 +11,9 @@ import platform.posix.AF_UNIX
 import platform.posix.memset
 import platform.posix.socklen_t
 
-// Linux caps AF_UNIX pathnames at 108 bytes including the NUL terminator;
-// see unix(7). Shared between UnixSocket (production) and UnixEchoServer
-// (test fixture) so both agree on the same pre-flight length check.
+// unix(7): AF_UNIX pathnames capped at 108 bytes including NUL.
 internal const val SUN_PATH_CAPACITY = 108
 
-/**
- * Populate a pre-allocated [sockaddr_un] with an AF_UNIX filesystem path
- * and return the matching `socklen_t` for `connect` / `bind` calls.
- *
- * Callers must ensure [pathBytes] is strictly shorter than
- * [SUN_PATH_CAPACITY] (room for the trailing NUL) — the oversize case is
- * reported with path-specific error variants at the call sites, so this
- * helper does not re-validate.
- *
- * The returned length is `offsetof(sockaddr_un, sun_path) + strlen + 1`
- * rather than `sizeof(sockaddr_un)`, keeping the door open for Linux
- * abstract sockets (leading NUL in `sun_path`) later.
- */
 @OptIn(ExperimentalForeignApi::class)
 internal fun fillSockaddrUn(addr: sockaddr_un, pathBytes: ByteArray): socklen_t {
     memset(addr.ptr, 0, sizeOf<sockaddr_un>().convert())

--- a/src/nativeMain/kotlin/kolt/infra/net/UnixSocket.kt
+++ b/src/nativeMain/kotlin/kolt/infra/net/UnixSocket.kt
@@ -25,18 +25,7 @@ import platform.posix.sockaddr
 import platform.posix.socket
 import platform.posix.strerror
 
-/**
- * AF_UNIX stream socket client, used by the native daemon client.
- *
- * Raw cinterop types (sockaddr_un, socket/connect/send/recv/close) are
- * confined to this file so callers never see them.
- *
- * Not thread-safe. The close-flag guard is a plain check-then-act, so
- * concurrent `close()` calls can double-close the underlying fd — and
- * once the kernel recycles a descriptor number, the second close will
- * hit an unrelated fd. Callers must confine a `UnixSocket` instance to
- * a single thread, or synchronize externally.
- */
+// Not thread-safe: concurrent close() can double-close the fd.
 class UnixSocket internal constructor(private val fd: Int) : AutoCloseable {
     private var closed = false
 
@@ -105,10 +94,6 @@ class UnixSocket internal constructor(private val fd: Int) : AutoCloseable {
         return Ok(buf)
     }
 
-    /**
-     * Half-close the write side of the socket, signalling EOF to the
-     * peer while still allowing incoming bytes to be read.
-     */
     @OptIn(ExperimentalForeignApi::class)
     fun shutdownWrite(): Result<Unit, UnixSocketError> {
         if (shutdown(fd, SHUT_WR) != 0) {
@@ -129,12 +114,6 @@ class UnixSocket internal constructor(private val fd: Int) : AutoCloseable {
         @OptIn(ExperimentalForeignApi::class)
         fun connect(path: String): Result<UnixSocket, UnixSocketError> {
             val pathBytes = path.encodeToByteArray()
-            // Kolt's own pre-flight (sun_path capacity) is a kolt bug
-            // when it trips, distinct from a kernel-side ENAMETOOLONG
-            // on the connect() syscall — so callers can classify "kolt
-            // built a bad path" as InternalMisuse instead of lumping
-            // it in with environment-level ConnectFailed. See
-            // DaemonCompilerBackend.mapFatalConnectError.
             if (pathBytes.size >= SUN_PATH_CAPACITY) {
                 return Err(
                     UnixSocketError.InvalidArgument(
@@ -152,12 +131,6 @@ class UnixSocket internal constructor(private val fd: Int) : AutoCloseable {
             return memScoped {
                 val addr = alloc<sockaddr_un>()
                 val addrLen = fillSockaddrUn(addr, pathBytes)
-                // Retry EINTR at the primitive layer, consistent with
-                // sendAll / recvExact above. Propagating EINTR to the
-                // caller would force every upstream (DaemonCompilerBackend,
-                // future `kolt watch` clients) to re-implement the same
-                // loop or misclassify transient signal noise as a fatal
-                // backend failure.
                 var rc: Int
                 while (true) {
                     rc = platform.posix.connect(

--- a/src/nativeMain/kotlin/kolt/resolve/AddDependency.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/AddDependency.kt
@@ -48,7 +48,6 @@ fun addDependencyToToml(
 ): Result<String, AlreadyExists> {
     val sectionHeader = if (isTest) "[test-dependencies]" else "[dependencies]"
 
-    // Check if the dependency already exists in the target section
     if (containsDependency(toml, groupArtifact, sectionHeader)) {
         return Err(AlreadyExists(groupArtifact))
     }
@@ -58,12 +57,9 @@ fun addDependencyToToml(
     val sectionIndex = lines.indexOfFirst { it.trim() == sectionHeader }
 
     if (sectionIndex >= 0) {
-        // Insert before trailing blank lines of the section
         val insertIndex = findSectionContentEnd(lines, sectionIndex)
         lines.add(insertIndex, newEntry)
     } else {
-        // Section doesn't exist — append it
-        // Ensure a blank line separator before the new section
         if (lines.isNotEmpty() && lines.last().isNotEmpty()) {
             lines.add("")
         }
@@ -72,7 +68,6 @@ fun addDependencyToToml(
     }
 
     val result = lines.joinToString("\n")
-    // Preserve trailing newline if input had one, or ensure one for new sections
     return Ok(if (result.endsWith("\n")) result else "$result\n")
 }
 

--- a/src/nativeMain/kotlin/kolt/resolve/DepsTree.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/DepsTree.kt
@@ -47,36 +47,14 @@ private fun isIncludedDep(dep: PomDependency): Boolean {
     return scope == "compile" || scope == "runtime"
 }
 
-/**
- * Information required to render a single node in the native dependency tree.
- * The display coordinate is the *redirected* target (e.g. `...-linuxx64`), so
- * users see the klib that will actually be linked rather than the root module
- * coordinate they declared in `kolt.toml`. Transitive deps are the contents of
- * the linux_x64 variant's `dependencies[]` from Gradle Module Metadata.
- */
 data class NativeNodeInfo(
     val displayGroupArtifact: String,
     val displayVersion: String,
     val dependencies: List<Pair<String, String>> = emptyList()
 )
 
-/**
- * Native counterpart of [buildDependencyTree]. Walks Gradle Module Metadata
- * via [nativeLookup] instead of POMs, rendering the redirected `-linuxx64`
- * display names and skipping kotlin-stdlib / kotlin-stdlib-common (ADR 0011)
- * at both direct and transitive positions.
- *
- * Note: this is a *display* walker, not a resolver. It does not perform the
- * "highest-version-wins" conflict resolution that [kolt.resolve.resolveNative]
- * applies across the whole graph, so two branches of the rendered tree can
- * show different versions of the same coordinate while the actual link would
- * pick only the highest. Matches the behaviour of [buildDependencyTree] for
- * JVM targets.
- *
- * When [nativeLookup] returns null (metadata missing or unparseable for a
- * coordinate), the tree renders that coordinate as a leaf with no children
- * rather than aborting — a partial tree is still useful.
- */
+// Display-only walker — no conflict resolution; two branches may show different
+// versions of the same coordinate. Skips kotlin-stdlib (ADR 0011).
 fun buildNativeDependencyTree(
     directDeps: Map<String, String>,
     nativeLookup: (groupArtifact: String, version: String) -> NativeNodeInfo?
@@ -110,9 +88,7 @@ private fun buildNativeNode(
     return TreeNode(info.displayGroupArtifact, info.displayVersion, children)
 }
 
-// Mirrors NativeResolver's stdlib skip policy (ADR 0011). Duplicated here so
-// the tree walker can be used with a stub lookup in tests without pulling in
-// NativeResolver; the two predicates must stay in sync.
+// Must stay in sync with NativeResolver's stdlib skip (ADR 0011).
 private fun isNativeStdlibSkipped(groupArtifact: String): Boolean =
     groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib" ||
         groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib-common"

--- a/src/nativeMain/kotlin/kolt/resolve/GradleMetadata.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/GradleMetadata.kt
@@ -5,23 +5,12 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 
-/**
- * Redirect target when a Kotlin Multiplatform module's .module file
- * redirects the JVM variant to a platform-specific artifact.
- */
 data class JvmRedirect(
     val group: String,
     val module: String,
     val version: String
 )
 
-/**
- * Parses a Gradle Module Metadata JSON string and extracts the JVM
- * platform redirect if present. Returns null when:
- * - the JSON is invalid
- * - no variant has `org.jetbrains.kotlin.platform.type` = "jvm"
- * - the JVM variant has no `available-at` redirect
- */
 fun parseJvmRedirect(moduleJson: String): JvmRedirect? {
     val metadata = try {
         lenientJson.decodeFromString<GradleModuleMetadata>(moduleJson)
@@ -36,8 +25,6 @@ fun parseJvmRedirect(moduleJson: String): JvmRedirect? {
 
         val availableAt = variant.availableAt
         if (availableAt == null) {
-            // A JVM variant without available-at means the library itself
-            // provides a JVM jar — no redirect needed.
             return null
         }
         if (redirect == null) {
@@ -51,22 +38,12 @@ fun parseJvmRedirect(moduleJson: String): JvmRedirect? {
     return redirect
 }
 
-/**
- * Redirect target for a Kotlin/Native platform variant. A multiplatform root
- * module redirects each native target to a separate module, e.g.
- * `kotlinx-coroutines-core` → `kotlinx-coroutines-core-linuxx64` for linux_x64.
- */
 data class NativeRedirect(
     val group: String,
     val module: String,
     val version: String
 )
 
-/**
- * A resolved native variant from a platform-specific module file. Carries the
- * `.klib` file reference (relative URL and sha256) and the transitive dependencies
- * declared in the Gradle module metadata.
- */
 data class NativeArtifact(
     val klibFileUrl: String,
     val klibSha256: String,
@@ -79,23 +56,8 @@ data class NativeDependency(
     val version: String
 )
 
-/**
- * Parses a Gradle Module Metadata JSON and extracts the available-at redirect
- * for the given Kotlin/Native target (e.g. "linux_x64"). Returns null when the
- * JSON is invalid, no matching variant exists, or matching variants exist but
- * none have an available-at redirect.
- *
- * A variant matches when ALL of these attributes are present:
- * - `org.jetbrains.kotlin.platform.type` == "native"
- * - `org.jetbrains.kotlin.native.target` == <nativeTarget>
- * - `org.gradle.usage` == "kotlin-api"
- * - `org.gradle.category` == "library"
- *
- * Unlike [parseJvmRedirect], a matching variant without `available-at` is
- * skipped rather than aborting: native modules list many targets in parallel,
- * and an earlier target with no redirect does not imply the requested target
- * is missing.
- */
+// Unlike parseJvmRedirect, a variant without available-at is skipped (not aborted)
+// because native modules list many targets in parallel.
 fun parseNativeRedirect(moduleJson: String, nativeTarget: String): NativeRedirect? {
     val metadata = try {
         lenientJson.decodeFromString<GradleModuleMetadata>(moduleJson)
@@ -115,12 +77,6 @@ fun parseNativeRedirect(moduleJson: String, nativeTarget: String): NativeRedirec
     return null
 }
 
-/**
- * Parses a Gradle Module Metadata JSON (a platform-specific redirect target)
- * and extracts the `.klib` file and dependencies for the given Kotlin/Native
- * target. Returns null when the JSON is invalid, no matching variant exists,
- * or the matching variant has no `.klib` file entry.
- */
 fun parseNativeArtifact(moduleJson: String, nativeTarget: String): NativeArtifact? {
     val metadata = try {
         lenientJson.decodeFromString<GradleModuleMetadata>(moduleJson)
@@ -143,13 +99,6 @@ fun parseNativeArtifact(moduleJson: String, nativeTarget: String): NativeArtifac
     return null
 }
 
-/**
- * Returns true when the JSON decodes as a well-formed Gradle Module Metadata
- * document (v1.1 schema, the subset kolt cares about). Use this to distinguish
- * "JSON is broken" from "JSON is valid but no variant matches our target",
- * since [parseNativeRedirect] and [parseNativeArtifact] both return null in
- * both cases.
- */
 internal fun isValidGradleModuleJson(moduleJson: String): Boolean =
     try {
         lenientJson.decodeFromString<GradleModuleMetadata>(moduleJson)

--- a/src/nativeMain/kotlin/kolt/resolve/Lockfile.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Lockfile.kt
@@ -15,20 +15,7 @@ sealed class LockfileError {
 
 data class LockEntry(val version: String, val sha256: String, val transitive: Boolean = false)
 
-/**
- * Domain model for kolt.lock. Serialized as JSON (v2):
- * ```json
- * {
- *   "version": 2,
- *   "kotlin": "2.1.0",
- *   "jvm_target": "17",
- *   "dependencies": {
- *     "group:artifact": { "version": "1.0.0", "sha256": "...", "transitive": false }
- *   }
- * }
- * ```
- * V1 lockfiles (without `transitive` field) are accepted with `transitive` defaulting to `false`.
- */
+// V1 lockfiles (without `transitive` field) are accepted with transitive defaulting to false.
 data class Lockfile(
     val version: Int,
     val kotlin: String,

--- a/src/nativeMain/kotlin/kolt/resolve/PomParser.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/PomParser.kt
@@ -57,7 +57,6 @@ fun parsePom(xml: String): Result<PomInfo, PomParseError> {
         }
     }
 
-    // Build interpolation map: explicit properties + project.* builtins
     val interpolationMap = buildInterpolationMap(properties, projectGroupId, projectVersion)
 
     val parent = root.child("parent")?.let { p ->
@@ -119,7 +118,6 @@ private fun parseDependencyElement(elem: XmlElement, interpolationMap: Map<Strin
 
 private fun interpolate(value: String, properties: Map<String, String>): String {
     var result = value
-    // Iterative interpolation to handle nested references (max 10 passes)
     repeat(10) {
         val next = PROPERTY_REGEX.replace(result) { match ->
             val key = match.groupValues[1]
@@ -132,8 +130,6 @@ private fun interpolate(value: String, properties: Map<String, String>): String 
 }
 
 private val PROPERTY_REGEX = Regex("""\$\{([^}]+)}""")
-
-// --- Minimal XML parser ---
 
 private class XmlElement(
     val name: String,
@@ -156,13 +152,11 @@ private fun parseElement(xml: String, start: Int): XmlElement? {
     val tagStart = xml.indexOf('<', start)
     if (tagStart == -1) return null
 
-    // Self-closing tag
     val selfCloseMatch = Regex("""<(\w[\w.\-]*)(\s[^>]*)?\s*/>""").find(xml, tagStart)
     if (selfCloseMatch != null && selfCloseMatch.range.first == tagStart) {
         return XmlElement(selfCloseMatch.groupValues[1], null, emptyList())
     }
 
-    // Opening tag
     val openMatch = Regex("""<(\w[\w.\-]*)(\s[^>]*)?>""").find(xml, tagStart) ?: return null
     if (openMatch.range.first != tagStart) return null
 
@@ -170,13 +164,11 @@ private fun parseElement(xml: String, start: Int): XmlElement? {
     val closeTag = "</$tagName>"
     val contentStart = openMatch.range.last + 1
 
-    // Find matching close tag (handle nesting)
     val closeIndex = findMatchingClose(xml, tagName, contentStart)
     if (closeIndex == -1) return null
 
     val content = xml.substring(contentStart, closeIndex)
 
-    // Try to parse children
     val children = mutableListOf<XmlElement>()
     var pos = 0
     while (pos < content.length) {
@@ -186,7 +178,6 @@ private fun parseElement(xml: String, start: Int): XmlElement? {
         val child = parseElement(content, nextTag)
         if (child != null) {
             children.add(child)
-            // Advance past this child element
             val childClose = findElementEnd(content, child.name, nextTag)
             pos = if (childClose != -1) childClose else content.length
         } else {
@@ -209,13 +200,10 @@ private fun findMatchingClose(xml: String, tagName: String, start: Int): Int {
         if (nextClose == -1) return -1
 
         if (nextOpen != -1 && nextOpen < nextClose) {
-            // Check it's actually an open tag (not a substring match)
             val afterOpen = nextOpen + openPattern.length
             if (afterOpen < xml.length && (xml[afterOpen] == '>' || xml[afterOpen] == ' ' || xml[afterOpen] == '/')) {
-                // Check for self-closing
                 val closeBracket = xml.indexOf('>', afterOpen)
                 if (closeBracket != -1 && xml[closeBracket - 1] == '/') {
-                    // Self-closing, don't increase depth
                     pos = closeBracket + 1
                 } else {
                     depth++
@@ -234,7 +222,6 @@ private fun findMatchingClose(xml: String, tagName: String, start: Int): Int {
 }
 
 private fun findElementEnd(xml: String, tagName: String, start: Int): Int {
-    // Check self-closing first
     val selfCloseMatch = Regex("""<\w[\w.\-]*(\s[^>]*)?\s*/>""").find(xml, start)
     if (selfCloseMatch != null && selfCloseMatch.range.first == start) {
         return selfCloseMatch.range.last + 1

--- a/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
@@ -5,10 +5,6 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 
-/**
- * A resolved dependency node in the dependency graph.
- * Pure data — no file paths, hashes, or I/O concerns.
- */
 data class DependencyNode(
     val groupArtifact: String,
     val version: String,
@@ -21,36 +17,16 @@ private data class QueueEntry(
     val exclusions: Set<PomExclusion>
 )
 
-/**
- * Pure dependency graph resolution via BFS.
- *
- * Given direct dependencies and a POM lookup function, resolves the full
- * transitive dependency graph. The algorithm is independent of I/O — POM
- * fetching is abstracted behind [pomLookup].
- *
- * Resolution rules:
- * - Direct deps always win over transitive version conflicts
- * - Among transitive deps, highest version wins
- * - Scopes: only `compile` and `runtime` are included
- * - Optional dependencies are skipped
- * - Exclusions propagate transitively through the dependency chain
- * - Cycles are detected via visited set
- * - Parent POM chain is followed for dependencyManagement version lookup
- *
- * @param directDeps Map of groupArtifact -> version from project config
- * @param pomLookup Function that returns parsed POM for a given (groupArtifact, version),
- *                  or null if unavailable. May perform I/O internally.
- */
+// Direct deps always win; among transitives, highest version wins.
+// Exclusions propagate transitively.
 fun resolveGraph(
     directDeps: Map<String, String>,
     pomLookup: (groupArtifact: String, version: String) -> PomInfo?
 ): Result<List<DependencyNode>, ResolveError> {
-    // Track resolved versions: groupArtifact -> (version, isDirect)
     val resolvedVersions = mutableMapOf<String, Pair<String, Boolean>>()
     val queue = ArrayDeque<QueueEntry>()
-    val visited = mutableSetOf<String>() // "groupArtifact:version"
+    val visited = mutableSetOf<String>()
 
-    // Seed with direct deps (no exclusions at the root level)
     for ((groupArtifact, version) in directDeps) {
         parseCoordinate(groupArtifact, version).getOrElse {
             return Err(ResolveError.InvalidDependency(groupArtifact))
@@ -59,7 +35,6 @@ fun resolveGraph(
         queue.addLast(QueueEntry(groupArtifact, version, emptySet()))
     }
 
-    // BFS
     while (queue.isNotEmpty()) {
         val entry = queue.removeFirst()
         val visitKey = "${entry.groupArtifact}:${entry.version}"
@@ -68,17 +43,14 @@ fun resolveGraph(
 
         val pomInfo = pomLookup(entry.groupArtifact, entry.version) ?: continue
 
-        // Collect dependencyManagement from this POM and its parent chain
         val depMgmt = collectDepMgmt(pomInfo, pomLookup)
 
-        // Process transitive dependencies
         for (pomDep in pomInfo.dependencies) {
             if (!isIncludedScope(pomDep.scope)) continue
             if (pomDep.optional) continue
 
             val depGroupArtifact = "${pomDep.groupId}:${pomDep.artifactId}"
 
-            // Check if this dep is excluded by inherited exclusions
             if (isExcluded(pomDep.groupId, pomDep.artifactId, entry.exclusions)) continue
 
             val rawVersion = pomDep.version
@@ -93,7 +65,6 @@ fun resolveGraph(
                 if (compareVersions(depVersion, existingVersion) <= 0) continue
             }
 
-            // Merge inherited exclusions with this dep's own exclusions
             val mergedExclusions = entry.exclusions + pomDep.exclusions.toSet()
 
             resolvedVersions[depGroupArtifact] = Pair(depVersion, false)
@@ -107,10 +78,6 @@ fun resolveGraph(
     return Ok(nodes)
 }
 
-/**
- * Checks if a dependency is excluded by the given exclusion set.
- * Supports wildcards: `*` matches any group or artifact.
- */
 private fun isExcluded(groupId: String, artifactId: String, exclusions: Set<PomExclusion>): Boolean {
     return exclusions.any { ex ->
         (ex.groupId == "*" || ex.groupId == groupId) &&
@@ -123,10 +90,6 @@ private fun isIncludedScope(scope: String?): Boolean {
     return s == "compile" || s == "runtime"
 }
 
-/**
- * Collects dependencyManagement entries from a POM and its parent chain.
- * Pure function — parent POM lookup is done via the same [pomLookup] function.
- */
 private fun collectDepMgmt(
     pomInfo: PomInfo,
     pomLookup: (String, String) -> PomInfo?,

--- a/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
@@ -8,15 +8,6 @@ import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltConfig
 import kolt.infra.DownloadError
 
-/**
- * Resolves dependencies transitively. Orchestrates I/O (POM/JAR fetching,
- * hashing) around the pure [resolveGraph] algorithm.
- *
- * 1. Creates a POM lookup function backed by cache + download
- * 2. Calls [resolveGraph] to resolve the dependency graph
- * 3. Downloads JARs and computes SHA256 hashes
- * 4. Detects lockfile changes
- */
 fun resolveTransitive(
     config: KoltConfig,
     existingLock: Lockfile?,
@@ -25,10 +16,8 @@ fun resolveTransitive(
 ): Result<ResolveResult, ResolveError> {
     val repos = config.repositories.values.toList()
 
-    // Create POM lookup backed by cache + download
     val basePomLookup = createPomLookup(repos, cacheBase, deps)
 
-    // Track KMP redirects: original groupArtifact -> redirected groupArtifact
     val redirects = mutableMapOf<String, String>()
     val moduleLookup = createModuleLookup(repos, cacheBase, deps)
 
@@ -43,19 +32,14 @@ fun resolveTransitive(
         }
     }
 
-    // Pure resolution
     val nodes = resolveGraph(config.dependencies, pomLookup).getOrElse { error ->
         return Err(error)
     }
 
-    // Download JARs and compute hashes
     return materialize(nodes, redirects, config, existingLock, cacheBase, deps, repos)
 }
 
-/**
- * Tries each repository in order, downloading to [destPath].
- * Falls back to the next repository only on HTTP 404. Any other error stops immediately.
- */
+// Falls back to next repo only on 404; any other error stops immediately.
 internal fun downloadFromRepositories(
     repos: List<String>,
     destPath: String,
@@ -76,11 +60,6 @@ internal fun downloadFromRepositories(
     return Err(lastError ?: DownloadError.NetworkError("", "no repositories configured"))
 }
 
-/**
- * Creates a POM lookup function that downloads, caches, and parses POM files.
- * Parsed POM metadata is cached in memory to avoid re-reading and re-parsing
- * the same POM (e.g., shared parent POMs in diamond dependencies).
- */
 internal fun createPomLookup(
     repos: List<String>,
     cacheBase: String,
@@ -96,7 +75,6 @@ internal fun createPomLookup(
                 val coord = Coordinate(parts[0], parts[1], version)
                 val pomCachePath = "$cacheBase/${buildPomCachePath(coord)}"
 
-                // Download POM if not cached on disk
                 if (!deps.fileExists(pomCachePath)) {
                     val parentDir = pomCachePath.substringBeforeLast('/')
                     val dirOk = deps.ensureDirectoryRecursive(parentDir).getOrElse { null }
@@ -105,7 +83,6 @@ internal fun createPomLookup(
                     }
                 }
 
-                // Read and parse POM
                 val content = deps.readFileContent(pomCachePath).getOrElse { null }
                 content?.let { parsePom(it).getOrElse { null } }
             } else {
@@ -115,11 +92,6 @@ internal fun createPomLookup(
     }
 }
 
-/**
- * Creates a memoized lookup function for Gradle Module Metadata JVM redirects.
- * Results (including "no redirect") are cached in memory to avoid redundant
- * .module file downloads for the same coordinate.
- */
 private fun createModuleLookup(
     repos: List<String>,
     cacheBase: String,
@@ -154,7 +126,6 @@ private fun checkModuleFile(
     val coord = Coordinate(parts[0], parts[1], version)
     val moduleCachePath = "$cacheBase/${buildModuleCachePath(coord)}"
 
-    // Download .module file if not cached on disk
     if (!deps.fileExists(moduleCachePath)) {
         val parentDir = moduleCachePath.substringBeforeLast('/')
         deps.ensureDirectoryRecursive(parentDir).getOrElse { return null }
@@ -165,16 +136,7 @@ private fun checkModuleFile(
     return parseJvmRedirect(content)
 }
 
-/**
- * Downloads JARs, computes SHA256 hashes, and checks lockfile for changes.
- * Converts pure [DependencyNode] list into [ResolveResult] with I/O.
- *
- * For KMP libraries, [redirects] maps the original groupArtifact (e.g.,
- * "com.squareup.okhttp3:okhttp") to the JVM-specific artifact (e.g.,
- * "com.squareup.okhttp3:okhttp-jvm"). The lockfile and ResolvedDep keep
- * the original groupArtifact as the key, but the SHA256 hash and cache
- * path correspond to the redirected JAR.
- */
+// KMP redirects: lockfile keys use original groupArtifact, but hash/path use the redirected JAR.
 private fun materialize(
     nodes: List<DependencyNode>,
     redirects: Map<String, String>,
@@ -188,7 +150,6 @@ private fun materialize(
     val resolvedDeps = mutableListOf<ResolvedDep>()
 
     for (node in nodes) {
-        // Use redirected artifact for JAR download (KMP libraries)
         val jarGroupArtifact = redirects[node.groupArtifact] ?: node.groupArtifact
         val coord = parseCoordinate(jarGroupArtifact, node.version).getOrElse {
             return Err(ResolveError.InvalidDependency(node.groupArtifact))
@@ -198,7 +159,6 @@ private fun materialize(
         val fullCachePath = "$cacheBase/$relativePath"
         val lockEntry = existingLock?.dependencies?.get(node.groupArtifact)
 
-        // Download JAR if not cached
         if (!deps.fileExists(fullCachePath)) {
             val parentDir = fullCachePath.substringBeforeLast('/')
             deps.ensureDirectoryRecursive(parentDir).getOrElse {
@@ -210,12 +170,10 @@ private fun materialize(
             lockChanged = true
         }
 
-        // Compute SHA256
         val hash = deps.computeSha256(fullCachePath).getOrElse { error ->
             return Err(ResolveError.HashComputeFailed(node.groupArtifact, error))
         }
 
-        // Verify against lockfile
         if (lockEntry != null) {
             if (lockEntry.version != node.version) {
                 lockChanged = true

--- a/src/nativeMain/kotlin/kolt/resolve/VersionCompare.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/VersionCompare.kt
@@ -1,10 +1,5 @@
 package kolt.resolve
 
-/**
- * Compares two Maven-style version strings.
- * Splits on `.` and `-`. Numeric segments are compared numerically.
- * Known qualifiers are ordered: SNAPSHOT < alpha < beta < rc < "" (release).
- */
 fun compareVersions(a: String, b: String): Int {
     val partsA = splitVersion(a)
     val partsB = splitVersion(b)
@@ -59,10 +54,8 @@ private fun splitVersion(version: String): List<VersionSegment> {
 }
 
 private fun parseSegment(token: String): VersionSegment {
-    // Pure numeric
     token.toLongOrNull()?.let { return VersionSegment.Numeric(it) }
 
-    // Qualifier with optional numeric suffix (e.g. "alpha2", "rc1")
     val lower = token.lowercase()
     val qualifierMatch = Regex("""^(snapshot|alpha|beta|rc)(\d*)$""").find(lower)
     if (qualifierMatch != null) {
@@ -78,15 +71,9 @@ private fun parseSegment(token: String): VersionSegment {
         return VersionSegment.Qualifier(rank, suffix)
     }
 
-    // Unknown qualifier treated as release-level
     return VersionSegment.Qualifier(VersionSegment.RANK_RELEASE, 0L)
 }
 
-// --- Version intervals (Maven version range syntax) ---
-
-/**
- * Represents a Maven version interval, e.g. `[1.0,2.0)`.
- */
 data class VersionInterval(
     val from: String?,
     val fromInclusive: Boolean,
@@ -108,21 +95,11 @@ data class VersionInterval(
     }
 }
 
-/**
- * A parsed version constraint — either a preferred (exact) version
- * or a version interval.
- */
 data class VersionConstraint(
     val preferred: String?,
     val interval: VersionInterval?
 )
 
-/**
- * Parses a Maven version constraint string.
- * - `1.0.0` → preferred version
- * - `[1.0,2.0)` → interval
- * - `[1.5]` → pinned interval (from == to, both inclusive)
- */
 fun parseVersionConstraint(constraint: String): VersionConstraint {
     val trimmed = constraint.trim()
     if (trimmed.isEmpty()) return VersionConstraint(trimmed, null)
@@ -139,7 +116,6 @@ fun parseVersionConstraint(constraint: String): VersionConstraint {
 
     val commaIndex = inner.indexOf(',')
     if (commaIndex == -1) {
-        // Pinned: [1.5.0]
         val version = inner.trim()
         return VersionConstraint(null, VersionInterval(version, true, version, true))
     }
@@ -158,13 +134,6 @@ fun parseVersionConstraint(constraint: String): VersionConstraint {
     )
 }
 
-/**
- * Selects a concrete version from a version constraint string.
- * - Exact version: returned as-is
- * - Interval with lower bound: uses lower bound
- * - Interval with only upper bound: uses upper bound
- * - Pinned interval `[X]`: uses X
- */
 fun selectVersion(constraint: String): String {
     val vc = parseVersionConstraint(constraint)
     if (vc.preferred != null) return vc.preferred

--- a/src/nativeMain/kotlin/kolt/tool/ToolchainManager.kt
+++ b/src/nativeMain/kotlin/kolt/tool/ToolchainManager.kt
@@ -8,14 +8,6 @@ import kolt.config.KoltPaths
 import kolt.infra.*
 import kotlinx.serialization.json.*
 
-// Failures from any toolchain install / ensure step. Carries a
-// pre-formatted, user-facing message so callers can `eprintln("error: ${err.message}")`
-// without re-deriving wording per error kind. A flat carrier is enough
-// because nothing downstream classifies these: the CLI entry points
-// map them 1:1 to an exit, and the daemon bring-up path wraps
-// `message` into a fallback warning. Keeping it a single value class
-// also means new failure sites do not have to touch callers — they
-// just produce a new `ToolchainError(...)`.
 internal data class ToolchainError(val message: String)
 
 internal fun jdkDownloadUrl(version: String): String =
@@ -84,7 +76,6 @@ internal fun installJdkToolchain(
         return Err(ToolchainError(formatDownloadError("jdk", version, tarPath, error)))
     }
 
-    // SHA256 verification via Adoptium metadata API
     downloadFile(jdkMetadataUrl(version), metadataPath).getOrElse { error ->
         deleteFile(tarPath)
         val msg = when (error) {
@@ -133,7 +124,6 @@ internal fun installJdkToolchain(
     }
     deleteFile(tarPath)
 
-    // Adoptium tar.gz contains a single top-level dir like "jdk-21.0.2+13/" — find and move it
     val lsOutput = executeAndCapture("ls '$extractTempDir'").getOrElse { _ ->
         removeDirectoryRecursive(extractTempDir).getOrElse { e ->
             eprintln("warning: could not remove temp directory ${e.path}")
@@ -241,7 +231,6 @@ internal fun installKotlincToolchain(
         deleteFile(sha256Path)
         return Err(ToolchainError("could not read ${error.path}"))
     }
-    // SHA256 files can be "<hash>  <filename>" or just "<hash>"
     val expectedHash = sha256Content.trim().split(Regex("\\s+")).first()
     deleteFile(sha256Path)
 

--- a/src/nativeTest/kotlin/kolt/build/BuildCacheTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuildCacheTest.kt
@@ -176,7 +176,6 @@ class BuildCacheTest {
 
     @Test
     fun upToDateWhenResourcesMtimesMatch() {
-        // Given: both current and cached have the same resourcesNewestMtime
         val state = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
@@ -189,7 +188,6 @@ class BuildCacheTest {
 
     @Test
     fun notUpToDateWhenResourcesMtimeChanged() {
-        // Given: cached has older resourcesNewestMtime
         val cached = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
@@ -203,7 +201,6 @@ class BuildCacheTest {
 
     @Test
     fun notUpToDateWhenResourcesMtimeChangedFromNullToValue() {
-        // Given: cached has null (no resources), current has resources
         val cached = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
@@ -217,7 +214,6 @@ class BuildCacheTest {
 
     @Test
     fun upToDateWhenBothResourcesMtimesNull() {
-        // Given: neither current nor cached have resources
         val state = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
@@ -257,18 +253,14 @@ class BuildCacheTest {
 
     @Test
     fun resourcesNewestMtimeDefaultsToNullForOlderStateJson() {
-        // Given: older JSON without resources_newest_mtime
         val oldJson = """{"config_mtime":1000,"sources_newest_mtime":2000,"classes_dir_mtime":3000,"lockfile_mtime":null}"""
         val parsed = parseBuildState(oldJson)
         assertNotNull(parsed)
         assertNull(parsed.resourcesNewestMtime)
     }
 
-    // --- defNewestMtime ---
-
     @Test
     fun upToDateWhenDefMtimesMatch() {
-        // Given: both current and cached have the same defNewestMtime
         val state = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
@@ -281,7 +273,6 @@ class BuildCacheTest {
 
     @Test
     fun notUpToDateWhenDefMtimeChanged() {
-        // Given: cached has older defNewestMtime (def file was modified)
         val cached = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
@@ -295,7 +286,6 @@ class BuildCacheTest {
 
     @Test
     fun notUpToDateWhenDefMtimeChangedFromNullToValue() {
-        // Given: cached has no def file (null), current has one (cinterop entry added)
         val cached = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
@@ -309,7 +299,6 @@ class BuildCacheTest {
 
     @Test
     fun notUpToDateWhenDefMtimeChangedFromValueToNull() {
-        // Given: cached had a def file, current has none (cinterop entry removed)
         val cached = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
@@ -323,7 +312,6 @@ class BuildCacheTest {
 
     @Test
     fun upToDateWhenBothDefMtimesNull() {
-        // Given: no cinterop entries in either current or cached
         val state = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
@@ -363,7 +351,6 @@ class BuildCacheTest {
 
     @Test
     fun defNewestMtimeDefaultsToNullForOlderStateJson() {
-        // Given: older JSON without def_newest_mtime (pre-cinterop state file)
         val oldJson = """{"config_mtime":1000,"sources_newest_mtime":2000,"classes_dir_mtime":3000,"lockfile_mtime":null}"""
         val parsed = parseBuildState(oldJson)
         assertNotNull(parsed)

--- a/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
@@ -8,8 +8,6 @@ import kotlin.test.assertTrue
 
 class BuilderTest {
 
-    // --- checkCommand ---
-
     @Test
     fun checkCommandDoesNotIncludeRuntimeOrOutput() {
         val cmd = checkCommand(testConfig())
@@ -55,17 +53,12 @@ class BuilderTest {
         )
     }
 
-    // --- checkCommand (kotlincPath) ---
-
     @Test
     fun checkCommandWithManagedKotlincPathUsesItAsCompiler() {
-        // Given: a managed kotlinc binary path
         val managedKotlincBin = "/home/user/.kolt/toolchains/kotlinc/2.1.0/bin/kotlinc"
 
-        // When: checkCommand is called with that path
         val cmd = checkCommand(testConfig(), kotlincPath = managedKotlincBin)
 
-        // Then: the managed path is first in args
         assertEquals(
             listOf(managedKotlincBin, "src", "-jvm-target", "17"),
             cmd
@@ -74,16 +67,13 @@ class BuilderTest {
 
     @Test
     fun checkCommandWithNullKotlincPathDefaultsToSystemKotlinc() {
-        // Given: no managed toolchain (null)
         val cmd = checkCommand(testConfig(), kotlincPath = null)
 
-        // Then: falls back to system "kotlinc"
         assertEquals("kotlinc", cmd.first())
     }
 
     @Test
     fun checkCommandWithManagedKotlincAndClasspath() {
-        // Given: managed kotlinc + classpath
         val managedKotlincBin = "/home/user/.kolt/toolchains/kotlinc/2.1.0/bin/kotlinc"
 
         val cmd = checkCommand(testConfig(), classpath = "/cache/a.jar", kotlincPath = managedKotlincBin)
@@ -93,8 +83,6 @@ class BuilderTest {
             cmd
         )
     }
-
-    // --- jarCommand ---
 
     @Test
     fun jarCommandPackagesClassesDirToJar() {
@@ -120,7 +108,6 @@ class BuilderTest {
 
     @Test
     fun jarCommandSourceDirectoryIsAlwaysClassesDir() {
-        // jar source is always build/classes regardless of project name
         val cmd1 = jarCommand(testConfig(name = "app-a"))
         val cmd2 = jarCommand(testConfig(name = "app-b"))
 
@@ -130,13 +117,10 @@ class BuilderTest {
 
     @Test
     fun jarCommandWithManagedJarPathUsesItAsJar() {
-        // Given: a managed jar binary path
         val managedJarBin = "/home/user/.kolt/toolchains/jdk/21/bin/jar"
 
-        // When: jarCommand is called with that path
         val cmd = jarCommand(testConfig(), jarPath = managedJarBin)
 
-        // Then: managed path is used as the first arg, not system "jar"
         assertEquals(
             listOf(managedJarBin, "cf", "build/my-app.jar", "-C", "build/classes", "."),
             cmd.args
@@ -145,15 +129,10 @@ class BuilderTest {
 
     @Test
     fun jarCommandWithNullJarPathDefaultsToSystemJar() {
-        // Given: no managed JDK (null)
-        // When: jarCommand is called with explicit null jarPath
         val cmd = jarCommand(testConfig(), jarPath = null)
 
-        // Then: falls back to system "jar"
         assertEquals("jar", cmd.args.first())
     }
-
-    // --- nativeLibraryCommand (Stage 1: sources -> klib) ---
 
     @Test
     fun nativeLibraryCommandProducesKlibDirectory() {
@@ -241,8 +220,6 @@ class BuilderTest {
 
         assertFalse(cmd.args.contains("-l"))
     }
-
-    // --- nativeLinkCommand (Stage 2: klib -> kexe) ---
 
     @Test
     fun nativeLinkCommandLinksKlibToProgramKexe() {
@@ -342,8 +319,6 @@ class BuilderTest {
         assertEquals("main", cmd.args[eIndex + 1])
     }
 
-    // --- nativeTestLibraryCommand (Stage 1: main+test sources -> klib) ---
-
     @Test
     fun nativeTestLibraryCommandIncludesMainAndTestSources() {
         val cmd = nativeTestLibraryCommand(testConfig(target = "native"))
@@ -432,8 +407,6 @@ class BuilderTest {
         assertEquals(managedKonanc, cmd.args.first())
     }
 
-    // --- nativeTestLinkCommand (Stage 2: klib -> test kexe) ---
-
     @Test
     fun nativeTestLinkCommandLinksWithGeneratedRunner() {
         val cmd = nativeTestLinkCommand(testConfig(target = "native"))
@@ -509,13 +482,10 @@ class BuilderTest {
 
     @Test
     fun jarCommandWithManagedJarPathPreservesOutputPath() {
-        // Given: a managed jar binary path
         val managedJarBin = "/home/user/.kolt/toolchains/jdk/21/bin/jar"
 
-        // When: jarCommand is called with jarPath
         val cmd = jarCommand(testConfig(name = "hello-world"), jarPath = managedJarBin)
 
-        // Then: outputPath is still derived from project name, not affected by jarPath
         assertEquals("build/hello-world.jar", cmd.outputPath)
         assertEquals(
             listOf(managedJarBin, "cf", "build/hello-world.jar", "-C", "build/classes", "."),

--- a/src/nativeTest/kotlin/kolt/build/CinteropSmokeTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CinteropSmokeTest.kt
@@ -14,24 +14,15 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import platform.posix.getpid
 
-// E2E smoke test: exercises the full cinterop → konanc → kexe pipeline against
-// a real libcurl fixture. Requires the managed konanc toolchain (2.1.0) and
-// libcurl headers (curl/curl.h) to be present at one of several well-known
-// locations. Skips when either prerequisite is missing.
 class CinteropSmokeTest {
 
-    // Candidate include directories that may contain curl/curl.h. Covers:
-    // - Debian/Ubuntu multiarch (/usr/include/x86_64-linux-gnu)
-    // - Default /usr/include (Fedora/Arch/Alpine and most other Linux)
-    // - /usr/local/include (source/manual installs)
+    // Debian/Ubuntu multiarch, default /usr/include, and /usr/local/include
     private val curlIncludeCandidates = listOf(
         "/usr/include/x86_64-linux-gnu",
         "/usr/include",
         "/usr/local/include",
     )
 
-    // Candidate library directories that may contain libcurl.so. Matches the
-    // same host layouts as the include candidates above.
     private val curlLibCandidates = listOf(
         "/usr/lib/x86_64-linux-gnu",
         "/usr/lib64",
@@ -47,15 +38,11 @@ class CinteropSmokeTest {
         val cinteropBin = paths.cinteropBin(kotlinVersion)
         val konancBin = paths.konancBin(kotlinVersion)
 
-        // Skip when managed toolchain is absent (CI without pre-installed konanc).
         if (!fileExists(cinteropBin) || !fileExists(konancBin)) {
             println("SKIP: managed konanc toolchain not found at ${paths.konancPath(kotlinVersion)}")
             return
         }
 
-        // Skip when libcurl headers are absent (non-Debian hosts without libcurl-dev).
-        // We always include /usr/include (base glibc headers) and add the directory
-        // holding curl/curl.h if it differs — on Debian/Ubuntu that's the multiarch path.
         val curlIncludeDir = curlIncludeCandidates.firstOrNull { fileExists("$it/curl/curl.h") }
         if (curlIncludeDir == null) {
             println(
@@ -81,7 +68,6 @@ class CinteropSmokeTest {
         ensureDirectoryRecursive(buildDir)
 
         try {
-            // --- Fixture: libcurl.def ---
             val defFile = "$tmpDir/libcurl.def"
             writeFileAsString(
                 defFile,
@@ -92,7 +78,6 @@ class CinteropSmokeTest {
                 """.trimIndent()
             )
 
-            // --- Fixture: Main.kt (calls curl_version()) ---
             val mainFile = "$tmpDir/Main.kt"
             writeFileAsString(
                 mainFile,
@@ -109,7 +94,6 @@ class CinteropSmokeTest {
                 """.trimIndent()
             )
 
-            // --- Step 1: cinterop — .def → libcurl.klib ---
             val klibBase = "$buildDir/libcurl"
             val cinteropResult = executeCommand(listOf(cinteropBin, "-def", defFile, "-o", klibBase))
             assertNotNull(
@@ -119,7 +103,6 @@ class CinteropSmokeTest {
             val klibFile = "$klibBase.klib"
             assertTrue(fileExists(klibFile), "Expected .klib at $klibFile after cinterop")
 
-            // --- Step 2: konanc stage 1 — sources + cinterop klib → project klib ---
             val appKlibBase = "$buildDir/smoke-klib"
             val stage1Result = executeCommand(
                 listOf(
@@ -135,7 +118,6 @@ class CinteropSmokeTest {
             )
             assertTrue(fileExists(appKlibBase), "Expected project klib at $appKlibBase")
 
-            // --- Step 3: konanc stage 2 — project klib → executable ---
             val exeBase = "$buildDir/smoke"
             val stage2Result = executeCommand(
                 listOf(
@@ -153,7 +135,6 @@ class CinteropSmokeTest {
             val exeFile = "$exeBase.kexe"
             assertTrue(fileExists(exeFile), "Expected executable at $exeFile after link")
 
-            // --- Step 4: run and verify curl_version() output ---
             val runResult = executeAndCapture("$exeFile 2>&1")
             val output = assertNotNull(runResult.get(), "executable run failed: $runResult")
             assertTrue(

--- a/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
@@ -8,20 +8,16 @@ import kotlin.test.assertTrue
 
 class CinteropTest {
 
-    // --- cinteropCommand ---
 
     @Test
     fun cinteropCommandMinimalProducesDefAndOutput() {
-        // Given: a minimal cinterop entry with only name and def
         val entry = CinteropConfig(
             name = "libcurl",
             def = "src/nativeInterop/cinterop/libcurl.def"
         )
 
-        // When: command is constructed
         val cmd = cinteropCommand(entry)
 
-        // Then: args contain cinterop binary, -def, and -o flags
         assertEquals(
             listOf("cinterop", "-target", "linux_x64", "-def", "src/nativeInterop/cinterop/libcurl.def", "-o", "build/libcurl"),
             cmd.args
@@ -30,29 +26,23 @@ class CinteropTest {
 
     @Test
     fun cinteropCommandOutputPathIsInBuildDir() {
-        // Given: an entry named "libcurl"
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
-        // When: command is constructed
         val cmd = cinteropCommand(entry)
 
-        // Then: -o points to build/<name> (cinterop appends .klib itself)
         assertEquals("build/libcurl", cmd.outputPath)
     }
 
     @Test
     fun cinteropCommandWithPackageNameEmitsPkgFlag() {
-        // Given: entry with packageName set
         val entry = CinteropConfig(
             name = "libcurl",
             def = "libcurl.def",
             packageName = "libcurl"
         )
 
-        // When: command is constructed
         val cmd = cinteropCommand(entry)
 
-        // Then: -pkg flag is included
         assertTrue(cmd.args.contains("-pkg"), "Expected -pkg flag in: ${cmd.args}")
         val pkgIndex = cmd.args.indexOf("-pkg")
         assertEquals("libcurl", cmd.args[pkgIndex + 1])
@@ -60,29 +50,23 @@ class CinteropTest {
 
     @Test
     fun cinteropCommandWithoutPackageNameOmitsPkgFlag() {
-        // Given: entry with no packageName
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def", packageName = null)
 
-        // When: command is constructed
         val cmd = cinteropCommand(entry)
 
-        // Then: -pkg flag is absent
         assertFalse(cmd.args.contains("-pkg"), "Unexpected -pkg flag in: ${cmd.args}")
     }
 
     @Test
     fun cinteropCommandWithAllOptionsProducesFullArgs() {
-        // Given: entry with all optional fields set
         val entry = CinteropConfig(
             name = "libcurl",
             def = "src/nativeInterop/cinterop/libcurl.def",
             packageName = "libcurl"
         )
 
-        // When: command is constructed
         val cmd = cinteropCommand(entry)
 
-        // Then: full args in canonical order
         assertEquals(
             listOf(
                 "cinterop",
@@ -97,38 +81,29 @@ class CinteropTest {
 
     @Test
     fun cinteropCommandWithCustomCinteropPath() {
-        // Given: a managed cinterop binary path
         val managedPath = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/cinterop"
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
-        // When: command is constructed with custom cinteropPath
         val cmd = cinteropCommand(entry, cinteropPath = managedPath)
 
-        // Then: managed path is used as the first arg, not system "cinterop"
         assertEquals(managedPath, cmd.args.first())
     }
 
     @Test
     fun cinteropCommandWithNullCinteropPathDefaultsToSystemCinterop() {
-        // Given: no managed path (null)
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
-        // When: command is constructed with explicit null cinteropPath
         val cmd = cinteropCommand(entry, cinteropPath = null)
 
-        // Then: falls back to system "cinterop"
         assertEquals("cinterop", cmd.args.first())
     }
 
     @Test
     fun cinteropCommandWithCustomOutputDir() {
-        // Given: a custom output directory
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
-        // When: command is constructed with custom outputDir
         val cmd = cinteropCommand(entry, outputDir = "custom/build")
 
-        // Then: -o uses the custom output dir
         val outputIndex = cmd.args.indexOf("-o")
         assertEquals("custom/build/libcurl", cmd.args[outputIndex + 1])
         assertEquals("custom/build/libcurl", cmd.outputPath)
@@ -136,7 +111,6 @@ class CinteropTest {
 
     @Test
     fun cinteropCommandOutputPathDoesNotIncludeKlibExtension() {
-        // cinterop tool appends .klib itself; we must not double-append it
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
         val cmd = cinteropCommand(entry)
@@ -145,33 +119,25 @@ class CinteropTest {
         assertFalse(cmd.args.any { it.endsWith(".klib") }, "No .klib suffix expected in args: ${cmd.args}")
     }
 
-    // --- cinteropOutputKlibPath ---
 
     @Test
     fun cinteropOutputKlibPathReturnsExpectedPath() {
-        // Given: an entry named "libcurl"
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
-        // When: klib path is computed
         val path = cinteropOutputKlibPath(entry)
 
-        // Then: path is build/<name>.klib
         assertEquals("build/libcurl.klib", path)
     }
 
     @Test
     fun cinteropOutputKlibPathWithCustomOutputDir() {
-        // Given: a custom output directory
         val entry = CinteropConfig(name = "libssl", def = "libssl.def")
 
-        // When: klib path is computed with custom dir
         val path = cinteropOutputKlibPath(entry, outputDir = "custom/build")
 
-        // Then: path uses custom dir
         assertEquals("custom/build/libssl.klib", path)
     }
 
-    // --- cinteropStamp ---
 
     @Test
     fun cinteropStampIsStableForIdenticalInputs() {
@@ -212,15 +178,11 @@ class CinteropTest {
 
     @Test
     fun cinteropStampChangesWhenKotlinVersionChanges() {
-        // Bumping `kotlin = "..."` in kolt.toml switches the cinterop/konanc
-        // toolchain. Kotlin/Native klib format is not guaranteed compatible
-        // across versions, so a cached klib from a previous Kotlin must not
-        // be reused.
+        // klib format is not guaranteed compatible across Kotlin versions.
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
         assertFalse(cinteropStamp(entry, 1000L, "2.1.0") == cinteropStamp(entry, 1000L, "2.3.20"))
     }
 
-    // --- cinteropStampPath ---
 
     @Test
     fun cinteropStampPathIsKlibPathPlusStamp() {
@@ -237,15 +199,12 @@ class CinteropTest {
 
     @Test
     fun cinteropOutputKlibPathUsesEntryName() {
-        // Given: two entries with different names
         val curl = CinteropConfig(name = "libcurl", def = "libcurl.def")
         val ssl = CinteropConfig(name = "openssl", def = "openssl.def")
 
-        // When: klib paths are computed
         val curlPath = cinteropOutputKlibPath(curl)
         val sslPath = cinteropOutputKlibPath(ssl)
 
-        // Then: paths differ by name
         assertEquals("build/libcurl.klib", curlPath)
         assertEquals("build/openssl.klib", sslPath)
     }

--- a/src/nativeTest/kotlin/kolt/build/FallbackCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/FallbackCompilerBackendTest.kt
@@ -171,9 +171,6 @@ class FallbackCompilerBackendTest {
 
     @Test
     fun onFallbackDefaultsToNoOp() {
-        // Constructing without the observer must compile and must not
-        // throw when fallback fires; the fallback's outcome must still
-        // be returned verbatim.
         val outcome = CompileOutcome(stdout = "subprocess ok", stderr = "")
         val primary = FakeBackend(Err(CompileError.BackendUnavailable.ForkFailed))
         val fallback = FakeBackend(Ok(outcome))

--- a/src/nativeTest/kotlin/kolt/build/RenderCompilationFailureTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/RenderCompilationFailureTest.kt
@@ -6,14 +6,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-// Pins the multi-line rendering of CompileError.CompilationFailed so the
-// body the daemon path hands back actually reaches the user. B-2c's
-// DaemonServer.icErrorToReply populates `Message.CompileResult.diagnostics`
-// (structured) and `stderr` (plain text for unparsable lines); the
-// native client must reunite the two streams before printing the
-// one-line `formatCompileError` summary, otherwise kotlinc diagnostics
-// disappear and the user sees only "error: compilation failed with
-// exit code 1". Dogfood on B-2c is what surfaced the bug.
 class RenderCompilationFailureTest {
 
     @Test
@@ -63,10 +55,6 @@ class RenderCompilationFailureTest {
 
     @Test
     fun appendsPlainStderrAfterStructuredDiagnostics() {
-        // DiagnosticParser leaves unparsable lines (e.g. trailing
-        // stack frames appended by CapturingKotlinLogger) in the
-        // stderr string. They still need to surface, after the
-        // structured lines for readability.
         val error = CompileError.CompilationFailed(
             exitCode = 1,
             stdout = "",
@@ -84,11 +72,6 @@ class RenderCompilationFailureTest {
 
     @Test
     fun subprocessPathProducesEmptyBody() {
-        // SubprocessCompilerBackend leaves both fields empty because
-        // kotlinc already wrote to the inherited terminal. The
-        // renderer must gracefully return an empty string rather than
-        // a lone "\n" or a synthetic placeholder, so the caller's
-        // `isNotEmpty()` skip works.
         val error = CompileError.CompilationFailed(
             exitCode = 1,
             stdout = "",
@@ -112,9 +95,7 @@ class RenderCompilationFailureTest {
 
     @Test
     fun fileNullWithLineColumnStillCollapsesToNoLocation() {
-        // Belt-and-suspenders: even if a future producer forgets to
-        // populate `file` but still passes line/column, the renderer
-        // must not emit a leading-colon `:5:3: error: msg` shape.
+        // Must not emit a leading-colon `:5:3: error: msg` when file is null.
         val error = CompileError.CompilationFailed(
             exitCode = 1,
             stdout = "",
@@ -128,10 +109,6 @@ class RenderCompilationFailureTest {
 
     @Test
     fun rendersStderrOnlyWhenDiagnosticsAreEmpty() {
-        // Pre-B-2c daemon behaviour and subprocess path with
-        // ProcessError.NonZeroExit carrying captured stderr both land
-        // here. The renderer must not synthesise an empty structured
-        // block when the diagnostic list is empty.
         val error = CompileError.CompilationFailed(
             exitCode = 1,
             stdout = "",

--- a/src/nativeTest/kotlin/kolt/build/RunnerTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/RunnerTest.kt
@@ -44,13 +44,10 @@ class RunnerTest {
 
     @Test
     fun runCommandWithManagedJavaPathUsesItAsJava() {
-        // Given: a managed java binary path
         val managedJavaBin = "/home/user/.kolt/toolchains/jdk/21/bin/java"
 
-        // When: runCommand is called with that path
         val cmd = runCommand(testConfig(), null, javaPath = managedJavaBin)
 
-        // Then: the managed path is used as the first arg, not system "java"
         assertEquals(
             listOf(managedJavaBin, "-cp", "build/classes", "com.example.MainKt"),
             cmd.args
@@ -59,30 +56,22 @@ class RunnerTest {
 
     @Test
     fun runCommandWithNullJavaPathDefaultsToSystemJava() {
-        // Given: no managed JDK (null)
-        // When: runCommand is called with explicit null javaPath
         val cmd = runCommand(testConfig(), null, javaPath = null)
 
-        // Then: falls back to system "java"
         assertEquals("java", cmd.args.first())
     }
 
     @Test
     fun runCommandWithManagedJavaAndClasspath() {
-        // Given: managed java + dependency classpath
         val managedJavaBin = "/home/user/.kolt/toolchains/jdk/21/bin/java"
 
-        // When: runCommand is called with both
         val cmd = runCommand(testConfig(), "/cache/lib.jar", javaPath = managedJavaBin)
 
-        // Then: managed path is first, classpath is appended after build/classes
         assertEquals(
             listOf(managedJavaBin, "-cp", "build/classes:/cache/lib.jar", "com.example.MainKt"),
             cmd.args
         )
     }
-
-    // --- nativeRunCommand ---
 
     @Test
     fun nativeRunCommandExecutesKexeBinary() {
@@ -101,8 +90,6 @@ class RunnerTest {
         val cmd = nativeRunCommand(testConfig(name = "hello", target = "native"))
         assertEquals(listOf("build/hello.kexe"), cmd.args)
     }
-
-    // --- nativeTestRunCommand ---
 
     @Test
     fun nativeTestRunCommandExecutesTestKexeBinary() {
@@ -130,13 +117,10 @@ class RunnerTest {
 
     @Test
     fun runCommandWithManagedJavaAndAppArgs() {
-        // Given: managed java + app arguments
         val managedJavaBin = "/home/user/.kolt/toolchains/jdk/21/bin/java"
 
-        // When: runCommand is called with javaPath and appArgs
         val cmd = runCommand(testConfig(), null, listOf("--port", "8080"), javaPath = managedJavaBin)
 
-        // Then: managed java path is first, appArgs are appended at the end
         assertEquals(
             listOf(managedJavaBin, "-cp", "build/classes", "com.example.MainKt", "--port", "8080"),
             cmd.args

--- a/src/nativeTest/kotlin/kolt/build/SubprocessCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/SubprocessCompilerBackendTest.kt
@@ -121,10 +121,7 @@ class SubprocessCompilerBackendMapProcessErrorTest {
     }
 }
 
-// Wording parity: every CompileError case produced by SubprocessCompilerBackend
-// must format to the same user-facing string that formatProcessError produced
-// pre-refactor. Legacy wording is reproduced here verbatim so a regression is
-// caught at test time rather than in user-visible output.
+// Pins user-facing wording against the pre-refactor formatProcessError strings.
 class FormatCompileErrorWordingTest {
 
     @Test
@@ -165,8 +162,6 @@ class FormatCompileErrorWordingTest {
 
     @Test
     fun backendUnavailableOtherIncludesDetail() {
-        // Free-form variant reserved for DaemonCompilerBackend (socket closed, protocol error etc.).
-        // No legacy wording to match — this is daemon-only and formats with a descriptive prefix.
         val message = formatCompileError(
             CompileError.BackendUnavailable.Other("daemon socket closed"),
             "compilation",
@@ -203,22 +198,16 @@ class SubprocessCompilerBackendIntegrationTest {
 
     @Test
     fun compileReturnsOkWhenBinaryExitsZero() {
-        // /bin/true ignores all args and exits 0. Exercises the success path of
-        // executeCommand → CompileOutcome mapping without needing a real kotlinc.
         val backend = SubprocessCompilerBackend(kotlincBin = "/bin/true")
         val result = backend.compile(trivialRequest)
         val outcome = assertNotNull(result.get())
-        // TODO(#14 S5+): once DaemonCompilerBackend returns populated stdout/stderr,
-        // this contract will diverge. Subprocess backend intentionally returns ""
-        // because kotlinc inherits our stdout/stderr directly.
+        // Subprocess backend returns "" because kotlinc inherits our stdout/stderr directly.
         assertEquals("", outcome.stdout)
         assertEquals("", outcome.stderr)
     }
 
     @Test
     fun compileReturnsCompilationFailedWhenBinaryExitsNonZero() {
-        // /bin/false ignores all args and exits 1. This is how a real kotlinc
-        // compile error surfaces at the process layer.
         val backend = SubprocessCompilerBackend(kotlincBin = "/bin/false")
         val result = backend.compile(trivialRequest)
         val error = assertNotNull(result.getError())

--- a/src/nativeTest/kotlin/kolt/build/TestBuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/TestBuilderTest.kt
@@ -63,7 +63,6 @@ class TestBuilderTest {
 
     @Test
     fun testBuildCommandOutputPathIsTestClassesDir() {
-        // outputPath is always build/test-classes regardless of project name
         val cmd = testBuildCommand(
             config = testConfig(name = "hello-world"),
             classesDir = "build/classes"
@@ -140,21 +139,16 @@ class TestBuilderTest {
         )
     }
 
-    // --- kotlincPath parameter ---
-
     @Test
     fun testBuildCommandWithManagedKotlincPathUsesItAsCompiler() {
-        // Given: a managed kotlinc binary path
         val managedKotlincBin = "/home/user/.kolt/toolchains/kotlinc/2.1.0/bin/kotlinc"
 
-        // When: testBuildCommand is called with that path
         val cmd = testBuildCommand(
             config = testConfig(),
             classesDir = "build/classes",
             kotlincPath = managedKotlincBin
         )
 
-        // Then: the managed path is used as the first arg, not system "kotlinc"
         assertEquals(
             listOf(managedKotlincBin, "-cp", "build/classes", "test", "-jvm-target", "17", "-d", "build/test-classes"),
             cmd.args
@@ -163,20 +157,17 @@ class TestBuilderTest {
 
     @Test
     fun testBuildCommandWithNullKotlincPathDefaultsToSystemKotlinc() {
-        // Given: no managed toolchain (null)
         val cmd = testBuildCommand(
             config = testConfig(),
             classesDir = "build/classes",
             kotlincPath = null
         )
 
-        // Then: falls back to system "kotlinc"
         assertEquals("kotlinc", cmd.args.first())
     }
 
     @Test
     fun testBuildCommandWithManagedKotlincAndClasspath() {
-        // Given: managed kotlinc + extra classpath
         val managedKotlincBin = "/home/user/.kolt/toolchains/kotlinc/2.1.0/bin/kotlinc"
 
         val cmd = testBuildCommand(

--- a/src/nativeTest/kotlin/kolt/build/TestDepsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/TestDepsTest.kt
@@ -47,7 +47,6 @@ class TestDepsTest {
         ))
         val allDeps = mergeAllDeps(config)
 
-        // User's [test-dependencies] version wins
         assertEquals("2.0.0", allDeps["org.jetbrains.kotlin:kotlin-test-junit5"])
     }
 
@@ -58,7 +57,6 @@ class TestDepsTest {
         ))
         val allDeps = mergeAllDeps(config)
 
-        // User's [dependencies] version wins over auto-injected
         assertEquals("2.0.0", allDeps["org.jetbrains.kotlin:kotlin-test-junit5"])
     }
 
@@ -74,7 +72,6 @@ class TestDepsTest {
         )
         val allDeps = mergeAllDeps(config)
 
-        // [test-dependencies] has highest priority
         assertEquals("1.9.0", allDeps["org.jetbrains.kotlin:kotlin-test-junit5"])
     }
 

--- a/src/nativeTest/kotlin/kolt/build/TestRunnerTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/TestRunnerTest.kt
@@ -84,7 +84,6 @@ class TestRunnerTest {
 
     @Test
     fun testRunCommandWithTestResourceDirs() {
-        // Given: a single test resource directory
         val cmd = testRunCommand(
             classesDir = "build/classes",
             testClassesDir = "build/test-classes",
@@ -92,7 +91,6 @@ class TestRunnerTest {
             testResourceDirs = listOf("test-resources")
         )
 
-        // Then: test resource dir is inserted between test-classes and deps
         assertEquals(
             listOf(
                 "java", "-jar", "/tools/launcher.jar",
@@ -105,7 +103,6 @@ class TestRunnerTest {
 
     @Test
     fun testRunCommandWithMultipleTestResourceDirs() {
-        // Given: multiple test resource directories
         val cmd = testRunCommand(
             classesDir = "build/classes",
             testClassesDir = "build/test-classes",
@@ -125,7 +122,6 @@ class TestRunnerTest {
 
     @Test
     fun testRunCommandWithTestResourceDirsAndClasspath() {
-        // Given: both test resource dirs and dependency classpath
         val cmd = testRunCommand(
             classesDir = "build/classes",
             testClassesDir = "build/test-classes",
@@ -134,7 +130,6 @@ class TestRunnerTest {
             classpath = "/cache/dep.jar"
         )
 
-        // Then: order is classes:test-classes:test-resources:deps
         assertEquals(
             listOf(
                 "java", "-jar", "/tools/launcher.jar",
@@ -147,7 +142,6 @@ class TestRunnerTest {
 
     @Test
     fun testRunCommandWithEmptyTestResourceDirs() {
-        // Given: empty testResourceDirs (same as not providing it)
         val cmd = testRunCommand(
             classesDir = "build/classes",
             testClassesDir = "build/test-classes",
@@ -167,10 +161,8 @@ class TestRunnerTest {
 
     @Test
     fun testRunCommandWithManagedJavaPathUsesItAsJava() {
-        // Given: a managed java binary path
         val managedJavaBin = "/home/user/.kolt/toolchains/jdk/21/bin/java"
 
-        // When: testRunCommand is called with javaPath
         val cmd = testRunCommand(
             classesDir = "build/classes",
             testClassesDir = "build/test-classes",
@@ -178,7 +170,6 @@ class TestRunnerTest {
             javaPath = managedJavaBin
         )
 
-        // Then: managed path is used as the first arg, not system "java"
         assertEquals(
             listOf(
                 managedJavaBin, "-jar", "/tools/launcher.jar",
@@ -191,8 +182,6 @@ class TestRunnerTest {
 
     @Test
     fun testRunCommandWithNullJavaPathDefaultsToSystemJava() {
-        // Given: no managed JDK (null)
-        // When: testRunCommand is called with explicit null javaPath
         val cmd = testRunCommand(
             classesDir = "build/classes",
             testClassesDir = "build/test-classes",
@@ -200,16 +189,13 @@ class TestRunnerTest {
             javaPath = null
         )
 
-        // Then: falls back to system "java"
         assertEquals("java", cmd.args.first())
     }
 
     @Test
     fun testRunCommandWithManagedJavaAndClasspath() {
-        // Given: managed java + classpath
         val managedJavaBin = "/home/user/.kolt/toolchains/jdk/21/bin/java"
 
-        // When: testRunCommand is called with both javaPath and classpath
         val cmd = testRunCommand(
             classesDir = "build/classes",
             testClassesDir = "build/test-classes",
@@ -218,7 +204,6 @@ class TestRunnerTest {
             javaPath = managedJavaBin
         )
 
-        // Then: managed java is first, classpath includes dependency
         assertEquals(
             listOf(
                 managedJavaBin, "-jar", "/tools/launcher.jar",

--- a/src/nativeTest/kotlin/kolt/build/daemon/BootstrapJdkTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/BootstrapJdkTest.kt
@@ -11,13 +11,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-/**
- * Drives every branch of [ensureBootstrapJavaBin] with injected seams.
- * The fast path (JDK already present) must not touch the installer,
- * the slow path (JDK absent) must run the installer and re-probe,
- * and a failing installer must surface as [BootstrapJdkError] with
- * the probed install dir and the underlying ToolchainError.
- */
 class EnsureBootstrapJavaBinTest {
 
     private val paths = KoltPaths(home = "/fake/home")
@@ -75,9 +68,6 @@ class EnsureBootstrapJavaBinTest {
 
     @Test
     fun postInstallProbeFailureSurfacesAsBootstrapJdkError() {
-        // installJdkToolchain returned Ok but the post-install probe
-        // cannot find bin/java — a ToolchainManager bug we still
-        // translate into a graceful daemon fallback.
         val result = ensureBootstrapJavaBin(
             paths = paths,
             resolve = { null },

--- a/src/nativeTest/kotlin/kolt/build/daemon/BtaImplJarResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/BtaImplJarResolverTest.kt
@@ -4,10 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
-// Pure unit tests for the -impl jar resolver. Mirrors the structure of
-// DaemonJarResolverTest — the pure entry point (`resolveBtaImplJarsPure`)
-// takes the env var, the /proc/self/exe probe, and a file-lister as lambdas
-// so every branch of the probe chain can be exercised without touching disk.
 class BtaImplJarResolverTest {
 
     @Test
@@ -27,9 +23,6 @@ class BtaImplJarResolverTest {
 
     @Test
     fun envOverrideEmptyDirectorySurfacesAsNotFound() {
-        // A user who sets the env var but points it at an empty or unreadable
-        // directory should see that exact path in the warning, not a fallback
-        // libexec path they did not ask for.
         val result = resolveBtaImplJarsPure(
             envDirValue = "/fake/empty",
             selfExePath = "/opt/kolt/bin/kolt",
@@ -41,7 +34,6 @@ class BtaImplJarResolverTest {
 
     @Test
     fun libexecLayoutResolvesRelativeToSelfExe() {
-        // A `kolt` binary at /opt/kolt/bin/kolt implies /opt/kolt/libexec/kolt-bta-impl.
         val fakeJars = listOf("/opt/kolt/libexec/kolt-bta-impl/kotlin-build-tools-impl.jar")
         val result = resolveBtaImplJarsPure(
             envDirValue = null,
@@ -57,16 +49,12 @@ class BtaImplJarResolverTest {
 
     @Test
     fun devFallbackResolvesFiveParentsUpFromTestBinary() {
-        // Dev layout: <repo>/build/bin/linuxX64/debugTest/test.kexe →
-        // <repo>/kolt-compiler-daemon/build/bta-impl-jars/*.jar
         val fakeJars = listOf("/repo/kolt-compiler-daemon/build/bta-impl-jars/a.jar")
         val result = resolveBtaImplJarsPure(
             envDirValue = null,
             selfExePath = "/repo/build/bin/linuxX64/debugTest/test.kexe",
             listJarFiles = { dir ->
                 when (dir) {
-                    // libexec probe returns nothing here — the debugTest binary
-                    // is not under a <prefix>/bin/ layout.
                     "/repo/build/bin/linuxX64/debugTest/libexec/kolt-bta-impl" -> null
                     "/repo/kolt-compiler-daemon/build/bta-impl-jars" -> fakeJars
                     else -> null
@@ -86,9 +74,6 @@ class BtaImplJarResolverTest {
             listJarFiles = { null },
         )
         val notFound = assertIs<BtaImplJarsResolution.NotFound>(result)
-        // The dev-fallback probe is the last one attempted, so its path is
-        // what the user sees — an actionable hint for the `stageBtaImplJars`
-        // Gradle task.
         assertEquals("/repo/kolt-compiler-daemon/build/bta-impl-jars", notFound.probedDir)
     }
 

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
@@ -20,8 +20,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-// Fake frame-level connection used as the seam for DaemonCompilerBackend
-// tests. Records the last request sent and replays a configured reply.
 private class FakeConnection(
     val reply: Result<Message, FrameError> = Ok(
         Message.CompileResult(
@@ -48,9 +46,6 @@ private class FakeConnection(
     }
 }
 
-// Test clock: `nowMs` advances by the argument each time `sleep` is
-// invoked. Lets us verify retry-budget exhaustion without burning
-// wall-clock seconds.
 private class FakeClock(var nowMs: Long = 0) {
     val clock: () -> Long = { nowMs }
     val sleeper: (Int) -> Unit = { ms -> nowMs += ms.toLong() }
@@ -109,9 +104,6 @@ class DaemonCompilerBackendHappyPathTest {
 
     @Test
     fun compileRequestFieldsAreForwardedVerbatimToWireMessage() {
-        // Wire contract: no adapter layer between CompileRequest and
-        // Message.Compile. A regression here would break JVM/native
-        // protocol parity and is cheap to catch at the unit-test level.
         val fake = FakeConnection()
         val backend = newBackend(connector = { Ok(fake) })
 
@@ -129,9 +121,6 @@ class DaemonCompilerBackendHappyPathTest {
 
     @Test
     fun nonZeroExitCodeMapsToCompilationFailed() {
-        // Daemon ran kotlinc but user's Kotlin did not compile. This
-        // is not fallback-eligible — retrying with a subprocess
-        // kotlinc would produce the same user-visible failure.
         val fake = FakeConnection(
             reply = Ok(
                 Message.CompileResult(
@@ -152,15 +141,6 @@ class DaemonCompilerBackendHappyPathTest {
 
     @Test
     fun diagnosticsFieldIsThreadedThroughToCompilationFailed() {
-        // ADR 0019 §7 + B-2c: `DaemonServer.icErrorToReply` parses
-        // kotlinc's `path:L:C: severity: msg` lines into the
-        // `Message.CompileResult.diagnostics` field and routes
-        // unparsable remains to `stderr`. This test pins that the
-        // native-side mapping propagates the structured list into
-        // `CompileError.CompilationFailed.diagnostics` so the
-        // `BuildCommands` rendering path can actually reach the user.
-        // Before this change the diagnostics field was silently
-        // dropped and dogfood users saw only the one-line summary.
         val fake = FakeConnection(
             reply = Ok(
                 Message.CompileResult(
@@ -197,12 +177,8 @@ class DaemonCompilerBackendHappyPathTest {
 
     @Test
     fun daemonProtocolErrorMapsToBackendUnavailable() {
-        // The JVM daemon's writeProtocolError wire contract emits
-        // exitCode=2, empty diagnostics, empty stdout, and a stderr
-        // prefixed "protocol error: ". Route those to
-        // BackendUnavailable so FallbackCompilerBackend falls through
-        // to subprocess compile instead of surfacing a confusing
-        // CompilationFailed.
+        // exitCode=2 + "protocol error: " prefix is the daemon's writeProtocolError
+        // wire shape; route to BackendUnavailable so the fallback fires.
         val fake = FakeConnection(
             reply = Ok(
                 Message.CompileResult(
@@ -225,10 +201,8 @@ class DaemonCompilerBackendHappyPathTest {
 
     @Test
     fun kotlincInternalErrorExitCode2DoesNotFalsePositive() {
-        // A real kotlinc internal error can also produce exitCode=2
-        // but carries real compiler output, not the "protocol error:"
-        // prefix. Make sure the sniff is narrow enough to leave that
-        // path as CompilationFailed.
+        // Real kotlinc internal error also exits 2 but without the
+        // "protocol error:" prefix — must stay CompilationFailed.
         val fake = FakeConnection(
             reply = Ok(
                 Message.CompileResult(
@@ -260,14 +234,8 @@ class DaemonCompilerBackendConnectAndSpawnTest {
         assertEquals(0, spawnCalls, "daemon should not be spawned when already listening")
     }
 
-    // Regression guard for issue #112: the Phase B daemon cannot initialise
-    // BtaIncrementalCompiler without the kotlin-build-tools-impl classpath,
-    // so `spawnArgv()` MUST include `--bta-impl-jars` alongside the existing
-    // `--compiler-jars`. If someone deletes the block in spawnArgv, every
-    // dev-fallback `kolt build` silently falls back to the subprocess
-    // compile path via `BtaImplJarsMissing` — green CI, quiet regression.
-    // Pinning the flag in argv catches that class of deletion at unit-test
-    // time instead of in a field bug report.
+    // #112: spawnArgv must include --bta-impl-jars; without it the daemon
+    // silently falls back to subprocess compile (green CI, quiet regression).
     @Test
     fun spawnArgvIncludesBtaImplJarsFlag() {
         var captured: List<String>? = null
@@ -297,11 +265,6 @@ class DaemonCompilerBackendConnectAndSpawnTest {
         )
     }
 
-    // #65 native client wiring: when kolt.toml [plugins] is empty (or all
-    // disabled) the native client must NOT pass --plugin-jars to the daemon.
-    // The daemon parser collapses an absent flag to an empty map, so omitting
-    // the flag is the canonical "no plugins" wire shape and avoids any risk of
-    // a malformed entry in the common path.
     @Test
     fun spawnArgvOmitsPluginJarsFlagWhenEmpty() {
         var captured: List<String>? = null
@@ -329,11 +292,7 @@ class DaemonCompilerBackendConnectAndSpawnTest {
         )
     }
 
-    // #65 native client wiring: a single enabled plugin must be serialised as
-    // `alias=cp1:cp2` (':' on linuxX64 == File.pathSeparator on the daemon
-    // side, see Main.kt:160). Pinning the wire format in a unit test means
-    // a future contributor cannot silently desync the two sides without
-    // failing CI.
+    // #65: wire format is `alias=cp1:cp2` — ':' matches File.pathSeparator on the daemon side.
     @Test
     fun spawnArgvSerialisesSinglePluginWithColonSeparatedClasspath() {
         var captured: List<String>? = null
@@ -360,14 +319,8 @@ class DaemonCompilerBackendConnectAndSpawnTest {
         assertEquals("serialization=/kt/lib/ser1.jar:/kt/lib/ser2.jar", argv[flagIdx + 1])
     }
 
-    // #65 native client wiring: multiple aliases are joined with ';' so that
-    // the daemon's parsePluginJars can re-split them. The serialised order
-    // mirrors the input map's iteration order — `linkedMapOf` is used here
-    // and `resolvePluginJarsMap` returns a `LinkedHashMap` in production, so
-    // the assertion below pins the exact wire string. A future caller that
-    // hands `DaemonCompilerBackend` a non-LinkedHashMap would break this
-    // test, which is the point: that change would also break the
-    // pluginsFingerprint stability and the warm-daemon reuse story.
+    // #65: multiple aliases joined with ';'. Iteration order matters —
+    // a non-LinkedHashMap would break pluginsFingerprint stability.
     @Test
     fun spawnArgvSerialisesMultiplePluginsSemicolonSeparated() {
         var captured: List<String>? = null
@@ -399,9 +352,6 @@ class DaemonCompilerBackendConnectAndSpawnTest {
 
     @Test
     fun enoentTriggersSpawnAndThenRetrySucceeds() {
-        // First connect fails with ENOENT (socket missing) so the
-        // backend spawns a daemon; the second connect (after the
-        // simulated sleep) succeeds.
         var attempts = 0
         var spawnCalls = 0
         val fake = FakeConnection()
@@ -442,10 +392,6 @@ class DaemonCompilerBackendConnectAndSpawnTest {
 
     @Test
     fun eaccesIsFatalAndDoesNotTriggerSpawn() {
-        // EACCES on the socket path means the daemon cannot bind to
-        // the user's ~/.kolt/daemon/ either — retrying under a fresh
-        // spawn will fail identically. Short-circuit to
-        // BackendUnavailable immediately so the build falls back.
         var spawnCalls = 0
         val connector: DaemonConnector = {
             Err(UnixSocketError.ConnectFailed(it, platform.posix.EACCES, "Permission denied"))
@@ -461,9 +407,6 @@ class DaemonCompilerBackendConnectAndSpawnTest {
 
     @Test
     fun invalidArgumentIsMappedToInternalMisuse() {
-        // kolt itself built a bad socket path (e.g. the rendered path
-        // exceeds sun_path capacity). This is a kolt bug, not a user
-        // bug — surface it loudly rather than silently fall back.
         val connector: DaemonConnector = {
             Err(UnixSocketError.InvalidArgument("path exceeds sun_path capacity"))
         }
@@ -475,9 +418,6 @@ class DaemonCompilerBackendConnectAndSpawnTest {
 
     @Test
     fun spawnFailureIsMappedToBackendUnavailable() {
-        // Simulate an unplausible-but-possible spawn failure: fork
-        // returned -1. The retry loop never starts and the build
-        // falls back cleanly.
         val connector: DaemonConnector = {
             Err(UnixSocketError.ConnectFailed(it, platform.posix.ENOENT, "No such file"))
         }
@@ -492,10 +432,6 @@ class DaemonCompilerBackendConnectAndSpawnTest {
 
     @Test
     fun retryExhaustedAfterBudgetReturnsBackendUnavailable() {
-        // Every retry attempt returns ENOENT. Each fake sleep
-        // advances the clock by the requested amount, so the 3000 ms
-        // budget is blown after a finite number of iterations — no
-        // wall-clock wait in the test.
         val clock = FakeClock()
         var attempts = 0
         val connector: DaemonConnector = {
@@ -547,10 +483,6 @@ class DaemonCompilerBackendReplyMappingTest {
 
     @Test
     fun sendSerializationFailureIsInternalMisuse() {
-        // A Malformed error on the write path means our own codec
-        // refused to serialise the request — i.e. kolt built a
-        // structurally invalid message. That is an internal bug,
-        // distinct from the daemon rejecting the wire.
         val fake = FakeConnection(sendResult = Err(FrameError.Malformed("not serialisable")))
         val backend = newBackend(connector = { Ok(fake) })
         val err = assertNotNull(backend.compile(sampleRequest()).getError())

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonIntegrationTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonIntegrationTest.kt
@@ -16,75 +16,7 @@ import platform.posix.getpid
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 
-/**
- * End-to-end round-trip against a real `kolt-compiler-daemon` fat
- * jar, a real bootstrap JDK, and a real kotlinc `lib/` directory.
- *
- * ## Opt-in via `KOLT_DAEMON_IT=1`
- *
- * This test is disabled by default — running it requires external
- * artefacts (JVM + kolt-compiler-daemon-all.jar + the jars in kotlinc/lib)
- * that a clean CI environment does not have. Set `KOLT_DAEMON_IT=1`
- * and supply the two env vars described below to run it locally.
- * Without `KOLT_DAEMON_IT=1` the test returns immediately and is
- * reported as passing, which keeps `./gradlew linuxX64Test` green on
- * any developer machine without ceremony.
- *
- * When `KOLT_DAEMON_IT=1` **is** set, any missing dependency (env
- * var unset, daemon jar not built, kotlinc lib empty) is a hard test
- * failure rather than another silent skip — the opt-in is an
- * explicit "I have the deps, run the test for real" signal, and
- * quietly passing on a broken setup would paper over the mistake
- * without surfacing it in the gradle test report.
- *
- * ## Environment variables
- *
- * - `KOLT_DAEMON_IT=1` — master switch.
- * - `JAVA_HOME` — pointed at any JDK new enough to run the Kotlin
- *   compiler (matches the bootstrap constant, but this test does not
- *   assume `~/.kolt/toolchains/jdk/<BOOTSTRAP_JDK_VERSION>` exists).
- * - `KOLT_IT_COMPILER_JARS_DIR` — absolute path to a kotlinc `lib/`
- *   directory containing `kotlin-compiler.jar` and friends. The test
- *   globs every .jar under it and feeds the list to the daemon via
- *   `--compiler-jars`.
- *
- * The daemon fat jar is resolved with the production
- * [resolveDaemonJar] helper so a locally-built
- * `kolt-compiler-daemon-all.jar` from `./gradlew :kolt-compiler-daemon:shadowJar`
- * is picked up automatically via the dev-fallback branch.
- *
- * ## What is verified
- *
- * 1. Cold compile of a trivial top-level function succeeds — this
- *    exercises the whole spawn -> socket retry -> FrameCodec
- *    round-trip -> SharedCompilerHost path on the JVM side.
- * 2. Warm compile (second `compile()` call against the same backend
- *    instance, therefore the same daemon process) also succeeds.
- *    This confirms the daemon stays alive between compiles and the
- *    connector's optimistic fast-path connects the already-running
- *    server instead of re-spawning.
- *
- * Cleanup leaves the daemon process running; it exits on its own
- * idle timeout (30 minutes by default). The `/tmp/kolt_daemon_it_<pid>/`
- * state directory is torn down in `finally` so a fresh run produces a
- * fresh socket path. Do **not** enable this test in a CI job that
- * runs many times per hour — each run leaks one daemon process for
- * up to 30 minutes. The test is designed for a developer workstation
- * where the opt-in is deliberate.
- *
- * ## Observed host-level failure modes
- *
- * One of the open questions from PR3 S6 was whether
- * `DaemonCompilerBackend.mapReplyToOutcome` needs to sniff
- * `exitCode==2 + empty diagnostics` as a "host-level protocol error"
- * and reroute it to `BackendUnavailable`. Running this test against
- * the current JVM side produces `exitCode==0` on success and normal
- * `CompilationFailed(exitCode=1, …)` on a deliberately-broken source
- * — the `writeProtocolError` path only fires on malformed wire
- * traffic, which this test cannot provoke without replacing the
- * FrameCodec. The sniff is therefore left as a TODO until a real
- * reproduction appears in the field.
- */
+// Opt-in via KOLT_DAEMON_IT=1. Requires JAVA_HOME and KOLT_IT_COMPILER_JARS_DIR.
 @OptIn(ExperimentalForeignApi::class)
 class DaemonIntegrationTest {
 
@@ -142,12 +74,6 @@ class DaemonIntegrationTest {
         val btaImplJars: List<String>,
     )
 
-    // Once the caller has opted in via `KOLT_DAEMON_IT=1`, every
-    // missing piece is a hard failure. Using `error()` makes the
-    // gradle test report surface the exact dependency the user needs
-    // to supply, instead of the earlier pattern of eprintln +
-    // silent-pass which left a green test that never touched the
-    // daemon path.
     private fun requireEnv(): ItEnv {
         val javaHome = getenv("JAVA_HOME")?.toKString()
         if (javaHome.isNullOrEmpty()) {
@@ -175,10 +101,6 @@ class DaemonIntegrationTest {
             error("KOLT_DAEMON_IT=1 but $libDir contains no .jar files")
         }
 
-        // BTA impl jars: prefer the production resolver so a locally-built
-        // kolt-compiler-daemon stage (from `./gradlew :kolt-compiler-daemon:build`)
-        // is picked up via the dev-fallback branch. Falls through to the env
-        // override if the caller supplies one.
         val btaJars = when (val res = resolveBtaImplJars()) {
             is BtaImplJarsResolution.Resolved -> res.jars
             is BtaImplJarsResolution.NotFound ->

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonJarResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonJarResolverTest.kt
@@ -13,9 +13,6 @@ class DaemonJarResolverTest {
 
     @Test
     fun envOverrideWinsWithoutExistenceCheck() {
-        // A non-empty KOLT_DAEMON_JAR is honoured even if no jar is on
-        // disk — documented as "user takes responsibility" in the
-        // resolver docstring.
         val result = resolveDaemonJarPure(
             envValue = "/nowhere/custom.jar",
             selfExePath = "/opt/kolt/bin/kolt",
@@ -54,9 +51,6 @@ class DaemonJarResolverTest {
 
     @Test
     fun devFallbackResolvesFromBinaryInsideBuildBinLinuxX64() {
-        // Realistic dev layout after `./gradlew build`:
-        //   <repo>/build/bin/linuxX64/debugExecutable/kolt.kexe
-        //   <repo>/kolt-compiler-daemon/build/libs/kolt-compiler-daemon-all.jar
         val kolt = "/home/alice/src/kolt/build/bin/linuxX64/debugExecutable/kolt.kexe"
         val devJar = "/home/alice/src/kolt/kolt-compiler-daemon/build/libs/kolt-compiler-daemon-all.jar"
         val result = resolveDaemonJarPure(
@@ -72,10 +66,6 @@ class DaemonJarResolverTest {
     @Test
     fun libexecWinsOverDevFallbackWhenBothExist() {
         val libexec = "/opt/kolt/libexec/kolt-compiler-daemon-all.jar"
-        // An improbable collision: the installed binary happens to sit
-        // deep enough that a sibling kolt-compiler-daemon/ exists too.
-        // Libexec must still win because it is the higher-priority
-        // candidate in the fallback chain.
         val devJar = "/kolt-compiler-daemon/build/libs/kolt-compiler-daemon-all.jar"
         val result = resolveDaemonJarPure(
             envValue = null,

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
@@ -20,21 +20,17 @@ class EnsureJdkBinsFromConfigTest {
 
     @Test
     fun jdkNullInConfigReturnsNullBins() {
-        // Given: config has no jdk field
         val config = testConfig(jdk = null)
         val paths = KoltPaths("/tmp/kolt_ensure_jdk_bins_null")
 
-        // When: ensureJdkBinsFromConfig is called
         val result = ensureJdkBinsFromConfig(config, paths)
 
-        // Then: both java and jar are null — no managed JDK
         assertNull(result.java)
         assertNull(result.jar)
     }
 
     @Test
     fun jdkSpecifiedAndInstalledReturnsBinPaths() {
-        // Given: config specifies jdk 21 and binaries exist at the managed location
         val config = testConfig(jdk = "21")
         val paths = KoltPaths("/tmp/kolt_ensure_jdk_bins_installed")
         val binDir = "${paths.toolchainsDir}/jdk/21/bin"
@@ -42,10 +38,8 @@ class EnsureJdkBinsFromConfigTest {
         writeFileAsString("$binDir/java", "#!/bin/sh")
         writeFileAsString("$binDir/jar", "#!/bin/sh")
         try {
-            // When: ensureJdkBinsFromConfig is called
             val result = ensureJdkBinsFromConfig(config, paths)
 
-            // Then: returns managed java and jar paths
             assertEquals(paths.javaBin("21"), result.java)
             assertEquals(paths.jarBin("21"), result.jar)
         } finally {
@@ -118,13 +112,10 @@ class FindOverlappingDependenciesTest {
     }
 }
 
-// Integration test: verifies the full cinterop data flow across Config → Builder → BuildCommands → KoltPaths.
-// This covers the native build pipeline that a `target = "native"` project with libcurl cinterop would exercise.
 class CinteropNativeBuildIntegrationTest {
 
     @Test
     fun nativeConfigWithCinteropPassesKlibToLibraryAndLinkCommands() {
-        // Given: a native project config with a libcurl cinterop entry
         val libcurlEntry = CinteropConfig(
             name = "libcurl",
             def = "src/nativeInterop/cinterop/libcurl.def",
@@ -137,28 +128,20 @@ class CinteropNativeBuildIntegrationTest {
         )
         val paths = KoltPaths("/home/testuser")
 
-        // When: cinterop command and klib path are derived from the config entry using KoltPaths
         val cinteropCmd = cinteropCommand(
             entry = libcurlEntry,
             cinteropPath = paths.cinteropBin(config.kotlin)
         )
         val klibPath = cinteropOutputKlibPath(libcurlEntry)
 
-        // Then: the cinterop binary comes from the managed konanc distribution (KoltPaths → cinterop)
         assertEquals(paths.cinteropBin(config.kotlin), cinteropCmd.args.first())
         assertEquals("build/libcurl.klib", klibPath)
 
-        // When: the cinterop klib is passed to native build commands (cinterop → nativeLibraryCommand)
         val libraryCmd = nativeLibraryCommand(config, klibs = listOf(klibPath))
-
-        // Then: the klib appears as -l in the library command
         val libLIdx = libraryCmd.args.indexOf("-l")
         assertEquals("build/libcurl.klib", libraryCmd.args[libLIdx + 1])
 
-        // When: the same klib is passed to the link command (cinterop → nativeLinkCommand)
         val linkCmd = nativeLinkCommand(config, klibs = listOf(klibPath))
-
-        // Then: the klib appears as -l in the link command, and the output is the expected executable
         val linkLIdx = linkCmd.args.indexOf("-l")
         assertEquals("build/libcurl.klib", linkCmd.args[linkLIdx + 1])
         assertEquals("build/myapp.kexe", linkCmd.outputPath)
@@ -166,21 +149,17 @@ class CinteropNativeBuildIntegrationTest {
 
     @Test
     fun cinteropOutputKlibPathIsConsistentWithCinteropCommandOutputBase() {
-        // The cinterop tool appends .klib to the -o path automatically.
-        // cinteropCommand.outputPath must not include .klib; cinteropOutputKlibPath adds it.
+        // cinterop tool appends .klib to -o automatically; cinteropCommand.outputPath omits it.
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
-        // When: both are computed for the same entry
         val cmd = cinteropCommand(entry)
         val klibPath = cinteropOutputKlibPath(entry)
 
-        // Then: klibPath == cmd.outputPath + ".klib" (consistent across Build package functions)
         assertEquals("${cmd.outputPath}.klib", klibPath)
     }
 
     @Test
     fun nativeConfigWithMultipleCinteropEntriesProducesAllKlibsInBuildCommands() {
-        // Given: a native config with two cinterop entries (libcurl + libssl)
         val libcurlEntry = CinteropConfig(name = "libcurl", def = "libcurl.def")
         val libsslEntry = CinteropConfig(name = "libssl", def = "libssl.def")
         val config = testConfig(
@@ -188,16 +167,10 @@ class CinteropNativeBuildIntegrationTest {
             cinterop = listOf(libcurlEntry, libsslEntry)
         )
 
-        // When: klib paths are computed for all entries (mirrors what runCinterop does)
         val klibPaths = config.cinterop.map { cinteropOutputKlibPath(it) }
-
-        // Then: each entry yields its own klib path under build/
         assertEquals(listOf("build/libcurl.klib", "build/libssl.klib"), klibPaths)
 
-        // When: native library command is built with all cinterop klibs
         val libraryCmd = nativeLibraryCommand(config, klibs = klibPaths)
-
-        // Then: -l flag is repeated for each klib in order
         val lIndices = libraryCmd.args.indices.filter { libraryCmd.args[it] == "-l" }
         assertEquals(2, lIndices.size)
         assertEquals("build/libcurl.klib", libraryCmd.args[lIndices[0] + 1])

--- a/src/nativeTest/kotlin/kolt/cli/PluginSupportTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/PluginSupportTest.kt
@@ -8,19 +8,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-// After #65 the plugin jar fetcher is the single source of truth for
-// compiler plugin jars on every compile path. `resolvePluginArgs` /
-// `resolvePluginJarsMap` are thin wrappers that delegate to
-// `fetchEnabledPluginJars` and translate errors into `exitProcess`
-// calls, so unit tests can only cover the "no network I/O" short-
-// circuit here — anything beyond that hits Maven Central and belongs
-// in `PluginJarFetcherTest`.
-//
-// These tests use a bogus `KoltPaths("/nonexistent-…")` as a defence:
-// if the short-circuit regresses and a zero-enabled-plugin build starts
-// touching the network or the filesystem, the mkdir / download attempt
-// under the bogus cache base will exit the test process and fail the
-// test.
+// Bogus KoltPaths: if the zero-plugin short-circuit regresses, any I/O
+// attempt under this path will fail the test.
 class PluginSupportTest {
 
     private val bogusPaths = KoltPaths("/nonexistent-home-for-test")
@@ -65,13 +54,6 @@ class PluginSupportTest {
         assertEquals(emptyMap(), result)
     }
 
-    // The native path used to have a separate `resolveNativePluginArgs`
-    // that called `ensureKotlincBin` before resolving plugin args. That
-    // split is gone: the native konanc path and the JVM subprocess
-    // fallback both call the same `resolvePluginArgs` now, and neither
-    // needs the kotlinc sidecar. `target = "native"` is intentionally
-    // exercised here to pin that the short-circuit has no target-specific
-    // branches left.
     @Test
     fun resolvePluginArgsNativeTargetSharesTheSameShortCircuit() {
         val config = testConfig(plugins = emptyMap(), target = "native")
@@ -81,22 +63,8 @@ class PluginSupportTest {
         assertTrue(result.isEmpty())
     }
 
-    // --- mapPluginFetchErrorToExit ---
-    //
-    // The error-to-exit translation is a pure function so every branch
-    // is exercised here without the `exitProcess` wrapper. The tests
-    // pin two invariants:
-    // 1. User-facing config mistakes (unknown alias, 404 on a coordinate
-    //    that kolt builds from `config.kotlin`) exit with
-    //    `EXIT_CONFIG_ERROR` regardless of the caller's operational
-    //    exit code. A `build` or `test` command that would otherwise
-    //    return EXIT_BUILD_ERROR / EXIT_TEST_ERROR still returns
-    //    EXIT_CONFIG_ERROR for these cases so wrapper scripts can
-    //    distinguish "network / build failure, retry" from "your
-    //    kolt.toml is wrong, fix it and re-run".
-    // 2. Everything else propagates to the caller-provided operational
-    //    code so `build` vs `test` can keep their own exit-status
-    //    conventions.
+    // Config mistakes (unknown alias, 404) always EXIT_CONFIG_ERROR;
+    // transient failures propagate the caller's operational exit code.
 
     @Test
     fun mapUnknownPluginIsConfigError() {
@@ -110,11 +78,6 @@ class PluginSupportTest {
 
     @Test
     fun mapHttp404DownloadFailureIsConfigErrorAndNamesTheKotlinPin() {
-        // A 404 on a `kolt-*-compiler-plugin:<ver>` coordinate means
-        // `kotlin = "<ver>"` in kolt.toml was set to a version that
-        // JetBrains never published. The error message must point the
-        // user at the right knob — "change kolt.toml", not "retry
-        // later".
         val exit = mapPluginFetchErrorToExit(
             PluginFetchError.DownloadFailed(
                 alias = "serialization",

--- a/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
@@ -19,14 +19,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-/**
- * Drives every branch of [resolveCompilerBackend] with fake seams.
- * The helper itself contains no I/O, but every production path it
- * touches (precondition resolution, daemon state directory creation,
- * daemon backend construction, warning sink) is exposed as a lambda
- * so the test can observe warning wording and backend identity
- * directly without standing up a real daemon.
- */
 class ResolveCompilerBackendTest {
 
     private val paths = KoltPaths(home = "/fake/home")
@@ -90,13 +82,9 @@ class ResolveCompilerBackendTest {
         )
     }
 
+    // ADR 0016 §5: daemon is never load-bearing for correctness.
     @Test
     fun bootstrapJdkInstallFailureFallsBackWithCauseInWarning() {
-        // Binds ADR 0016 §5 "daemon is never load-bearing for
-        // correctness" for the auto-install path: a download failure
-        // during first-run bootstrap JDK provisioning must produce a
-        // one-line warning naming the cause and degrade to the
-        // subprocess backend, never propagate as a build failure.
         val warnings = mutableListOf<String>()
         val backend = resolveCompilerBackend(
             config = config,
@@ -153,12 +141,6 @@ class ResolveCompilerBackendTest {
         assertEquals(listOf(WARNING_DAEMON_DIR_UNWRITABLE), warnings)
     }
 
-    // #65 native client wiring: the `pluginJars` map flows through
-    // `resolveCompilerBackend` into `daemonBackendFactory` verbatim, so the
-    // daemon backend can serialise it onto `--plugin-jars` when it spawns
-    // the JVM. Pinning the pass-through here means a future contributor
-    // cannot silently drop the wiring between `doBuild` and the daemon
-    // spawn — the JVM build path's plugin support depends on it.
     @Test
     fun pluginJarsArgumentIsForwardedToDaemonBackendFactory() {
         val warnings = mutableListOf<String>()
@@ -215,20 +197,11 @@ class ResolveCompilerBackendTest {
 
         assertEquals(emptyList(), warnings)
         val fallback = assertNotNull(backend as? FallbackCompilerBackend)
-        // Tightness: asserting `as FallbackCompilerBackend` alone
-        // would still pass if the factory were called but its
-        // return value thrown away and primary wired to something
-        // else. The identity checks below pin the wiring.
         assertSame(daemonSentinel, fallback.primary)
         assertSame(subprocess, fallback.fallback)
         assertEquals(okSetup, createdFrom)
     }
 
-    // #65 native client wiring: editing kolt.toml [plugins] between builds
-    // must NOT reuse a warm daemon spawned with a stale plugin set. The
-    // socket and log paths get a plugin-set fingerprint suffix so a
-    // different plugin set probes a different (absent) socket and trips
-    // the ENOENT spawn path in DaemonCompilerBackend.connectOrSpawn.
     @Test
     fun pluginsFingerprintIsStableForSamePluginMap() {
         val a = pluginsFingerprint(mapOf("serialization" to listOf("/k/lib/ser.jar")))
@@ -238,9 +211,6 @@ class ResolveCompilerBackendTest {
 
     @Test
     fun pluginsFingerprintIsOrderInsensitiveOnAliases() {
-        // Iteration order of a caller's map must not affect the fingerprint —
-        // otherwise a future caller swapping a `linkedMapOf` for a `mapOf`
-        // would orphan all warm daemons for no semantic change.
         val a = pluginsFingerprint(linkedMapOf("a" to listOf("/x"), "b" to listOf("/y")))
         val b = pluginsFingerprint(linkedMapOf("b" to listOf("/y"), "a" to listOf("/x")))
         assertEquals(a, b)
@@ -255,8 +225,6 @@ class ResolveCompilerBackendTest {
 
     @Test
     fun pluginsFingerprintEmptyMapHasFixedMarker() {
-        // The no-plugin path must collapse to a single, stable bucket so the
-        // common case keeps a single warm daemon across repeated builds.
         assertEquals("noplugins", pluginsFingerprint(emptyMap()))
     }
 

--- a/src/nativeTest/kotlin/kolt/cli/ToolchainCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ToolchainCommandsTest.kt
@@ -15,27 +15,15 @@ class FormatToolchainListTest {
 
     @Test
     fun noToolchainsInstalledReturnsMessage() {
-        // Given: no toolchains installed
-        val kotlincVersions = emptyList<String>()
-        val jdkVersions = emptyList<String>()
+        val result = formatToolchainList(emptyList(), emptyList(), emptyList())
 
-        // When: formatting the list
-        val result = formatToolchainList(kotlincVersions, jdkVersions, emptyList())
-
-        // Then: returns "no toolchains installed" message
         assertEquals("no toolchains installed", result)
     }
 
     @Test
     fun onlyKotlincInstalled() {
-        // Given: kotlinc versions installed
-        val kotlincVersions = listOf("2.1.0", "2.3.0")
-        val jdkVersions = emptyList<String>()
+        val result = formatToolchainList(listOf("2.1.0", "2.3.0"), emptyList(), emptyList())
 
-        // When: formatting the list
-        val result = formatToolchainList(kotlincVersions, jdkVersions, emptyList())
-
-        // Then: shows kotlinc section only with description
         val expected = """
             kotlinc (Kotlin compiler):
               2.1.0
@@ -46,14 +34,8 @@ class FormatToolchainListTest {
 
     @Test
     fun onlyJdkInstalled() {
-        // Given: jdk versions installed
-        val kotlincVersions = emptyList<String>()
-        val jdkVersions = listOf("21")
+        val result = formatToolchainList(emptyList(), listOf("21"), emptyList())
 
-        // When: formatting the list
-        val result = formatToolchainList(kotlincVersions, jdkVersions, emptyList())
-
-        // Then: shows jdk section only with description
         val expected = """
             jdk (Java Development Kit):
               21
@@ -63,14 +45,8 @@ class FormatToolchainListTest {
 
     @Test
     fun bothKotlincAndJdkInstalled() {
-        // Given: both kotlinc and jdk installed
-        val kotlincVersions = listOf("2.1.0")
-        val jdkVersions = listOf("17", "21")
+        val result = formatToolchainList(listOf("2.1.0"), listOf("17", "21"), emptyList())
 
-        // When: formatting the list
-        val result = formatToolchainList(kotlincVersions, jdkVersions, emptyList())
-
-        // Then: shows both sections separated by blank line, with descriptions
         val expected = """
             kotlinc (Kotlin compiler):
               2.1.0
@@ -84,7 +60,6 @@ class FormatToolchainListTest {
 
     @Test
     fun onlyKonancInstalled() {
-        // Given: konanc versions installed
         val result = formatToolchainList(emptyList(), emptyList(), listOf("2.3.20"))
 
         val expected = """
@@ -96,7 +71,6 @@ class FormatToolchainListTest {
 
     @Test
     fun allThreeToolchainsInstalled() {
-        // Given: kotlinc, jdk, konanc all installed
         val result = formatToolchainList(
             listOf("2.1.0"),
             listOf("21"),
@@ -121,10 +95,8 @@ class ValidateToolchainRemoveArgsTest {
 
     @Test
     fun validKotlincArgs() {
-        // Given: valid kotlinc remove args
         val result = validateToolchainRemoveArgs(listOf("kotlinc", "2.1.0"))
 
-        // Then: returns Ok with parsed args
         val args = assertNotNull(result.get())
         assertEquals("kotlinc", args.name)
         assertEquals("2.1.0", args.version)
@@ -132,10 +104,8 @@ class ValidateToolchainRemoveArgsTest {
 
     @Test
     fun validJdkArgs() {
-        // Given: valid jdk remove args
         val result = validateToolchainRemoveArgs(listOf("jdk", "21"))
 
-        // Then: returns Ok with parsed args
         val args = assertNotNull(result.get())
         assertEquals("jdk", args.name)
         assertEquals("21", args.version)
@@ -143,10 +113,8 @@ class ValidateToolchainRemoveArgsTest {
 
     @Test
     fun validKonancArgs() {
-        // Given: valid konanc remove args
         val result = validateToolchainRemoveArgs(listOf("konanc", "2.3.20"))
 
-        // Then: returns Ok with parsed args
         val args = assertNotNull(result.get())
         assertEquals("konanc", args.name)
         assertEquals("2.3.20", args.version)
@@ -154,30 +122,24 @@ class ValidateToolchainRemoveArgsTest {
 
     @Test
     fun unknownToolchainNameReturnsError() {
-        // Given: unknown toolchain name
         val result = validateToolchainRemoveArgs(listOf("foo", "1.0"))
 
-        // Then: returns Err with message
         assertNull(result.get())
         assertEquals("error: unknown toolchain 'foo' (available: kotlinc, jdk, konanc)", result.getError())
     }
 
     @Test
     fun missingArgsReturnsError() {
-        // Given: not enough args
         val result = validateToolchainRemoveArgs(listOf("kotlinc"))
 
-        // Then: returns Err with usage message
         assertNull(result.get())
         assertEquals("usage: kolt toolchain remove <name> <version>", result.getError())
     }
 
     @Test
     fun emptyArgsReturnsError() {
-        // Given: no args
         val result = validateToolchainRemoveArgs(emptyList())
 
-        // Then: returns Err with usage message
         assertNull(result.get())
         assertEquals("usage: kolt toolchain remove <name> <version>", result.getError())
     }
@@ -187,16 +149,13 @@ class ResolveToolchainPathForRemoveTest {
 
     @Test
     fun kotlincInstalledReturnsKoltPathsPath() {
-        // Given: kotlinc 2.1.0 is installed
         val paths = KoltPaths("/tmp/kolt_tc_remove_kotlinc")
         val binDir = "${paths.toolchainsDir}/kotlinc/2.1.0/bin"
         ensureDirectoryRecursive(binDir)
         writeFileAsString("$binDir/kotlinc", "#!/bin/sh")
         try {
-            // When: resolving path for removal
             val result = resolveToolchainPathForRemove("kotlinc", "2.1.0", paths)
 
-            // Then: returns the path from KoltPaths.kotlincPath()
             assertEquals(paths.kotlincPath("2.1.0"), result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
@@ -205,16 +164,13 @@ class ResolveToolchainPathForRemoveTest {
 
     @Test
     fun jdkInstalledReturnsKoltPathsPath() {
-        // Given: jdk 21 is installed
         val paths = KoltPaths("/tmp/kolt_tc_remove_jdk")
         val binDir = "${paths.toolchainsDir}/jdk/21/bin"
         ensureDirectoryRecursive(binDir)
         writeFileAsString("$binDir/java", "#!/bin/sh")
         try {
-            // When: resolving path for removal
             val result = resolveToolchainPathForRemove("jdk", "21", paths)
 
-            // Then: returns the path from KoltPaths.jdkPath()
             assertEquals(paths.jdkPath("21"), result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
@@ -223,7 +179,6 @@ class ResolveToolchainPathForRemoveTest {
 
     @Test
     fun konancInstalledReturnsKoltPathsPath() {
-        // Given: konanc 2.3.20 is installed
         val paths = KoltPaths("/tmp/kolt_tc_remove_konanc")
         val binDir = "${paths.toolchainsDir}/konanc/2.3.20/bin"
         ensureDirectoryRecursive(binDir)
@@ -239,13 +194,10 @@ class ResolveToolchainPathForRemoveTest {
 
     @Test
     fun notInstalledReturnsNull() {
-        // Given: kotlinc 2.1.0 is not installed
         val paths = KoltPaths("/tmp/kolt_tc_remove_not_installed")
 
-        // When: resolving path for removal
         val result = resolveToolchainPathForRemove("kotlinc", "2.1.0", paths)
 
-        // Then: returns null
         assertNull(result)
     }
 }

--- a/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
@@ -192,7 +192,6 @@ class ConfigTest {
 
         assertNull(result.get())
         val error = assertIs<ConfigError.ParseFailed>(result.getError())
-        // message should mention valid targets
         kotlin.test.assertTrue(error.message.contains("target"))
         kotlin.test.assertTrue(error.message.contains("jvm"))
         kotlin.test.assertTrue(error.message.contains("native"))
@@ -372,11 +371,8 @@ class ConfigTest {
 
     @Test
     fun parseMinimalConfigHasDefaultRepositories() {
-        // Given: no [repositories] section in TOML
-        // When: config is parsed
         val config = assertNotNull(parseConfig(minimalToml).get())
 
-        // Then: default is Maven Central
         assertEquals(1, config.repositories.size)
         assertEquals(MAVEN_CENTRAL_BASE, config.repositories["central"])
     }
@@ -402,7 +398,6 @@ class ConfigTest {
 
     @Test
     fun parseConfigWithMultipleRepositoriesPreservesOrder() {
-        // Given: two repositories declared in a specific order
         val toml = """
             name = "my-app"
             version = "0.1.0"
@@ -418,7 +413,6 @@ class ConfigTest {
 
         val config = assertNotNull(parseConfig(toml).get())
         assertEquals(2, config.repositories.size)
-        // Map preserves insertion order
         val entries = config.repositories.entries.toList()
         assertEquals("internal", entries[0].key)
         assertEquals("https://nexus.example.com/repository/internal", entries[0].value)
@@ -451,7 +445,6 @@ class ConfigTest {
 
     @Test
     fun repositoryTrailingSlashIsNormalized() {
-        // Given: a repository URL with a trailing slash
         val toml = """
             name = "my-app"
             version = "0.1.0"
@@ -466,18 +459,14 @@ class ConfigTest {
         """.trimIndent()
 
         val config = assertNotNull(parseConfig(toml).get())
-        // Trailing slashes must be stripped to prevent double-slash in constructed URLs
         assertEquals("https://jitpack.io", config.repositories["jitpack"])
         assertEquals(MAVEN_CENTRAL_BASE, config.repositories["central"])
     }
 
     @Test
     fun parseMinimalConfigHasDefaultResources() {
-        // Given: no resources or test_resources fields in TOML
-        // When: config is parsed
         val config = assertNotNull(parseConfig(minimalToml).get())
 
-        // Then: both default to empty list
         assertEquals(emptyList(), config.resources)
         assertEquals(emptyList(), config.testResources)
     }
@@ -582,28 +571,20 @@ class ConfigTest {
 
     @Test
     fun mavenCentralBaseDefinedInConfigPackage() {
-        // Verifies MAVEN_CENTRAL_BASE is defined in kolt.config (not scattered to resolve/tool),
-        // and matches the canonical Maven Central URL used as the default repository.
         assertEquals("https://repo1.maven.org/maven2", MAVEN_CENTRAL_BASE)
         val config = assertNotNull(parseConfig(minimalToml).get())
         assertEquals(MAVEN_CENTRAL_BASE, config.repositories["central"])
     }
 
-    // --- jdk field ---
-
     @Test
     fun parseMinimalConfigHasNullJdk() {
-        // Given: minimal config with no jdk field
-        // When: parsing
         val config = assertNotNull(parseConfig(minimalToml).get())
 
-        // Then: jdk defaults to null (use system java)
         assertNull(config.jdk)
     }
 
     @Test
     fun parseConfigWithJdkVersion() {
-        // Given: config with jdk = "21"
         val toml = """
             name = "my-app"
             version = "0.1.0"
@@ -614,16 +595,12 @@ class ConfigTest {
             sources = ["src"]
         """.trimIndent()
 
-        // When: parsing
         val config = assertNotNull(parseConfig(toml).get())
-
-        // Then: jdk field contains the specified version
         assertEquals("21", config.jdk)
     }
 
     @Test
     fun parseConfigWithJdkAndJvmTargetAreIndependent() {
-        // Given: config with both jdk and jvm_target set to different values
         val toml = """
             name = "my-app"
             version = "0.1.0"
@@ -635,29 +612,20 @@ class ConfigTest {
             sources = ["src"]
         """.trimIndent()
 
-        // When: parsing
         val config = assertNotNull(parseConfig(toml).get())
-
-        // Then: jdk and jvm_target are independent fields
         assertEquals("21", config.jdk)
         assertEquals("17", config.jvmTarget)
     }
 
-    // --- [[cinterop]] ---
-
     @Test
     fun parseMinimalConfigHasEmptyCinteropList() {
-        // Given: no [[cinterop]] section in TOML
-        // When: config is parsed
         val config = assertNotNull(parseConfig(minimalToml).get())
 
-        // Then: cinterop defaults to empty list
         assertEquals(emptyList(), config.cinterop)
     }
 
     @Test
     fun parseConfigWithSingleCinteropEntry() {
-        // Given: one [[cinterop]] entry with only required fields
         val toml = """
             name = "my-app"
             version = "0.1.0"
@@ -671,10 +639,8 @@ class ConfigTest {
             def = "src/nativeInterop/cinterop/libcurl.def"
         """.trimIndent()
 
-        // When: config is parsed
         val config = assertNotNull(parseConfig(toml).get())
 
-        // Then: one entry is parsed with correct fields
         assertEquals(1, config.cinterop.size)
         val entry = config.cinterop[0]
         assertEquals("libcurl", entry.name)
@@ -684,7 +650,6 @@ class ConfigTest {
 
     @Test
     fun parseConfigWithCinteropEntryAllFields() {
-        // Given: one [[cinterop]] entry with all optional fields
         val toml = """
             name = "my-app"
             version = "0.1.0"
@@ -699,10 +664,8 @@ class ConfigTest {
             package = "libcurl"
         """.trimIndent()
 
-        // When: config is parsed
         val config = assertNotNull(parseConfig(toml).get())
 
-        // Then: all fields are parsed correctly
         assertEquals(1, config.cinterop.size)
         val entry = config.cinterop[0]
         assertEquals("libcurl", entry.name)
@@ -712,7 +675,6 @@ class ConfigTest {
 
     @Test
     fun parseConfigWithMultipleCinteropEntries() {
-        // Given: two [[cinterop]] entries
         val toml = """
             name = "my-app"
             version = "0.1.0"
@@ -731,10 +693,8 @@ class ConfigTest {
             package = "openssl"
         """.trimIndent()
 
-        // When: config is parsed
         val config = assertNotNull(parseConfig(toml).get())
 
-        // Then: both entries are parsed in order
         assertEquals(2, config.cinterop.size)
         assertEquals("libcurl", config.cinterop[0].name)
         assertEquals("openssl", config.cinterop[1].name)
@@ -744,7 +704,6 @@ class ConfigTest {
 
     @Test
     fun parseConfigCinteropWithDependencies() {
-        // Given: [[cinterop]] alongside [dependencies]
         val toml = """
             name = "my-app"
             version = "0.1.0"
@@ -761,10 +720,8 @@ class ConfigTest {
             def = "libcurl.def"
         """.trimIndent()
 
-        // When: config is parsed
         val config = assertNotNull(parseConfig(toml).get())
 
-        // Then: both sections are parsed independently
         assertEquals(1, config.dependencies.size)
         assertEquals(1, config.cinterop.size)
     }

--- a/src/nativeTest/kotlin/kolt/config/InitTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/InitTest.kt
@@ -24,8 +24,7 @@ class InitTest {
 
     @Test
     fun generateTomlUsesKotlinFunctionFqnForMain() {
-        // Init writes the bare function FQN "main" (root package) rather than
-        // a JVM facade class name. See ADR 0015.
+        // ADR 0015: bare function FQN, not JVM facade class name.
         val toml = generateKoltToml("my-app")
         assertTrue(toml.contains("main = \"main\""))
     }
@@ -63,7 +62,6 @@ class InitTest {
     @Test
     fun generateTomlDoesNotContainTestDependencies() {
         val toml = generateKoltToml("my-app")
-        // kotlin-test-junit5 is auto-injected by kolt, not declared in kolt.toml
         assertFalse(toml.contains("[test-dependencies]"))
         assertFalse(toml.contains("kotlin-test-junit5"))
     }

--- a/src/nativeTest/kotlin/kolt/config/KoltPathsTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/KoltPathsTest.kt
@@ -19,35 +19,23 @@ class KoltPathsTest {
 
     @Test
     fun toolchainsDirConstructedFromHome() {
-        // Given: KoltPaths with a known home
         val paths = KoltPaths("/home/user")
 
-        // Then: toolchainsDir is under ~/.kolt/toolchains
         assertEquals("/home/user/.kolt/toolchains", paths.toolchainsDir)
     }
 
     @Test
     fun kotlincPathBuildsVersionedDirectory() {
-        // Given: KoltPaths with a known home
         val paths = KoltPaths("/home/user")
 
-        // When: kotlincPath is called for a specific version
-        val path = paths.kotlincPath("2.1.0")
-
-        // Then: path points to the versioned directory under toolchains
-        assertEquals("/home/user/.kolt/toolchains/kotlinc/2.1.0", path)
+        assertEquals("/home/user/.kolt/toolchains/kotlinc/2.1.0", paths.kotlincPath("2.1.0"))
     }
 
     @Test
     fun kotlincBinBuildsVersionedBinPath() {
-        // Given: KoltPaths with a known home
         val paths = KoltPaths("/home/user")
 
-        // When: kotlincBin is called for a specific version
-        val bin = paths.kotlincBin("2.1.0")
-
-        // Then: bin path points to bin/kotlinc inside the versioned directory
-        assertEquals("/home/user/.kolt/toolchains/kotlinc/2.1.0/bin/kotlinc", bin)
+        assertEquals("/home/user/.kolt/toolchains/kotlinc/2.1.0/bin/kotlinc", paths.kotlincBin("2.1.0"))
     }
 
     @Test
@@ -64,18 +52,11 @@ class KoltPathsTest {
         assertEquals("/root/.kolt/toolchains/kotlinc/2.3.20/bin/kotlinc", paths.kotlincBin("2.3.20"))
     }
 
-    // --- jdkPath ---
-
     @Test
     fun jdkPathBuildsVersionedDirectory() {
-        // Given: KoltPaths with a known home
         val paths = KoltPaths("/home/user")
 
-        // When: jdkPath is called for a specific major version
-        val path = paths.jdkPath("21")
-
-        // Then: path points to the versioned directory under toolchains/jdk
-        assertEquals("/home/user/.kolt/toolchains/jdk/21", path)
+        assertEquals("/home/user/.kolt/toolchains/jdk/21", paths.jdkPath("21"))
     }
 
     @Test
@@ -85,18 +66,11 @@ class KoltPathsTest {
         assertEquals("/home/alice/.kolt/toolchains/jdk/17", paths.jdkPath("17"))
     }
 
-    // --- javaBin ---
-
     @Test
     fun javaBinBuildsVersionedBinPath() {
-        // Given: KoltPaths with a known home
         val paths = KoltPaths("/home/user")
 
-        // When: javaBin is called for a specific major version
-        val bin = paths.javaBin("21")
-
-        // Then: bin path points to bin/java inside the versioned directory
-        assertEquals("/home/user/.kolt/toolchains/jdk/21/bin/java", bin)
+        assertEquals("/home/user/.kolt/toolchains/jdk/21/bin/java", paths.javaBin("21"))
     }
 
     @Test
@@ -106,18 +80,11 @@ class KoltPathsTest {
         assertEquals("/root/.kolt/toolchains/jdk/17/bin/java", paths.javaBin("17"))
     }
 
-    // --- jarBin ---
-
     @Test
     fun jarBinBuildsVersionedBinPath() {
-        // Given: KoltPaths with a known home
         val paths = KoltPaths("/home/user")
 
-        // When: jarBin is called for a specific major version
-        val bin = paths.jarBin("21")
-
-        // Then: bin path points to bin/jar inside the versioned directory
-        assertEquals("/home/user/.kolt/toolchains/jdk/21/bin/jar", bin)
+        assertEquals("/home/user/.kolt/toolchains/jdk/21/bin/jar", paths.jarBin("21"))
     }
 
     @Test
@@ -126,8 +93,6 @@ class KoltPathsTest {
 
         assertEquals("/root/.kolt/toolchains/jdk/17/bin/jar", paths.jarBin("17"))
     }
-
-    // --- konancPath ---
 
     @Test
     fun konancPathBuildsVersionedDirectory() {
@@ -144,8 +109,6 @@ class KoltPathsTest {
 
         assertEquals("/home/alice/.kolt/toolchains/konanc/2.1.0", paths.konancPath("2.1.0"))
     }
-
-    // --- konancBin ---
 
     @Test
     fun konancBinBuildsVersionedBinPath() {
@@ -165,27 +128,17 @@ class KoltPathsTest {
 
     @Test
     fun jdkJavaBinAndJarBinShareSameVersionedDirectory() {
-        // Given: jdkPath, javaBin, and jarBin for the same version
         val paths = KoltPaths("/home/user")
-
-        // Then: javaBin and jarBin are both under jdkPath
         val base = paths.jdkPath("21")
         assertEquals("$base/bin/java", paths.javaBin("21"))
         assertEquals("$base/bin/jar", paths.jarBin("21"))
     }
 
-    // --- cinteropBin ---
-
     @Test
     fun cinteropBinBuildsVersionedBinPath() {
-        // Given: KoltPaths with a known home
         val paths = KoltPaths("/home/user")
 
-        // When: cinteropBin is called for a specific version
-        val bin = paths.cinteropBin("2.3.20")
-
-        // Then: bin path points to bin/cinterop inside the konanc versioned directory
-        assertEquals("/home/user/.kolt/toolchains/konanc/2.3.20/bin/cinterop", bin)
+        assertEquals("/home/user/.kolt/toolchains/konanc/2.3.20/bin/cinterop", paths.cinteropBin("2.3.20"))
     }
 
     @Test
@@ -197,11 +150,8 @@ class KoltPathsTest {
 
     @Test
     fun cinteropBinSharesKonancDirectory() {
-        // Given: cinterop ships alongside konanc in the same distribution
         val paths = KoltPaths("/home/user")
         val version = "2.3.20"
-
-        // Then: cinteropBin is in the same directory as konancBin
         val konancDir = paths.konancPath(version)
         assertEquals("$konancDir/bin/cinterop", paths.cinteropBin(version))
     }

--- a/src/nativeTest/kotlin/kolt/config/MainTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/MainTest.kt
@@ -10,8 +10,6 @@ import kotlin.test.assertTrue
 
 class MainTest {
 
-    // --- jvmMainClass ---
-
     @Test
     fun jvmMainClassForRootPackage() {
         assertEquals("MainKt", jvmMainClass("main"))
@@ -27,8 +25,6 @@ class MainTest {
         assertEquals("com.example.app.MainKt", jvmMainClass("com.example.app.main"))
     }
 
-    // --- validateMainFqn: accepts ---
-
     @Test
     fun validateMainFqnAcceptsRootMain() {
         assertNull(validateMainFqn("main").getError())
@@ -43,8 +39,6 @@ class MainTest {
     fun validateMainFqnAcceptsDeeplyPackagedMain() {
         assertNull(validateMainFqn("foo.bar.baz.main").getError())
     }
-
-    // --- validateMainFqn: rejects JVM class style with the migration hint ---
 
     @Test
     fun validateMainFqnRejectsRootMainKtWithHint() {
@@ -65,13 +59,9 @@ class MainTest {
 
     @Test
     fun validateMainFqnRejectsArbitraryKtFacade() {
-        // Non-"MainKt" Kt-suffixed class names (e.g. from an App.kt file) are
-        // also rejected — they're still JVM class names, not Kotlin FQNs.
         val err = assertNotNull(validateMainFqn("com.example.AppKt").getError())
         assertTrue(err.message.contains("JVM class name"))
     }
-
-    // --- validateMainFqn: rejects other malformed values ---
 
     @Test
     fun validateMainFqnRejectsEmpty() {
@@ -80,21 +70,17 @@ class MainTest {
 
     @Test
     fun validateMainFqnRejectsCapitalizedNonKt() {
-        // "Main" looks like a JVM class but doesn't end with Kt. Still invalid
-        // because it's neither "main" nor "<pkg>.main".
         val err = assertNotNull(validateMainFqn("Main").getError())
         assertTrue(err.message.contains("Kotlin function FQN"))
     }
 
     @Test
     fun validateMainFqnRejectsNonMainSuffix() {
-        // Ends with a different function name.
         assertNotNull(validateMainFqn("com.example.run").getError())
     }
 
     @Test
     fun validateMainFqnRejectsEndingInRemain() {
-        // "remain" ends in "main" as a substring but not as a dotted segment.
         assertNotNull(validateMainFqn("remain").getError())
     }
 }

--- a/src/nativeTest/kotlin/kolt/daemon/wire/FrameCodecTest.kt
+++ b/src/nativeTest/kotlin/kolt/daemon/wire/FrameCodecTest.kt
@@ -90,9 +90,6 @@ class FrameCodecTest {
 
     @Test
     fun readFrameReturnsEofOnCleanClose() {
-        // Handler returns no bytes; the server closes the connection
-        // immediately after the client half-closes. readFrame sees a
-        // clean EOF at the start of the header.
         UnixEchoServer.start(handler = { ByteArray(0) })
             .getOrElse { fail("start failed: $it") }
             .use { server -> withReadFrame(server) { it.shutdownWrite() } }
@@ -130,9 +127,6 @@ class FrameCodecTest {
 
     @Test
     fun readFrameReturnsTruncatedOnPartialBody() {
-        // Valid header claiming 10 bytes but the server delivers only 3
-        // — exercises the body-side `UnexpectedEof -> Truncated` branch
-        // that the header-truncated test cannot reach.
         val claimedLen = 10
         val framed = encodeBigEndianU32(claimedLen) + byteArrayOf(1, 2, 3)
         UnixEchoServer.start(handler = { framed })
@@ -171,14 +165,6 @@ class FrameCodecTest {
             }
     }
 
-    /**
-     * Sends the encoded frame to a byte-echo fixture, half-closes the
-     * write side, and reads back what should be the same frame — this
-     * proves that `writeFrame` emits bytes that `readFrame` can parse,
-     * which is the only property the codec owes its callers in S4.
-     * A true Compile -> CompileResult fake daemon is deferred to S5
-     * when DaemonCompilerBackend needs it.
-     */
     private fun roundTripViaByteEcho(message: Message): Message {
         UnixEchoServer.start().getOrElse { fail("start failed: $it") }.use { server ->
             UnixSocket.connect(server.socketPath)
@@ -194,12 +180,6 @@ class FrameCodecTest {
         }
     }
 
-    /**
-     * Opens one client connection against [server], lets [prime]
-     * kick the server's byte-echo handler (typically by half-closing),
-     * calls `readFrame`, and returns its error — all failing-path
-     * tests above share this shape.
-     */
     private fun withReadFrame(
         server: UnixEchoServer,
         prime: (UnixSocket) -> Unit,

--- a/src/nativeTest/kotlin/kolt/infra/DownloaderTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/DownloaderTest.kt
@@ -17,7 +17,6 @@ class DownloaderTest {
         val destPath = "/tmp/kolt_test_download.xml"
         remove(destPath)
         try {
-            // maven-metadata.xml is small and stable, suitable for testing
             val url = "https://repo1.maven.org/maven2/junit/junit/maven-metadata.xml"
             val result = downloadFile(url, destPath)
             assertNotNull(result.get())

--- a/src/nativeTest/kotlin/kolt/infra/FileSystemTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/FileSystemTest.kt
@@ -296,7 +296,6 @@ class FileSystemTest {
         writeTestFile("$root/notes.md", "ignored")
         try {
             val files = assertNotNull(expandKotlinSources(listOf(root)).get())
-            // Only .kt files; sorted; nested dir walked.
             assertEquals(listOf("$root/A.kt", "$sub/B.kt"), files)
         } finally {
             remove("$root/A.kt")
@@ -313,8 +312,6 @@ class FileSystemTest {
         platform.posix.mkdir(root, 0b111111101u)
         writeTestFile("$root/Main.kt", "fun main() {}")
         try {
-            // A caller-supplied individual file must pass through
-            // verbatim — no flattening, no walk.
             val files = assertNotNull(expandKotlinSources(listOf("$root/Main.kt")).get())
             assertEquals(listOf("$root/Main.kt"), files)
         } finally {
@@ -331,10 +328,6 @@ class FileSystemTest {
         writeTestFile("$dir/Inside.kt", "fun inside() {}")
         writeTestFile(loose, "fun loose() {}")
         try {
-            // Mixing a dir and a standalone file: the caller's
-            // positional order must be preserved so kotlinc / BTA see
-            // the same module-boundary order a hand-written CLI would
-            // produce.
             val files = assertNotNull(expandKotlinSources(listOf(dir, loose)).get())
             assertEquals(listOf("$dir/Inside.kt", loose), files)
         } finally {
@@ -346,13 +339,6 @@ class FileSystemTest {
 
     @Test
     fun expandKotlinSourcesPassesThroughNonExistentEntriesUnchanged() {
-        // A path that is neither an existing directory nor an existing
-        // file is treated as "caller's intent" and passed through
-        // verbatim. The backend (kotlinc / BTA) then surfaces a real
-        // "no such file" error, which is strictly more informative
-        // than a wrapped `ListFilesFailed` would be. The test pins
-        // this policy so a future rewrite does not silently drop
-        // missing entries.
         val missing = "/tmp/kolt_expand_sources_missing_${platform.posix.getpid()}.kt"
         val files = assertNotNull(expandKotlinSources(listOf(missing)).get())
         assertEquals(listOf(missing), files)
@@ -360,17 +346,14 @@ class FileSystemTest {
 
     @Test
     fun copyDirectoryContentsCopiesFilesToDest() {
-        // Given: source dir with one file
         val src = "/tmp/kolt_copy_src_basic"
         val dest = "/tmp/kolt_copy_dest_basic"
         platform.posix.mkdir(src, 0b111111101u)
         platform.posix.mkdir(dest, 0b111111101u)
         writeTestFile("$src/hello.txt", "hello")
         try {
-            // When: copyDirectoryContents is called
             val result = copyDirectoryContents(src, dest)
 
-            // Then: file exists in dest
             assertNotNull(result.get())
             assertTrue(fileExists("$dest/hello.txt"))
             assertEquals("hello", assertNotNull(readFileAsString("$dest/hello.txt").get()))
@@ -384,7 +367,6 @@ class FileSystemTest {
 
     @Test
     fun copyDirectoryContentsPreservesRelativePaths() {
-        // Given: source dir with a nested file
         val src = "/tmp/kolt_copy_src_nested"
         val sub = "$src/config"
         val dest = "/tmp/kolt_copy_dest_nested"
@@ -393,10 +375,8 @@ class FileSystemTest {
         platform.posix.mkdir(dest, 0b111111101u)
         writeTestFile("$sub/app.properties", "key=value")
         try {
-            // When: copyDirectoryContents is called
             val result = copyDirectoryContents(src, dest)
 
-            // Then: nested file exists at same relative path in dest
             assertNotNull(result.get())
             assertTrue(fileExists("$dest/config/app.properties"))
             assertEquals("key=value", assertNotNull(readFileAsString("$dest/config/app.properties").get()))
@@ -412,7 +392,6 @@ class FileSystemTest {
 
     @Test
     fun copyDirectoryContentsCopiesMultipleFiles() {
-        // Given: source dir with multiple files
         val src = "/tmp/kolt_copy_src_multi"
         val dest = "/tmp/kolt_copy_dest_multi"
         platform.posix.mkdir(src, 0b111111101u)
@@ -420,10 +399,8 @@ class FileSystemTest {
         writeTestFile("$src/a.txt", "aaa")
         writeTestFile("$src/b.conf", "bbb")
         try {
-            // When: copyDirectoryContents is called
             val result = copyDirectoryContents(src, dest)
 
-            // Then: all files exist in dest
             assertNotNull(result.get())
             assertTrue(fileExists("$dest/a.txt"))
             assertTrue(fileExists("$dest/b.conf"))
@@ -441,7 +418,6 @@ class FileSystemTest {
 
     @Test
     fun copyDirectoryContentsOverwritesExistingFile() {
-        // Given: dest already has a file with old content
         val src = "/tmp/kolt_copy_src_overwrite"
         val dest = "/tmp/kolt_copy_dest_overwrite"
         platform.posix.mkdir(src, 0b111111101u)
@@ -449,10 +425,8 @@ class FileSystemTest {
         writeTestFile("$src/data.txt", "new content")
         writeTestFile("$dest/data.txt", "old content")
         try {
-            // When: copyDirectoryContents is called
             copyDirectoryContents(src, dest)
 
-            // Then: dest file has new content
             assertEquals("new content", assertNotNull(readFileAsString("$dest/data.txt").get()))
         } finally {
             remove("$src/data.txt")
@@ -464,29 +438,24 @@ class FileSystemTest {
 
     @Test
     fun copyDirectoryContentsForNonExistentSrcReturnsErr() {
-        // Given: source dir does not exist
         val result = copyDirectoryContents(
             src = "/tmp/kolt_copy_nonexistent_src",
             dest = "/tmp/kolt_copy_dest_err"
         )
 
-        // Then: returns Err
         assertNull(result.get())
         assertIs<CopyFailed>(result.getError())
     }
 
     @Test
     fun copyDirectoryContentsForEmptySrcSucceeds() {
-        // Given: source dir exists but is empty
         val src = "/tmp/kolt_copy_src_empty"
         val dest = "/tmp/kolt_copy_dest_empty"
         platform.posix.mkdir(src, 0b111111101u)
         platform.posix.mkdir(dest, 0b111111101u)
         try {
-            // When: copyDirectoryContents is called
             val result = copyDirectoryContents(src, dest)
 
-            // Then: succeeds with no files copied
             assertNotNull(result.get())
         } finally {
             platform.posix.rmdir(src)
@@ -494,21 +463,16 @@ class FileSystemTest {
         }
     }
 
-    // --- listSubdirectories ---
-
     @Test
     fun listSubdirectoriesReturnsSortedNames() {
-        // Given: directory with multiple subdirectories
         val base = "/tmp/kolt_list_subdirs_sorted"
         platform.posix.mkdir(base, 0b111111101u)
         platform.posix.mkdir("$base/beta", 0b111111101u)
         platform.posix.mkdir("$base/alpha", 0b111111101u)
         platform.posix.mkdir("$base/gamma", 0b111111101u)
         try {
-            // When: listing subdirectories
             val result = listSubdirectories(base)
 
-            // Then: returns sorted directory names
             assertEquals(listOf("alpha", "beta", "gamma"), result.get())
         } finally {
             platform.posix.rmdir("$base/alpha")
@@ -520,14 +484,11 @@ class FileSystemTest {
 
     @Test
     fun listSubdirectoriesReturnsEmptyForEmptyDir() {
-        // Given: empty directory
         val base = "/tmp/kolt_list_subdirs_empty"
         platform.posix.mkdir(base, 0b111111101u)
         try {
-            // When: listing subdirectories
             val result = listSubdirectories(base)
 
-            // Then: returns empty list
             assertEquals(emptyList(), result.get())
         } finally {
             platform.posix.rmdir(base)
@@ -536,26 +497,21 @@ class FileSystemTest {
 
     @Test
     fun listSubdirectoriesReturnsErrForNonExistentDir() {
-        // Given: non-existent directory
         val result = listSubdirectories("/tmp/kolt_list_subdirs_nonexistent")
 
-        // Then: returns Err
         assertNull(result.get())
         assertIs<ListFilesFailed>(result.getError())
     }
 
     @Test
     fun listSubdirectoriesExcludesFiles() {
-        // Given: directory with a file and a subdirectory
         val base = "/tmp/kolt_list_subdirs_mixed"
         platform.posix.mkdir(base, 0b111111101u)
         platform.posix.mkdir("$base/subdir", 0b111111101u)
         writeTestFile("$base/file.txt", "content")
         try {
-            // When: listing subdirectories
             val result = listSubdirectories(base)
 
-            // Then: includes only subdirectories, not files
             assertEquals(listOf("subdir"), result.get())
         } finally {
             remove("$base/file.txt")
@@ -563,8 +519,6 @@ class FileSystemTest {
             platform.posix.rmdir(base)
         }
     }
-
-    // --- listJarFiles ---
 
     @Test
     fun listJarFilesReturnsSortedJarPathsOnly() {
@@ -574,7 +528,7 @@ class FileSystemTest {
         writeTestFile("$base/alpha.jar", "a")
         writeTestFile("$base/beta.jar", "b")
         writeTestFile("$base/notes.txt", "ignored")
-        platform.posix.mkdir("$base/nested.jar", 0b111111101u) // directory, not a file
+        platform.posix.mkdir("$base/nested.jar", 0b111111101u)
         try {
             val result = listJarFiles(base)
             assertEquals(
@@ -611,8 +565,6 @@ class FileSystemTest {
         assertNull(result.get())
         assertIs<ListFilesFailed>(result.getError())
     }
-
-    // --- absolutise ---
 
     @Test
     fun absolutisePreservesAbsolutePath() {

--- a/src/nativeTest/kotlin/kolt/infra/SpawnDetachedTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/SpawnDetachedTest.kt
@@ -26,12 +26,6 @@ class SpawnDetachedTest {
 
     @Test
     fun spawnRunsGrandchildAndReturnsOkImmediately() {
-        // /bin/sh -c "echo ok > $scratch.marker" writes a file and
-        // exits. The parent reaps only the intermediate child, so the
-        // call returns as soon as the double-fork finishes — the
-        // marker file is written by the detached grandchild at some
-        // point after that. A short polling loop waits for the
-        // grandchild to reach the write.
         val result = spawnDetached(
             listOf("/bin/sh", "-c", "echo ok > $scratch.marker"),
         )
@@ -50,9 +44,6 @@ class SpawnDetachedTest {
 
     @Test
     fun logPathCapturesStdoutAndStderrOfGrandchild() {
-        // sh echoes the same marker to stdout and stderr; both must
-        // land in the log file because dup2 redirects fd 1 and fd 2
-        // onto the log fd.
         val logPath = "$scratch.log"
         deleteFile(logPath)
         val result = spawnDetached(

--- a/src/nativeTest/kotlin/kolt/infra/net/UnixSocketTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/net/UnixSocketTest.kt
@@ -37,9 +37,6 @@ class UnixSocketTest {
 
     @Test
     fun recvExactReturnsInvalidArgumentForNegativeLength() {
-        // A stray invalid fd cannot reach the recv() call because the
-        // length check fires first, so this test is independent of
-        // any server.
         UnixSocket(fd = -1).use { socket ->
             val result = socket.recvExact(-1)
             val err = assertIs<UnixSocketError.InvalidArgument>(result.getError())
@@ -52,8 +49,6 @@ class UnixSocketTest {
 
     @Test
     fun recvExactReturnsUnexpectedEofWhenPeerProvidesFewerBytes() {
-        // The echo server hands back exactly three bytes; asking for
-        // four exercises the partial-read branch of recvExact.
         UnixEchoServer.start(handler = { byteArrayOf(1, 2, 3) })
             .getOrElse { fail("start failed: $it") }
             .use { server ->

--- a/src/nativeTest/kotlin/kolt/infra/net/testfixture/UnixEchoServer.kt
+++ b/src/nativeTest/kotlin/kolt/infra/net/testfixture/UnixEchoServer.kt
@@ -43,18 +43,7 @@ import platform.posix.stderr
 import platform.posix.strerror
 import platform.posix.unlink
 
-/**
- * Test-only AF_UNIX server used as the "other side" for UnixSocket tests.
- *
- * Each instance owns a listening socket plus a dedicated accept thread
- * that serves one connection at a time using the configured handler.
- * The request side of every connection is read until EOF (the client
- * must half-close its write side via `UnixSocket.shutdownWrite()`),
- * the handler produces a response, and the response is written back
- * before the worker closes the client fd and loops.
- *
- * Not thread-safe; each test owns its own instance.
- */
+// Client must half-close write side via shutdownWrite() to signal request end.
 // Class-level opt-in: every method on UnixEchoServer touches cinterop,
 // so function-level annotations would be pure noise here. The free
 // helpers below stay at function level since there is no enclosing

--- a/src/nativeTest/kotlin/kolt/resolve/AddDependencyTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/AddDependencyTest.kt
@@ -121,7 +121,6 @@ class AddDependencyTest {
         val result = addDependencyToToml(toml, "com.squareup.okhttp3:okhttp", "4.12.0", false)
         val updated = assertNotNull(result.get())
         val lines = updated.lines()
-        // The blank line between sections should still be present
         val testSectionIndex = lines.indexOfFirst { it == "[test-dependencies]" }
         assertTrue(testSectionIndex > 0)
         assertEquals("", lines[testSectionIndex - 1])

--- a/src/nativeTest/kotlin/kolt/resolve/DependencyTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/DependencyTest.kt
@@ -159,8 +159,6 @@ class DependencyTest {
         )
     }
 
-    // --- klib helpers ---
-
     @Test
     fun buildKlibDownloadUrlProducesCorrectMavenCentralUrl() {
         val coord = Coordinate("org.jetbrains.kotlinx", "kotlinx-coroutines-core-linuxx64", "1.9.0")

--- a/src/nativeTest/kotlin/kolt/resolve/DepsTreeTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/DepsTreeTest.kt
@@ -122,13 +122,6 @@ class DepsTreeTest {
         assertEquals(expected, output)
     }
 
-    // --- buildNativeDependencyTree ---
-    //
-    // Native tree walks Gradle Module Metadata (not POMs): each lookup returns
-    // the redirected *native* display coordinate (e.g. ...-linuxx64) and the
-    // transitive list from the linux_x64 variant. kotlin-stdlib is skipped to
-    // mirror NativeResolver.
-
     private fun nativeInfo(
         displayGroupArtifact: String,
         displayVersion: String,
@@ -137,8 +130,6 @@ class DepsTreeTest {
 
     @Test
     fun nativeTreeDisplaysRedirectedCoordinate() {
-        // The user declared kotlinx-serialization-json but what actually gets
-        // linked is the -linuxx64 redirect target. The tree must reflect that.
         val directDeps = mapOf("org.jetbrains.kotlinx:kotlinx-serialization-json" to "1.7.3")
         val lookup = { ga: String, v: String ->
             if (ga == "org.jetbrains.kotlinx:kotlinx-serialization-json" && v == "1.7.3") {
@@ -182,7 +173,6 @@ class DepsTreeTest {
 
     @Test
     fun nativeTreeSkipsKotlinStdlibAsDirect() {
-        // Mirrors NativeResolver's stdlib skip (ADR 0011).
         val directDeps = mapOf(
             "org.jetbrains.kotlin:kotlin-stdlib" to "2.0.20",
             "org.jetbrains.kotlinx:kotlinx-serialization-json" to "1.7.3"
@@ -201,8 +191,6 @@ class DepsTreeTest {
 
     @Test
     fun nativeTreeSkipsKotlinStdlibAsTransitive() {
-        // Gradle module metadata declares kotlin-stdlib as a transitive dep on
-        // every native variant; the tree must not render it as a child either.
         val directDeps = mapOf("org.jetbrains.kotlinx:kotlinx-serialization-json" to "1.7.3")
         val lookup = { ga: String, _: String ->
             if (ga == "org.jetbrains.kotlinx:kotlinx-serialization-json") nativeInfo(
@@ -239,24 +227,18 @@ class DepsTreeTest {
 
         val tree = buildNativeDependencyTree(directDeps, lookup)
 
-        // First visit of lib-a should walk to lib-b, which walks back to lib-a
-        // but cuts off (no grandchildren). The tree terminates rather than
-        // recursing forever.
         assertEquals(1, tree.size)
         val libA = tree[0]
         assertEquals("com.example:lib-a-linuxx64", libA.groupArtifact)
         assertEquals(1, libA.children.size)
         val libB = libA.children[0]
         assertEquals("com.example:lib-b-linuxx64", libB.groupArtifact)
-        // lib-b's only dep is lib-a, which was already visited → no children.
         assertEquals(1, libB.children.size)
         assertEquals(0, libB.children[0].children.size)
     }
 
     @Test
     fun nativeTreeRendersOriginalCoordinateWhenLookupReturnsNull() {
-        // If metadata can't be fetched or parsed, the tree should still show
-        // what the user declared (so they see something), with no children.
         val directDeps = mapOf("com.example:missing" to "9.9.9")
         val lookup = { _: String, _: String -> null }
 

--- a/src/nativeTest/kotlin/kolt/resolve/GradleMetadataTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/GradleMetadataTest.kt
@@ -129,8 +129,6 @@ class GradleMetadataTest {
 
     @Test
     fun parseJvmRedirectReturnsNullWhenJvmVariantWithoutAvailableAtComesFirst() {
-        // kotlin-test has jvmApiElements (no available-at) before jvmJUnitApiElements (with available-at).
-        // When the library itself provides a JVM jar, we should NOT redirect.
         val json = """
         {
           "formatVersion": "1.1",
@@ -171,8 +169,6 @@ class GradleMetadataTest {
 
     @Test
     fun parseJvmRedirectReturnsNullWhenJvmVariantWithoutAvailableAtComesAfter() {
-        // Reverse of the above: available-at variant comes first, then a plain JVM variant.
-        // Should still return null because the library provides its own JVM jar.
         val json = """
         {
           "formatVersion": "1.1",
@@ -211,11 +207,8 @@ class GradleMetadataTest {
         assertNull(redirect)
     }
 
-    // --- parseNativeRedirect ---
-
     @Test
     fun parseNativeRedirectExtractsLinuxX64AvailableAt() {
-        // Based on kotlinx-coroutines-core:1.9.0 actual .module structure.
         val json = """
         {
           "formatVersion": "1.1",
@@ -271,7 +264,6 @@ class GradleMetadataTest {
 
     @Test
     fun parseNativeRedirectReturnsNullForDifferentTarget() {
-        // Only linuxX64 variant present; asked for macos_arm64 → null
         val json = """
         {
           "formatVersion": "1.1",
@@ -302,7 +294,6 @@ class GradleMetadataTest {
 
     @Test
     fun parseNativeRedirectSkipsNonNativePlatformTypes() {
-        // jvm variants with native.target attribute should not match
         val json = """
         {
           "formatVersion": "1.1",
@@ -330,7 +321,6 @@ class GradleMetadataTest {
 
     @Test
     fun parseNativeRedirectRequiresLibraryCategory() {
-        // A native variant in the documentation category should be skipped
         val json = """
         {
           "formatVersion": "1.1",
@@ -361,8 +351,6 @@ class GradleMetadataTest {
 
     @Test
     fun parseNativeRedirectRequiresKotlinApiUsage() {
-        // Non-api usages (e.g. kotlin-metadata, kotlin-runtime) must be
-        // skipped so we only resolve compile-time klibs.
         val json = """
         {
           "formatVersion": "1.1",
@@ -403,11 +391,8 @@ class GradleMetadataTest {
         assertNull(parseNativeRedirect(json, "linux_x64"))
     }
 
-    // --- parseNativeArtifact ---
-
     @Test
     fun parseNativeArtifactExtractsKlibFileAndDependencies() {
-        // Based on kotlinx-coroutines-core-linuxx64:1.9.0 actual .module structure.
         val json = """
         {
           "formatVersion": "1.1",
@@ -529,7 +514,6 @@ class GradleMetadataTest {
 
     @Test
     fun parseNativeArtifactReturnsNullWhenNoKlibFile() {
-        // Variant matches but files[] has no .klib entry (edge case)
         val json = """
         {
           "formatVersion": "1.1",
@@ -558,8 +542,6 @@ class GradleMetadataTest {
 
     @Test
     fun parseNativeArtifactPicksKlibFileAmongMultiple() {
-        // In practice .module files list only .klib; but if some future
-        // variant lists multiple, we should pick the one ending in .klib.
         val json = """
         {
           "formatVersion": "1.1",
@@ -624,19 +606,11 @@ class GradleMetadataTest {
         assertEquals("1.0", redirect?.version)
     }
 
-    // --- numeric attribute values ---
-    //
-    // kotlinx-datetime:0.7.1-0.6.x-compat emits `"org.gradle.jvm.version": 8`
-    // (integer, not string) on its JVM variants. Gradle Module Metadata does
-    // not require attribute values to be strings, so the resolver must accept
-    // numeric values — treating them as their string form is fine because all
-    // comparisons are against known string literals like "jvm" or "linux_x64".
+    // Gradle Module Metadata attribute values can be non-string JSON primitives
+    // (e.g. kotlinx-datetime:0.7.1-0.6.x-compat emits `"org.gradle.jvm.version": 8`).
 
     @Test
     fun parseNativeRedirectToleratesNumericAttributeValueOnUnrelatedVariant() {
-        // A JVM variant with an integer attribute sits alongside the native
-        // variant we actually want. Previously Map<String, String> deserialization
-        // threw on the integer and the whole document was rejected as invalid.
         val json = """
         {
           "formatVersion": "1.1",
@@ -684,9 +658,6 @@ class GradleMetadataTest {
 
     @Test
     fun parseJvmRedirectToleratesNumericJvmVersionAttribute() {
-        // The JVM variant we actually want carries the integer attribute.
-        // `org.gradle.jvm.version` is checked nowhere, but its mere presence
-        // as a non-string broke decoding before the fix.
         val json = """
         {
           "formatVersion": "1.1",
@@ -719,11 +690,6 @@ class GradleMetadataTest {
 
     @Test
     fun parseNativeRedirectToleratesBooleanAttributeValue() {
-        // Gradle Module Metadata attribute values can be any JSON primitive,
-        // not just strings. Integers are covered above; this pins down the
-        // boolean case so the JsonPrimitive.content contract is exercised
-        // uniformly across JsonLiteral subtypes and future schema evolution
-        // doesn't silently regress.
         val json = """
         {
           "formatVersion": "1.1",

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -133,16 +133,13 @@ class NativeResolverTest {
 
         val result = resolveNative(config, "/cache", deps)
         val resolved = assertNotNull(result.get())
-        // kotlin-stdlib should NOT appear in resolved deps
         assertEquals(1, resolved.deps.size)
         assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
     }
 
     @Test
     fun skipsKotlinStdlibCommonFromTransitives() {
-        // kotlin-stdlib-common has no Gradle module metadata (pre-GMM artifact),
-        // so the resolver must skip it alongside kotlin-stdlib. Appears in the
-        // transitive closure of e.g. org.kotlincrypto.hash:sha2-256.
+        // kotlin-stdlib-common has no Gradle module metadata (pre-GMM artifact).
         val config = testConfig(target = "native").copy(
             dependencies = mapOf("com.example:lib" to "1.0.0")
         )
@@ -245,7 +242,6 @@ class NativeResolverTest {
             dependencies = mapOf("com.example:jvmonly" to "1.0.0")
         )
 
-        // Module only has a jvm variant
         val jvmOnlyModule = """
         {
           "formatVersion": "1.1",
@@ -306,7 +302,6 @@ class NativeResolverTest {
 
     @Test
     fun diamondDependencyHighestVersionWins() {
-        // a -> shared:1.0, b -> shared:2.0 => shared:2.0 should win
         val config = testConfig(target = "native").copy(
             dependencies = mapOf(
                 "com.example:a" to "1.0.0",
@@ -354,7 +349,6 @@ class NativeResolverTest {
 
     @Test
     fun directDepVersionWinsOverTransitive() {
-        // direct: shared:1.0, transitive from a: shared:2.0 => direct wins
         val config = testConfig(target = "native").copy(
             dependencies = mapOf(
                 "com.example:a" to "1.0.0",
@@ -404,8 +398,6 @@ class NativeResolverTest {
 
     @Test
     fun failsOnInvalidJsonWithMetadataParseFailed() {
-        // Broken JSON must not surface as NoNativeVariant — the user would
-        // mistake it for "this library has no linux_x64 build".
         val config = testConfig(target = "native").copy(
             dependencies = mapOf("com.example:lib" to "1.0.0")
         )
@@ -420,8 +412,6 @@ class NativeResolverTest {
         val error = assertIs<ResolveError.MetadataParseFailed>(result.getError())
         assertEquals("com.example:lib", error.groupArtifact)
     }
-
-    // --- fixtures ---
 
     private fun rootModuleJson(
         redirectGroup: String,
@@ -495,7 +485,6 @@ class NativeResolverTest {
         contents: Map<String, String> = emptyMap(),
         sha256: Map<String, String> = emptyMap()
     ): ResolverDeps {
-        // Files whose content is provided are considered already cached on disk.
         cachedFiles.addAll(contents.keys)
         return object : ResolverDeps {
             override fun fileExists(path: String): Boolean = path in cachedFiles

--- a/src/nativeTest/kotlin/kolt/resolve/PluginJarFetcherTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/PluginJarFetcherTest.kt
@@ -16,13 +16,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-// FakeDeps records every seam call so each test can assert exactly which
-// I/O the fetcher performed. Callers pre-populate `existingFiles` (cache
-// contents before the call), `sha256Results` (hash that `computeSha256`
-// will return for a given path), and `stampContents` (what
-// `readFileAsString` will return for a given stamp path). All writes —
-// downloads and stamp updates — are recorded on the same maps so a
-// second lookup of the same path sees the updated view.
 private class FakeFetcherDeps(
     val existingFiles: MutableSet<String> = mutableSetOf(),
     val sha256Results: MutableMap<String, String> = mutableMapOf(),
@@ -77,9 +70,6 @@ class PluginJarFetcherTest {
     private val cacheBase = "/home/u/.kolt/cache"
     private val kotlinVersion = "2.3.20"
 
-    // Cache layout mirrors the existing Maven-shaped dependency cache so
-    // a future `kolt clean --cache` sweep does not need to special-case
-    // plugin jars. See issue #65 + discussion on coordinate shape.
     private val serializationJar =
         "$cacheBase/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin/2.3.20/" +
             "kotlin-serialization-compiler-plugin-2.3.20.jar"
@@ -168,19 +158,11 @@ class PluginJarFetcherTest {
 
     @Test
     fun cacheHitWithStampMismatchReDownloadsAndRewritesStampAndWarns() {
-        // TOFU self-heal: a corrupt stamp or corrupt jar means one of
-        // the two drifted. Re-download + re-stamp is the only safe move —
-        // silently trusting either side would let bit rot survive forever.
-        // #65 review finding #4: emit a single observable warning so a
-        // user staring at "why is every build slow" can grep stderr.
         val deps = FakeFetcherDeps(
             existingFiles = mutableSetOf(serializationJar, serializationStamp),
             sha256Results = mutableMapOf(serializationJar to "hash-actual"),
             stampContents = mutableMapOf(serializationStamp to "hash-stale"),
         )
-        // After the re-download the freshly-downloaded jar hashes to
-        // "hash-fresh". The fake keeps `sha256Results` and updates it
-        // alongside the "successful" download.
         deps.sha256Results[serializationJar] = "hash-fresh"
 
         val result = fetchPluginJar("serialization", kotlinVersion, cacheBase, deps)
@@ -197,15 +179,9 @@ class PluginJarFetcherTest {
 
     @Test
     fun cacheHitWithUnreadableStampWarnsAndReDownloads() {
-        // Stamp file exists but cannot be read (fs error, race, etc.).
-        // The self-heal path still falls through to re-download, but it
-        // must not do so silently — that would let a systematic fs
-        // failure (disk full, fs bug) drain the network on every build
-        // with no user-visible signal.
         val deps = FakeFetcherDeps(
             existingFiles = mutableSetOf(serializationJar, serializationStamp),
             sha256Results = mutableMapOf(serializationJar to "hash-fresh"),
-            // stampContents deliberately empty → readFileAsString returns OpenFailed
         )
 
         fetchPluginJar("serialization", kotlinVersion, cacheBase, deps)
@@ -216,18 +192,9 @@ class PluginJarFetcherTest {
 
     @Test
     fun cacheHitWithHashFailureWarnsBeforeReDownload() {
-        // computeSha256 fails on the existing jar (fs error, io race).
-        // The cache-hit branch logs a warning and falls through to the
-        // download path. `sha256Results` stays empty for this test so
-        // the re-download's own `computeSha256` call also fails — the
-        // whole fetch then returns `HashComputationFailed`. That is
-        // fine for this assertion: we only care that the *cache-hit*
-        // failure emitted a warning, because the silent-self-heal
-        // regression the warning defends against happens on that path.
         val deps = FakeFetcherDeps(
             existingFiles = mutableSetOf(serializationJar, serializationStamp),
             stampContents = mutableMapOf(serializationStamp to "hash-x"),
-            // sha256Results intentionally empty
         )
 
         val result = fetchPluginJar("serialization", kotlinVersion, cacheBase, deps)
@@ -242,10 +209,6 @@ class PluginJarFetcherTest {
 
     @Test
     fun cacheHitWithMissingStampReDownloads() {
-        // Legacy cache state: jar is present from before the fetcher
-        // switch (previously written by `ensureKotlincBin` in-place from
-        // the kotlinc sidecar). No stamp means no TOFU anchor, so we
-        // must not trust the cached jar — re-download to establish one.
         val deps = FakeFetcherDeps(
             existingFiles = mutableSetOf(serializationJar),
             sha256Results = mutableMapOf(serializationJar to "hash-fresh"),
@@ -273,11 +236,6 @@ class PluginJarFetcherTest {
 
     @Test
     fun hashComputationFailureAfterDownloadMapsToFetchError() {
-        // downloadFile succeeded, so the jar exists on disk, but
-        // computeSha256 is unable to open it (disk error, race with
-        // another kolt process, etc.). This is rare but must not
-        // corrupt the cache — returning HashComputationFailed leaves
-        // the stamp absent so the next build re-downloads.
         val deps = FakeFetcherDeps()
 
         val result = fetchPluginJar("serialization", kotlinVersion, cacheBase, deps)
@@ -310,11 +268,6 @@ class PluginJarFetcherTest {
 
     @Test
     fun fetchEnabledPluginJarsAbortsOnFirstError() {
-        // A missing jar must surface as a build-breaking error, not a
-        // silently half-plugged compile. We seed only allopen with a
-        // hash so serialization's computeSha256 call fails after the
-        // stubbed download, and the iterator stops before even
-        // attempting allopen.
         val deps = FakeFetcherDeps()
 
         val result = fetchEnabledPluginJars(
@@ -352,11 +305,6 @@ class PluginJarFetcherTest {
 
     @Test
     fun mkdirRunsOnColdCachePath() {
-        // Regression guard: the fetcher must create the cache directory
-        // tree before delegating to `downloadFile`. `downloadFile` itself
-        // opens the destination with O_CREAT but not the enclosing
-        // directory — same rationale as the daemon dir setup path in
-        // DaemonPreconditions.
         val deps = FakeFetcherDeps(
             sha256Results = mutableMapOf(serializationJar to "h"),
         )

--- a/src/nativeTest/kotlin/kolt/resolve/ResolutionTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolutionTest.kt
@@ -237,15 +237,12 @@ class ResolutionTest {
             mapOf("com.example:lib" to "1.0.0")
         ) { _, _ -> null }  // No POMs available
         val nodes = assertNotNull(result.get())
-        // Direct dep is still resolved, just no transitive deps
         assertEquals(1, nodes.size)
         assertEquals("com.example:lib", nodes[0].groupArtifact)
     }
 
     @Test
     fun resolveGraphExcludesSpecificTransitiveDep() {
-        // lib depends on a (with exclusion of b), a depends on b
-        // b should be excluded
         val poms = mapOf(
             "com.example:lib:1.0.0" to pomInfo(
                 "com.example", "lib", "1.0.0",
@@ -273,7 +270,6 @@ class ResolutionTest {
 
     @Test
     fun resolveGraphWildcardExclusionExcludesAllTransitives() {
-        // lib depends on a (with *:* exclusion), a depends on b and c
         val poms = mapOf(
             "com.example:lib:1.0.0" to pomInfo(
                 "com.example", "lib", "1.0.0",
@@ -300,14 +296,12 @@ class ResolutionTest {
         val names = nodes.map { it.groupArtifact }.toSet()
         assertTrue("com.example:lib" in names)
         assertTrue("com.example:a" in names)
-        // b and c excluded by wildcard
         assertFalse("com.example:b" in names)
         assertFalse("com.example:c" in names)
     }
 
     @Test
     fun resolveGraphExclusionsPropagateTransitively() {
-        // lib excludes c, lib -> a -> b -> c. c should be excluded at any depth.
         val poms = mapOf(
             "com.example:lib:1.0.0" to pomInfo(
                 "com.example", "lib", "1.0.0",
@@ -339,8 +333,6 @@ class ResolutionTest {
 
     @Test
     fun resolveGraphExclusionDoesNotAffectOtherPaths() {
-        // a excludes c, but b does not. Both a and b are direct deps.
-        // a -> c (excluded), b -> c (not excluded) => c should be included
         val poms = mapOf(
             "com.example:a:1.0.0" to pomInfo(
                 "com.example", "a", "1.0.0",
@@ -368,7 +360,6 @@ class ResolutionTest {
             ),
             "com.example:c:1.0.0" to pomInfo("com.example", "c", "1.0.0")
         )
-        // Both a and b depend on c without exclusions → c is included
         val result = resolveGraph(
             mapOf("com.example:a" to "1.0.0", "com.example:b" to "1.0.0"),
             pomsWithExclusion.pomLookup()
@@ -377,8 +368,6 @@ class ResolutionTest {
         val names = nodes.map { it.groupArtifact }.toSet()
         assertTrue("com.example:c" in names)
     }
-
-    // --- Test helpers ---
 
     private fun pomDep(
         group: String,
@@ -408,7 +397,6 @@ class ResolutionTest {
 
     @Test
     fun resolveGraphVersionRangeSelectsConcreteVersion() {
-        // lib depends on util with version range [1.0.0,2.0.0)
         val poms = mapOf(
             "com.example:lib:1.0.0" to pomInfo(
                 "com.example", "lib", "1.0.0",

--- a/src/nativeTest/kotlin/kolt/resolve/ResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolverTest.kt
@@ -87,7 +87,6 @@ class ResolverTest {
         val resolved = assertNotNull(result.get())
         assertEquals(1, resolved.deps.size)
         assertFalse(resolved.lockChanged)
-        // Verify no JAR downloads occurred (module metadata downloads are expected)
         val jarDownloads = downloaded.keys.filter { it.endsWith(".jar") }
         assertTrue(jarDownloads.isEmpty())
     }
@@ -280,7 +279,6 @@ class ResolverTest {
     private fun simplePom(group: String, artifact: String, version: String): String =
         "<project><groupId>$group</groupId><artifactId>$artifact</artifactId><version>$version</version></project>"
 
-    // Fake side-effect injection for testing
     private fun fakeDeps(
         cachedFiles: MutableSet<String> = mutableSetOf(),
         downloadedFiles: MutableMap<String, String> = mutableMapOf(),

--- a/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
@@ -98,7 +98,6 @@ class TransitiveResolverTest {
 
     @Test
     fun diamondDependencyHighestVersionWins() {
-        // A -> C:1.0, B -> C:2.0 => C:2.0 should win
         val config = testConfig().copy(
             dependencies = mapOf(
                 "com.example:a" to "1.0.0",
@@ -217,7 +216,6 @@ class TransitiveResolverTest {
         )
         val result = resolveTransitive(config, null, "/cache", deps)
         val resolved = assertNotNull(result.get())
-        // Should have lib + compile-dep + runtime-dep (3 total), no junit or servlet-api
         assertEquals(3, resolved.deps.size)
         val names = resolved.deps.map { it.groupArtifact }.toSet()
         assertTrue("com.example:compile-dep" in names)
@@ -275,7 +273,6 @@ class TransitiveResolverTest {
 
     @Test
     fun cycleDetection() {
-        // A -> B -> A (cycle)
         val config = testConfig().copy(
             dependencies = mapOf("com.example:a" to "1.0.0")
         )
@@ -320,7 +317,6 @@ class TransitiveResolverTest {
         )
         val result = resolveTransitive(config, null, "/cache", deps)
         val resolved = assertNotNull(result.get())
-        // Should resolve both without infinite loop
         assertEquals(2, resolved.deps.size)
     }
 
@@ -400,7 +396,6 @@ class TransitiveResolverTest {
 
     @Test
     fun directDepsWinOverTransitiveVersionConflict() {
-        // Direct: C:1.0.0. Transitive via A: C:2.0.0. Direct should win.
         val config = testConfig().copy(
             dependencies = mapOf(
                 "com.example:a" to "1.0.0",
@@ -444,7 +439,6 @@ class TransitiveResolverTest {
 
     @Test
     fun multiLevelTransitivity() {
-        // A -> B -> C (two levels deep)
         val config = testConfig().copy(
             dependencies = mapOf("com.example:a" to "1.0.0")
         )
@@ -491,8 +485,6 @@ class TransitiveResolverTest {
 
     @Test
     fun pomLookupCachesSharedParentPom() {
-        // child-a and child-b share the same parent POM.
-        // The parent POM should be read only once.
         val config = testConfig().copy(
             dependencies = mapOf(
                 "com.example:child-a" to "1.0.0",
@@ -621,12 +613,10 @@ class TransitiveResolverTest {
         val result = resolveTransitive(config, null, "/cache", deps)
         val resolved = assertNotNull(result.get())
 
-        // kmp-lib should use kmp-lib-jvm JAR
         val kmpDep = resolved.deps.first { it.groupArtifact == "com.example:kmp-lib" }
         assertEquals("/cache/com/example/kmp-lib-jvm/1.0.0/kmp-lib-jvm-1.0.0.jar", kmpDep.cachePath)
         assertFalse(kmpDep.transitive)
 
-        // Transitive dep from kmp-lib-jvm POM should be resolved
         val util = resolved.deps.first { it.groupArtifact == "com.example:util" }
         assertEquals("2.0.0", util.version)
         assertTrue(util.transitive)
@@ -644,7 +634,6 @@ class TransitiveResolverTest {
                 <version>1.0.0</version>
             </project>
         """.trimIndent()
-        // Module file exists but has no JVM redirect (like Guava)
         val moduleJson = """
         {
           "formatVersion": "1.1",
@@ -670,7 +659,6 @@ class TransitiveResolverTest {
         val result = resolveTransitive(config, null, "/cache", deps)
         val resolved = assertNotNull(result.get())
         assertEquals(1, resolved.deps.size)
-        // Should use original artifact JAR path
         assertEquals("/cache/com/example/lib/1.0.0/lib-1.0.0.jar", resolved.deps[0].cachePath)
     }
 
@@ -741,7 +729,6 @@ class TransitiveResolverTest {
         val config = testConfig().copy(
             dependencies = mapOf("com.example:kmp-lib" to "1.0.0")
         )
-        // Lockfile stores original groupArtifact key with hash of redirected JAR
         val lock = Lockfile(
             version = 2,
             kotlin = "2.1.0",
@@ -795,7 +782,6 @@ class TransitiveResolverTest {
         assertFalse(resolved.lockChanged)
     }
 
-    // Helper: creates a fake ResolverDeps with POM content support
     private fun fakeTransitiveDeps(
         cachedFiles: MutableSet<String> = mutableSetOf(),
         sha256Results: Map<String, String> = emptyMap(),
@@ -825,15 +811,11 @@ class TransitiveResolverTest {
         }
     }
 
-    // ---- Multi-repository fallback tests ----
-
     @Test
     fun downloadFromRepositoriesSucceedsOnFirstRepo() {
-        // Given: two repos, first repo returns the artifact
         val coord = Coordinate("com.example", "lib", "1.0.0")
         val downloadedUrls = mutableListOf<String>()
 
-        // When: downloading with two repos
         val result = downloadFromRepositories(
             repos = listOf("https://repo1.example.com", "https://repo2.example.com"),
             destPath = "/cache/lib.jar",
@@ -841,7 +823,6 @@ class TransitiveResolverTest {
             download = { url, _ -> downloadedUrls.add(url); Ok(Unit) }
         )
 
-        // Then: succeeds, only contacts first repo
         assertNotNull(result.get())
         assertEquals(1, downloadedUrls.size)
         assertEquals(
@@ -852,13 +833,11 @@ class TransitiveResolverTest {
 
     @Test
     fun downloadFromRepositoriesFallsBackToSecondRepoOn404() {
-        // Given: first repo returns 404, second repo has the artifact
         val coord = Coordinate("com.example", "lib", "1.0.0")
         val downloadedUrls = mutableListOf<String>()
         val repo1Base = "https://repo1.example.com"
         val repo2Base = "https://repo2.example.com"
 
-        // When: downloading with two repos
         val result = downloadFromRepositories(
             repos = listOf(repo1Base, repo2Base),
             destPath = "/cache/lib.jar",
@@ -869,7 +848,6 @@ class TransitiveResolverTest {
             }
         )
 
-        // Then: succeeds using second repo
         assertNotNull(result.get())
         assertEquals(2, downloadedUrls.size)
         assertEquals("https://repo1.example.com/com/example/lib/1.0.0/lib-1.0.0.jar", downloadedUrls[0])
@@ -878,10 +856,8 @@ class TransitiveResolverTest {
 
     @Test
     fun downloadFromRepositoriesReturnsErrWhenAllRepos404() {
-        // Given: all repos return 404
         val coord = Coordinate("com.example", "lib", "1.0.0")
 
-        // When: all repos 404
         val result = downloadFromRepositories(
             repos = listOf("https://repo1.example.com", "https://repo2.example.com"),
             destPath = "/cache/lib.jar",
@@ -889,18 +865,15 @@ class TransitiveResolverTest {
             download = { url, _ -> Err(DownloadError.HttpFailed(url, 404)) }
         )
 
-        // Then: returns the last 404 error
         val error = assertIs<DownloadError.HttpFailed>(result.getError())
         assertEquals(404, error.statusCode)
     }
 
     @Test
     fun downloadFromRepositoriesStopsOnNon404Error() {
-        // Given: first repo returns a non-404 error (network failure)
         val coord = Coordinate("com.example", "lib", "1.0.0")
         val downloadedUrls = mutableListOf<String>()
 
-        // When: first repo has a non-404 error
         val result = downloadFromRepositories(
             repos = listOf("https://repo1.example.com", "https://repo2.example.com"),
             destPath = "/cache/lib.jar",
@@ -911,14 +884,12 @@ class TransitiveResolverTest {
             }
         )
 
-        // Then: stops immediately, returns the network error without trying second repo
         assertIs<DownloadError.NetworkError>(result.getError())
         assertEquals(1, downloadedUrls.size)
     }
 
     @Test
     fun resolveWithCustomRepositoryUrl() {
-        // Given: config with a custom repository instead of Maven Central
         val customRepoBase = "https://nexus.example.com/repository/maven-public"
         val config = testConfig(
             dependencies = mapOf("com.example:lib" to "1.0.0"),
@@ -953,18 +924,15 @@ class TransitiveResolverTest {
             }
         }
 
-        // When: resolving dependencies
         val result = resolveTransitive(config, null, "/cache", deps)
         val resolved = assertNotNull(result.get())
 
-        // Then: downloaded from custom repo
         assertEquals(1, resolved.deps.size)
         assertTrue(downloadedUrls.any { it.startsWith(customRepoBase) })
     }
 
     @Test
     fun resolveWithMultipleRepositoriesFallsBackOn404() {
-        // Given: config with two repos; jar is only in the second repo
         val repo1Base = "https://repo1.example.com"
         val repo2Base = "https://repo2.example.com"
         val config = testConfig(
@@ -1002,16 +970,13 @@ class TransitiveResolverTest {
             }
         }
 
-        // When: resolving with first repo returning 404 for jar
         val result = resolveTransitive(config, null, "/cache", deps)
         val resolved = assertNotNull(result.get())
 
-        // Then: resolves successfully using the second repo
         assertEquals(1, resolved.deps.size)
         assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
     }
 
-    // Helper: like fakeTransitiveDeps but tracks readFileContent call counts
     private fun countingDeps(
         cachedFiles: MutableSet<String> = mutableSetOf(),
         sha256Results: Map<String, String> = emptyMap(),

--- a/src/nativeTest/kotlin/kolt/tool/ToolchainManagerTest.kt
+++ b/src/nativeTest/kotlin/kolt/tool/ToolchainManagerTest.kt
@@ -11,15 +11,10 @@ import kotlin.test.assertNull
 
 class ToolchainManagerTest {
 
-    // --- kotlincDownloadUrl ---
-
     @Test
     fun kotlincDownloadUrlHasVersionInTagAndFilename() {
-        // Given: version 2.1.0
-        // When: building download URL
         val url = kotlincDownloadUrl("2.1.0")
 
-        // Then: URL uses v-prefixed tag and includes version in filename
         assertEquals(
             "https://github.com/JetBrains/kotlin/releases/download/v2.1.0/kotlin-compiler-2.1.0.zip",
             url
@@ -28,26 +23,18 @@ class ToolchainManagerTest {
 
     @Test
     fun kotlincDownloadUrlDifferentVersion() {
-        // Given: version 2.3.20
-        // When: building download URL
         val url = kotlincDownloadUrl("2.3.20")
 
-        // Then: URL has correct version in both tag and filename
         assertEquals(
             "https://github.com/JetBrains/kotlin/releases/download/v2.3.20/kotlin-compiler-2.3.20.zip",
             url
         )
     }
 
-    // --- kotlincSha256Url ---
-
     @Test
     fun kotlincSha256UrlIsZipUrlWithSha256Suffix() {
-        // Given: version 2.1.0
-        // When: building SHA256 URL
         val url = kotlincSha256Url("2.1.0")
 
-        // Then: URL points to the .sha256 sidecar file alongside the zip
         assertEquals(
             "https://github.com/JetBrains/kotlin/releases/download/v2.1.0/kotlin-compiler-2.1.0.zip.sha256",
             url
@@ -56,7 +43,6 @@ class ToolchainManagerTest {
 
     @Test
     fun kotlincSha256UrlDifferentVersion() {
-        // Given: version 2.3.20
         val url = kotlincSha256Url("2.3.20")
 
         assertEquals(
@@ -65,21 +51,16 @@ class ToolchainManagerTest {
         )
     }
 
-    // --- resolveKotlincPath ---
-
     @Test
     fun resolveKotlincPathReturnsBinPathWhenManagedVersionInstalled() {
-        // Given: managed kotlinc bin exists at paths.kotlincBin(version)
         val paths = KoltPaths("/tmp/kolt_tc_resolve_installed")
         val binDir = "${paths.toolchainsDir}/kotlinc/2.1.0/bin"
         val binPath = "$binDir/kotlinc"
         ensureDirectoryRecursive(binDir)
         writeFileAsString(binPath, "#!/bin/sh")
         try {
-            // When: resolveKotlincPath is called with matching version
             val result = resolveKotlincPath("2.1.0", paths)
 
-            // Then: returns exactly paths.kotlincBin(version)
             assertEquals(paths.kotlincBin("2.1.0"), result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
@@ -88,17 +69,14 @@ class ToolchainManagerTest {
 
     @Test
     fun resolveKotlincPathDelegatesPathConstructionToKoltPaths() {
-        // Given: a paths object and a file at the expected location
         val paths = KoltPaths("/tmp/kolt_tc_resolve_delegation")
         val expectedBin = paths.kotlincBin("2.3.20")
         val binDir = expectedBin.substringBeforeLast("/")
         ensureDirectoryRecursive(binDir)
         writeFileAsString(expectedBin, "#!/bin/sh")
         try {
-            // When: resolveKotlincPath is called
             val result = resolveKotlincPath("2.3.20", paths)
 
-            // Then: returned path equals paths.kotlincBin() — no independent path construction
             assertEquals(expectedBin, result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
@@ -107,27 +85,21 @@ class ToolchainManagerTest {
 
     @Test
     fun resolveKotlincPathReturnsNullWhenToolchainsDirAbsent() {
-        // Given: toolchains directory does not exist at all
         val paths = KoltPaths("/tmp/kolt_tc_resolve_no_dir")
 
-        // When: resolveKotlincPath is called
         val result = resolveKotlincPath("2.1.0", paths)
 
-        // Then: returns null (system kotlinc fallback)
         assertNull(result)
     }
 
     @Test
     fun resolveKotlincPathReturnsNullWhenVersionDirExistsButBinMissing() {
-        // Given: version directory exists but bin/kotlinc is absent
         val paths = KoltPaths("/tmp/kolt_tc_resolve_no_bin")
         val versionDir = "${paths.toolchainsDir}/kotlinc/2.1.0"
         ensureDirectoryRecursive(versionDir)
         try {
-            // When: resolveKotlincPath is called
             val result = resolveKotlincPath("2.1.0", paths)
 
-            // Then: returns null — partial installation is not usable
             assertNull(result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
@@ -136,17 +108,14 @@ class ToolchainManagerTest {
 
     @Test
     fun resolveKotlincPathReturnsNullForDifferentInstalledVersion() {
-        // Given: only version 2.3.0 is installed, not 2.1.0
         val paths = KoltPaths("/tmp/kolt_tc_resolve_version_isolation")
         val binDir = "${paths.toolchainsDir}/kotlinc/2.3.0/bin"
         val binPath = "$binDir/kotlinc"
         ensureDirectoryRecursive(binDir)
         writeFileAsString(binPath, "#!/bin/sh")
         try {
-            // When: resolveKotlincPath is called for 2.1.0
             val result = resolveKotlincPath("2.1.0", paths)
 
-            // Then: returns null — version isolation must be exact
             assertNull(result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
@@ -155,7 +124,6 @@ class ToolchainManagerTest {
 
     @Test
     fun resolveKotlincPathReturnsBinPathForCorrectVersionAmongMultiple() {
-        // Given: both 2.1.0 and 2.3.0 are installed
         val paths = KoltPaths("/tmp/kolt_tc_resolve_multi_version")
         val bin210 = "${paths.toolchainsDir}/kotlinc/2.1.0/bin"
         val bin230 = "${paths.toolchainsDir}/kotlinc/2.3.0/bin"
@@ -164,25 +132,18 @@ class ToolchainManagerTest {
         writeFileAsString("$bin210/kotlinc", "#!/bin/sh")
         writeFileAsString("$bin230/kotlinc", "#!/bin/sh")
         try {
-            // When: resolveKotlincPath is called for 2.1.0
             val result = resolveKotlincPath("2.1.0", paths)
 
-            // Then: returns paths.kotlincBin("2.1.0"), not 2.3.0
             assertEquals(paths.kotlincBin("2.1.0"), result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
         }
     }
 
-    // --- jdkDownloadUrl ---
-
     @Test
     fun jdkDownloadUrlContainsMajorVersion() {
-        // Given: major version 21
-        // When: building JDK download URL
         val url = jdkDownloadUrl("21")
 
-        // Then: URL contains the major version
         assertEquals(
             "https://api.adoptium.net/v3/binary/latest/21/ga/linux/x64/jdk/hotspot/normal/eclipse",
             url
@@ -191,7 +152,6 @@ class ToolchainManagerTest {
 
     @Test
     fun jdkDownloadUrlDifferentVersion() {
-        // Given: major version 17
         val url = jdkDownloadUrl("17")
 
         assertEquals(
@@ -200,15 +160,10 @@ class ToolchainManagerTest {
         )
     }
 
-    // --- jdkMetadataUrl ---
-
     @Test
     fun jdkMetadataUrlContainsMajorVersion() {
-        // Given: major version 21
-        // When: building JDK metadata URL
         val url = jdkMetadataUrl("21")
 
-        // Then: URL points to Adoptium assets API with correct filters
         assertEquals(
             "https://api.adoptium.net/v3/assets/latest/21/hotspot?architecture=x64&image_type=jdk&os=linux&vendor=eclipse",
             url
@@ -217,7 +172,6 @@ class ToolchainManagerTest {
 
     @Test
     fun jdkMetadataUrlDifferentVersion() {
-        // Given: major version 17
         val url = jdkMetadataUrl("17")
 
         assertEquals(
@@ -226,111 +180,61 @@ class ToolchainManagerTest {
         )
     }
 
-    // --- parseJdkChecksum ---
-
     @Test
     fun parseJdkChecksumExtractsHashFromMetadataJson() {
-        // Given: Adoptium metadata API JSON response
         val json = """
             [{"binary":{"package":{"checksum":"ea3b9bd464d6dd253e9a7accf59f7ccd2a36e4aa69640b7251e3370caef896a4","name":"OpenJDK21U-jdk_x64_linux_hotspot_21.0.10_7.tar.gz","link":"https://example.com/jdk.tar.gz"}}}]
         """.trimIndent()
 
-        // When: parsing the checksum
         val result = parseJdkChecksum(json)
 
-        // Then: returns the checksum string
         assertEquals("ea3b9bd464d6dd253e9a7accf59f7ccd2a36e4aa69640b7251e3370caef896a4", result)
     }
 
     @Test
     fun parseJdkChecksumReturnsNullOnInvalidJson() {
-        // Given: invalid JSON
-        val json = "not json"
+        val result = parseJdkChecksum("not json")
 
-        // When: parsing the checksum
-        val result = parseJdkChecksum(json)
-
-        // Then: returns null
         assertNull(result)
     }
 
     @Test
     fun parseJdkChecksumReturnsNullOnEmptyArray() {
-        // Given: empty JSON array
-        val json = "[]"
+        val result = parseJdkChecksum("[]")
 
-        // When: parsing the checksum
-        val result = parseJdkChecksum(json)
-
-        // Then: returns null
         assertNull(result)
     }
 
-    // --- findSingleEntry ---
-
     @Test
     fun findSingleEntryReturnsTrimmedNameWhenOneEntry() {
-        // Given: ls output with a single directory name
-        val lsOutput = "jdk-21.0.2+13\n"
-
-        // When: finding the single entry
-        val result = findSingleEntry(lsOutput)
-
-        // Then: returns the trimmed directory name
-        assertEquals("jdk-21.0.2+13", result)
+        assertEquals("jdk-21.0.2+13", findSingleEntry("jdk-21.0.2+13\n"))
     }
 
     @Test
     fun findSingleEntryReturnsNullWhenMultipleEntries() {
-        // Given: ls output with multiple entries
-        val lsOutput = "jdk-21.0.2+13\nextra-dir\n"
-
-        // When: finding the single entry
-        val result = findSingleEntry(lsOutput)
-
-        // Then: returns null — ambiguous
-        assertNull(result)
+        assertNull(findSingleEntry("jdk-21.0.2+13\nextra-dir\n"))
     }
 
     @Test
     fun findSingleEntryReturnsNullWhenEmpty() {
-        // Given: empty ls output
-        val lsOutput = ""
-
-        // When: finding the single entry
-        val result = findSingleEntry(lsOutput)
-
-        // Then: returns null
-        assertNull(result)
+        assertNull(findSingleEntry(""))
     }
 
     @Test
     fun findSingleEntryReturnsNullWhenBlank() {
-        // Given: whitespace-only ls output
-        val lsOutput = "   \n  \n"
-
-        // When: finding the single entry
-        val result = findSingleEntry(lsOutput)
-
-        // Then: returns null
-        assertNull(result)
+        assertNull(findSingleEntry("   \n  \n"))
     }
-
-    // --- resolveJavaBinPath ---
 
     @Test
     fun resolveJavaBinPathReturnsBinPathWhenManagedVersionInstalled() {
-        // Given: managed java bin exists at paths.javaBin(version)
         val paths = KoltPaths("/tmp/kolt_tc_jdk_resolve_installed")
         val binDir = "${paths.toolchainsDir}/jdk/21/bin"
         val binPath = "$binDir/java"
         ensureDirectoryRecursive(binDir)
         writeFileAsString(binPath, "#!/bin/sh")
         try {
-            // When: resolveJavaBinPath is called with matching version
             val result = resolveJavaBinPath("21", paths)
 
-            // Then: returns exactly paths.javaBin(version)
             assertEquals(paths.javaBin("21"), result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
@@ -339,28 +243,18 @@ class ToolchainManagerTest {
 
     @Test
     fun resolveJavaBinPathReturnsNullWhenToolchainsDirAbsent() {
-        // Given: toolchains directory does not exist at all
         val paths = KoltPaths("/tmp/kolt_tc_jdk_resolve_no_dir")
 
-        // When: resolveJavaBinPath is called
-        val result = resolveJavaBinPath("21", paths)
-
-        // Then: returns null (system java fallback)
-        assertNull(result)
+        assertNull(resolveJavaBinPath("21", paths))
     }
 
     @Test
     fun resolveJavaBinPathReturnsNullWhenVersionDirExistsButBinMissing() {
-        // Given: version directory exists but bin/java is absent
         val paths = KoltPaths("/tmp/kolt_tc_jdk_resolve_no_bin")
         val versionDir = "${paths.toolchainsDir}/jdk/21"
         ensureDirectoryRecursive(versionDir)
         try {
-            // When: resolveJavaBinPath is called
-            val result = resolveJavaBinPath("21", paths)
-
-            // Then: returns null — partial installation is not usable
-            assertNull(result)
+            assertNull(resolveJavaBinPath("21", paths))
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
         }
@@ -368,18 +262,13 @@ class ToolchainManagerTest {
 
     @Test
     fun resolveJavaBinPathReturnsNullForDifferentInstalledVersion() {
-        // Given: only version 17 is installed, not 21
         val paths = KoltPaths("/tmp/kolt_tc_jdk_resolve_version_isolation")
         val binDir = "${paths.toolchainsDir}/jdk/17/bin"
         val binPath = "$binDir/java"
         ensureDirectoryRecursive(binDir)
         writeFileAsString(binPath, "#!/bin/sh")
         try {
-            // When: resolveJavaBinPath is called for 21
-            val result = resolveJavaBinPath("21", paths)
-
-            // Then: returns null — version isolation must be exact
-            assertNull(result)
+            assertNull(resolveJavaBinPath("21", paths))
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
         }
@@ -387,38 +276,30 @@ class ToolchainManagerTest {
 
     @Test
     fun resolveJavaBinPathDelegatesPathConstructionToKoltPaths() {
-        // Given: a paths object and a file at the expected location
         val paths = KoltPaths("/tmp/kolt_tc_jdk_resolve_delegation")
         val expectedBin = paths.javaBin("21")
         val binDir = expectedBin.substringBeforeLast("/")
         ensureDirectoryRecursive(binDir)
         writeFileAsString(expectedBin, "#!/bin/sh")
         try {
-            // When: resolveJavaBinPath is called
             val result = resolveJavaBinPath("21", paths)
 
-            // Then: returned path equals paths.javaBin() — no independent path construction
             assertEquals(expectedBin, result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
         }
     }
 
-    // --- resolveJarBinPath ---
-
     @Test
     fun resolveJarBinPathReturnsBinPathWhenManagedVersionInstalled() {
-        // Given: managed jar bin exists at paths.jarBin(version)
         val paths = KoltPaths("/tmp/kolt_tc_jar_resolve_installed")
         val binDir = "${paths.toolchainsDir}/jdk/21/bin"
         val binPath = "$binDir/jar"
         ensureDirectoryRecursive(binDir)
         writeFileAsString(binPath, "#!/bin/sh")
         try {
-            // When: resolveJarBinPath is called with matching version
             val result = resolveJarBinPath("21", paths)
 
-            // Then: returns exactly paths.jarBin(version)
             assertEquals(paths.jarBin("21"), result)
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
@@ -427,54 +308,37 @@ class ToolchainManagerTest {
 
     @Test
     fun resolveJarBinPathReturnsNullWhenToolchainsDirAbsent() {
-        // Given: toolchains directory does not exist at all
         val paths = KoltPaths("/tmp/kolt_tc_jar_resolve_no_dir")
 
-        // When: resolveJarBinPath is called
-        val result = resolveJarBinPath("21", paths)
-
-        // Then: returns null (system jar fallback)
-        assertNull(result)
+        assertNull(resolveJarBinPath("21", paths))
     }
 
     @Test
     fun resolveJarBinPathReturnsNullWhenVersionDirExistsButBinMissing() {
-        // Given: version directory exists but bin/jar is absent
         val paths = KoltPaths("/tmp/kolt_tc_jar_resolve_no_bin")
         val versionDir = "${paths.toolchainsDir}/jdk/21"
         ensureDirectoryRecursive(versionDir)
         try {
-            // When: resolveJarBinPath is called
-            val result = resolveJarBinPath("21", paths)
-
-            // Then: returns null — partial installation is not usable
-            assertNull(result)
+            assertNull(resolveJarBinPath("21", paths))
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
         }
     }
 
-    // --- ensureKotlincBin ---
-
     @Test
     fun ensureKotlincBinReturnsPathWhenAlreadyInstalled() {
-        // Given: managed kotlinc 2.1.0 is already installed
         val paths = KoltPaths("/tmp/kolt_tc_ensure_kotlinc_installed")
         val binDir = "${paths.toolchainsDir}/kotlinc/2.1.0/bin"
         ensureDirectoryRecursive(binDir)
         writeFileAsString("$binDir/kotlinc", "#!/bin/sh")
         try {
-            // When: ensureKotlincBin is called
             val result = ensureKotlincBin("2.1.0", paths)
 
-            // Then: returns the managed bin path without triggering download
             assertEquals(paths.kotlincBin("2.1.0"), result.get())
         } finally {
             removeDirectoryRecursive(paths.home + "/.kolt")
         }
     }
-
-    // --- konancDownloadUrl ---
 
     @Test
     fun konancDownloadUrlHasVersionInTagAndFilename() {
@@ -496,8 +360,6 @@ class ToolchainManagerTest {
         )
     }
 
-    // --- konancSha256Url ---
-
     @Test
     fun konancSha256UrlIsTarGzUrlWithSha256Suffix() {
         val url = konancSha256Url("2.1.0")
@@ -507,8 +369,6 @@ class ToolchainManagerTest {
             url
         )
     }
-
-    // --- resolveKonancPath ---
 
     @Test
     fun resolveKonancPathReturnsBinPathWhenManagedVersionInstalled() {
@@ -564,8 +424,6 @@ class ToolchainManagerTest {
         }
     }
 
-    // --- ensureKonancBin ---
-
     @Test
     fun ensureKonancBinReturnsPathWhenAlreadyInstalled() {
         val paths = KoltPaths("/tmp/kolt_tc_ensure_konanc_installed")
@@ -581,21 +439,16 @@ class ToolchainManagerTest {
         }
     }
 
-    // --- ensureJdkBins ---
-
     @Test
     fun ensureJdkBinsReturnsPathsWhenAlreadyInstalled() {
-        // Given: managed jdk 21 is already installed
         val paths = KoltPaths("/tmp/kolt_tc_ensure_jdk_installed")
         val binDir = "${paths.toolchainsDir}/jdk/21/bin"
         ensureDirectoryRecursive(binDir)
         writeFileAsString("$binDir/java", "#!/bin/sh")
         writeFileAsString("$binDir/jar", "#!/bin/sh")
         try {
-            // When: ensureJdkBins is called
             val result = ensureJdkBins("21", paths)
 
-            // Then: returns managed java and jar paths
             val bins = result.get()!!
             assertEquals(paths.javaBin("21"), bins.java)
             assertEquals(paths.jarBin("21"), bins.jar)


### PR DESCRIPTION
Applied the project's comment discipline (CLAUDE.md / kolt-dev skill) to all native main and test sources. 78 files touched, ~2300 lines removed. Two commits: main sources first, then test sources.

Kept design invariants, "why not" decisions, and anchored external-tool gotchas. Deleted narration, signature restatements, ADR paragraph summaries, Given/When/Then test scaffolding, and section headings.

No code or test logic changes — comments only.