### PR TITLE
Reap stale daemon directories and orphaned sockets (#106)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
@@ -12,7 +12,7 @@ import kolt.infra.listSubdirectories
 import kolt.infra.net.UnixSocket
 import kotlin.system.exitProcess
 
-private val DAEMON_SUBCOMMANDS = setOf("stop")
+private val DAEMON_SUBCOMMANDS = setOf("stop", "reap")
 
 internal fun validateDaemonSubcommand(args: List<String>): Boolean =
     args.isNotEmpty() && args[0] in DAEMON_SUBCOMMANDS
@@ -24,6 +24,7 @@ internal fun doDaemon(args: List<String>) {
     }
     when (args[0]) {
         "stop" -> doDaemonStop(args.drop(1))
+        "reap" -> doDaemonReap()
         else -> {
             eprintln("error: unknown daemon command '${args[0]}'")
             printDaemonUsage()
@@ -81,9 +82,20 @@ private fun sendShutdown(socketPath: String): Boolean {
     return sent
 }
 
+private fun doDaemonReap() {
+    val paths = resolveKoltPaths(EXIT_CONFIG_ERROR)
+    val result = reapStaleDaemons(paths.daemonBaseDir)
+    if (result.reaped == 0) {
+        println("no stale daemons found")
+    } else {
+        println("reaped ${result.reaped} stale daemon dir${if (result.reaped > 1) "s" else ""}")
+    }
+}
+
 private fun printDaemonUsage() {
     eprintln("usage: kolt daemon <command>")
     eprintln("")
     eprintln("commands:")
     eprintln("  stop       Stop the compiler daemon (--all for all daemons)")
+    eprintln("  reap       Remove stale daemon directories and orphaned sockets")
 }

--- a/src/nativeMain/kotlin/kolt/cli/DaemonReaper.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonReaper.kt
@@ -1,0 +1,36 @@
+package kolt.cli
+
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.fileExists
+import kolt.infra.listSubdirectories
+import kolt.infra.net.UnixSocket
+import kolt.infra.removeDirectoryRecursive
+
+data class ReapResult(val reaped: Int, val alive: Int)
+
+// Probe-based reaper for orphaned daemon sockets under `daemonBaseDir`.
+// A daemon directory is reaped when: (a) no `daemon.sock` exists, or
+// (b) `daemon.sock` exists but connect fails (daemon already exited).
+// Invariant: a live daemon is never touched.
+internal fun reapStaleDaemons(daemonBaseDir: String): ReapResult {
+    if (!fileExists(daemonBaseDir)) return ReapResult(0, 0)
+    val dirs = listSubdirectories(daemonBaseDir).getOrElse { return ReapResult(0, 0) }
+
+    var reaped = 0
+    var alive = 0
+    for (dir in dirs) {
+        val fullDir = "$daemonBaseDir/$dir"
+        val socketPath = "$fullDir/daemon.sock"
+        if (fileExists(socketPath)) {
+            val socket = UnixSocket.connect(socketPath)
+            if (socket.isOk) {
+                socket.getOrElse { null }?.close()
+                alive++
+                continue
+            }
+        }
+        removeDirectoryRecursive(fullDir)
+        reaped++
+    }
+    return ReapResult(reaped, alive)
+}

--- a/src/nativeTest/kotlin/kolt/cli/DaemonCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DaemonCommandsTest.kt
@@ -22,6 +22,11 @@ class ValidateDaemonSubcommandTest {
     }
 
     @Test
+    fun reapIsValid() {
+        assertTrue(validateDaemonSubcommand(listOf("reap")))
+    }
+
+    @Test
     fun unknownSubcommandIsInvalid() {
         assertFalse(validateDaemonSubcommand(listOf("restart")))
     }

--- a/src/nativeTest/kotlin/kolt/cli/DaemonReaperTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DaemonReaperTest.kt
@@ -1,0 +1,68 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package kolt.cli
+
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.ensureDirectory
+import kolt.infra.fileExists
+import kolt.infra.writeFileAsString
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.mkdtemp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class DaemonReaperTest {
+
+    @Test
+    fun emptyDaemonDirReturnsZeroReaped() {
+        val dir = createTempDir("reaper-empty-")
+        val result = reapStaleDaemons(dir)
+        assertEquals(0, result.reaped)
+        assertEquals(0, result.alive)
+    }
+
+    @Test
+    fun directoryWithoutSocketIsReaped() {
+        val base = createTempDir("reaper-nosock-")
+        val projectDir = "$base/abc123"
+        ensureDirectory(projectDir).getOrElse { error("mkdir failed") }
+        writeFileAsString("$projectDir/daemon.log", "some log").getOrElse { error("write failed") }
+
+        val result = reapStaleDaemons(base)
+        assertEquals(1, result.reaped)
+        assertFalse(fileExists(projectDir))
+    }
+
+    @Test
+    fun directoryWithOrphanedSocketIsReaped() {
+        val base = createTempDir("reaper-orphan-")
+        val projectDir = "$base/def456"
+        ensureDirectory(projectDir).getOrElse { error("mkdir failed") }
+        // A regular file named daemon.sock — connect will fail (not a real socket)
+        writeFileAsString("$projectDir/daemon.sock", "").getOrElse { error("write failed") }
+
+        val result = reapStaleDaemons(base)
+        assertEquals(1, result.reaped)
+        assertFalse(fileExists(projectDir))
+    }
+
+    @Test
+    fun nonexistentBaseDirReturnsZero() {
+        val result = reapStaleDaemons("/tmp/kolt-reaper-nonexistent-${kotlin.random.Random.nextLong()}")
+        assertEquals(0, result.reaped)
+        assertEquals(0, result.alive)
+    }
+
+    private fun createTempDir(prefix: String): String {
+        val template = "/tmp/${prefix}XXXXXX"
+        val buf = template.encodeToByteArray().copyOf(template.length + 1)
+        buf.usePinned { pinned ->
+            val result = mkdtemp(pinned.addressOf(0))
+                ?: error("mkdtemp failed")
+            return result.toKString()
+        }
+    }
+}


### PR DESCRIPTION
Probe-based reaper for orphaned daemon sockets under `~/.kolt/daemon/`. For each project directory, attempts a Unix socket connect — if no socket exists or connect fails, the directory tree is removed. Live daemons are never touched.

Available as `kolt daemon reap`. Reuses existing `removeDirectoryRecursive` from `infra/FileSystem.kt`.