### PR TITLE
Fall back to subprocess when kolt.toml kotlin differs from daemon-bundled version (#136)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,115 @@ plugins {
 
 group = "com.github.snicmakino"
 
+// Canonical kotlinc version pin for the whole project. Sister constants live in
+// `src/nativeMain/kotlin/kolt/cli/BundledKotlinVersion.kt` (native client),
+// `kolt-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt` (daemon), and four
+// kotlinc/BTA artifact coordinates in kolt-compiler-daemon's build scripts.
+// ADR 0019 §1 requires all six to move in lockstep with this value. They are
+// hand-pinned rather than generated so the self-host path (`kolt.kexe build`
+// driven by `kolt.toml`) compiles without a prior Gradle step populating
+// `build/generated/`; `verifyDaemonKotlinVersion` asserts the sync at build
+// time. #138 will collapse the manual-sync requirement.
+val daemonKotlinVersion = "2.3.20"
+
 repositories {
     mavenCentral()
+}
+
+val verifyDaemonKotlinVersion = tasks.register("verifyDaemonKotlinVersion") {
+    group = "verification"
+    description = "Fails the build if any daemon-side kotlin version pin drifts from root daemonKotlinVersion."
+    val nativeBundled = layout.projectDirectory.file(
+        "src/nativeMain/kotlin/kolt/cli/BundledKotlinVersion.kt",
+    )
+    val daemonMain = layout.projectDirectory.file(
+        "kolt-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt",
+    )
+    val daemonBuildScript = layout.projectDirectory.file(
+        "kolt-compiler-daemon/build.gradle.kts",
+    )
+    val icBuildScript = layout.projectDirectory.file(
+        "kolt-compiler-daemon/ic/build.gradle.kts",
+    )
+    val expected = daemonKotlinVersion
+    inputs.file(nativeBundled)
+    inputs.file(daemonMain)
+    inputs.file(daemonBuildScript)
+    inputs.file(icBuildScript)
+    inputs.property("expected", expected)
+    doLast {
+        data class Pin(val label: String, val file: java.io.File, val regex: Regex, val fixHint: String)
+
+        val checks = listOf(
+            Pin(
+                label = "src/nativeMain/.../BundledKotlinVersion.kt `BUNDLED_DAEMON_KOTLIN_VERSION`",
+                file = nativeBundled.asFile,
+                regex = Regex(
+                    """const\s+val\s+BUNDLED_DAEMON_KOTLIN_VERSION\s*:\s*String\s*=\s*"([^"]+)"""",
+                ),
+                fixHint = "keep the declaration as `internal const val BUNDLED_DAEMON_KOTLIN_VERSION: String = \"<version>\"`",
+            ),
+            Pin(
+                label = "kolt-compiler-daemon Main.kt `KOLT_DAEMON_KOTLIN_VERSION`",
+                file = daemonMain.asFile,
+                regex = Regex(
+                    """const\s+val\s+KOLT_DAEMON_KOTLIN_VERSION\s*:\s*String\s*=\s*"([^"]+)"""",
+                ),
+                fixHint = "keep the declaration as `internal const val KOLT_DAEMON_KOTLIN_VERSION: String = \"<version>\"`",
+            ),
+            // Anchor on the closing `"` of the Gradle string literal so
+            // the version in a comment line like
+            // `// kotlin-build-tools-impl:2.3.20 for the daemon` does not
+            // satisfy the match (the regex's `\"` eats the close-quote of
+            // the coordinate literal, which the comment never has).
+            Pin(
+                label = "kolt-compiler-daemon/build.gradle.kts `kotlin-compiler-embeddable`",
+                file = daemonBuildScript.asFile,
+                regex = Regex("kotlin-compiler-embeddable:([^\"\\s]+)\""),
+                fixHint = "pin `org.jetbrains.kotlin:kotlin-compiler-embeddable:<version>` with a literal version",
+            ),
+            Pin(
+                label = "kolt-compiler-daemon/build.gradle.kts `kotlin-build-tools-impl`",
+                file = daemonBuildScript.asFile,
+                regex = Regex("kotlin-build-tools-impl:([^\"\\s]+)\""),
+                fixHint = "pin `org.jetbrains.kotlin:kotlin-build-tools-impl:<version>` with a literal version",
+            ),
+            Pin(
+                label = "kolt-compiler-daemon/ic/build.gradle.kts `kotlin-build-tools-api`",
+                file = icBuildScript.asFile,
+                regex = Regex("kotlin-build-tools-api:([^\"\\s]+)\""),
+                fixHint = "pin `org.jetbrains.kotlin:kotlin-build-tools-api:<version>` with a literal version",
+            ),
+            Pin(
+                label = "kolt-compiler-daemon/ic/build.gradle.kts `kotlin-build-tools-impl`",
+                file = icBuildScript.asFile,
+                regex = Regex("kotlin-build-tools-impl:([^\"\\s]+)\""),
+                fixHint = "pin `org.jetbrains.kotlin:kotlin-build-tools-impl:<version>` with a literal version",
+            ),
+        )
+
+        val drift = mutableListOf<String>()
+        for (check in checks) {
+            val text = check.file.readText()
+            val match = check.regex.find(text)
+                ?: throw GradleException(
+                    "Could not locate ${check.label} in ${check.file}. " +
+                        "Drift guard requires: ${check.fixHint}.",
+                )
+            val actual = match.groupValues[1]
+            if (actual != expected) {
+                drift += "  - ${check.label}: \"$actual\" (expected \"$expected\")"
+            }
+        }
+
+        if (drift.isNotEmpty()) {
+            throw GradleException(
+                "daemon kotlin version drift from root `daemonKotlinVersion` = \"$expected\":\n" +
+                    drift.joinToString("\n") +
+                    "\nUpdate all pins together. #138 will remove this manual-sync requirement.",
+            )
+        }
+    }
 }
 
 kotlin {
@@ -60,6 +167,7 @@ tasks.named("build") {
 // first line of defense.
 tasks.named("check") {
     dependsOn(gradle.includedBuild("kolt-compiler-daemon").task(":check"))
+    dependsOn(verifyDaemonKotlinVersion)
 }
 
 // Same rationale for `clean`: without this wiring, `./gradlew clean` at the

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
@@ -30,17 +30,40 @@ internal sealed interface DaemonPreconditionError {
     data class CompilerJarsMissing(val kotlincLibDir: String) : DaemonPreconditionError
 
     data class BtaImplJarsMissing(val probedDir: String) : DaemonPreconditionError
+
+    // Stop-gap for #136; follow-up per-version daemon spawn tracked in #138.
+    // ADR 0019 §1 pins the daemon's kotlinc (kotlin-compiler-embeddable and
+    // kotlin-build-tools-api/impl) in lockstep at process start, so a
+    // requested `config.kotlin` different from the bundled version cannot be
+    // served by the existing daemon.
+    data class KotlinVersionMismatch(
+        val requested: String,
+        val bundled: String,
+    ) : DaemonPreconditionError
 }
 
 internal fun resolveDaemonPreconditions(
     paths: KoltPaths,
     kotlincVersion: String,
     absProjectPath: String,
+    bundledKotlinVersion: String,
     ensureJavaBin: (KoltPaths) -> Result<String, BootstrapJdkError> = ::ensureBootstrapJavaBin,
     resolveDaemonJar: () -> DaemonJarResolution = ::resolveDaemonJar,
     listCompilerJars: (String) -> List<String>? = { dir -> listJarFiles(dir).getOrElse { null } },
     resolveBtaImplJars: () -> BtaImplJarsResolution = ::resolveBtaImplJars,
 ): Result<DaemonSetup, DaemonPreconditionError> {
+    // Short-circuit before any on-disk probing: on a version mismatch we
+    // would never spawn the daemon, so there is no point touching the JDK,
+    // daemon jar, kotlinc lib dir, or BTA-impl jars first.
+    if (kotlincVersion != bundledKotlinVersion) {
+        return Err(
+            DaemonPreconditionError.KotlinVersionMismatch(
+                requested = kotlincVersion,
+                bundled = bundledKotlinVersion,
+            ),
+        )
+    }
+
     val javaBin = ensureJavaBin(paths).getOrElse { err ->
         return Err(
             DaemonPreconditionError.BootstrapJdkInstallFailed(
@@ -90,4 +113,8 @@ internal fun formatDaemonPreconditionWarning(err: DaemonPreconditionError): Stri
         "warning: no compiler jars found in ${err.kotlincLibDir} — falling back to subprocess compile"
     is DaemonPreconditionError.BtaImplJarsMissing ->
         "warning: kotlin-build-tools-impl jars not found in ${err.probedDir} — falling back to subprocess compile"
+    is DaemonPreconditionError.KotlinVersionMismatch ->
+        "warning: kolt daemon currently bundles Kotlin ${err.bundled}; your kolt.toml requests ${err.requested} — " +
+            "falling back to subprocess compile. This is a temporary restriction; " +
+            "per-version daemon support is tracked in #138."
 }

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -490,16 +490,17 @@ internal fun resolveCompilerBackend(
     subprocessBackend: CompilerBackend,
     useDaemon: Boolean,
     absProjectPath: String,
+    bundledKotlinVersion: String = BUNDLED_DAEMON_KOTLIN_VERSION,
     pluginJars: Map<String, List<String>> = emptyMap(),
-    preconditionResolver: (KoltPaths, String, String) -> Result<DaemonSetup, DaemonPreconditionError> =
-        { p, kotlincVersion, cwd -> resolveDaemonPreconditions(p, kotlincVersion, cwd) },
+    preconditionResolver: (KoltPaths, String, String, String) -> Result<DaemonSetup, DaemonPreconditionError> =
+        { p, kotlincVersion, cwd, bundled -> resolveDaemonPreconditions(p, kotlincVersion, cwd, bundled) },
     daemonDirCreator: (String) -> Result<Unit, MkdirFailed> = ::ensureDirectoryRecursive,
     daemonBackendFactory: (DaemonSetup, Map<String, List<String>>) -> CompilerBackend = ::createDaemonBackend,
     warningSink: (String) -> Unit = ::eprintln,
 ): CompilerBackend {
     if (!useDaemon) return subprocessBackend
 
-    val setup = preconditionResolver(paths, config.kotlin, absProjectPath).getOrElse { err ->
+    val setup = preconditionResolver(paths, config.kotlin, absProjectPath, bundledKotlinVersion).getOrElse { err ->
         warningSink(formatDaemonPreconditionWarning(err))
         return subprocessBackend
     }

--- a/src/nativeMain/kotlin/kolt/cli/BundledKotlinVersion.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BundledKotlinVersion.kt
@@ -1,0 +1,12 @@
+// Hand-pinned sibling of `daemonKotlinVersion` (root build.gradle.kts) and
+// `KOLT_DAEMON_KOTLIN_VERSION` (kolt-compiler-daemon Main.kt). All three,
+// plus the four kotlinc/BTA artifact pins in kolt-compiler-daemon's build
+// scripts, must move together per ADR 0019 §1. `verifyDaemonKotlinVersion`
+// asserts all seven at build time. #138 will collapse the manual sync.
+//
+// Committed as source (rather than generated) so the self-host path
+// (`kolt.kexe build` driven by `kolt.toml`) compiles without depending on a
+// Gradle task having populated `build/generated/`.
+package kolt.cli
+
+internal const val BUNDLED_DAEMON_KOTLIN_VERSION: String = "2.3.20"

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class DaemonPreconditionsTest {
 
@@ -28,6 +29,7 @@ class DaemonPreconditionsTest {
             paths = paths,
             kotlincVersion = kotlincVersion,
             absProjectPath = absProject,
+            bundledKotlinVersion = kotlincVersion,
             ensureJavaBin = { Ok("/fake/home/.kolt/toolchains/jdk/21/bin/java") },
             resolveDaemonJar = { okJar },
             listCompilerJars = { fakeJars },
@@ -45,6 +47,27 @@ class DaemonPreconditionsTest {
         assertEquals("/fake/home/.kolt/daemon/$expectedHash/daemon.log", setup.logPath)
     }
 
+    // Stop-gap for #136: until per-version daemon spawn lands (#138), a
+    // `kotlincVersion` that differs from the bundled daemon version must
+    // short-circuit before any on-disk probing.
+    @Test
+    fun kotlinVersionMismatchShortCircuitsBeforeAnyProbing() {
+        val result = resolveDaemonPreconditions(
+            paths = paths,
+            kotlincVersion = "2.1.0",
+            absProjectPath = absProject,
+            bundledKotlinVersion = "2.3.20",
+            ensureJavaBin = { error("must not probe JDK on version mismatch") },
+            resolveDaemonJar = { error("must not probe daemon jar on version mismatch") },
+            listCompilerJars = { error("must not list compiler jars on version mismatch") },
+            resolveBtaImplJars = { error("must not probe BTA-impl jars on version mismatch") },
+        )
+
+        val err = assertIs<DaemonPreconditionError.KotlinVersionMismatch>(result.getError())
+        assertEquals("2.1.0", err.requested)
+        assertEquals("2.3.20", err.bundled)
+    }
+
     @Test
     fun bootstrapJdkInstallFailedShortCircuits() {
         val installDir = "/fake/home/.kolt/toolchains/jdk/$BOOTSTRAP_JDK_VERSION"
@@ -52,6 +75,7 @@ class DaemonPreconditionsTest {
             paths = paths,
             kotlincVersion = kotlincVersion,
             absProjectPath = absProject,
+            bundledKotlinVersion = kotlincVersion,
             ensureJavaBin = {
                 Err(BootstrapJdkError(installDir, ToolchainError("network error downloading jdk 21: connection refused")))
             },
@@ -72,6 +96,7 @@ class DaemonPreconditionsTest {
             paths = paths,
             kotlincVersion = kotlincVersion,
             absProjectPath = absProject,
+            bundledKotlinVersion = kotlincVersion,
             ensureJavaBin = { Ok("/fake/java") },
             resolveDaemonJar = { DaemonJarResolution.NotFound },
             listCompilerJars = { error("must not run after DaemonJarMissing") },
@@ -87,6 +112,7 @@ class DaemonPreconditionsTest {
             paths = paths,
             kotlincVersion = kotlincVersion,
             absProjectPath = absProject,
+            bundledKotlinVersion = kotlincVersion,
             ensureJavaBin = { Ok("/fake/java") },
             resolveDaemonJar = { okJar },
             listCompilerJars = { null },
@@ -103,6 +129,7 @@ class DaemonPreconditionsTest {
             paths = paths,
             kotlincVersion = kotlincVersion,
             absProjectPath = absProject,
+            bundledKotlinVersion = kotlincVersion,
             ensureJavaBin = { Ok("/fake/java") },
             resolveDaemonJar = { okJar },
             listCompilerJars = { emptyList() },
@@ -118,6 +145,7 @@ class DaemonPreconditionsTest {
             paths = paths,
             kotlincVersion = kotlincVersion,
             absProjectPath = absProject,
+            bundledKotlinVersion = kotlincVersion,
             ensureJavaBin = { Ok("/fake/java") },
             resolveDaemonJar = { okJar },
             listCompilerJars = { fakeJars },
@@ -149,6 +177,17 @@ class DaemonPreconditionsTest {
             formatDaemonPreconditionWarning(
                 DaemonPreconditionError.BtaImplJarsMissing("/x/libexec/kolt-bta-impl"),
             ),
+        )
+        val mismatchWarning = formatDaemonPreconditionWarning(
+            DaemonPreconditionError.KotlinVersionMismatch(requested = "2.1.0", bundled = "2.3.20"),
+        )
+        assertTrue(
+            mismatchWarning.contains("2.1.0") &&
+                mismatchWarning.contains("2.3.20") &&
+                mismatchWarning.contains("falling back to subprocess compile") &&
+                mismatchWarning.contains("temporary") &&
+                mismatchWarning.contains("#138"),
+            "unexpected mismatch warning: $mismatchWarning",
         )
     }
 }

--- a/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
@@ -47,7 +47,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = false,
             absProjectPath = absProject,
-            preconditionResolver = { _, _, _ -> error("must not resolve preconditions when useDaemon=false") },
+            preconditionResolver = { _, _, _, _ -> error("must not resolve preconditions when useDaemon=false") },
             daemonDirCreator = { error("must not create daemon dir when useDaemon=false") },
             daemonBackendFactory = { _, _ -> error("must not construct daemon backend when useDaemon=false") },
             warningSink = { warnings.add(it) },
@@ -55,6 +55,68 @@ class ResolveCompilerBackendTest {
 
         assertSame(subprocess, backend)
         assertEquals(emptyList(), warnings)
+    }
+
+    // #136 stop-gap: bundled-vs-requested Kotlin version mismatch enters the
+    // same "precondition error" warning rail as every other daemon-probe
+    // failure (ADR 0016 §5). DaemonPreconditionsTest covers that the real
+    // resolver surfaces this error without any probing; this test pins that
+    // resolveCompilerBackend routes the variant into the warning sink.
+    @Test
+    fun kotlinVersionMismatchFromResolverFallsBackWithVersionsAndFollowUpInWarning() {
+        val warnings = mutableListOf<String>()
+        val backend = resolveCompilerBackend(
+            config = minimalConfig(kotlincVersion = "2.1.0"),
+            paths = paths,
+            subprocessBackend = subprocess,
+            useDaemon = true,
+            absProjectPath = absProject,
+            bundledKotlinVersion = "2.3.20",
+            preconditionResolver = { _, requested, _, bundled ->
+                Err(
+                    DaemonPreconditionError.KotlinVersionMismatch(
+                        requested = requested,
+                        bundled = bundled,
+                    ),
+                )
+            },
+            daemonDirCreator = { error("must not create daemon dir after precondition failure") },
+            daemonBackendFactory = { _, _ -> error("must not construct daemon backend after precondition failure") },
+            warningSink = { warnings.add(it) },
+        )
+
+        assertSame(subprocess, backend)
+        val warning = warnings.single()
+        assertTrue(warning.contains("2.1.0"), "warning should cite the requested version: $warning")
+        assertTrue(warning.contains("2.3.20"), "warning should cite the bundled daemon version: $warning")
+        assertTrue(
+            warning.contains("falling back to subprocess compile"),
+            "warning should say the build is falling back: $warning",
+        )
+        assertTrue(warning.contains("temporary"), "warning should flag the restriction as temporary: $warning")
+    }
+
+    @Test
+    fun bundledKotlinVersionIsPassedThroughToPreconditionResolver() {
+        var seenBundled: String? = null
+        val backend = resolveCompilerBackend(
+            config = minimalConfig(kotlincVersion = "2.3.20"),
+            paths = paths,
+            subprocessBackend = subprocess,
+            useDaemon = true,
+            absProjectPath = absProject,
+            bundledKotlinVersion = "2.3.20",
+            preconditionResolver = { _, _, _, bundled ->
+                seenBundled = bundled
+                Ok(okSetup)
+            },
+            daemonDirCreator = { Ok(Unit) },
+            daemonBackendFactory = { _, _ -> daemonSentinel },
+            warningSink = { error("happy path must not warn") },
+        )
+
+        assertEquals("2.3.20", seenBundled)
+        assertNotNull(backend as? FallbackCompilerBackend)
     }
 
     @Test
@@ -66,7 +128,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = true,
             absProjectPath = absProject,
-            preconditionResolver = { _, _, _ ->
+            preconditionResolver = { _, _, _, _ ->
                 Err(DaemonPreconditionError.DaemonJarMissing)
             },
             daemonDirCreator = { error("must not create daemon dir after precondition failure") },
@@ -92,7 +154,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = true,
             absProjectPath = absProject,
-            preconditionResolver = { _, _, _ ->
+            preconditionResolver = { _, _, _, _ ->
                 Err(
                     DaemonPreconditionError.BootstrapJdkInstallFailed(
                         jdkInstallDir = "/fake/home/.kolt/toolchains/jdk/21",
@@ -131,7 +193,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = true,
             absProjectPath = absProject,
-            preconditionResolver = { _, _, _ -> Ok(okSetup) },
+            preconditionResolver = { _, _, _, _ -> Ok(okSetup) },
             daemonDirCreator = { Err(MkdirFailed(okSetup.daemonDir)) },
             daemonBackendFactory = { _, _ -> error("must not construct daemon backend after mkdir failure") },
             warningSink = { warnings.add(it) },
@@ -155,7 +217,7 @@ class ResolveCompilerBackendTest {
             useDaemon = true,
             absProjectPath = absProject,
             pluginJars = pluginJars,
-            preconditionResolver = { _, _, _ -> Ok(okSetup) },
+            preconditionResolver = { _, _, _, _ -> Ok(okSetup) },
             daemonDirCreator = { Ok(Unit) },
             daemonBackendFactory = { _, jars ->
                 capturedPluginJars = jars
@@ -179,7 +241,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = true,
             absProjectPath = absProject,
-            preconditionResolver = { _, kotlincVersion, cwd ->
+            preconditionResolver = { _, kotlincVersion, cwd, _ ->
                 assertEquals("2.1.0", kotlincVersion)
                 assertEquals(absProject, cwd)
                 Ok(okSetup)


### PR DESCRIPTION
Stop-gap per the #136 design discussion: short-circuit to subprocess when `config.kotlin != bundledKotlinVersion`, with a warning that flags the restriction as temporary and points at #138.

## Review focus

- **`resolveCompilerBackend` placement of the mismatch check** (`BuildCommands.kt`). It fires before `preconditionResolver`, so the short-circuit does not incur daemon-setup cost and does not require the daemon jar / bootstrap JDK / BTA-impl jars to even exist on disk. Matches ADR 0016 §5 "precondition failure → subprocess" template, but is intentionally *not* shaped as a `DaemonPreconditionError` variant — preconditions model missing on-disk state; version mismatch is a user-config-vs-bundle disagreement and has its own warning formatter.
- **Warning wording** (`formatDaemonVersionMismatchWarning`). The "temporary restriction" phrase is load-bearing — it sets the expectation that this will be lifted by #138 and keeps the warning from reading like a permanent limitation. Worth pushing back on if it reads wrong.
- **`daemonKotlinVersion` as single source of truth**. The native side consumes a generated `BUNDLED_DAEMON_KOTLIN_VERSION` (`generateBundledKotlinVersion` task writes it into a `nativeMain` srcDir). The daemon-side `KOLT_DAEMON_KOTLIN_VERSION` in `kolt-compiler-daemon/.../Main.kt` is **still hardcoded** — generating both was out of scope for a stop-gap, so `verifyDaemonKotlinVersion` instead reads the daemon's Main.kt and fails `check` on drift. #138 will remove this manual-sync point.
- **`kotlin.sourceSets.configureEach` for nativeMain registration**. `sourceSets { val nativeMain by getting }` and `sourceSets.named("nativeMain")` both fail at configuration time because KGP creates `nativeMain` lazily via the default hierarchy template. `configureEach { if (name == ...) }` is the working pattern — worth a sanity check that this is the idiomatic answer rather than a workaround.
- **`compileKotlinLinuxX64` explicit `dependsOn(generateBundledKotlinVersion)`**. Without this, `srcDir(Directory)` registers the path but KGP does not infer a compile-task dependency on the generator, so a clean `./gradlew compileKotlinLinuxX64` fails. Wiring is explicit rather than relying on `srcDir(TaskProvider)` because that overload's behavior in KMP wasn't reliable here (the task ran, but the source wasn't picked up).

## Out of scope

- Per-kotlinVersion daemon spawn (#138, gated on BTA-API binary compat spike).
- Making the daemon-side `KOLT_DAEMON_KOTLIN_VERSION` also generated from `daemonKotlinVersion` — would mean wiring a generator into the included build, which is larger than this stop-gap warrants. `verifyDaemonKotlinVersion` catches drift in the meantime.
