### PR TITLE
BTA-API binary-compat spike for #138 — verdict, re-scope input

### DIFF
--- a/spike/bta-compat-138/README.md
+++ b/spike/bta-compat-138/README.md
@@ -1,0 +1,32 @@
+# bta-compat-138 spike
+
+**Throwaway. Not production code.**
+
+Prerequisite spike for issue #138 (per-kotlinVersion daemon spawn). Answers:
+
+> Is `kotlin-build-tools-api` binary-stable enough that an adapter compiled
+> against API 2.3.20 can load API+impl pairs at 2.1.0 / 2.2.x at runtime
+> through the daemon's `SharedApiClassesClassLoader` + `URLClassLoader`
+> topology?
+
+See `REPORT.md` for the verdict.
+
+## Usage
+
+```
+./gradlew -p spike/bta-compat-138 run --args="fixtures/linear-10 /tmp/bta-compat-work"
+```
+
+The matrix (`2.1.0`, `2.2.20`, `2.3.0`, `2.3.10`, `2.3.20`) is hard-coded in
+`build.gradle.kts`. Each impl version ships with a matching `kotlin-stdlib` in
+its own resolvable configuration so the fixture classpath matches the impl.
+
+For each impl version the harness:
+
+1. Builds `URLClassLoader(impl jars, parent = SharedApiClassesClassLoader())`
+2. Calls `KotlinToolchains.loadImplementation(loader)`
+3. Runs a cold compile on `fixtures/linear-10`, touches `F2.kt`, runs an incremental compile
+4. Classifies the outcome (`GREEN` / `RED_LINKAGE` / `RED_METHOD` / `RED_OTHER` / `COMPILE_ERROR`)
+
+Every phase is wrapped so a thrown `LinkageError` / `NoSuchMethodError` does
+not abort the matrix — we want to see *which* versions break and *how*.

