### PR TITLE
Add --watch flag to build/check/test/run (#15)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -16,7 +16,8 @@ fun main(args: Array<String>) {
     val koltLevel = if (passthroughStart >= 0) argList.subList(0, passthroughStart) else argList
     val passthrough = if (passthroughStart >= 0) argList.subList(passthroughStart, argList.size) else emptyList()
     val useDaemon = !koltLevel.contains(NO_DAEMON_FLAG)
-    val filteredArgs = koltLevel.filter { it != NO_DAEMON_FLAG } + passthrough
+    val watch = koltLevel.contains(WATCH_FLAG)
+    val filteredArgs = koltLevel.filter { it != NO_DAEMON_FLAG && it != WATCH_FLAG } + passthrough
     if (filteredArgs.isEmpty()) {
         printUsage()
         return
@@ -24,22 +25,29 @@ fun main(args: Array<String>) {
 
     when (filteredArgs[0]) {
         "init" -> doInit(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
-        "build" -> doBuild(useDaemon = useDaemon).getOrElse { exitProcess(it) }
-        "check" -> doCheck(useDaemon = useDaemon).getOrElse { exitProcess(it) }
+        "build" -> if (watch) watchCommandLoop("build", useDaemon)
+            else doBuild(useDaemon = useDaemon).getOrElse { exitProcess(it) }
+        "check" -> if (watch) watchCommandLoop("check", useDaemon)
+            else doCheck(useDaemon = useDaemon).getOrElse { exitProcess(it) }
         "run" -> {
             val appArgs = filteredArgs.let { all ->
                 val sep = all.indexOf("--")
                 if (sep >= 0) all.subList(sep + 1, all.size) else emptyList()
             }
-            val (config, classpath, javaPath) = doBuild(useDaemon = useDaemon).getOrElse { exitProcess(it) }
-            doRun(config, classpath, appArgs, javaPath).getOrElse { exitProcess(it) }
+            if (watch) {
+                watchRunLoop(useDaemon, appArgs)
+            } else {
+                val (config, classpath, javaPath) = doBuild(useDaemon = useDaemon).getOrElse { exitProcess(it) }
+                doRun(config, classpath, appArgs, javaPath).getOrElse { exitProcess(it) }
+            }
         }
         "test" -> {
             val testArgs = filteredArgs.let { all ->
                 val sep = all.indexOf("--")
                 if (sep >= 0) all.subList(sep + 1, all.size) else emptyList()
             }
-            doTest(testArgs, useDaemon = useDaemon).getOrElse { exitProcess(it) }
+            if (watch) watchCommandLoop("test", useDaemon, testArgs)
+            else doTest(testArgs, useDaemon = useDaemon).getOrElse { exitProcess(it) }
         }
         "fmt" -> doFmt(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
         "clean" -> doClean().getOrElse { exitProcess(it) }
@@ -60,6 +68,7 @@ fun main(args: Array<String>) {
 }
 
 private const val NO_DAEMON_FLAG = "--no-daemon"
+private const val WATCH_FLAG = "--watch"
 
 private fun printUsage() {
     eprintln("usage: kolt <command>")
@@ -80,5 +89,6 @@ private fun printUsage() {
     eprintln("  version    Show version information")
     eprintln("")
     eprintln("flags:")
+    eprintln("  --watch      Watch source files and re-run on change")
     eprintln("  --no-daemon  Skip the warm compiler daemon for this invocation")
 }

--- a/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
+++ b/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
@@ -1,0 +1,341 @@
+package kolt.cli
+
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.build.nativeRunCommand
+import kolt.build.runCommand
+import kolt.config.KoltConfig
+import kolt.infra.*
+import kotlinx.cinterop.*
+import platform.linux.IN_CREATE
+import platform.linux.IN_ISDIR
+import platform.posix.*
+import kotlin.concurrent.AtomicInt
+
+internal fun collectWatchPaths(config: KoltConfig, command: String): List<String> {
+    val seen = mutableSetOf<String>()
+    val paths = mutableListOf<String>()
+    fun add(p: String) { if (seen.add(p)) paths.add(p) }
+    add(".")
+    config.sources.forEach(::add)
+    if (command == "test") config.testSources.forEach(::add)
+    config.resources.forEach(::add)
+    if (command == "test") config.testResources.forEach(::add)
+    return paths
+}
+
+internal fun shouldTriggerRebuild(name: String): Boolean {
+    if (name.isEmpty()) return false
+    if (name.startsWith(".")) return false
+    if (name.endsWith("~")) return false
+    if (name.endsWith(".swp") || name.endsWith(".swo") || name.endsWith(".swx")) return false
+    if (name.endsWith(".tmp")) return false
+    if (name == "4913") return false
+    if (name == "kolt.toml") return true
+    return name.endsWith(".kt") || name.endsWith(".kts")
+}
+
+private val sigintReceived = AtomicInt(0)
+
+@OptIn(ExperimentalForeignApi::class)
+private fun installSigintHandler() {
+    sigintReceived.value = 0
+    signal(SIGINT, staticCFunction<Int, Unit> { _ ->
+        sigintReceived.value = 1
+    })
+}
+
+private fun shouldExit(): Boolean = sigintReceived.value != 0
+
+private enum class WatchKind { ROOT_DIR, SOURCE_DIR, RESOURCE_DIR }
+
+private data class WatchSetup(
+    val watcher: InotifyWatcher,
+    val wdKinds: Map<Int, WatchKind>,
+)
+
+private fun setupWatches(watchDirs: List<String>, config: KoltConfig): WatchSetup? {
+    val watcher = InotifyWatcher.create().getOrElse { err ->
+        eprintln("error: failed to initialize inotify: $err")
+        return null
+    }
+    val wdKinds = mutableMapOf<Int, WatchKind>()
+    val resourceDirs = config.resources.toSet() + config.testResources.toSet()
+
+    for (dir in watchDirs) {
+        if (!fileExists(dir)) continue
+        if (dir == ".") {
+            // Invariant: "." is only watched for kolt.toml changes (non-recursive).
+            val wd = watcher.addWatch(dir, DEFAULT_WATCH_MASK).getOrElse { err ->
+                reportWatchError(err); watcher.close(); return null
+            }
+            wdKinds[wd] = WatchKind.ROOT_DIR
+        } else {
+            val kind = if (dir in resourceDirs) WatchKind.RESOURCE_DIR else WatchKind.SOURCE_DIR
+            val wds = watcher.addWatchRecursive(dir).getOrElse { err ->
+                reportWatchError(err); watcher.close(); return null
+            }
+            for (wd in wds) {
+                wdKinds[wd] = kind
+            }
+        }
+    }
+    return WatchSetup(watcher, wdKinds)
+}
+
+private fun reportWatchError(err: InotifyError) {
+    when (err) {
+        is InotifyError.WatchLimitExceeded ->
+            eprintln("error: inotify watch limit exceeded on ${err.path}\n" +
+                "hint: increase with: sudo sysctl -w fs.inotify.max_user_watches=65536")
+        else -> eprintln("error: inotify watch failed: $err")
+    }
+}
+
+private fun hasRelevantEvents(events: List<InotifyEvent>, wdKinds: Map<Int, WatchKind>): Boolean {
+    for (event in events) {
+        when (wdKinds[event.wd]) {
+            WatchKind.ROOT_DIR -> {
+                if (event.name == "kolt.toml") return true
+            }
+            WatchKind.RESOURCE_DIR -> return true
+            WatchKind.SOURCE_DIR -> {
+                if (shouldTriggerRebuild(event.name)) return true
+            }
+            null -> {
+                // wd not in map — auto-added subdirectory; treat as source.
+                if (shouldTriggerRebuild(event.name)) return true
+            }
+        }
+    }
+    return false
+}
+
+private fun autoAddNewDirs(
+    events: List<InotifyEvent>,
+    wdKinds: MutableMap<Int, WatchKind>,
+    watcher: InotifyWatcher,
+) {
+    for (event in events) {
+        if (event.mask and IN_CREATE.toUInt() == 0u) continue
+        if (event.mask and IN_ISDIR.toUInt() == 0u) continue
+        if (wdKinds[event.wd] == WatchKind.ROOT_DIR) continue
+        if (event.name in EXCLUDED_DIRS) continue
+        val parentPath = watcher.pathForWd(event.wd) ?: continue
+        val newDirPath = "$parentPath/${event.name}"
+        val parentKind = wdKinds[event.wd] ?: WatchKind.SOURCE_DIR
+        val newWds = watcher.addWatchRecursive(newDirPath).getOrElse { err ->
+            reportWatchError(err)
+            continue
+        }
+        for (wd in newWds) {
+            wdKinds[wd] = parentKind
+        }
+    }
+}
+
+private fun settleAndDrain(
+    watcher: InotifyWatcher,
+    wdKinds: MutableMap<Int, WatchKind>,
+): Boolean {
+    var relevant = false
+    while (true) {
+        val more = watcher.pollEvents(timeoutMs = 100).getOrElse { return relevant }
+        if (more.isEmpty()) break
+        autoAddNewDirs(more, wdKinds, watcher)
+        if (hasRelevantEvents(more, wdKinds)) relevant = true
+    }
+    return relevant
+}
+
+internal fun watchCommandLoop(
+    command: String,
+    useDaemon: Boolean,
+    testArgs: List<String> = emptyList(),
+    commandRunner: (String, Boolean, List<String>) -> Result<*, Int> = { cmd, daemon, args ->
+        when (cmd) {
+            "build" -> doBuild(useDaemon = daemon)
+            "check" -> doCheck(useDaemon = daemon)
+            "test" -> doTest(testArgs = args, useDaemon = daemon)
+            else -> doBuild(useDaemon = daemon)
+        }
+    },
+) {
+    val config = loadProjectConfig().getOrElse {
+        eprintln("error: cannot start watch mode with invalid config")
+        return
+    }
+    val watchDirs = collectWatchPaths(config, command)
+    val setup = setupWatches(watchDirs, config) ?: return
+    val watcher = setup.watcher
+    val wdKinds = setup.wdKinds.toMutableMap()
+
+    installSigintHandler()
+    eprintln("watching for changes (Ctrl+C to stop)...")
+
+    commandRunner(command, useDaemon, testArgs)
+
+    while (!shouldExit()) {
+        val events = watcher.pollEvents(timeoutMs = 500).getOrElse {
+            if (!shouldExit()) eprintln("warning: inotify read failed")
+            break
+        }
+        if (shouldExit()) break
+        if (events.isEmpty()) continue
+
+        autoAddNewDirs(events, wdKinds, watcher)
+        val relevant = hasRelevantEvents(events, wdKinds)
+        val settleRelevant = settleAndDrain(watcher, wdKinds)
+        if (!relevant && !settleRelevant) continue
+
+        if (shouldExit()) break
+        eprintln("\n--- change detected, rebuilding ---")
+        commandRunner(command, useDaemon, testArgs)
+
+        val pending = watcher.pollEvents(timeoutMs = 0).getOrElse { emptyList() }
+        if (pending.isNotEmpty()) {
+            autoAddNewDirs(pending, wdKinds, watcher)
+            if (hasRelevantEvents(pending, wdKinds)) {
+                settleAndDrain(watcher, wdKinds)
+                if (!shouldExit()) {
+                    eprintln("\n--- pending changes detected, rebuilding ---")
+                    commandRunner(command, useDaemon, testArgs)
+                }
+            }
+        }
+    }
+
+    watcher.close()
+    eprintln("\nwatch mode stopped")
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun spawnInProcessGroup(args: List<String>): Int {
+    val pid = fork()
+    if (pid < 0) return -1
+    if (pid == 0) {
+        setpgid(0, 0)
+        memScoped {
+            val argv = allocArray<CPointerVar<ByteVar>>(args.size + 1)
+            for (i in args.indices) {
+                argv[i] = args[i].cstr.ptr
+            }
+            argv[args.size] = null
+            execvp(args[0], argv)
+            _exit(127)
+        }
+    }
+    setpgid(pid, pid)
+    return pid
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun killProcessGroup(pid: Int) {
+    kill(-pid, SIGTERM)
+    for (i in 0 until 5) {
+        usleep(100_000u)
+        memScoped {
+            val status = alloc<IntVar>()
+            val ret = waitpid(pid, status.ptr, WNOHANG)
+            if (ret > 0) return
+            if (ret < 0) return // ECHILD — already reaped
+        }
+    }
+    kill(-pid, SIGKILL)
+    memScoped {
+        val status = alloc<IntVar>()
+        waitpid(pid, status.ptr, 0)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun reapChild(pid: Int): Boolean {
+    memScoped {
+        val status = alloc<IntVar>()
+        val ret = waitpid(pid, status.ptr, WNOHANG)
+        return ret != 0
+    }
+}
+
+internal fun watchRunLoop(
+    useDaemon: Boolean,
+    appArgs: List<String> = emptyList(),
+) {
+    val config = loadProjectConfig().getOrElse {
+        eprintln("error: cannot start watch mode with invalid config")
+        return
+    }
+    val watchDirs = collectWatchPaths(config, "run")
+    val setup = setupWatches(watchDirs, config) ?: return
+    val watcher = setup.watcher
+    val wdKinds = setup.wdKinds.toMutableMap()
+
+    installSigintHandler()
+    eprintln("watching for changes (Ctrl+C to stop)...")
+
+    while (!shouldExit()) {
+        val buildResult = doBuild(useDaemon = useDaemon).getOrElse {
+            eprintln("build failed, waiting for changes...")
+            waitForRelevantChange(watcher, wdKinds)
+            continue
+        }
+
+        val runCmd = if (buildResult.config.target == "native") {
+            nativeRunCommand(buildResult.config, appArgs)
+        } else {
+            runCommand(buildResult.config, buildResult.classpath, appArgs, javaPath = buildResult.javaPath)
+        }
+        val childPid = spawnInProcessGroup(runCmd.args)
+        if (childPid < 0) {
+            eprintln("error: failed to spawn application")
+            break
+        }
+
+        var childAlive = true
+        var changeDetected = false
+        while (!shouldExit()) {
+            val events = watcher.pollEvents(timeoutMs = 200).getOrElse { emptyList() }
+            if (shouldExit()) break
+
+            if (events.isNotEmpty()) {
+                autoAddNewDirs(events, wdKinds, watcher)
+                if (hasRelevantEvents(events, wdKinds)) {
+                    settleAndDrain(watcher, wdKinds)
+                    changeDetected = true
+                    break
+                }
+            }
+
+            if (childAlive && reapChild(childPid)) {
+                childAlive = false
+                waitForRelevantChange(watcher, wdKinds)
+                changeDetected = true
+                break
+            }
+        }
+
+        if (childAlive) {
+            killProcessGroup(childPid)
+        }
+
+        if (shouldExit()) break
+        if (changeDetected) {
+            eprintln("\n--- change detected, rebuilding ---")
+        }
+    }
+
+    watcher.close()
+    eprintln("\nwatch mode stopped")
+}
+
+private fun waitForRelevantChange(watcher: InotifyWatcher, wdKinds: MutableMap<Int, WatchKind>) {
+    while (!shouldExit()) {
+        val events = watcher.pollEvents(timeoutMs = 500).getOrElse { return }
+        if (events.isEmpty()) continue
+        autoAddNewDirs(events, wdKinds, watcher)
+        if (hasRelevantEvents(events, wdKinds)) {
+            settleAndDrain(watcher, wdKinds)
+            return
+        }
+    }
+}

--- a/src/nativeMain/kotlin/kolt/infra/Inotify.kt
+++ b/src/nativeMain/kotlin/kolt/infra/Inotify.kt
@@ -1,0 +1,141 @@
+package kolt.infra
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kotlinx.cinterop.*
+import platform.linux.*
+import platform.posix.*
+
+sealed class InotifyError {
+    data class InitFailed(val errno: Int) : InotifyError()
+    data class WatchFailed(val path: String, val errno: Int) : InotifyError()
+    data class WatchLimitExceeded(val path: String) : InotifyError()
+    data class ReadFailed(val errno: Int) : InotifyError()
+}
+
+data class InotifyEvent(val wd: Int, val mask: UInt, val name: String)
+
+private const val EVENT_BUF_SIZE = 4096
+// struct inotify_event { int wd; uint32_t mask; uint32_t cookie; uint32_t len; char name[]; }
+// = 16 bytes before the flexible array member (/usr/include/linux/inotify.h)
+private const val EVENT_HEADER_SIZE = 16
+
+internal val DEFAULT_WATCH_MASK: UInt =
+    (IN_MODIFY or IN_CREATE or IN_DELETE or IN_MOVED_FROM or IN_MOVED_TO).toUInt()
+
+internal val EXCLUDED_DIRS = setOf("build", ".git", ".gradle", "node_modules", ".idea")
+
+class InotifyWatcher private constructor(private var fd: Int) {
+
+    private val wdToPath = mutableMapOf<Int, String>()
+
+    companion object {
+        @OptIn(ExperimentalForeignApi::class)
+        fun create(): Result<InotifyWatcher, InotifyError> {
+            val fd = inotify_init1(IN_CLOEXEC)
+            if (fd < 0) return Err(InotifyError.InitFailed(errno))
+            return Ok(InotifyWatcher(fd))
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    fun addWatch(path: String, mask: UInt): Result<Int, InotifyError> {
+        val wd = inotify_add_watch(fd, path, mask)
+        if (wd < 0) {
+            val e = errno
+            return if (e == ENOSPC) {
+                Err(InotifyError.WatchLimitExceeded(path))
+            } else {
+                Err(InotifyError.WatchFailed(path, e))
+            }
+        }
+        wdToPath[wd] = path
+        return Ok(wd)
+    }
+
+    fun pathForWd(wd: Int): String? = wdToPath[wd]
+
+    fun addWatchRecursive(directory: String): Result<List<Int>, InotifyError> {
+        val wds = mutableListOf<Int>()
+        val rootWd = addWatch(directory, DEFAULT_WATCH_MASK).getOrElse { return Err(it) }
+        wds.add(rootWd)
+        addWatchSubdirs(directory, wds).let { err -> if (err != null) return Err(err) }
+        return Ok(wds)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun addWatchSubdirs(directory: String, wds: MutableList<Int>): InotifyError? {
+        val dir = opendir(directory) ?: return null
+        try {
+            while (true) {
+                val entry = readdir(dir) ?: break
+                val name = entry.pointed.d_name.toKString()
+                if (name == "." || name == ".." || name in EXCLUDED_DIRS) continue
+                val childPath = "$directory/$name"
+                if (!isDirectory(childPath)) continue
+                val wd = addWatch(childPath, DEFAULT_WATCH_MASK).getOrElse { return it }
+                wds.add(wd)
+                addWatchSubdirs(childPath, wds)?.let { return it }
+            }
+        } finally {
+            closedir(dir)
+        }
+        return null
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    fun pollEvents(timeoutMs: Int): Result<List<InotifyEvent>, InotifyError> {
+        memScoped {
+            val pfd = alloc<pollfd>()
+            pfd.fd = fd
+            pfd.events = POLLIN.toShort()
+            pfd.revents = 0
+
+            val ret = poll(pfd.ptr, 1u, timeoutMs)
+            if (ret == 0) return Ok(emptyList())
+            if (ret < 0) {
+                val e = errno
+                if (e == EINTR) return Ok(emptyList())
+                return Err(InotifyError.ReadFailed(e))
+            }
+            return readPendingEvents()
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    internal fun readPendingEvents(): Result<List<InotifyEvent>, InotifyError> {
+        val events = mutableListOf<InotifyEvent>()
+        memScoped {
+            val buf = allocArray<ByteVar>(EVENT_BUF_SIZE)
+            val bytesRead = read(fd, buf, EVENT_BUF_SIZE.toULong())
+            if (bytesRead < 0) {
+                val e = errno
+                if (e == EAGAIN || e == EINTR) return Ok(events)
+                return Err(InotifyError.ReadFailed(e))
+            }
+
+            var offset = 0
+            while (offset + EVENT_HEADER_SIZE <= bytesRead.toInt()) {
+                val wd = (buf + offset)!!.reinterpret<IntVar>().pointed.value
+                val mask = (buf + offset + 4)!!.reinterpret<UIntVar>().pointed.value
+                val len = (buf + offset + 12)!!.reinterpret<UIntVar>().pointed.value.toInt()
+                val name = if (len > 0) {
+                    (buf + offset + EVENT_HEADER_SIZE)!!.toKString()
+                } else ""
+                events.add(InotifyEvent(wd, mask, name))
+                offset += EVENT_HEADER_SIZE + len
+            }
+        }
+        return Ok(events)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    fun close() {
+        if (fd >= 0) {
+            platform.posix.close(fd)
+            fd = -1
+        }
+    }
+}

--- a/src/nativeTest/kotlin/kolt/cli/WatchLoopTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/WatchLoopTest.kt
@@ -1,0 +1,131 @@
+package kolt.cli
+
+import kolt.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class CollectWatchPathsTest {
+
+    @Test
+    fun buildWatchesCurrentDirAndSources() {
+        val config = testConfig(sources = listOf("src"))
+        val paths = collectWatchPaths(config, "build")
+        assertEquals(listOf(".", "src"), paths)
+    }
+
+    @Test
+    fun buildIncludesResources() {
+        val config = testConfig(sources = listOf("src")).copy(resources = listOf("res"))
+        val paths = collectWatchPaths(config, "build")
+        assertEquals(listOf(".", "src", "res"), paths)
+    }
+
+    @Test
+    fun checkWatchesSameAsBuild() {
+        val config = testConfig(sources = listOf("src"))
+        assertEquals(
+            collectWatchPaths(config, "build"),
+            collectWatchPaths(config, "check"),
+        )
+    }
+
+    @Test
+    fun runWatchesSameAsBuild() {
+        val config = testConfig(sources = listOf("src"))
+        assertEquals(
+            collectWatchPaths(config, "build"),
+            collectWatchPaths(config, "run"),
+        )
+    }
+
+    @Test
+    fun testIncludesTestSourcesAndResources() {
+        val config = testConfig(
+            sources = listOf("src"),
+            testSources = listOf("test"),
+        ).copy(testResources = listOf("test-res"))
+        val paths = collectWatchPaths(config, "test")
+        assertEquals(listOf(".", "src", "test", "test-res"), paths)
+    }
+
+    @Test
+    fun testOmitsEmptyTestResources() {
+        val config = testConfig(sources = listOf("src"), testSources = listOf("test"))
+        val paths = collectWatchPaths(config, "test")
+        assertEquals(listOf(".", "src", "test"), paths)
+    }
+
+    @Test
+    fun multipleSources() {
+        val config = testConfig(sources = listOf("src/main", "src/gen"))
+        val paths = collectWatchPaths(config, "build")
+        assertEquals(listOf(".", "src/main", "src/gen"), paths)
+    }
+
+    @Test
+    fun currentDirAlwaysFirst() {
+        val config = testConfig(sources = listOf("a", "b"))
+        assertEquals(".", collectWatchPaths(config, "build").first())
+    }
+
+    @Test
+    fun deduplicatesDotInSources() {
+        val config = testConfig(sources = listOf("."))
+        val paths = collectWatchPaths(config, "build")
+        assertEquals(listOf("."), paths)
+    }
+
+    @Test
+    fun deduplicatesOverlappingPaths() {
+        val config = testConfig(sources = listOf("src"), testSources = listOf("src"))
+        val paths = collectWatchPaths(config, "test")
+        assertEquals(listOf(".", "src"), paths)
+    }
+}
+
+class ShouldTriggerRebuildTest {
+
+    @Test
+    fun kotlinSourceTriggers() {
+        assertTrue(shouldTriggerRebuild("Main.kt"))
+        assertTrue(shouldTriggerRebuild("build.kts"))
+    }
+
+    @Test
+    fun koltTomlTriggers() {
+        assertTrue(shouldTriggerRebuild("kolt.toml"))
+    }
+
+    @Test
+    fun dotfileIgnored() {
+        assertFalse(shouldTriggerRebuild(".hidden"))
+        assertFalse(shouldTriggerRebuild(".gitignore"))
+    }
+
+    @Test
+    fun vimSwapFilesIgnored() {
+        assertFalse(shouldTriggerRebuild("Main.kt.swp"))
+        assertFalse(shouldTriggerRebuild("Main.kt.swo"))
+        assertFalse(shouldTriggerRebuild("Main.kt.swx"))
+        assertFalse(shouldTriggerRebuild("4913"))
+    }
+
+    @Test
+    fun backupAndTempFilesIgnored() {
+        assertFalse(shouldTriggerRebuild("Main.kt~"))
+        assertFalse(shouldTriggerRebuild("file.tmp"))
+    }
+
+    @Test
+    fun nonKotlinFileDoesNotTrigger() {
+        assertFalse(shouldTriggerRebuild("readme.md"))
+        assertFalse(shouldTriggerRebuild("data.json"))
+    }
+
+    @Test
+    fun emptyNameDoesNotTrigger() {
+        assertFalse(shouldTriggerRebuild(""))
+    }
+}

--- a/src/nativeTest/kotlin/kolt/infra/InotifyTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/InotifyTest.kt
@@ -1,0 +1,100 @@
+package kolt.infra
+
+import com.github.michaelbull.result.getOrElse
+import platform.linux.IN_CREATE
+import platform.linux.IN_MODIFY
+import platform.posix.getpid
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class InotifyWatcherTest {
+
+    @Test
+    fun createAndClose() {
+        val watcher = InotifyWatcher.create().getOrElse { fail("create failed: $it") }
+        watcher.close()
+    }
+
+    @Test
+    fun watchNonexistentPathFails() {
+        val watcher = InotifyWatcher.create().getOrElse { fail("create failed: $it") }
+        try {
+            val result = watcher.addWatch("/nonexistent_${getpid()}", IN_MODIFY.toUInt())
+            assertTrue(result.isErr)
+        } finally {
+            watcher.close()
+        }
+    }
+
+    @Test
+    fun detectsFileCreation() {
+        val dir = "/tmp/kolt_inotify_test_${getpid()}"
+        ensureDirectoryRecursive(dir).getOrElse { fail("mkdir failed") }
+        try {
+            val watcher = InotifyWatcher.create().getOrElse { fail("create failed: $it") }
+            try {
+                watcher.addWatch(dir, (IN_CREATE or IN_MODIFY).toUInt())
+                    .getOrElse { fail("addWatch failed: $it") }
+
+                writeFileAsString("$dir/hello.kt", "fun main() {}")
+                    .getOrElse { fail("write failed") }
+
+                val events = watcher.pollEvents(timeoutMs = 3000)
+                    .getOrElse { fail("pollEvents failed: $it") }
+                assertTrue(events.isNotEmpty(), "expected at least one event")
+                val names = events.map { it.name }
+                assertTrue("hello.kt" in names, "expected hello.kt in events, got: $names")
+            } finally {
+                watcher.close()
+            }
+        } finally {
+            removeDirectoryRecursive(dir)
+        }
+    }
+
+    @Test
+    fun addWatchRecursiveCoversSubdirs() {
+        val dir = "/tmp/kolt_inotify_rec_${getpid()}"
+        ensureDirectoryRecursive("$dir/sub/deep").getOrElse { fail("mkdir failed") }
+        try {
+            val watcher = InotifyWatcher.create().getOrElse { fail("create failed: $it") }
+            try {
+                watcher.addWatchRecursive(dir).getOrElse { fail("addWatchRecursive failed: $it") }
+
+                writeFileAsString("$dir/sub/deep/Nested.kt", "class Nested")
+                    .getOrElse { fail("write failed") }
+
+                val events = watcher.pollEvents(timeoutMs = 3000)
+                    .getOrElse { fail("pollEvents failed: $it") }
+                assertTrue(events.isNotEmpty(), "expected at least one event from subdirectory")
+                val names = events.map { it.name }
+                assertTrue("Nested.kt" in names, "expected Nested.kt, got: $names")
+            } finally {
+                watcher.close()
+            }
+        } finally {
+            removeDirectoryRecursive(dir)
+        }
+    }
+
+    @Test
+    fun pollReturnsEmptyOnTimeout() {
+        val dir = "/tmp/kolt_inotify_empty_${getpid()}"
+        ensureDirectoryRecursive(dir).getOrElse { fail("mkdir failed") }
+        try {
+            val watcher = InotifyWatcher.create().getOrElse { fail("create failed: $it") }
+            try {
+                watcher.addWatch(dir, IN_MODIFY.toUInt())
+                    .getOrElse { fail("addWatch failed: $it") }
+                val events = watcher.pollEvents(timeoutMs = 50)
+                    .getOrElse { fail("pollEvents failed: $it") }
+                assertTrue(events.isEmpty(), "expected no events on timeout")
+            } finally {
+                watcher.close()
+            }
+        } finally {
+            removeDirectoryRecursive(dir)
+        }
+    }
+}


### PR DESCRIPTION
inotify-based file watching for all four build commands. Two loop variants:
build/check/test call the do* closures directly (enabled by #132); run
spawns the app in a new process group and kill+restarts on change.

Reviewer focus: inotify event parsing in Inotify.kt (manual struct offset
arithmetic), the settle-window debounce in settleAndDrain, and process
group lifecycle in watchRunLoop (spawnInProcessGroup / killProcessGroup).

Closes #15.