### PR TITLE
Remove daemon IC state on `kolt clean` (#135)

### DIFF
--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/IcStateLayout.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/IcStateLayout.kt
@@ -39,6 +39,9 @@ object IcStateLayout {
     const val BTA_SUBDIR: String = "bta"
     const val CLASSPATH_SNAPSHOTS_SUBDIR: String = "classpath-snapshots"
 
+    // The native client mirrors this in
+    // `src/nativeMain/kotlin/kolt/build/daemon/IcStateCleanup.kt`
+    // (`daemonIcProjectIdOf`). Update both when changing the algorithm.
     fun projectIdFor(projectRoot: Path): String {
         val md = MessageDigest.getInstance("SHA-256")
         val digest = md.digest(projectRoot.toString().toByteArray(Charsets.UTF_8))

--- a/src/nativeMain/kotlin/kolt/build/daemon/IcStateCleanup.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/IcStateCleanup.kt
@@ -1,0 +1,41 @@
+package kolt.build.daemon
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.config.KoltPaths
+import kolt.infra.RemoveFailed
+import kolt.infra.fileExists
+import kolt.infra.listSubdirectories
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.sha256Hex
+
+// Mirrors the daemon-side `IcStateLayout.projectIdFor` (ADR 0019 §5).
+// `projectHashOf` is intentionally not reused: it produces an 8-byte
+// digest used only for the daemon socket directory, and the two ID
+// shapes must stay independent.
+internal fun daemonIcProjectIdOf(absProjectPath: String): String =
+    sha256Hex(absProjectPath.encodeToByteArray()).take(32)
+
+// Removes daemon-owned IC state directories for a project across all
+// kotlinVersion segments under `<icRoot>/`. Called from `kolt clean` so
+// the daemon does not skip recompilation against state pointing at a
+// just-deleted `build/classes/` (issue #135).
+internal fun cleanDaemonIcStateForProject(
+    paths: KoltPaths,
+    absProjectPath: String,
+): Result<Unit, RemoveFailed> {
+    val icRoot = paths.daemonIcDir
+    if (!fileExists(icRoot)) return Ok(Unit)
+    val projectId = daemonIcProjectIdOf(absProjectPath)
+    // Listing failure after the existence check is exotic (TOCTOU / perm flip);
+    // treat it as "nothing to clean" rather than failing the user-visible clean.
+    val versions = listSubdirectories(icRoot).getOrElse { return Ok(Unit) }
+    for (version in versions) {
+        val projectIcDir = "$icRoot/$version/$projectId"
+        if (!fileExists(projectIcDir)) continue
+        removeDirectoryRecursive(projectIcDir).getOrElse { err -> return Err(err) }
+    }
+    return Ok(Unit)
+}

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -10,6 +10,7 @@ import kolt.build.*
 import kolt.build.daemon.DaemonCompilerBackend
 import kolt.build.daemon.DaemonPreconditionError
 import kolt.build.daemon.DaemonSetup
+import kolt.build.daemon.cleanDaemonIcStateForProject
 import kolt.build.daemon.formatDaemonPreconditionWarning
 import kolt.build.daemon.resolveDaemonPreconditions
 import kolt.config.*
@@ -68,15 +69,28 @@ internal fun doCheck(useDaemon: Boolean = true): Result<Unit, Int> {
 }
 
 internal fun doClean(): Result<Unit, Int> {
-    if (!fileExists(BUILD_DIR)) {
-        println("nothing to clean")
-        return Ok(Unit)
+    val buildDirRemoved = if (fileExists(BUILD_DIR)) {
+        removeDirectoryRecursive(BUILD_DIR).getOrElse { error ->
+            eprintln("error: could not remove ${error.path}")
+            return Err(EXIT_BUILD_ERROR)
+        }
+        println("removed $BUILD_DIR/")
+        true
+    } else false
+
+    // Daemon-owned IC state at `~/.kolt/daemon/ic/<version>/<projectId>/`
+    // (ADR 0019 §5) survives `build/` removal; without this the next
+    // daemon-backed build emits an empty `build/classes/` (#135).
+    // Best-effort: paths/cwd lookup failure must not block clean.
+    val paths = resolveKoltPaths().getOrElse { null }
+    val cwd = currentWorkingDirectory()
+    if (paths != null && cwd != null) {
+        cleanDaemonIcStateForProject(paths, cwd).getOrElse { error ->
+            eprintln("warning: could not remove daemon IC state at ${error.path}")
+        }
     }
-    removeDirectoryRecursive(BUILD_DIR).getOrElse { error ->
-        eprintln("error: could not remove ${error.path}")
-        return Err(EXIT_BUILD_ERROR)
-    }
-    println("removed $BUILD_DIR/")
+
+    if (!buildDirRemoved) println("nothing to clean")
     return Ok(Unit)
 }
 

--- a/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
+++ b/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
@@ -10,6 +10,7 @@ internal data class KoltPaths(val home: String) {
     val toolsDir: String = "$home/.kolt/tools"
     val toolchainsDir: String = "$home/.kolt/toolchains"
     val daemonBaseDir: String = "$home/.kolt/daemon"
+    val daemonIcDir: String = "$daemonBaseDir/ic"
 
     fun daemonDir(projectHash: String): String = "$daemonBaseDir/$projectHash"
     fun daemonSocketPath(projectHash: String): String = "${daemonDir(projectHash)}/daemon.sock"

--- a/src/nativeTest/kotlin/kolt/build/daemon/IcStateCleanupTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/IcStateCleanupTest.kt
@@ -1,0 +1,67 @@
+package kolt.build.daemon
+
+import com.github.michaelbull.result.getError
+import kolt.config.KoltPaths
+import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.fileExists
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class IcStateCleanupTest {
+    private val homeDir = "build_test_ic_cleanup_home"
+    private val projectPath = "/work/some-project"
+
+    @AfterTest
+    fun cleanup() {
+        if (fileExists(homeDir)) removeDirectoryRecursive(homeDir)
+    }
+
+    @Test
+    fun projectIdMatchesDaemonAlgorithm() {
+        // Pin the algorithm to IcStateLayout.projectIdFor (32 hex chars,
+        // first 16 bytes of SHA-256 of the absolute path string).
+        val id = daemonIcProjectIdOf("/abs/path")
+        assertEquals(32, id.length)
+        assertTrue(id.all { it.isDigit() || it in 'a'..'f' }, "id must be lowercase hex, got: $id")
+        // Same input on the daemon side produces the same value
+        // (kept in sync via IcStateLayoutTest's "uses the absolute path string verbatim").
+        assertEquals("6d80187b454107127bf995f2c31a2a92", daemonIcProjectIdOf("/abs/path"))
+    }
+
+    @Test
+    fun removesIcStateForProjectAcrossAllKotlinVersions() {
+        val paths = KoltPaths(homeDir)
+        val projectId = daemonIcProjectIdOf(projectPath)
+        val v1Dir = "${paths.daemonIcDir}/2.3.20/$projectId"
+        val v2Dir = "${paths.daemonIcDir}/2.4.0/$projectId"
+        val otherProjectDir = "${paths.daemonIcDir}/2.3.20/0123456789abcdef0123456789abcdef"
+        ensureDirectoryRecursive(v1Dir)
+        ensureDirectoryRecursive(v2Dir)
+        ensureDirectoryRecursive(otherProjectDir)
+        writeFileAsString("$v1Dir/marker", "x")
+        writeFileAsString("$v2Dir/marker", "y")
+        writeFileAsString("$otherProjectDir/marker", "z")
+
+        cleanDaemonIcStateForProject(paths, projectPath)
+
+        assertFalse(fileExists(v1Dir), "v1 IC state for this project must be removed")
+        assertFalse(fileExists(v2Dir), "v2 IC state for this project must be removed")
+        assertTrue(fileExists(otherProjectDir), "other project's IC state must be left intact")
+    }
+
+    @Test
+    fun noOpWhenIcRootMissing() {
+        val paths = KoltPaths(homeDir)
+
+        val result = cleanDaemonIcStateForProject(paths, projectPath)
+
+        assertNull(result.getError())
+        assertFalse(fileExists(paths.daemonIcDir))
+    }
+}


### PR DESCRIPTION
Fixes #135 (Bug 2 of the original report; Bug 1 split into #136).

`kolt clean` only removed `build/`, leaving daemon-owned IC state at `~/.kolt/daemon/ic/<kotlinVersion>/<projectId>/` (ADR 0019 §5) untouched. The next daemon-backed build saw "no source changes" against that stale state and produced an empty `build/classes/` while still reporting success.

The native client now mirrors the daemon's `IcStateLayout.projectIdFor` algorithm (`daemonIcProjectIdOf` in `IcStateCleanup.kt`) and removes the project's IC state across every `kotlinVersion` segment after `build/` is gone.

## Reviewer focus

- **Cross-side hash parity**: `daemonIcProjectIdOf` and `IcStateLayout.projectIdFor` must agree forever. The native test pins the algorithm against a hardcoded hex literal, and a comment on `IcStateLayout.projectIdFor` points at the native mirror. Worth confirming that's the right shape vs. e.g. a shared fixture.
- **Best-effort failure handling in `doClean`**: paths/cwd lookup failures are silently swallowed and IC removal failures degrade to a `warning:` line. The clean still exits 0. This matches "clean is housekeeping, never blocking" but is a UX judgment.
- **`listSubdirectories` failure swallowed as Ok** in `cleanDaemonIcStateForProject` after the existence check passed. Annotated with a comment; the alternative is widening the error type which adds churn for a TOCTOU/perm-flip case the caller would log identically anyway.
- **No daemon shutdown signal** is sent. End-to-end repro (`build → clean → build` with the daemon process still alive) confirmed the on-disk cleanup alone is sufficient — BTA reads IC state from disk per request and doesn't keep an in-memory cache that would need invalidation.

Verified end-to-end with a release binary against the original reproduction in #135: post-clean rebuild produces `MainKt.class` in both `build/classes/` and the JAR.