--- a/spike/bta-compat-138/REPORT.md
+++ b/spike/bta-compat-138/REPORT.md
@@ -1,0 +1,111 @@
+# BTA-API binary-compat spike — verdict
+
+**Issue:** #138
+**Adapter compile-time API:** `kotlin-build-tools-api:2.3.20`
+**Topology under test:** `URLClassLoader(impl jars, parent = SharedApiClassesClassLoader())` (matches `BtaIncrementalCompiler.create` in `kolt-compiler-daemon/ic`).
+**Date:** 2026-04-17
+
+## Verdict: RED across the 2.x line, GREEN within 2.3.x
+
+| impl version | verdict | compiler version | cold | inc   | notes |
+|--------------|---------|------------------|------|-------|-------|
+| 2.1.0        | **RED** | —                | —    | —     | fails at `KotlinToolchains.loadImplementation` |
+| 2.2.20       | **RED** | —                | —    | —     | same failure mode as 2.1.0 |
+| 2.3.0        | GREEN   | 2.3.0            | 3730 | 508   | |
+| 2.3.10       | GREEN   | 2.3.10           | 3106 | 499   | |
+| 2.3.20       | GREEN   | 2.3.20           | 3275 | 423   | |
+
+Wall times in ms. `linear-10` fixture, touch `F2.kt`.
+
+## Failure mode (2.1.0 / 2.2.20)
+
+```
+org.jetbrains.kotlin.buildtools.api.NoImplementationFoundException:
+    The classpath contains no implementation for org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+    at KotlinToolchains$Companion.loadImplementation(KotlinToolchains.kt:171)
+Caused by: java.lang.ClassNotFoundException:
+    org.jetbrains.kotlin.buildtools.internal.compat.KotlinToolchainsV1Adapter
+    at URLClassLoader.findClass(URLClassLoader.java:445)
+    ...
+    at KotlinToolchains$Companion.loadImplementation(KotlinToolchains.kt:167)
+```
+
+Reading the 2.3.20 `KotlinToolchains.loadImplementation` path:
+
+1. `KotlinToolchains` is the 2.3.x entry type. Pre-2.3 impls do not ship a
+   `ServiceLoader` service descriptor for it — they ship the old
+   `CompilationService` SPI instead.
+2. 2.3.x API tries to bridge old impls via a shim class
+   `org.jetbrains.kotlin.buildtools.internal.compat.KotlinToolchainsV1Adapter`.
+   It `classLoader.loadClass(...)`es that shim on the classloader it was given.
+3. The shim lives in the `...internal.compat.*` package. The daemon's
+   `SharedApiClassesClassLoader` only exposes `org.jetbrains.kotlin.buildtools.api.*`
+   and does *not* share `internal.compat.*`. The child `URLClassLoader` has
+   the impl jars but not the shim, so the `loadClass` fails and the whole
+   call turns into `NoImplementationFoundException`.
+
+In short: `@ExperimentalBuildToolsApi` made no binary-compat promise, and the
+concrete breaking change is a new entry type (`KotlinToolchains` in 2.3.0)
+with a compat shim that our classloader topology does not expose.
+
+## Patch-level stability within 2.3.x
+
+2.3.0 / 2.3.10 / 2.3.20 all GREEN. The impl jar for 2.3.0 and 2.3.10 differ
+by 1 byte; 2.3.20 is larger but API-compatible. Treat 2.3.x as one
+binary-compat family for daemon-spawn purposes.
+
+## Implications for #138
+
+- **The "per-kotlinVersion daemon spawn" sketch as written does not work.**
+  The sketch assumes the adapter stays compiled against 2.3.20 and we
+  fetch an older `kotlin-build-tools-impl` to match `config.kotlin`. The
+  spike shows that combination crashes at `loadImplementation` for any
+  impl from before the 2.3.x line.
+- **Proposed re-scope: floor = 2.3.0, forward on a per-release basis.**
+  Kotlin has no LTS; 2.3.x is the current language release line, 2.4 is
+  still EXPERIMENTAL at spike time (2026-04-17). Picking 2.3.0 as the
+  floor means the adapter stays a single JAR — no per-API-major
+  distribution, no V1 shim investigation — and every daemon user is on
+  the tested topology. Below 2.3.0 is subprocess-only, same shape as the
+  #136 stop-gap.
+- **Forward policy is event-driven, not N-pinned.** Re-run this spike
+  when the next language release (2.4.0) hits stable. If API+impl stays
+  binary-compat with the 2.3.20-compiled adapter, extend the daemon
+  support table and keep the existing JAR. If it drifts, choose then:
+  ship a second adapter JAR or let 2.4 fall through to subprocess. We
+  deliberately do **not** commit to `N=2` or "latest + previous" up
+  front — Kotlin's own cadence (language release every ~6 months,
+  tooling releases in between) makes a specific N brittle, and the
+  spike harness here (`spike/bta-compat-138`) is the cheap reusable
+  input to that judgement call.
+- **BtaImplFetcher still lands.** Even with a single supported API line,
+  the daemon needs to fetch `kotlin-build-tools-impl:<config.kotlin>`
+  for each 2.3.x patch the user pins — the spike confirms 2.3.0 / 2.3.10
+  / 2.3.20 all work against the 2.3.20-compiled adapter, so per-patch
+  impl fetch is the load-bearing work item. Socket path keeps
+  `<kotlinVersion>` as the issue sketches; IC state is already
+  version-stamped (ADR 0019 §5).
+- **Info-gate wording simplifies.** "Outside tested range" now means
+  "not a 2.3.x release" rather than "a specific version kolt has not
+  seen." The three-signal distinction (quiet / info / warning) still
+  holds. `--no-daemon` remains the permanent escape hatch.
+
+## Not in this spike (flagged for follow-up)
+
+- Whether a custom parent classloader that also exposes `internal.compat.*`
+  can resolve the V1 shim and rescue 2.2.x / 2.1.x impls with the current
+  2.3.20 adapter. Plausible but untested. Not worth pursuing unless the
+  floor-2.3 decision is reversed.
+- Re-running this spike at Kotlin 2.4.0 stable — the harness here is
+  the input to the forward-policy judgement call. Keep the spike
+  checked in for that reason rather than deleting after #138 merges.
+
+## Raw run log
+
+`/tmp/bta-compat-work/run.log` after `./gradlew -p spike/bta-compat-138 run`.
+
+## Reproducing
+
+```
+./gradlew -p spike/bta-compat-138 run --args="fixtures/linear-10 /tmp/bta-compat-work"
+```

