### PR TITLE
Refactor all commands to return Result instead of calling exitProcess (#132)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -1,5 +1,7 @@
 package kolt.cli
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
@@ -14,7 +16,6 @@ import kolt.config.*
 import kolt.infra.*
 import kolt.resolve.*
 import kolt.tool.*
-import kotlin.system.exitProcess
 import kotlin.time.TimeSource
 
 internal const val KOLT_TOML = "kolt.toml"
@@ -28,58 +29,60 @@ internal data class BuildResult(
     val javaPath: String? = null,
 )
 
-internal fun loadProjectConfig(): KoltConfig {
+internal fun loadProjectConfig(): Result<KoltConfig, Int> {
     val tomlString = readFileAsString(KOLT_TOML).getOrElse { error ->
         eprintln("error: could not read ${error.path}")
-        exitProcess(EXIT_CONFIG_ERROR)
+        return Err(EXIT_CONFIG_ERROR)
     }
     return parseConfig(tomlString).getOrElse { error ->
         when (error) {
             is ConfigError.ParseFailed -> eprintln("error: ${error.message}")
         }
-        exitProcess(EXIT_CONFIG_ERROR)
-    }
+        return Err(EXIT_CONFIG_ERROR)
+    }.let { Ok(it) }
 }
 
-internal fun doCheck(useDaemon: Boolean = true) {
+internal fun doCheck(useDaemon: Boolean = true): Result<Unit, Int> {
     val startMark = TimeSource.Monotonic.markNow()
-    val config = loadProjectConfig()
+    val config = loadProjectConfig().getOrElse { return Err(it) }
     // konanc has no syntax-only mode; a full build is the only option.
     if (config.target == "native") {
-        doBuild(useDaemon = useDaemon)
-        return
+        doBuild(useDaemon = useDaemon).getOrElse { return Err(it) }
+        return Ok(Unit)
     }
-    val paths = resolveKoltPaths(EXIT_BUILD_ERROR)
-    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_BUILD_ERROR) }
+    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
 
-    val classpath = resolveDependencies(config)
-    val pArgs = resolvePluginArgs(config, paths, EXIT_BUILD_ERROR)
+    val classpath = resolveDependencies(config).getOrElse { return Err(it) }
+    val pArgs = resolvePluginArgs(config, paths, EXIT_BUILD_ERROR).getOrElse { eprintln("error: ${it.message}"); return Err(it.exitCode) }
     val cmd = checkCommand(config, classpath, pArgs, kotlincPath = managedKotlincBin)
 
     println("checking ${config.name}...")
     executeCommand(cmd).getOrElse { error ->
         eprintln("error: " + formatProcessError(error, "check"))
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
     val elapsed = startMark.elapsedNow()
     println("check passed in ${formatDuration(elapsed)}")
+    return Ok(Unit)
 }
 
-internal fun doClean() {
+internal fun doClean(): Result<Unit, Int> {
     if (!fileExists(BUILD_DIR)) {
         println("nothing to clean")
-        return
+        return Ok(Unit)
     }
     removeDirectoryRecursive(BUILD_DIR).getOrElse { error ->
         eprintln("error: could not remove ${error.path}")
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
     println("removed $BUILD_DIR/")
+    return Ok(Unit)
 }
 
-internal fun doBuild(useDaemon: Boolean = true): BuildResult {
+internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
     val startMark = TimeSource.Monotonic.markNow()
-    val config = loadProjectConfig()
+    val config = loadProjectConfig().getOrElse { return Err(it) }
 
     if (config.target == "native") {
         return doNativeBuild(config)
@@ -96,8 +99,8 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
     val cachedState = readFileAsString(BUILD_STATE_FILE).getOrElse { null }
         ?.let { parseBuildState(it) }
 
-    val paths = resolveKoltPaths(EXIT_BUILD_ERROR)
-    val (managedJavaBin, managedJarBin) = ensureJdkBinsFromConfig(config, paths)
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_BUILD_ERROR) }
+    val (managedJavaBin, managedJarBin) = ensureJdkBinsFromConfig(config, paths).getOrElse { return Err(it) }
 
     if (isBuildUpToDate(current = currentState, cached = cachedState)) {
         val elapsed = startMark.elapsedNow()
@@ -105,21 +108,21 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
         // Invariant: the up-to-date path must stay a pure mtime compare —
         // no plugin jar resolution or toolchain provisioning — so offline
         // cached builds don't hard-exit on a failed fetch.
-        return BuildResult(config, cachedState!!.classpath, managedJavaBin)
+        return Ok(BuildResult(config, cachedState!!.classpath, managedJavaBin))
     }
-    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
-    val classpath = resolveDependencies(config)
-    val pluginJarPathsByAlias = resolveEnabledPluginJarPaths(config, paths, EXIT_BUILD_ERROR)
+    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
+    val classpath = resolveDependencies(config).getOrElse { return Err(it) }
+    val pluginJarPathsByAlias = resolveEnabledPluginJarPaths(config, paths, EXIT_BUILD_ERROR).getOrElse { eprintln("error: ${it.message}"); return Err(it.exitCode) }
     val pArgs = pluginJarPathsByAlias.values.map { "-Xplugin=$it" }
     val pluginJarsForDaemon = pluginJarPathsByAlias.mapValues { (_, path) -> listOf(path) }
     ensureDirectoryRecursive(CLASSES_DIR).getOrElse { error ->
         eprintln("error: could not create directory ${error.path}")
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     val cwd = currentWorkingDirectory() ?: run {
         eprintln("error: could not determine current working directory")
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     val subprocessBackend = SubprocessCompilerBackend(kotlincBin = managedKotlincBin)
@@ -142,7 +145,7 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
         sources = expandKotlinSources(config.sources.map { absolutise(it, cwd) })
             .getOrElse { err ->
                 eprintln("error: could not list Kotlin sources under ${err.path}")
-                exitProcess(EXIT_BUILD_ERROR)
+                return Err(EXIT_BUILD_ERROR)
             },
         outputPath = absolutise(CLASSES_DIR, cwd),
         moduleName = config.name,
@@ -160,21 +163,21 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
             if (body.isNotEmpty()) eprintln(body)
         }
         eprintln(formatCompileError(error, "compilation"))
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     for (resourceDir in config.resources) {
         if (!fileExists(resourceDir)) continue
         copyDirectoryContents(resourceDir, CLASSES_DIR).getOrElse { error ->
             eprintln("error: could not copy resources from ${error.path}")
-            exitProcess(EXIT_BUILD_ERROR)
+            return Err(EXIT_BUILD_ERROR)
         }
     }
 
     val jarCmd = jarCommand(config, jarPath = managedJarBin)
     executeCommand(jarCmd.args).getOrElse { error ->
         eprintln("error: " + formatProcessError(error, "jar packaging"))
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     val newState = currentState.copy(
@@ -188,16 +191,16 @@ internal fun doBuild(useDaemon: Boolean = true): BuildResult {
 
     val elapsed = startMark.elapsedNow()
     println("built ${jarCmd.outputPath} in ${formatDuration(elapsed)}")
-    return BuildResult(config, classpath, managedJavaBin)
+    return Ok(BuildResult(config, classpath, managedJavaBin))
 }
 
-private fun doNativeBuild(config: KoltConfig): BuildResult {
+private fun doNativeBuild(config: KoltConfig): Result<BuildResult, Int> {
     val startMark = TimeSource.Monotonic.markNow()
 
-    val paths = resolveKoltPaths(EXIT_BUILD_ERROR)
-    val managedKonancBin = ensureKonancBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_BUILD_ERROR) }
+    val managedKonancBin = ensureKonancBin(config.kotlin, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
 
-    val depKlibs = resolveNativeDependencies(config, paths)
+    val depKlibs = resolveNativeDependencies(config, paths).getOrElse { return Err(it) }
 
     val kexePath = outputKexePath(config)
     val defNewestMtime = newestDefMtime(config)
@@ -215,36 +218,36 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
     if (isBuildUpToDate(current = currentState, cached = cachedState)) {
         val elapsed = startMark.elapsedNow()
         println("${config.name} is up to date (${formatDuration(elapsed)})")
-        return BuildResult(config, classpath = null, javaPath = null)
+        return Ok(BuildResult(config, classpath = null, javaPath = null))
     }
 
-    val nativePluginArgs = resolvePluginArgs(config, paths, EXIT_BUILD_ERROR)
+    val nativePluginArgs = resolvePluginArgs(config, paths, EXIT_BUILD_ERROR).getOrElse { eprintln("error: ${it.message}"); return Err(it.exitCode) }
 
     ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
         eprintln("error: could not create directory ${error.path}")
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
-    val cinteropKlibs = runCinterop(config, paths)
+    val cinteropKlibs = runCinterop(config, paths).getOrElse { return Err(it) }
     val klibs = depKlibs + cinteropKlibs
 
     val libraryCmd = nativeLibraryCommand(config, pluginArgs = nativePluginArgs, konancPath = managedKonancBin, klibs = klibs)
     println("compiling ${config.name} (native)...")
     executeCommand(libraryCmd.args).getOrElse { error ->
         eprintln("error: " + formatProcessError(error, "compilation"))
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     val linkCmd = nativeLinkCommand(config, konancPath = managedKonancBin, klibs = klibs)
     println("linking ${config.name} (native)...")
     executeCommand(linkCmd.args).getOrElse { error ->
         eprintln("error: " + formatProcessError(error, "linking"))
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     if (!fileExists(kexePath)) {
         eprintln("error: $kexePath not produced by konanc")
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     val newState = currentState.copy(classesDirMtime = fileMtime(kexePath))
@@ -254,7 +257,7 @@ private fun doNativeBuild(config: KoltConfig): BuildResult {
 
     val elapsed = startMark.elapsedNow()
     println("built $kexePath in ${formatDuration(elapsed)}")
-    return BuildResult(config, classpath = null, javaPath = null)
+    return Ok(BuildResult(config, classpath = null, javaPath = null))
 }
 
 private fun newestDefMtime(config: KoltConfig): Long? {
@@ -263,10 +266,11 @@ private fun newestDefMtime(config: KoltConfig): Long? {
     return if (mtimes.isEmpty()) null else mtimes.max()
 }
 
-private fun runCinterop(config: KoltConfig, paths: KoltPaths): List<String> {
-    if (config.cinterop.isEmpty()) return emptyList()
+private fun runCinterop(config: KoltConfig, paths: KoltPaths): Result<List<String>, Int> {
+    if (config.cinterop.isEmpty()) return Ok(emptyList())
     val managedCinteropBin = paths.cinteropBin(config.kotlin)
-    return config.cinterop.map { entry ->
+    val klibs = mutableListOf<String>()
+    for (entry in config.cinterop) {
         val klibPath = cinteropOutputKlibPath(entry)
         val stampPath = cinteropStampPath(entry)
         val defMtime = fileMtime(entry.def)
@@ -275,7 +279,8 @@ private fun runCinterop(config: KoltConfig, paths: KoltPaths): List<String> {
         if (currentStamp != null && fileExists(klibPath) && fileExists(stampPath)) {
             val previousStamp = readFileAsString(stampPath).get()
             if (previousStamp == currentStamp) {
-                return@map klibPath
+                klibs.add(klibPath)
+                continue
             }
         }
 
@@ -283,86 +288,87 @@ private fun runCinterop(config: KoltConfig, paths: KoltPaths): List<String> {
         println("generating cinterop klib for ${entry.name}...")
         executeCommand(cmd.args).getOrElse { error ->
             eprintln("error: " + formatProcessError(error, "cinterop (${entry.name})"))
-            exitProcess(EXIT_BUILD_ERROR)
+            return Err(EXIT_BUILD_ERROR)
         }
         if (currentStamp != null) {
             writeFileAsString(stampPath, currentStamp).getOrElse { error ->
                 eprintln("warning: failed to write cinterop stamp ${error.path}")
             }
         }
-        klibPath
+        klibs.add(klibPath)
     }
+    return Ok(klibs)
 }
 
-internal fun resolveNativeDependencies(config: KoltConfig, paths: KoltPaths): List<String> {
-    if (config.dependencies.isEmpty()) return emptyList()
+private fun resolveNativeDependencies(config: KoltConfig, paths: KoltPaths): Result<List<String>, Int> {
+    if (config.dependencies.isEmpty()) return Ok(emptyList())
 
     println("resolving native dependencies...")
     val result = resolve(config, existingLock = null, paths.cacheBase, createResolverDeps()).getOrElse { error ->
         eprintln(formatResolveError(error))
-        exitProcess(EXIT_DEPENDENCY_ERROR)
+        return Err(EXIT_DEPENDENCY_ERROR)
     }
-    return result.deps.map { it.cachePath }
+    return Ok(result.deps.map { it.cachePath })
 }
 
-internal fun doRun(config: KoltConfig, classpath: String?, appArgs: List<String> = emptyList(), javaPath: String? = null) {
+internal fun doRun(config: KoltConfig, classpath: String?, appArgs: List<String> = emptyList(), javaPath: String? = null): Result<Unit, Int> {
     if (config.target == "native") {
         val kexePath = outputKexePath(config)
         if (!fileExists(kexePath)) {
             eprintln("error: $kexePath not found. Run 'kolt build' first.")
-            exitProcess(EXIT_BUILD_ERROR)
+            return Err(EXIT_BUILD_ERROR)
         }
         val cmd = nativeRunCommand(config, appArgs)
         executeCommand(cmd.args).getOrElse { error ->
-            when (error) {
-                is ProcessError.NonZeroExit -> exitProcess(error.exitCode)
-                else -> exitProcess(EXIT_BUILD_ERROR)
-            }
+            return Err(when (error) {
+                is ProcessError.NonZeroExit -> error.exitCode
+                else -> EXIT_BUILD_ERROR
+            })
         }
-        return
+        return Ok(Unit)
     }
     if (!fileExists(CLASSES_DIR)) {
         eprintln("error: $CLASSES_DIR not found. Run 'kolt build' first.")
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     val cmd = runCommand(config, classpath, appArgs, javaPath = javaPath)
     executeCommand(cmd.args).getOrElse { error ->
-        when (error) {
-            is ProcessError.NonZeroExit -> exitProcess(error.exitCode)
-            else -> exitProcess(EXIT_BUILD_ERROR)
-        }
+        return Err(when (error) {
+            is ProcessError.NonZeroExit -> error.exitCode
+            else -> EXIT_BUILD_ERROR
+        })
     }
+    return Ok(Unit)
 }
 
-internal fun doTest(testArgs: List<String> = emptyList(), useDaemon: Boolean = true) {
-    val config = loadProjectConfig()
+internal fun doTest(testArgs: List<String> = emptyList(), useDaemon: Boolean = true): Result<Unit, Int> {
+    val config = loadProjectConfig().getOrElse { return Err(it) }
     if (config.target == "native") {
-        doNativeTest(config, testArgs)
-        return
+        return doNativeTest(config, testArgs)
     }
-    val (_, classpath, javaPath) = doBuild(useDaemon = useDaemon)
+    val (_, classpath, javaPath) = doBuild(useDaemon = useDaemon).getOrElse { return Err(it) }
 
     val existingTestSources = config.testSources.filter { fileExists(it) }
     if (existingTestSources.isEmpty()) {
         eprintln("error: no test sources found in ${config.testSources}")
-        exitProcess(EXIT_TEST_ERROR)
+        return Err(EXIT_TEST_ERROR)
     }
 
     val testStartMark = TimeSource.Monotonic.markNow()
 
-    val paths = resolveKoltPaths(EXIT_TEST_ERROR)
-    val consoleLauncherPath = ensureTool(paths, CONSOLE_LAUNCHER_SPEC, EXIT_TEST_ERROR)
-    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_TEST_ERROR) }
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_TEST_ERROR) }
+    val consoleLauncherPath = ensureTool(paths, CONSOLE_LAUNCHER_SPEC).getOrElse { eprintln("error: $it"); return Err(EXIT_TEST_ERROR) }
+    val managedKotlincBin = ensureKotlincBin(config.kotlin, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_TEST_ERROR) }
 
-    val pArgs = resolvePluginArgs(config, paths, EXIT_TEST_ERROR)
+    val pArgs = resolvePluginArgs(config, paths, EXIT_TEST_ERROR).getOrElse { eprintln("error: ${it.message}"); return Err(it.exitCode) }
 
     val testConfig = config.copy(testSources = existingTestSources)
     val testCmd = testBuildCommand(testConfig, CLASSES_DIR, classpath, pArgs, kotlincPath = managedKotlincBin)
     println("compiling tests...")
     executeCommand(testCmd.args).getOrElse { error ->
         eprintln("error: " + formatProcessError(error, "test compilation"))
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     val existingTestResourceDirs = config.testResources.filter { fileExists(it) }
@@ -384,33 +390,34 @@ internal fun doTest(testArgs: List<String> = emptyList(), useDaemon: Boolean = t
             }
             else -> eprintln("error: failed to run tests")
         }
-        exitProcess(EXIT_TEST_ERROR)
+        return Err(EXIT_TEST_ERROR)
     }
     val elapsed = testStartMark.elapsedNow()
     println("tests passed in ${formatDuration(elapsed)}")
+    return Ok(Unit)
 }
 
-private fun doNativeTest(config: KoltConfig, testArgs: List<String>) {
+private fun doNativeTest(config: KoltConfig, testArgs: List<String>): Result<Unit, Int> {
     val existingTestSources = config.testSources.filter { fileExists(it) }
     if (existingTestSources.isEmpty()) {
         eprintln("error: no test sources found in ${config.testSources}")
-        exitProcess(EXIT_TEST_ERROR)
+        return Err(EXIT_TEST_ERROR)
     }
 
     val testStartMark = TimeSource.Monotonic.markNow()
 
-    val paths = resolveKoltPaths(EXIT_TEST_ERROR)
-    val managedKonancBin = ensureKonancBin(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_TEST_ERROR) }
-    val nativePluginArgs = resolvePluginArgs(config, paths, EXIT_TEST_ERROR)
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_TEST_ERROR) }
+    val managedKonancBin = ensureKonancBin(config.kotlin, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_TEST_ERROR) }
+    val nativePluginArgs = resolvePluginArgs(config, paths, EXIT_TEST_ERROR).getOrElse { eprintln("error: ${it.message}"); return Err(it.exitCode) }
 
-    val depKlibs = resolveNativeDependencies(config, paths)
+    val depKlibs = resolveNativeDependencies(config, paths).getOrElse { return Err(it) }
 
     ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
         eprintln("error: could not create directory ${error.path}")
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
-    val cinteropKlibs = runCinterop(config, paths)
+    val cinteropKlibs = runCinterop(config, paths).getOrElse { return Err(it) }
     val klibs = depKlibs + cinteropKlibs
 
     val testConfig = config.copy(testSources = existingTestSources)
@@ -418,19 +425,19 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>) {
     println("compiling tests (native)...")
     executeCommand(libraryCmd.args).getOrElse { error ->
         eprintln("error: " + formatProcessError(error, "test compilation"))
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     val linkCmd = nativeTestLinkCommand(testConfig, konancPath = managedKonancBin, klibs = klibs)
     println("linking tests (native)...")
     executeCommand(linkCmd.args).getOrElse { error ->
         eprintln("error: " + formatProcessError(error, "test linking"))
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     if (!fileExists(linkCmd.outputPath)) {
         eprintln("error: ${linkCmd.outputPath} not produced by konanc")
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     val runCmd = nativeTestRunCommand(testConfig, testArgs)
@@ -443,20 +450,19 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>) {
             }
             else -> eprintln("error: failed to run tests")
         }
-        exitProcess(EXIT_TEST_ERROR)
+        return Err(EXIT_TEST_ERROR)
     }
     val elapsed = testStartMark.elapsedNow()
     println("tests passed in ${formatDuration(elapsed)}")
+    return Ok(Unit)
 }
 
-internal fun ensureJdkBinsFromConfig(config: KoltConfig, paths: KoltPaths): JdkBins {
-    val version = config.jdk ?: return JdkBins(null, null)
-    return ensureJdkBins(version, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
-}
-
-internal fun exitWithToolchainError(err: ToolchainError, exitCode: Int): Nothing {
-    eprintln("error: ${err.message}")
-    exitProcess(exitCode)
+internal fun ensureJdkBinsFromConfig(config: KoltConfig, paths: KoltPaths): Result<JdkBins, Int> {
+    val version = config.jdk ?: return Ok(JdkBins(null, null))
+    return ensureJdkBins(version, paths).getOrElse { err ->
+        eprintln("error: ${err.message}")
+        return Err(EXIT_BUILD_ERROR)
+    }.let { Ok(it) }
 }
 
 internal const val WARNING_DAEMON_DIR_UNWRITABLE =
@@ -564,7 +570,7 @@ internal fun findOverlappingDependencies(
         .map { OverlappingDep(it, mainDeps[it], testDeps[it]) }
 }
 
-internal fun resolveDependencies(config: KoltConfig): String? {
+internal fun resolveDependencies(config: KoltConfig): Result<String?, Int> {
     for (dep in findOverlappingDependencies(config.dependencies, config.testDependencies)) {
         eprintln("warning: '${dep.groupArtifact}' is in both [dependencies] (${dep.mainVersion}) and [test-dependencies] (${dep.testVersion}); using ${dep.mainVersion}")
     }
@@ -574,12 +580,12 @@ internal fun resolveDependencies(config: KoltConfig): String? {
         if (fileExists(LOCK_FILE)) {
             deleteFile(LOCK_FILE)
         }
-        return null
+        return Ok(null)
     }
 
     val resolveConfig = config.copy(dependencies = allDeps)
 
-    val paths = resolveKoltPaths(EXIT_DEPENDENCY_ERROR)
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_DEPENDENCY_ERROR) }
 
     val existingLock = if (fileExists(LOCK_FILE)) {
         val lockJson = readFileAsString(LOCK_FILE).getOrElse { error ->
@@ -603,7 +609,7 @@ internal fun resolveDependencies(config: KoltConfig): String? {
         if (error is ResolveError.Sha256Mismatch) {
             eprintln("delete the cached jar and rebuild to re-download")
         }
-        exitProcess(EXIT_DEPENDENCY_ERROR)
+        return Err(EXIT_DEPENDENCY_ERROR)
     }
 
     if (resolveResult.lockChanged) {
@@ -611,7 +617,7 @@ internal fun resolveDependencies(config: KoltConfig): String? {
         val lockJson = serializeLockfile(lockfile)
         writeFileAsString(LOCK_FILE, lockJson).getOrElse { error ->
             eprintln("error: could not write ${error.path}")
-            exitProcess(EXIT_DEPENDENCY_ERROR)
+            return Err(EXIT_DEPENDENCY_ERROR)
         }
     }
 
@@ -620,7 +626,7 @@ internal fun resolveDependencies(config: KoltConfig): String? {
     }
 
     val jarPaths = resolveResult.deps.map { it.cachePath }
-    return buildClasspath(jarPaths).ifEmpty { null }
+    return Ok(buildClasspath(jarPaths).ifEmpty { null })
 }
 
 private fun writeWorkspaceFiles(config: KoltConfig, deps: List<ResolvedDep>) {

--- a/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
@@ -35,7 +35,7 @@ internal fun doDaemon(args: List<String>) {
 
 private fun doDaemonStop(args: List<String>) {
     val all = args.contains("--all")
-    val paths = resolveKoltPaths(EXIT_CONFIG_ERROR)
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_CONFIG_ERROR) }
 
     if (all) {
         stopAllDaemons(paths.daemonBaseDir)
@@ -83,7 +83,7 @@ private fun sendShutdown(socketPath: String): Boolean {
 }
 
 private fun doDaemonReap() {
-    val paths = resolveKoltPaths(EXIT_CONFIG_ERROR)
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_CONFIG_ERROR) }
     val result = reapStaleDaemons(paths.daemonBaseDir)
     if (result.reaped == 0) {
         println("no stale daemons found")

--- a/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
@@ -1,5 +1,8 @@
 package kolt.cli
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.build.daemon.projectHashOf
 import kolt.config.resolveKoltPaths
@@ -10,49 +13,49 @@ import kolt.infra.eprintln
 import kolt.infra.fileExists
 import kolt.infra.listSubdirectories
 import kolt.infra.net.UnixSocket
-import kotlin.system.exitProcess
 
 private val DAEMON_SUBCOMMANDS = setOf("stop", "reap")
 
 internal fun validateDaemonSubcommand(args: List<String>): Boolean =
     args.isNotEmpty() && args[0] in DAEMON_SUBCOMMANDS
 
-internal fun doDaemon(args: List<String>) {
+internal fun doDaemon(args: List<String>): Result<Unit, Int> {
     if (args.isEmpty()) {
         printDaemonUsage()
-        exitProcess(EXIT_CONFIG_ERROR)
+        return Err(EXIT_CONFIG_ERROR)
     }
-    when (args[0]) {
+    return when (args[0]) {
         "stop" -> doDaemonStop(args.drop(1))
         "reap" -> doDaemonReap()
         else -> {
             eprintln("error: unknown daemon command '${args[0]}'")
             printDaemonUsage()
-            exitProcess(EXIT_CONFIG_ERROR)
+            Err(EXIT_CONFIG_ERROR)
         }
     }
 }
 
-private fun doDaemonStop(args: List<String>) {
+private fun doDaemonStop(args: List<String>): Result<Unit, Int> {
     val all = args.contains("--all")
-    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_CONFIG_ERROR) }
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_CONFIG_ERROR) }
 
     if (all) {
         stopAllDaemons(paths.daemonBaseDir)
     } else {
         val cwd = currentWorkingDirectory() ?: run {
             eprintln("error: could not determine project directory")
-            exitProcess(EXIT_CONFIG_ERROR)
+            return Err(EXIT_CONFIG_ERROR)
         }
         val hash = projectHashOf(cwd)
         val socketPath = paths.daemonSocketPath(hash)
         if (!fileExists(socketPath)) {
             println("no daemon running for this project")
-            return
+            return Ok(Unit)
         }
         val stopped = sendShutdown(socketPath)
         if (stopped) println("daemon stopped") else println("no daemon running for this project")
     }
+    return Ok(Unit)
 }
 
 private fun stopAllDaemons(daemonBaseDir: String) {
@@ -82,14 +85,15 @@ private fun sendShutdown(socketPath: String): Boolean {
     return sent
 }
 
-private fun doDaemonReap() {
-    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_CONFIG_ERROR) }
+private fun doDaemonReap(): Result<Unit, Int> {
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_CONFIG_ERROR) }
     val result = reapStaleDaemons(paths.daemonBaseDir)
     if (result.reaped == 0) {
         println("no stale daemons found")
     } else {
         println("reaped ${result.reaped} stale daemon dir${if (result.reaped > 1) "s" else ""}")
     }
+    return Ok(Unit)
 }
 
 private fun printDaemonUsage() {

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -134,7 +134,7 @@ internal fun doAdd(args: List<String>) {
 }
 
 private fun fetchLatestVersion(group: String, artifact: String, repos: List<String>): String {
-    val paths = resolveKoltPaths(EXIT_DEPENDENCY_ERROR)
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_DEPENDENCY_ERROR) }
     val groupPath = group.replace('.', '/')
     val metadataPath = "${paths.cacheBase}/$groupPath/$artifact/maven-metadata.xml"
 
@@ -170,20 +170,20 @@ private fun fetchLatestVersion(group: String, artifact: String, repos: List<Stri
 }
 
 internal fun doInstall() {
-    val config = loadProjectConfig()
-    resolveDependencies(config)
+    val config = loadProjectConfig().getOrElse { exitProcess(it) }
+    resolveDependencies(config).getOrElse { exitProcess(it) }
     println("install complete")
 }
 
 internal fun doUpdate() {
-    val config = loadProjectConfig()
+    val config = loadProjectConfig().getOrElse { exitProcess(it) }
     val allDeps = mergeAllDeps(config)
     if (allDeps.isEmpty()) {
         println("no dependencies to update")
         return
     }
 
-    val paths = resolveKoltPaths(EXIT_DEPENDENCY_ERROR)
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_DEPENDENCY_ERROR) }
 
     for ((groupArtifact, version) in allDeps) {
         val coord = parseCoordinate(groupArtifact, version).getOrElse { continue }
@@ -210,7 +210,7 @@ internal fun doUpdate() {
 }
 
 internal fun doTree() {
-    val config = loadProjectConfig()
+    val config = loadProjectConfig().getOrElse { exitProcess(it) }
 
     val hasAnyDeps = config.dependencies.isNotEmpty() ||
         config.testDependencies.isNotEmpty() ||
@@ -220,7 +220,7 @@ internal fun doTree() {
         return
     }
 
-    val paths = resolveKoltPaths(EXIT_DEPENDENCY_ERROR)
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_DEPENDENCY_ERROR) }
 
     if (config.target == "native") {
         val nativeLookup = createNativeLookup(

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -1,5 +1,8 @@
 package kolt.cli
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
 import kolt.build.*
@@ -13,15 +16,14 @@ import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.toKString
 import platform.posix.PATH_MAX
 import platform.posix.getcwd
-import kotlin.system.exitProcess
 
 private const val SRC_DIR = "src"
 
 @OptIn(ExperimentalForeignApi::class)
-internal fun doInit(args: List<String>) {
+internal fun doInit(args: List<String>): Result<Unit, Int> {
     if (fileExists(KOLT_TOML)) {
         eprintln("error: $KOLT_TOML already exists")
-        exitProcess(EXIT_CONFIG_ERROR)
+        return Err(EXIT_CONFIG_ERROR)
     }
 
     val projectName = if (args.isNotEmpty()) {
@@ -33,7 +35,7 @@ internal fun doInit(args: List<String>) {
         }
         if (cwd == null) {
             eprintln("error: could not determine current directory")
-            exitProcess(EXIT_CONFIG_ERROR)
+            return Err(EXIT_CONFIG_ERROR)
         }
         inferProjectName(cwd)
     }
@@ -41,19 +43,19 @@ internal fun doInit(args: List<String>) {
     if (!isValidProjectName(projectName)) {
         eprintln("error: invalid project name '$projectName'")
         eprintln("  project name must start with a letter or digit and contain only letters, digits, '.', '-', '_'")
-        exitProcess(EXIT_CONFIG_ERROR)
+        return Err(EXIT_CONFIG_ERROR)
     }
 
     writeFileAsString(KOLT_TOML, generateKoltToml(projectName)).getOrElse { error ->
         eprintln("error: could not write ${error.path}")
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
     println("created $KOLT_TOML")
 
     if (!fileExists(SRC_DIR)) {
         ensureDirectory(SRC_DIR).getOrElse { error ->
             eprintln("error: could not create directory ${error.path}")
-            exitProcess(EXIT_BUILD_ERROR)
+            return Err(EXIT_BUILD_ERROR)
         }
     }
 
@@ -61,7 +63,7 @@ internal fun doInit(args: List<String>) {
     if (!fileExists(mainKtPath)) {
         writeFileAsString(mainKtPath, generateMainKt()).getOrElse { error ->
             eprintln("error: could not write ${error.path}")
-            exitProcess(EXIT_BUILD_ERROR)
+            return Err(EXIT_BUILD_ERROR)
         }
         println("created $mainKtPath")
     }
@@ -70,7 +72,7 @@ internal fun doInit(args: List<String>) {
     if (!fileExists(testDir)) {
         ensureDirectory(testDir).getOrElse { error ->
             eprintln("error: could not create directory ${error.path}")
-            exitProcess(EXIT_BUILD_ERROR)
+            return Err(EXIT_BUILD_ERROR)
         }
     }
 
@@ -78,33 +80,34 @@ internal fun doInit(args: List<String>) {
     if (!fileExists(testKtPath)) {
         writeFileAsString(testKtPath, generateTestKt()).getOrElse { error ->
             eprintln("error: could not write ${error.path}")
-            exitProcess(EXIT_BUILD_ERROR)
+            return Err(EXIT_BUILD_ERROR)
         }
         println("created $testKtPath")
     }
 
     println("initialized project '$projectName'")
+    return Ok(Unit)
 }
 
-internal fun doAdd(args: List<String>) {
+internal fun doAdd(args: List<String>): Result<Unit, Int> {
     val addArgs = parseAddArgs(args).getOrElse { error ->
         when (error) {
             is AddArgsError.MissingCoordinate -> eprintln("usage: kolt add <group:artifact[:version]> [--test]")
             is AddArgsError.InvalidFormat -> eprintln("error: invalid coordinate '${error.input}'")
         }
-        exitProcess(EXIT_DEPENDENCY_ERROR)
+        return Err(EXIT_DEPENDENCY_ERROR)
     }
 
     val toml = readFileAsString(KOLT_TOML).getOrElse { error ->
         eprintln("error: could not read ${error.path}")
-        exitProcess(EXIT_CONFIG_ERROR)
+        return Err(EXIT_CONFIG_ERROR)
     }
 
     val config = parseConfig(toml).getOrElse { error ->
         when (error) {
             is ConfigError.ParseFailed -> eprintln("error: ${error.message}")
         }
-        exitProcess(EXIT_CONFIG_ERROR)
+        return Err(EXIT_CONFIG_ERROR)
     }
 
     val version = if (addArgs.version != null) {
@@ -112,6 +115,7 @@ internal fun doAdd(args: List<String>) {
     } else {
         println("fetching latest version for ${addArgs.group}:${addArgs.artifact}...")
         fetchLatestVersion(addArgs.group, addArgs.artifact, config.repositories.values.toList())
+            .getOrElse { return Err(it) }
     }
 
     val groupArtifact = "${addArgs.group}:${addArgs.artifact}"
@@ -119,28 +123,28 @@ internal fun doAdd(args: List<String>) {
         when (error) {
             is AlreadyExists -> eprintln("error: '${error.groupArtifact}' already exists in ${if (addArgs.isTest) "[test-dependencies]" else "[dependencies]"}")
         }
-        exitProcess(EXIT_DEPENDENCY_ERROR)
+        return Err(EXIT_DEPENDENCY_ERROR)
     }
 
     writeFileAsString(KOLT_TOML, updatedToml).getOrElse { error ->
         eprintln("error: could not write ${error.path}")
-        exitProcess(EXIT_CONFIG_ERROR)
+        return Err(EXIT_CONFIG_ERROR)
     }
 
     val section = if (addArgs.isTest) "[test-dependencies]" else "[dependencies]"
     println("added $groupArtifact = \"$version\" to $section")
 
-    doInstall()
+    return doInstall()
 }
 
-private fun fetchLatestVersion(group: String, artifact: String, repos: List<String>): String {
-    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_DEPENDENCY_ERROR) }
+private fun fetchLatestVersion(group: String, artifact: String, repos: List<String>): Result<String, Int> {
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_DEPENDENCY_ERROR) }
     val groupPath = group.replace('.', '/')
     val metadataPath = "${paths.cacheBase}/$groupPath/$artifact/maven-metadata.xml"
 
     ensureDirectoryRecursive("${paths.cacheBase}/$groupPath/$artifact").getOrElse { error ->
         eprintln("error: could not create directory ${error.path}")
-        exitProcess(EXIT_DEPENDENCY_ERROR)
+        return Err(EXIT_DEPENDENCY_ERROR)
     }
 
     val fetchErr = downloadFromRepositories(
@@ -155,35 +159,36 @@ private fun fetchLatestVersion(group: String, artifact: String, repos: List<Stri
             is DownloadError.WriteFailed -> eprintln("error: could not write metadata to ${fetchErr.path}")
             is DownloadError.NetworkError -> eprintln("error: network error fetching metadata for $group:$artifact: ${fetchErr.message}")
         }
-        exitProcess(EXIT_DEPENDENCY_ERROR)
+        return Err(EXIT_DEPENDENCY_ERROR)
     }
 
     val xml = readFileAsString(metadataPath).getOrElse { error ->
         eprintln("error: could not read ${error.path}")
-        exitProcess(EXIT_DEPENDENCY_ERROR)
+        return Err(EXIT_DEPENDENCY_ERROR)
     }
 
     return parseMetadataXml(xml).getOrElse { error ->
         eprintln("error: ${error.message}")
-        exitProcess(EXIT_DEPENDENCY_ERROR)
-    }
+        return Err(EXIT_DEPENDENCY_ERROR)
+    }.let { Ok(it) }
 }
 
-internal fun doInstall() {
-    val config = loadProjectConfig().getOrElse { exitProcess(it) }
-    resolveDependencies(config).getOrElse { exitProcess(it) }
+internal fun doInstall(): Result<Unit, Int> {
+    val config = loadProjectConfig().getOrElse { return Err(it) }
+    resolveDependencies(config).getOrElse { return Err(it) }
     println("install complete")
+    return Ok(Unit)
 }
 
-internal fun doUpdate() {
-    val config = loadProjectConfig().getOrElse { exitProcess(it) }
+internal fun doUpdate(): Result<Unit, Int> {
+    val config = loadProjectConfig().getOrElse { return Err(it) }
     val allDeps = mergeAllDeps(config)
     if (allDeps.isEmpty()) {
         println("no dependencies to update")
-        return
+        return Ok(Unit)
     }
 
-    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_DEPENDENCY_ERROR) }
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_DEPENDENCY_ERROR) }
 
     for ((groupArtifact, version) in allDeps) {
         val coord = parseCoordinate(groupArtifact, version).getOrElse { continue }
@@ -197,30 +202,31 @@ internal fun doUpdate() {
     println("updating dependencies...")
     val resolveResult = resolve(resolveConfig, null, paths.cacheBase, createResolverDeps()).getOrElse { error ->
         eprintln(formatResolveError(error))
-        exitProcess(EXIT_DEPENDENCY_ERROR)
+        return Err(EXIT_DEPENDENCY_ERROR)
     }
 
     val lockfile = buildLockfileFromResolved(resolveConfig, resolveResult.deps)
     val lockJson = serializeLockfile(lockfile)
     writeFileAsString(LOCK_FILE, lockJson).getOrElse { error ->
         eprintln("error: could not write ${error.path}")
-        exitProcess(EXIT_DEPENDENCY_ERROR)
+        return Err(EXIT_DEPENDENCY_ERROR)
     }
     println("updated ${resolveResult.deps.size} dependencies")
+    return Ok(Unit)
 }
 
-internal fun doTree() {
-    val config = loadProjectConfig().getOrElse { exitProcess(it) }
+internal fun doTree(): Result<Unit, Int> {
+    val config = loadProjectConfig().getOrElse { return Err(it) }
 
     val hasAnyDeps = config.dependencies.isNotEmpty() ||
         config.testDependencies.isNotEmpty() ||
         autoInjectedTestDeps(config).isNotEmpty()
     if (!hasAnyDeps) {
         println("no dependencies")
-        return
+        return Ok(Unit)
     }
 
-    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_DEPENDENCY_ERROR) }
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_DEPENDENCY_ERROR) }
 
     if (config.target == "native") {
         val nativeLookup = createNativeLookup(
@@ -238,7 +244,7 @@ internal fun doTree() {
             val testTree = buildNativeDependencyTree(config.testDependencies, nativeLookup)
             println(formatDependencyTree(testTree))
         }
-        return
+        return Ok(Unit)
     }
 
     val allTestDeps = autoInjectedTestDeps(config) + config.testDependencies
@@ -253,6 +259,7 @@ internal fun doTree() {
         val testTree = buildDependencyTree(allTestDeps, pomLookup)
         println(formatDependencyTree(testTree))
     }
+    return Ok(Unit)
 }
 
 private val DEPS_SUBCOMMANDS = setOf("add", "install", "update", "tree")
@@ -260,16 +267,17 @@ private val DEPS_SUBCOMMANDS = setOf("add", "install", "update", "tree")
 internal fun validateDepsSubcommand(args: List<String>): Boolean =
     args.isNotEmpty() && args[0] in DEPS_SUBCOMMANDS
 
-internal fun doDeps(args: List<String>) {
+internal fun doDeps(args: List<String>): Result<Unit, Int> {
     if (!validateDepsSubcommand(args)) {
         printDepsUsage()
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
-    when (args[0]) {
+    return when (args[0]) {
         "add" -> doAdd(args.drop(1))
         "install" -> doInstall()
         "update" -> doUpdate()
         "tree" -> doTree()
+        else -> Ok(Unit)
     }
 }
 

--- a/src/nativeMain/kotlin/kolt/cli/FormatCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/FormatCommands.kt
@@ -10,10 +10,10 @@ import kotlin.system.exitProcess
 internal fun doFmt(args: List<String>) {
     val checkOnly = "--check" in args
 
-    val config = loadProjectConfig()
+    val config = loadProjectConfig().getOrElse { exitProcess(it) }
 
-    val paths = resolveKoltPaths(EXIT_FORMAT_ERROR)
-    val ktfmtPath = ensureTool(paths, KTFMT_SPEC, EXIT_FORMAT_ERROR)
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_FORMAT_ERROR) }
+    val ktfmtPath = ensureTool(paths, KTFMT_SPEC).getOrElse { eprintln("error: $it"); exitProcess(EXIT_FORMAT_ERROR) }
 
     val files = buildList {
         for (dir in config.sources) {

--- a/src/nativeMain/kotlin/kolt/cli/FormatCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/FormatCommands.kt
@@ -1,42 +1,43 @@
 package kolt.cli
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.build.formatCommand
 import kolt.config.*
 import kolt.infra.*
 import kolt.tool.*
-import kotlin.system.exitProcess
 
-internal fun doFmt(args: List<String>) {
+internal fun doFmt(args: List<String>): Result<Unit, Int> {
     val checkOnly = "--check" in args
 
-    val config = loadProjectConfig().getOrElse { exitProcess(it) }
+    val config = loadProjectConfig().getOrElse { return Err(it) }
 
-    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_FORMAT_ERROR) }
-    val ktfmtPath = ensureTool(paths, KTFMT_SPEC).getOrElse { eprintln("error: $it"); exitProcess(EXIT_FORMAT_ERROR) }
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_FORMAT_ERROR) }
+    val ktfmtPath = ensureTool(paths, KTFMT_SPEC).getOrElse { eprintln("error: $it"); return Err(EXIT_FORMAT_ERROR) }
 
-    val files = buildList {
-        for (dir in config.sources) {
-            if (isDirectory(dir)) {
-                addAll(listKotlinFiles(dir).getOrElse { error ->
-                    eprintln("error: could not read directory ${error.path}")
-                    exitProcess(EXIT_FORMAT_ERROR)
-                })
-            }
+    val files = mutableListOf<String>()
+    for (dir in config.sources) {
+        if (isDirectory(dir)) {
+            files.addAll(listKotlinFiles(dir).getOrElse { error ->
+                eprintln("error: could not read directory ${error.path}")
+                return Err(EXIT_FORMAT_ERROR)
+            })
         }
-        for (dir in config.testSources) {
-            if (isDirectory(dir)) {
-                addAll(listKotlinFiles(dir).getOrElse { error ->
-                    eprintln("error: could not read directory ${error.path}")
-                    exitProcess(EXIT_FORMAT_ERROR)
-                })
-            }
+    }
+    for (dir in config.testSources) {
+        if (isDirectory(dir)) {
+            files.addAll(listKotlinFiles(dir).getOrElse { error ->
+                eprintln("error: could not read directory ${error.path}")
+                return Err(EXIT_FORMAT_ERROR)
+            })
         }
     }
 
     if (files.isEmpty()) {
         println("no kotlin files to format")
-        return
+        return Ok(Unit)
     }
 
     val cmd = formatCommand(ktfmtPath, files, checkOnly, style = config.fmtStyle)
@@ -52,7 +53,7 @@ internal fun doFmt(args: List<String>) {
             is ProcessError.NonZeroExit -> eprintln(if (checkOnly) "error: format check failed" else "error: formatting failed")
             else -> eprintln("error: failed to run ktfmt")
         }
-        exitProcess(EXIT_FORMAT_ERROR)
+        return Err(EXIT_FORMAT_ERROR)
     }
 
     if (checkOnly) {
@@ -60,4 +61,5 @@ internal fun doFmt(args: List<String>) {
     } else {
         println("formatted ${files.size} files")
     }
+    return Ok(Unit)
 }

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -1,5 +1,6 @@
 package kolt.cli
 
+import com.github.michaelbull.result.getOrElse
 import kolt.config.versionString
 import kolt.infra.eprintln
 import kotlin.system.exitProcess
@@ -23,25 +24,25 @@ fun main(args: Array<String>) {
 
     when (filteredArgs[0]) {
         "init" -> doInit(filteredArgs.drop(1))
-        "build" -> doBuild(useDaemon = useDaemon)
-        "check" -> doCheck(useDaemon = useDaemon)
+        "build" -> doBuild(useDaemon = useDaemon).getOrElse { exitProcess(it) }
+        "check" -> doCheck(useDaemon = useDaemon).getOrElse { exitProcess(it) }
         "run" -> {
             val appArgs = filteredArgs.let { all ->
                 val sep = all.indexOf("--")
                 if (sep >= 0) all.subList(sep + 1, all.size) else emptyList()
             }
-            val (config, classpath, javaPath) = doBuild(useDaemon = useDaemon)
-            doRun(config, classpath, appArgs, javaPath)
+            val (config, classpath, javaPath) = doBuild(useDaemon = useDaemon).getOrElse { exitProcess(it) }
+            doRun(config, classpath, appArgs, javaPath).getOrElse { exitProcess(it) }
         }
         "test" -> {
             val testArgs = filteredArgs.let { all ->
                 val sep = all.indexOf("--")
                 if (sep >= 0) all.subList(sep + 1, all.size) else emptyList()
             }
-            doTest(testArgs, useDaemon = useDaemon)
+            doTest(testArgs, useDaemon = useDaemon).getOrElse { exitProcess(it) }
         }
         "fmt" -> doFmt(filteredArgs.drop(1))
-        "clean" -> doClean()
+        "clean" -> doClean().getOrElse { exitProcess(it) }
         "deps" -> doDeps(filteredArgs.drop(1))
         "add" -> doDeps(listOf("add") + filteredArgs.drop(1))
         "install" -> doDeps(listOf("install"))

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -23,7 +23,7 @@ fun main(args: Array<String>) {
     }
 
     when (filteredArgs[0]) {
-        "init" -> doInit(filteredArgs.drop(1))
+        "init" -> doInit(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
         "build" -> doBuild(useDaemon = useDaemon).getOrElse { exitProcess(it) }
         "check" -> doCheck(useDaemon = useDaemon).getOrElse { exitProcess(it) }
         "run" -> {
@@ -41,15 +41,15 @@ fun main(args: Array<String>) {
             }
             doTest(testArgs, useDaemon = useDaemon).getOrElse { exitProcess(it) }
         }
-        "fmt" -> doFmt(filteredArgs.drop(1))
+        "fmt" -> doFmt(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
         "clean" -> doClean().getOrElse { exitProcess(it) }
-        "deps" -> doDeps(filteredArgs.drop(1))
-        "add" -> doDeps(listOf("add") + filteredArgs.drop(1))
-        "install" -> doDeps(listOf("install"))
-        "update" -> doDeps(listOf("update"))
-        "tree" -> doDeps(listOf("tree"))
-        "toolchain" -> doToolchain(filteredArgs.drop(1))
-        "daemon" -> doDaemon(filteredArgs.drop(1))
+        "deps" -> doDeps(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
+        "add" -> doDeps(listOf("add") + filteredArgs.drop(1)).getOrElse { exitProcess(it) }
+        "install" -> doDeps(listOf("install")).getOrElse { exitProcess(it) }
+        "update" -> doDeps(listOf("update")).getOrElse { exitProcess(it) }
+        "tree" -> doDeps(listOf("tree")).getOrElse { exitProcess(it) }
+        "toolchain" -> doToolchain(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
+        "daemon" -> doDaemon(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
         "--version", "version" -> println(versionString())
         else -> {
             eprintln("error: unknown command '${filteredArgs[0]}'")

--- a/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
+++ b/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
@@ -1,7 +1,10 @@
 package kolt.cli
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
+import com.github.michaelbull.result.map
 import kolt.config.KoltConfig
 import kolt.config.KoltPaths
 import kolt.infra.DownloadError
@@ -13,7 +16,6 @@ import kolt.infra.eprintln
 import kolt.resolve.PluginFetchError
 import kolt.resolve.PluginFetcherDeps
 import kolt.resolve.fetchEnabledPluginJars
-import kotlin.system.exitProcess
 
 private fun defaultPluginFetcherDeps(): PluginFetcherDeps = object : PluginFetcherDeps {
     override fun fileExists(path: String): Boolean = kolt.infra.fileExists(path)
@@ -34,23 +36,22 @@ internal fun resolveEnabledPluginJarPaths(
     config: KoltConfig,
     paths: KoltPaths,
     operationalExitCode: Int,
-): Map<String, String> = resolveEnabledPluginJarsOrExit(config, paths, operationalExitCode)
+): Result<Map<String, String>, PluginFetchExit> =
+    resolveEnabledPluginJarsResult(config, paths, operationalExitCode)
 
-private fun resolveEnabledPluginJarsOrExit(
+private fun resolveEnabledPluginJarsResult(
     config: KoltConfig,
     paths: KoltPaths,
     operationalExitCode: Int,
-): Map<String, String> {
+): Result<Map<String, String>, PluginFetchExit> {
     return fetchEnabledPluginJars(
         plugins = config.plugins,
         kotlinVersion = config.kotlin,
         cacheBase = paths.cacheBase,
         deps = defaultPluginFetcherDeps(),
     ).getOrElse { err ->
-        val exit = mapPluginFetchErrorToExit(err, operationalExitCode)
-        eprintln("error: ${exit.message}")
-        exitProcess(exit.exitCode)
-    }
+        return Err(mapPluginFetchErrorToExit(err, operationalExitCode))
+    }.let { Ok(it) }
 }
 
 // 404 on a plugin jar → EXIT_CONFIG_ERROR (bad kotlin version in kolt.toml).
@@ -95,13 +96,15 @@ private fun formatDownloadError(err: DownloadError): String = when (err) {
 internal fun resolvePluginArgs(
     config: KoltConfig,
     paths: KoltPaths,
-    exitCode: Int,
-): List<String> =
-    resolveEnabledPluginJarsOrExit(config, paths, exitCode).values.map { "-Xplugin=$it" }
+    operationalExitCode: Int,
+): Result<List<String>, PluginFetchExit> =
+    resolveEnabledPluginJarsResult(config, paths, operationalExitCode)
+        .map { it.values.map { path -> "-Xplugin=$path" } }
 
 internal fun resolvePluginJarsMap(
     config: KoltConfig,
     paths: KoltPaths,
-    exitCode: Int,
-): Map<String, List<String>> =
-    resolveEnabledPluginJarsOrExit(config, paths, exitCode).mapValues { (_, path) -> listOf(path) }
+    operationalExitCode: Int,
+): Result<Map<String, List<String>>, PluginFetchExit> =
+    resolveEnabledPluginJarsResult(config, paths, operationalExitCode)
+        .map { it.mapValues { (_, path) -> listOf(path) } }

--- a/src/nativeMain/kotlin/kolt/cli/ToolchainCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/ToolchainCommands.kt
@@ -4,8 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
-import kolt.config.KoltPaths
-import kolt.config.resolveKoltPaths
+import kolt.config.*
 import kolt.infra.*
 import kolt.tool.installJdkToolchain
 import kolt.tool.installKonancToolchain
@@ -40,19 +39,19 @@ private fun printToolchainUsage() {
 }
 
 private fun doToolchainInstall() {
-    val config = loadProjectConfig()
-    val paths = resolveKoltPaths(EXIT_CONFIG_ERROR)
-    installKotlincToolchain(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
+    val config = loadProjectConfig().getOrElse { exitProcess(it) }
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_CONFIG_ERROR) }
+    installKotlincToolchain(config.kotlin, paths).getOrElse { eprintln("error: ${it.message}"); exitProcess(EXIT_BUILD_ERROR) }
     if (config.jdk != null) {
-        installJdkToolchain(config.jdk, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
+        installJdkToolchain(config.jdk, paths).getOrElse { eprintln("error: ${it.message}"); exitProcess(EXIT_BUILD_ERROR) }
     }
     if (config.target == "native") {
-        installKonancToolchain(config.kotlin, paths).getOrElse { exitWithToolchainError(it, EXIT_BUILD_ERROR) }
+        installKonancToolchain(config.kotlin, paths).getOrElse { eprintln("error: ${it.message}"); exitProcess(EXIT_BUILD_ERROR) }
     }
 }
 
 private fun doToolchainList() {
-    val paths = resolveKoltPaths(EXIT_CONFIG_ERROR)
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_CONFIG_ERROR) }
     val kotlincVersions = listInstalledVersions("${paths.toolchainsDir}/kotlinc")
     val jdkVersions = listInstalledVersions("${paths.toolchainsDir}/jdk")
     val konancVersions = listInstalledVersions("${paths.toolchainsDir}/konanc")
@@ -114,7 +113,7 @@ private fun doToolchainRemove(args: List<String>) {
         exitProcess(EXIT_CONFIG_ERROR)
     }
 
-    val paths = resolveKoltPaths(EXIT_CONFIG_ERROR)
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_CONFIG_ERROR) }
     val toolchainPath = resolveToolchainPathForRemove(parsed.name, parsed.version, paths)
     if (toolchainPath == null) {
         eprintln("error: ${parsed.name} ${parsed.version} is not installed")

--- a/src/nativeMain/kotlin/kolt/cli/ToolchainCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/ToolchainCommands.kt
@@ -9,22 +9,21 @@ import kolt.infra.*
 import kolt.tool.installJdkToolchain
 import kolt.tool.installKonancToolchain
 import kolt.tool.installKotlincToolchain
-import kotlin.system.exitProcess
 
 private val KNOWN_TOOLCHAINS = listOf("kotlinc", "jdk", "konanc")
 
-internal fun doToolchain(args: List<String>) {
+internal fun doToolchain(args: List<String>): Result<Unit, Int> {
     if (args.isEmpty()) {
         printToolchainUsage()
-        exitProcess(EXIT_CONFIG_ERROR)
+        return Err(EXIT_CONFIG_ERROR)
     }
-    when (args[0]) {
+    return when (args[0]) {
         "install" -> doToolchainInstall()
         "list" -> doToolchainList()
         "remove" -> doToolchainRemove(args.drop(1))
         else -> {
             printToolchainUsage()
-            exitProcess(EXIT_CONFIG_ERROR)
+            Err(EXIT_CONFIG_ERROR)
         }
     }
 }
@@ -38,24 +37,26 @@ private fun printToolchainUsage() {
     eprintln("  remove     Remove an installed toolchain (e.g. kolt toolchain remove kotlinc 2.1.0)")
 }
 
-private fun doToolchainInstall() {
-    val config = loadProjectConfig().getOrElse { exitProcess(it) }
-    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_CONFIG_ERROR) }
-    installKotlincToolchain(config.kotlin, paths).getOrElse { eprintln("error: ${it.message}"); exitProcess(EXIT_BUILD_ERROR) }
+private fun doToolchainInstall(): Result<Unit, Int> {
+    val config = loadProjectConfig().getOrElse { return Err(it) }
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_CONFIG_ERROR) }
+    installKotlincToolchain(config.kotlin, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
     if (config.jdk != null) {
-        installJdkToolchain(config.jdk, paths).getOrElse { eprintln("error: ${it.message}"); exitProcess(EXIT_BUILD_ERROR) }
+        installJdkToolchain(config.jdk, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
     }
     if (config.target == "native") {
-        installKonancToolchain(config.kotlin, paths).getOrElse { eprintln("error: ${it.message}"); exitProcess(EXIT_BUILD_ERROR) }
+        installKonancToolchain(config.kotlin, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
     }
+    return Ok(Unit)
 }
 
-private fun doToolchainList() {
-    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_CONFIG_ERROR) }
+private fun doToolchainList(): Result<Unit, Int> {
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_CONFIG_ERROR) }
     val kotlincVersions = listInstalledVersions("${paths.toolchainsDir}/kotlinc")
     val jdkVersions = listInstalledVersions("${paths.toolchainsDir}/jdk")
     val konancVersions = listInstalledVersions("${paths.toolchainsDir}/konanc")
     println(formatToolchainList(kotlincVersions, jdkVersions, konancVersions))
+    return Ok(Unit)
 }
 
 private fun listInstalledVersions(dir: String): List<String> {
@@ -107,22 +108,23 @@ internal fun resolveToolchainPathForRemove(name: String, version: String, paths:
     return if (fileExists(dir)) dir else null
 }
 
-private fun doToolchainRemove(args: List<String>) {
+private fun doToolchainRemove(args: List<String>): Result<Unit, Int> {
     val parsed = validateToolchainRemoveArgs(args).getOrElse { error ->
         eprintln(error)
-        exitProcess(EXIT_CONFIG_ERROR)
+        return Err(EXIT_CONFIG_ERROR)
     }
 
-    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); exitProcess(EXIT_CONFIG_ERROR) }
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_CONFIG_ERROR) }
     val toolchainPath = resolveToolchainPathForRemove(parsed.name, parsed.version, paths)
     if (toolchainPath == null) {
         eprintln("error: ${parsed.name} ${parsed.version} is not installed")
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
 
     removeDirectoryRecursive(toolchainPath).getOrElse { err ->
         eprintln("error: could not remove ${parsed.name} ${parsed.version}: ${err.path}")
-        exitProcess(EXIT_BUILD_ERROR)
+        return Err(EXIT_BUILD_ERROR)
     }
     println("removed ${parsed.name} ${parsed.version}")
+    return Ok(Unit)
 }

--- a/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
+++ b/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
@@ -1,9 +1,9 @@
 package kolt.config
 
-import com.github.michaelbull.result.getOrElse
-import kolt.infra.eprintln
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import com.github.michaelbull.result.mapError
 import kolt.infra.homeDirectory
-import kotlin.system.exitProcess
 
 internal data class KoltPaths(val home: String) {
     val cacheBase: String = "$home/.kolt/cache"
@@ -27,10 +27,5 @@ internal data class KoltPaths(val home: String) {
     fun cinteropBin(version: String): String = "${konancPath(version)}/bin/cinterop"
 }
 
-internal fun resolveKoltPaths(exitCode: Int): KoltPaths {
-    val home = homeDirectory().getOrElse { error ->
-        eprintln("error: ${error.message}")
-        exitProcess(exitCode)
-    }
-    return KoltPaths(home)
-}
+internal fun resolveKoltPaths(): Result<KoltPaths, String> =
+    homeDirectory().map { KoltPaths(it) }.mapError { it.message }

--- a/src/nativeMain/kotlin/kolt/tool/ToolManager.kt
+++ b/src/nativeMain/kotlin/kolt/tool/ToolManager.kt
@@ -1,10 +1,12 @@
 package kolt.tool
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltPaths
 import kolt.infra.*
 import kolt.config.MAVEN_CENTRAL_BASE
-import kotlin.system.exitProcess
 
 internal data class ToolSpec(
     val group: String,
@@ -34,24 +36,22 @@ internal val CONSOLE_LAUNCHER_SPEC = ToolSpec(
     fileName = "junit-platform-console-standalone-1.11.4.jar"
 )
 
-internal fun ensureTool(paths: KoltPaths, spec: ToolSpec, exitCode: Int): String {
+internal fun ensureTool(paths: KoltPaths, spec: ToolSpec): Result<String, String> {
     val path = spec.toolPath(paths.toolsDir)
-    if (fileExists(path)) return path
+    if (fileExists(path)) return Ok(path)
 
     ensureDirectoryRecursive(paths.toolsDir).getOrElse { error ->
-        eprintln("error: could not create directory ${error.path}")
-        exitProcess(exitCode)
+        return Err("could not create directory ${error.path}")
     }
 
     val url = spec.downloadUrl()
     println("downloading ${spec.artifact}...")
     downloadFile(url, path).getOrElse { error ->
-        when (error) {
-            is DownloadError.HttpFailed -> eprintln("error: failed to download ${spec.artifact} (HTTP ${error.statusCode})")
-            is DownloadError.WriteFailed -> eprintln("error: could not write $path")
-            is DownloadError.NetworkError -> eprintln("error: network error downloading ${spec.artifact}: ${error.message}")
-        }
-        exitProcess(exitCode)
+        return Err(when (error) {
+            is DownloadError.HttpFailed -> "failed to download ${spec.artifact} (HTTP ${error.statusCode})"
+            is DownloadError.WriteFailed -> "could not write $path"
+            is DownloadError.NetworkError -> "network error downloading ${spec.artifact}: ${error.message}"
+        })
     }
-    return path
+    return Ok(path)
 }

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
@@ -1,5 +1,6 @@
 package kolt.cli
 
+import com.github.michaelbull.result.get
 import kolt.testConfig
 import kolt.build.cinteropCommand
 import kolt.build.cinteropOutputKlibPath
@@ -13,6 +14,7 @@ import kolt.infra.writeFileAsString
 import kolt.tool.JdkBins
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -23,7 +25,7 @@ class EnsureJdkBinsFromConfigTest {
         val config = testConfig(jdk = null)
         val paths = KoltPaths("/tmp/kolt_ensure_jdk_bins_null")
 
-        val result = ensureJdkBinsFromConfig(config, paths)
+        val result = assertNotNull(ensureJdkBinsFromConfig(config, paths).get())
 
         assertNull(result.java)
         assertNull(result.jar)
@@ -38,7 +40,7 @@ class EnsureJdkBinsFromConfigTest {
         writeFileAsString("$binDir/java", "#!/bin/sh")
         writeFileAsString("$binDir/jar", "#!/bin/sh")
         try {
-            val result = ensureJdkBinsFromConfig(config, paths)
+            val result = assertNotNull(ensureJdkBinsFromConfig(config, paths).get())
 
             assertEquals(paths.javaBin("21"), result.java)
             assertEquals(paths.jarBin("21"), result.jar)

--- a/src/nativeTest/kotlin/kolt/cli/PluginSupportTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/PluginSupportTest.kt
@@ -1,11 +1,13 @@
 package kolt.cli
 
+import com.github.michaelbull.result.get
 import kolt.config.KoltPaths
 import kolt.infra.DownloadError
 import kolt.resolve.PluginFetchError
 import kolt.testConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 // Bogus KoltPaths: if the zero-plugin short-circuit regresses, any I/O
@@ -18,7 +20,7 @@ class PluginSupportTest {
     fun resolvePluginArgsNoPluginsReturnsEmptyWithoutTouchingTheNetwork() {
         val config = testConfig(plugins = emptyMap())
 
-        val result = resolvePluginArgs(config, bogusPaths, exitCode = 999)
+        val result = assertNotNull(resolvePluginArgs(config, bogusPaths, operationalExitCode = 999).get())
 
         assertTrue(result.isEmpty())
     }
@@ -29,7 +31,7 @@ class PluginSupportTest {
             plugins = mapOf("serialization" to false, "allopen" to false),
         )
 
-        val result = resolvePluginArgs(config, bogusPaths, exitCode = 999)
+        val result = assertNotNull(resolvePluginArgs(config, bogusPaths, operationalExitCode = 999).get())
 
         assertTrue(result.isEmpty())
     }
@@ -38,7 +40,7 @@ class PluginSupportTest {
     fun resolvePluginJarsMapNoPluginsReturnsEmptyMap() {
         val config = testConfig(plugins = emptyMap())
 
-        val result = resolvePluginJarsMap(config, bogusPaths, exitCode = 999)
+        val result = assertNotNull(resolvePluginJarsMap(config, bogusPaths, operationalExitCode = 999).get())
 
         assertEquals(emptyMap(), result)
     }
@@ -49,7 +51,7 @@ class PluginSupportTest {
             plugins = mapOf("serialization" to false, "allopen" to false),
         )
 
-        val result = resolvePluginJarsMap(config, bogusPaths, exitCode = 999)
+        val result = assertNotNull(resolvePluginJarsMap(config, bogusPaths, operationalExitCode = 999).get())
 
         assertEquals(emptyMap(), result)
     }
@@ -58,7 +60,7 @@ class PluginSupportTest {
     fun resolvePluginArgsNativeTargetSharesTheSameShortCircuit() {
         val config = testConfig(plugins = emptyMap(), target = "native")
 
-        val result = resolvePluginArgs(config, bogusPaths, exitCode = 999)
+        val result = assertNotNull(resolvePluginArgs(config, bogusPaths, operationalExitCode = 999).get())
 
         assertTrue(result.isEmpty())
     }


### PR DESCRIPTION
Build commands and all other command files (DependencyCommands, FormatCommands, ToolchainCommands, DaemonCommands) now return `Result<T, Int>` instead of calling `exitProcess` directly. Helper functions (`resolveKoltPaths`, `ensureTool`, `resolvePluginArgs`, `loadProjectConfig`, `resolveDependencies`) also return Result. `exitProcess` is consolidated exclusively in Main.kt's dispatch layer. `exitWithToolchainError` is removed.

This unblocks #15 (--watch), which needs to call commands as closures without terminating the process on failure.

Review focus: the `doAdd` → `fetchLatestVersion` chain in DependencyCommands now returns `Result<String, Int>` — verify the error propagation reads naturally. The `PluginFetchExit` error type still carries `operationalExitCode` since different callers need different codes for transient failures.