--- a/spike/bta-compat-138/build.gradle.kts
+++ b/spike/bta-compat-138/build.gradle.kts
@@ -1,0 +1,64 @@
+// Throwaway spike for issue #138 — BTA-API binary compat across 2.x.
+//
+// Layout:
+//   * `implementation("...-api:2.3.20")` freezes the adapter's compile-time
+//     signatures, matching `kolt-compiler-daemon/ic/build.gradle.kts:56`.
+//   * For each target impl version we resolve kotlin-build-tools-impl and a
+//     matching kotlin-stdlib into separate resolvable configurations, then
+//     expose them to the harness as system properties. The harness loads each
+//     impl via `URLClassLoader(parent = SharedApiClassesClassLoader())` —
+//     the same topology the daemon uses, so a LinkageError here means the
+//     daemon would crash the same way in production.
+
+plugins {
+    kotlin("jvm") version "2.3.20"
+    application
+}
+
+repositories {
+    mavenCentral()
+}
+
+val btaApiVersion = "2.3.20"
+
+// Covers: one representative from each pre-adapter minor line (2.1.0, 2.2.20)
+// plus every publicly shipped 2.3.x patch — 2.3.x is the adapter's own line,
+// so in-line patch stability is a support-policy input for ADR 0022.
+val implMatrix = listOf("2.1.0", "2.2.20", "2.3.0", "2.3.10", "2.3.20")
+
+implMatrix.forEach { version ->
+    val implName = "btaImpl_${version.replace('.', '_')}"
+    val fixtureName = "fixture_${version.replace('.', '_')}"
+    configurations.create(implName) {
+        isCanBeResolved = true
+        isCanBeConsumed = false
+    }
+    configurations.create(fixtureName) {
+        isCanBeResolved = true
+        isCanBeConsumed = false
+    }
+    dependencies.add(implName, "org.jetbrains.kotlin:kotlin-build-tools-impl:$version")
+    dependencies.add(fixtureName, "org.jetbrains.kotlin:kotlin-stdlib:$version")
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-build-tools-api:$btaApiVersion")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+application {
+    mainClass.set("spike.bta.compat.MainKt")
+}
+
+tasks.named<JavaExec>("run") {
+    implMatrix.forEach { version ->
+        val implName = "btaImpl_${version.replace('.', '_')}"
+        val fixtureName = "fixture_${version.replace('.', '_')}"
+        systemProperty("bta.impl.classpath.$version", configurations.getByName(implName).asPath)
+        systemProperty("fixture.classpath.$version", configurations.getByName(fixtureName).asPath)
+    }
+    systemProperty("bta.impl.matrix", implMatrix.joinToString(","))
+}

--- a/spike/bta-compat-138/fixtures/linear-10/F10.kt
+++ b/spike/bta-compat-138/fixtures/linear-10/F10.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M10(val v: Int)
+
+fun work10(prev: M9): M10 = M10(prev.v + 10)

--- a/spike/bta-compat-138/fixtures/linear-10/F2.kt
+++ b/spike/bta-compat-138/fixtures/linear-10/F2.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M2(val v: Int)
+
+fun work2(prev: M1): M2 = M2(prev.v + 2)

--- a/spike/bta-compat-138/fixtures/linear-10/F3.kt
+++ b/spike/bta-compat-138/fixtures/linear-10/F3.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M3(val v: Int)
+
+fun work3(prev: M2): M3 = M3(prev.v + 3)

--- a/spike/bta-compat-138/fixtures/linear-10/F4.kt
+++ b/spike/bta-compat-138/fixtures/linear-10/F4.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M4(val v: Int)
+
+fun work4(prev: M3): M4 = M4(prev.v + 4)

--- a/spike/bta-compat-138/fixtures/linear-10/F5.kt
+++ b/spike/bta-compat-138/fixtures/linear-10/F5.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M5(val v: Int)
+
+fun work5(prev: M4): M5 = M5(prev.v + 5)

--- a/spike/bta-compat-138/fixtures/linear-10/F6.kt
+++ b/spike/bta-compat-138/fixtures/linear-10/F6.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M6(val v: Int)
+
+fun work6(prev: M5): M6 = M6(prev.v + 6)

--- a/spike/bta-compat-138/fixtures/linear-10/F7.kt
+++ b/spike/bta-compat-138/fixtures/linear-10/F7.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M7(val v: Int)
+
+fun work7(prev: M6): M7 = M7(prev.v + 7)

--- a/spike/bta-compat-138/fixtures/linear-10/F8.kt
+++ b/spike/bta-compat-138/fixtures/linear-10/F8.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M8(val v: Int)
+
+fun work8(prev: M7): M8 = M8(prev.v + 8)

--- a/spike/bta-compat-138/fixtures/linear-10/F9.kt
+++ b/spike/bta-compat-138/fixtures/linear-10/F9.kt
@@ -1,0 +1,5 @@
+package fixture
+
+class M9(val v: Int)
+
+fun work9(prev: M8): M9 = M9(prev.v + 9)

--- a/spike/bta-compat-138/fixtures/linear-10/Main.kt
+++ b/spike/bta-compat-138/fixtures/linear-10/Main.kt
@@ -1,0 +1,8 @@
+package fixture
+
+class M1(val v: Int)
+
+fun main() {
+    val result = work10(work9(work8(work7(work6(work5(work4(work3(work2(M1(1)))))))))).v
+    println(result)
+}

--- a/spike/bta-compat-138/settings.gradle.kts
+++ b/spike/bta-compat-138/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "bta-compat-138"

--- a/spike/bta-compat-138/src/main/kotlin/spike/bta/compat/Main.kt
+++ b/spike/bta-compat-138/src/main/kotlin/spike/bta/compat/Main.kt
@@ -1,0 +1,265 @@
+@file:OptIn(ExperimentalBuildToolsApi::class)
+
+package spike.bta.compat
+
+// Throwaway harness for #138 spike. Walks each impl version in `bta.impl.matrix`,
+// loads it via the daemon's SharedApiClassesClassLoader topology, and runs a
+// hello-world cold + incremental cycle. Every phase is wrapped so a thrown
+// LinkageError / NoSuchMethodError does not abort the matrix — we need to see
+// *which* versions break and how.
+
+import org.jetbrains.kotlin.buildtools.api.BuildOperation
+import org.jetbrains.kotlin.buildtools.api.CompilationResult
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader
+import org.jetbrains.kotlin.buildtools.api.SourcesChanges
+import org.jetbrains.kotlin.buildtools.api.arguments.JvmCompilerArguments
+import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain.Companion.jvm
+import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperation
+import org.jetbrains.kotlin.buildtools.api.trackers.BuildMetricsCollector
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.extension
+import kotlin.io.path.relativeTo
+import kotlin.io.path.walk
+import kotlin.time.DurationUnit
+import kotlin.time.TimeSource
+
+private enum class Stage { LOAD_TOOLCHAIN, COMPILER_VERSION, COLD, TOUCH, INCREMENTAL }
+
+private enum class Verdict { GREEN, RED_LINKAGE, RED_METHOD, RED_OTHER, COMPILE_ERROR }
+
+private data class RunOutcome(
+    val implVersion: String,
+    val verdict: Verdict,
+    val failedStage: Stage?,
+    val compilerVersion: String?,
+    val coldStatus: String?,
+    val coldWallMs: Long?,
+    val incStatus: String?,
+    val incWallMs: Long?,
+    val error: Throwable?,
+)
+
+fun main(args: Array<String>) {
+    val fixtureDir = Path.of(args.getOrElse(0) { "fixtures/linear-10" }).toAbsolutePath()
+    val workRoot = Path.of(args.getOrElse(1) { "/tmp/bta-compat-work" }).toAbsolutePath()
+    val matrix = System.getProperty("bta.impl.matrix")!!.split(",")
+
+    println("=== BTA compat spike (#138) ===")
+    println("adapter compile-time API: 2.3.20")
+    println("fixture: $fixtureDir")
+    println("workdir: $workRoot")
+    println("matrix:  ${matrix.joinToString(", ")}")
+    println()
+
+    val outcomes = matrix.map { version ->
+        println("--- impl $version ---")
+        val outcome = runOne(version, fixtureDir, workRoot.resolve(version))
+        printOutcome(outcome)
+        println()
+        outcome
+    }
+
+    println("=== summary ===")
+    outcomes.forEach { o ->
+        val tail = o.error?.let { " :: ${it.javaClass.name}: ${it.message?.take(160)}" } ?: ""
+        val stageTag = o.failedStage?.let { " [$it]" } ?: ""
+        println("${o.implVersion.padEnd(8)}  ${o.verdict}$stageTag$tail")
+    }
+}
+
+private fun runOne(implVersion: String, fixtureDir: Path, workDir: Path): RunOutcome {
+    resetDir(workDir)
+    val sourcesDir = workDir.resolve("sources")
+    copyFixture(fixtureDir, sourcesDir)
+    val classesDir = workDir.resolve("classes").also { it.createDirectories() }
+    val icDir = workDir.resolve("ic").also { it.createDirectories() }
+    val snapshotDir = workDir.resolve("snapshots").also { it.createDirectories() }
+    val shrunk = snapshotDir.resolve("shrunk-classpath-snapshot.bin")
+
+    val fixtureClasspath = System.getProperty("fixture.classpath.$implVersion")
+        ?: return outcomeForError(implVersion, Stage.LOAD_TOOLCHAIN,
+            IllegalStateException("fixture.classpath.$implVersion not set"))
+
+    val toolchain = try {
+        loadToolchain(implVersion)
+    } catch (t: Throwable) {
+        return outcomeForError(implVersion, Stage.LOAD_TOOLCHAIN, t)
+    }
+
+    val compilerVersion = try {
+        toolchain.getCompilerVersion()
+    } catch (t: Throwable) {
+        return outcomeForError(implVersion, Stage.COMPILER_VERSION, t)
+            .copy(compilerVersion = null)
+    }
+
+    val cold = try {
+        runCompilation(toolchain, sourcesDir, classesDir, icDir, shrunk, fixtureClasspath)
+    } catch (t: Throwable) {
+        return outcomeForError(implVersion, Stage.COLD, t).copy(compilerVersion = compilerVersion)
+    }
+
+    val touched = sourcesDir.resolve("F2.kt")
+    try {
+        touchSourceFile(touched)
+    } catch (t: Throwable) {
+        return outcomeForError(implVersion, Stage.TOUCH, t).copy(
+            compilerVersion = compilerVersion,
+            coldStatus = cold.compilationResult.name,
+            coldWallMs = cold.wallMs,
+        )
+    }
+
+    val inc = try {
+        runCompilation(toolchain, sourcesDir, classesDir, icDir, shrunk, fixtureClasspath)
+    } catch (t: Throwable) {
+        return outcomeForError(implVersion, Stage.INCREMENTAL, t).copy(
+            compilerVersion = compilerVersion,
+            coldStatus = cold.compilationResult.name,
+            coldWallMs = cold.wallMs,
+        )
+    }
+
+    val verdict = when {
+        cold.compilationResult != CompilationResult.COMPILATION_SUCCESS -> Verdict.COMPILE_ERROR
+        inc.compilationResult != CompilationResult.COMPILATION_SUCCESS -> Verdict.COMPILE_ERROR
+        else -> Verdict.GREEN
+    }
+
+    return RunOutcome(
+        implVersion = implVersion,
+        verdict = verdict,
+        failedStage = null,
+        compilerVersion = compilerVersion,
+        coldStatus = cold.compilationResult.name,
+        coldWallMs = cold.wallMs,
+        incStatus = inc.compilationResult.name,
+        incWallMs = inc.wallMs,
+        error = null,
+    )
+}
+
+private fun outcomeForError(version: String, stage: Stage, t: Throwable): RunOutcome {
+    val verdict = classify(t)
+    return RunOutcome(
+        implVersion = version,
+        verdict = verdict,
+        failedStage = stage,
+        compilerVersion = null,
+        coldStatus = null,
+        coldWallMs = null,
+        incStatus = null,
+        incWallMs = null,
+        error = t,
+    )
+}
+
+private fun classify(t: Throwable): Verdict {
+    var cur: Throwable? = t
+    while (cur != null) {
+        when (cur) {
+            is NoSuchMethodError, is AbstractMethodError -> return Verdict.RED_METHOD
+            is LinkageError, is NoClassDefFoundError -> return Verdict.RED_LINKAGE
+        }
+        cur = cur.cause
+    }
+    return Verdict.RED_OTHER
+}
+
+private fun printOutcome(o: RunOutcome) {
+    println("verdict: ${o.verdict}${o.failedStage?.let { " at $it" } ?: ""}")
+    o.compilerVersion?.let { println("compiler version: $it") }
+    o.coldStatus?.let { println("cold: $it (${o.coldWallMs}ms)") }
+    o.incStatus?.let { println("inc:  $it (${o.incWallMs}ms)") }
+    o.error?.let { t ->
+        println("error: ${t.javaClass.name}: ${t.message}")
+        t.printStackTrace(System.out)
+    }
+}
+
+private data class CompileResult(val compilationResult: CompilationResult, val wallMs: Long)
+
+@OptIn(ExperimentalPathApi::class)
+private fun runCompilation(
+    toolchain: KotlinToolchains,
+    sourcesDir: Path,
+    classesDir: Path,
+    icDir: Path,
+    shrunkClasspathSnapshot: Path,
+    fixtureClasspath: String,
+): CompileResult {
+    val sources: List<Path> = sourcesDir.walk()
+        .filter { it.extension == "kt" || it.extension == "java" }
+        .sorted()
+        .toList()
+
+    val builder = toolchain.jvm.jvmCompilationOperationBuilder(sources, classesDir)
+    builder.compilerArguments[JvmCompilerArguments.CLASSPATH] = fixtureClasspath
+    builder.compilerArguments[JvmCompilerArguments.MODULE_NAME] = "spike-bta-compat"
+    builder.compilerArguments[JvmCompilerArguments.NO_STDLIB] = true
+    builder.compilerArguments[JvmCompilerArguments.NO_REFLECT] = true
+
+    val icConfig = builder.snapshotBasedIcConfigurationBuilder(
+        workingDirectory = icDir,
+        sourcesChanges = SourcesChanges.ToBeCalculated,
+        dependenciesSnapshotFiles = emptyList(),
+        shrunkClasspathSnapshot = shrunkClasspathSnapshot,
+    ).build()
+    builder[JvmCompilationOperation.INCREMENTAL_COMPILATION] = icConfig
+
+    builder[BuildOperation.METRICS_COLLECTOR] = object : BuildMetricsCollector {
+        override fun collectMetric(name: String, type: BuildMetricsCollector.ValueType, value: Long) { /* ignore */ }
+    }
+
+    val op = builder.build()
+    val policy = toolchain.createInProcessExecutionPolicy()
+    val start = TimeSource.Monotonic.markNow()
+    val result = toolchain.createBuildSession().use { session ->
+        session.executeOperation(op, policy)
+    }
+    val wall = start.elapsedNow().toLong(DurationUnit.MILLISECONDS)
+    return CompileResult(result, wall)
+}
+
+private fun loadToolchain(implVersion: String): KotlinToolchains {
+    val cp = System.getProperty("bta.impl.classpath.$implVersion")
+        ?: error("bta.impl.classpath.$implVersion not set")
+    val urls = cp.split(File.pathSeparator)
+        .filter { it.isNotBlank() }
+        .map { File(it).toURI().toURL() }
+        .toTypedArray()
+    val loader = URLClassLoader(urls, SharedApiClassesClassLoader())
+    return KotlinToolchains.loadImplementation(loader)
+}
+
+@OptIn(ExperimentalPathApi::class)
+private fun resetDir(dir: Path) {
+    if (Files.exists(dir)) dir.deleteRecursively()
+    dir.createDirectories()
+}
+
+@OptIn(ExperimentalPathApi::class)
+private fun copyFixture(src: Path, dst: Path) {
+    dst.createDirectories()
+    src.walk().filter { Files.isRegularFile(it) }.forEach { p ->
+        val rel = p.relativeTo(src)
+        val target = dst.resolve(rel.toString())
+        target.parent?.createDirectories()
+        Files.copy(p, target, StandardCopyOption.REPLACE_EXISTING)
+    }
+}
+
+private fun touchSourceFile(path: Path) {
+    val uniq = System.nanoTime()
+    val marker = "\nfun spikeTouch$uniq(): Long = $uniq\n"
+    Files.writeString(path, marker, java.nio.file.StandardOpenOption.APPEND)
+}


### PR DESCRIPTION
Prerequisite spike for #138. Throwaway harness under `spike/bta-compat-138/` that loads `kotlin-build-tools-impl` at 2.1.0 / 2.2.20 / 2.3.0 / 2.3.10 / 2.3.20 against an adapter compiled for API 2.3.20, through the daemon's `SharedApiClassesClassLoader` + `URLClassLoader` topology, and runs a hello-world cold + incremental cycle for each.

## Review focus

- **`REPORT.md` "Implications for #138" section.** The re-scope proposal (floor 2.3.0, event-driven forward policy) is the load-bearing output of this PR. Issue #138 body is already updated to match; push back here if the framing reads wrong.
- **Decision to check the spike harness in instead of deleting.** Rationale in `REPORT.md` — reusable input for the next judgement call when Kotlin 2.4.0 ships. The `spike/incremental-ic` precedent checks in too, so this is not a new pattern, but worth a sanity check that "throwaway but retained" is the right call here rather than "delete after merge."
- **Out-of-scope calls.** 2.2.x / 2.1.x daemon support is rejected in the REPORT's "Implications" and "Not in this spike" sections — neither the V1-shim-via-custom-parent-loader path nor a second adapter JAR. Worth pushing back if either reads as premature.
- **Classifier in `Main.kt` (`RED_LINKAGE` vs `RED_METHOD` vs `RED_OTHER`).** The actual failure came back as `RED_OTHER` (NoImplementationFoundException wrapping a ClassNotFoundException), which is correct but means the finer-grained classifier is untested. Left in because it's the input for a 2.4.0 re-run that might hit actual LinkageError / NoSuchMethodError.

## Not in this PR

- Implementation of #138 DoD items (`BtaImplFetcher`, daemon CLI `--bta-impl-jars`, socket path `<kotlinVersion>`, ADR 0022, info-gate wording). Follow-up PR.
- Retiring #136 stop-gap warning. Part of the #138 implementation PR.
