### PR TITLE
Per-version daemon spawn for Kotlin 2.3.x family (#138)

### DIFF
--- a/.claude/skills/kolt-usage/SKILL.md
+++ b/.claude/skills/kolt-usage/SKILL.md
@@ -53,7 +53,7 @@ kolt --version              Show version
 | Flag | Description |
 |------|-------------|
 | `--watch` | Watch source files and re-run on change (build/check/test/run) |
-| `--no-daemon` | Skip the warm compiler daemon for this invocation |
+| `--no-daemon` | Skip the warm compiler daemon for this invocation. Always available, even on Kotlin versions outside the daemon's supported range (ADR 0022). |
 
 ### Watch Mode
 
@@ -73,7 +73,7 @@ For `run --watch`, the running application is killed and restarted on each sourc
 ```toml
 name = "my-app"
 version = "0.1.0"
-kotlin = "2.1.0"
+kotlin = "2.3.20"
 target = "jvm"
 jvm_target = "17"
 main = "main"

--- a/README.ja.md
+++ b/README.ja.md
@@ -92,7 +92,7 @@ kolt --version         バージョンを表示
 | フラグ | 説明 |
 |--------|------|
 | `--watch` | ソースファイルを監視し、変更時にコマンドを再実行（build/check/test/run） |
-| `--no-daemon` | この実行でウォームコンパイラデーモンをスキップ |
+| `--no-daemon` | この実行でウォームコンパイラデーモンをスキップ。daemon サポート対象外の Kotlin バージョン (ADR 0022) でも常に利用可能。 |
 
 ## 設定
 
@@ -101,7 +101,7 @@ kolt --version         バージョンを表示
 ```toml
 name = "my-app"
 version = "0.1.0"
-kotlin = "2.1.0"
+kotlin = "2.3.20"
 target = "jvm"
 jvm_target = "17"
 main = "main"

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ kolt --version         Show version
 | Flag | Description |
 |------|-------------|
 | `--watch` | Watch source files and re-run the command on change (build/check/test/run) |
-| `--no-daemon` | Skip the warm compiler daemon for this invocation |
+| `--no-daemon` | Skip the warm compiler daemon for this invocation. Always available, including on Kotlin versions outside the daemon's supported range (ADR 0022). |
 
 ## Configuration
 
@@ -101,7 +101,7 @@ kolt --version         Show version
 ```toml
 name = "my-app"
 version = "0.1.0"
-kotlin = "2.1.0"
+kotlin = "2.3.20"
 target = "jvm"
 jvm_target = "17"
 main = "main"

--- a/docs/adr/0022-supported-kotlin-version-policy.md
+++ b/docs/adr/0022-supported-kotlin-version-policy.md
@@ -133,16 +133,7 @@ threads the needle.
 
 ### 2. Warning frequency and lifecycle: daemon-probe path, cache-miss only
 
-This section describes the **steady-state** behaviour after §7's
-per-version daemon spawn ships. During the #136 stop-gap interim
-(now through the #138 implementation merge), the fallback predicate
-is broader — `config.kotlin != BUNDLED_DAEMON_KOTLIN_VERSION`, which
-covers every non-bundled version including supported 2.3.x patches —
-and the warning text describes a "temporary restriction" rather than
-the policy below. The frequency cap in this section applies unchanged
-in both phases.
-
-In steady state, the `< 2.3.0` warning is emitted exactly when:
+The `< 2.3.0` warning is emitted exactly when:
 
 - the native client would otherwise have dispatched to the daemon
   (i.e., not `--no-daemon`, not already subprocess), **and**
@@ -321,8 +312,7 @@ condition itself: from `!= BUNDLED_DAEMON_KOTLIN_VERSION` (a single
 equality check) to "is this daemon-capable?" — answered positively
 for all 2.3.x under §7's per-version scheme, negatively for `< 2.3`.
 
-The warning text and its two-phase lifecycle (interim → steady state)
-are covered in §2.
+The warning text on the subprocess fallback rail is specified in §2.
 
 No ADR 0019 §5 / §7 behaviour changes for the supported range.
 Incremental compile, self-heal, classpath snapshot caching all work

--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
@@ -148,11 +148,17 @@ class BtaIncrementalCompiler private constructor(
         builder.compilerArguments[JvmCompilerArguments.MODULE_NAME] = moduleNameFor(request)
 
         // ADR 0019 §9: kolt.toml [plugins] → List<CompilerPlugin> translation
-        // happens inside the adapter, not in daemon core. An empty list here is
-        // a "no plugins requested" signal and is the common case; emitting it
-        // unconditionally keeps the wiring obvious to a reader.
+        // happens inside the adapter, not in daemon core. The COMPILER_PLUGINS
+        // structured argument key was introduced in BTA 2.3.20; setting it
+        // against a 2.3.0–2.3.10 impl raises "available only since 2.3.20"
+        // even with an empty list (#138 follow-up audit). Skip the assignment
+        // when there are no plugins so plugin-free projects build on the full
+        // 2.3.x family. Plugin-using projects still need 2.3.20+ daemon, or
+        // --no-daemon, until a freeArgs-based pre-2.3.20 path lands.
         val translatedPlugins = PluginTranslator.translate(request.projectRoot, pluginJarResolver)
-        builder.compilerArguments[CommonCompilerArguments.COMPILER_PLUGINS] = translatedPlugins
+        if (translatedPlugins.isNotEmpty()) {
+            builder.compilerArguments[CommonCompilerArguments.COMPILER_PLUGINS] = translatedPlugins
+        }
 
         // #127: cached by ClasspathSnapshotCache; see class doc for key/error policy.
         val dependenciesSnapshotFiles = classpathSnapshotCache.getOrComputeSnapshots(request.classpath)

--- a/src/nativeMain/kotlin/kolt/build/daemon/BtaImplFetcher.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/BtaImplFetcher.kt
@@ -1,0 +1,58 @@
+package kolt.build.daemon
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.config.KoltConfig
+import kolt.config.MAVEN_CENTRAL_BASE
+import kolt.resolve.Lockfile
+import kolt.resolve.ResolveError
+import kolt.resolve.ResolveResult
+import kolt.resolve.ResolverDeps
+import kolt.resolve.resolveTransitive
+
+// #138: per-version daemon. Fetches the kotlin-build-tools-impl classpath
+// (impl jar + transitive deps) for a requested 2.3.x patch when the
+// libexec-bundled set does not match. The resolver does the heavy lifting
+// (POM walk, Maven Central GETs, sha256 stamping); this file is a thin
+// shim that synthesises a one-dependency KoltConfig and unwraps the
+// resulting cache paths.
+
+sealed interface BtaImplFetchError {
+    data class ResolveFailed(val version: String, val cause: ResolveError) : BtaImplFetchError
+    // Defensive: malformed coords or a 404 the resolver swallows could leave
+    // us with an empty list. Catching here lets the precondition layer route
+    // it through the daemon-fail warning rail instead of letting an empty
+    // classpath reach BtaIncrementalCompiler.create's require check.
+    data class ResolvedEmpty(val version: String) : BtaImplFetchError
+}
+
+private const val BTA_IMPL_GROUP_ARTIFACT = "org.jetbrains.kotlin:kotlin-build-tools-impl"
+
+internal fun ensureBtaImplJars(
+    version: String,
+    cacheBase: String,
+    deps: ResolverDeps,
+    resolver: (KoltConfig, Lockfile?, String, ResolverDeps) -> Result<ResolveResult, ResolveError> =
+        ::resolveTransitive,
+): Result<List<String>, BtaImplFetchError> {
+    // KoltConfig has many irrelevant fields here (name, main, sources). We
+    // pin them to safe sentinels: nothing in the resolver path inspects
+    // them, and `target = "jvm"` keeps us on the JVM resolution branch.
+    val syntheticConfig = KoltConfig(
+        name = "kolt-bta-impl-fetch",
+        version = version,
+        kotlin = version,
+        target = "jvm",
+        main = "unused.Main",
+        sources = emptyList(),
+        dependencies = mapOf(BTA_IMPL_GROUP_ARTIFACT to version),
+        repositories = mapOf("central" to MAVEN_CENTRAL_BASE),
+    )
+    val result = resolver(syntheticConfig, null, cacheBase, deps).getOrElse {
+        return Err(BtaImplFetchError.ResolveFailed(version, it))
+    }
+    if (result.deps.isEmpty()) return Err(BtaImplFetchError.ResolvedEmpty(version))
+    return Ok(result.deps.map { it.cachePath })
+}

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
@@ -6,6 +6,8 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltPaths
 import kolt.infra.listJarFiles
+import kolt.resolve.compareVersions
+import kolt.resolve.defaultResolverDeps
 
 
 internal data class DaemonSetup(
@@ -17,6 +19,22 @@ internal data class DaemonSetup(
     val socketPath: String,
     val logPath: String,
 )
+
+// Soft floor for daemon-supported Kotlin versions per ADR 0022. The 2.3.x
+// family shares one binary-compat surface (verified by spike #138); 2.2.x
+// and earlier crash at `KotlinToolchains.loadImplementation` because their
+// V1 compat shim lives in `internal.compat.*`, outside what the daemon's
+// SharedApiClassesClassLoader exposes.
+internal const val KOTLIN_VERSION_FLOOR = "2.3.0"
+
+// BTA's structured `COMPILER_PLUGINS` argument key was introduced in 2.3.20.
+// Before that, the impl rejects the key even with an empty list, so a
+// project that actually has plugins configured cannot run on the daemon
+// against a pre-2.3.20 BTA-impl. The gap is recoverable in principle via
+// `freeArgs` passthrough (`-Xplugin=...`) but that path is unimplemented;
+// for now, plugin-using projects on 2.3.0–2.3.10 take the subprocess
+// fallback rail with a dedicated warning. Tracked as a #138 follow-up.
+internal const val KOTLIN_VERSION_FOR_PLUGINS = "2.3.20"
 
 // None of these are build failures — ADR 0016 §5.
 internal sealed interface DaemonPreconditionError {
@@ -31,14 +49,26 @@ internal sealed interface DaemonPreconditionError {
 
     data class BtaImplJarsMissing(val probedDir: String) : DaemonPreconditionError
 
-    // Stop-gap for #136; follow-up per-version daemon spawn tracked in #138.
-    // ADR 0019 §1 pins the daemon's kotlinc (kotlin-compiler-embeddable and
-    // kotlin-build-tools-api/impl) in lockstep at process start, so a
-    // requested `config.kotlin` different from the bundled version cannot be
-    // served by the existing daemon.
-    data class KotlinVersionMismatch(
+    // ADR 0022: the daemon adapter is compiled against BTA-API 2.3.x.
+    // Below the floor, no fetch can rescue us — the impl jar's V1 compat
+    // shim lives in `internal.compat.*`, which the daemon classloader
+    // hierarchy does not share.
+    data class KotlinVersionBelowFloor(
         val requested: String,
-        val bundled: String,
+        val floor: String,
+    ) : DaemonPreconditionError
+
+    data class BtaImplFetchFailed(
+        val version: String,
+        val cause: BtaImplFetchError,
+    ) : DaemonPreconditionError
+
+    // Plugins requested but the requested Kotlin version pre-dates
+    // BTA's structured COMPILER_PLUGINS argument (2.3.20). See the
+    // KOTLIN_VERSION_FOR_PLUGINS const for context.
+    data class PluginsRequireMinKotlinVersion(
+        val requested: String,
+        val minVersion: String,
     ) : DaemonPreconditionError
 }
 
@@ -47,19 +77,31 @@ internal fun resolveDaemonPreconditions(
     kotlincVersion: String,
     absProjectPath: String,
     bundledKotlinVersion: String,
+    pluginsRequested: Boolean = false,
     ensureJavaBin: (KoltPaths) -> Result<String, BootstrapJdkError> = ::ensureBootstrapJavaBin,
     resolveDaemonJar: () -> DaemonJarResolution = ::resolveDaemonJar,
     listCompilerJars: (String) -> List<String>? = { dir -> listJarFiles(dir).getOrElse { null } },
-    resolveBtaImplJars: () -> BtaImplJarsResolution = ::resolveBtaImplJars,
+    resolveBundledBtaImplJars: () -> BtaImplJarsResolution = ::resolveBtaImplJars,
+    fetchBtaImplJars: (String, String) -> Result<List<String>, BtaImplFetchError> =
+        { v, base -> ensureBtaImplJars(v, base, defaultResolverDeps()) },
 ): Result<DaemonSetup, DaemonPreconditionError> {
-    // Short-circuit before any on-disk probing: on a version mismatch we
-    // would never spawn the daemon, so there is no point touching the JDK,
-    // daemon jar, kotlinc lib dir, or BTA-impl jars first.
-    if (kotlincVersion != bundledKotlinVersion) {
+    // Floor check first: cheaper than any disk probe and short-circuits
+    // every variant the daemon cannot serve. Equal to or above 2.3.0
+    // counts as in-family per ADR 0022 §3.
+    if (compareVersions(kotlincVersion, KOTLIN_VERSION_FLOOR) < 0) {
         return Err(
-            DaemonPreconditionError.KotlinVersionMismatch(
+            DaemonPreconditionError.KotlinVersionBelowFloor(
                 requested = kotlincVersion,
-                bundled = bundledKotlinVersion,
+                floor = KOTLIN_VERSION_FLOOR,
+            ),
+        )
+    }
+
+    if (pluginsRequested && compareVersions(kotlincVersion, KOTLIN_VERSION_FOR_PLUGINS) < 0) {
+        return Err(
+            DaemonPreconditionError.PluginsRequireMinKotlinVersion(
+                requested = kotlincVersion,
+                minVersion = KOTLIN_VERSION_FOR_PLUGINS,
             ),
         )
     }
@@ -84,10 +126,20 @@ internal fun resolveDaemonPreconditions(
         return Err(DaemonPreconditionError.CompilerJarsMissing(kotlincLibDir))
     }
 
-    val btaImplJars = when (val res = resolveBtaImplJars()) {
-        is BtaImplJarsResolution.Resolved -> res.jars
-        is BtaImplJarsResolution.NotFound ->
-            return Err(DaemonPreconditionError.BtaImplJarsMissing(res.probedDir))
+    // Bundled-version fast path: a fresh kolt install ships the matching
+    // BTA-impl classpath under <prefix>/libexec/kolt-bta-impl/, so a
+    // first build at the bundled version pays no Maven Central round
+    // trip. Other 2.3.x patches resolve through the fetcher.
+    val btaImplJars = if (kotlincVersion == bundledKotlinVersion) {
+        when (val res = resolveBundledBtaImplJars()) {
+            is BtaImplJarsResolution.Resolved -> res.jars
+            is BtaImplJarsResolution.NotFound ->
+                return Err(DaemonPreconditionError.BtaImplJarsMissing(res.probedDir))
+        }
+    } else {
+        fetchBtaImplJars(kotlincVersion, paths.cacheBase).getOrElse {
+            return Err(DaemonPreconditionError.BtaImplFetchFailed(kotlincVersion, it))
+        }
     }
 
     val projectHash = projectHashOf(absProjectPath)
@@ -97,9 +149,9 @@ internal fun resolveDaemonPreconditions(
             daemonJarPath = daemonJar,
             compilerJars = compilerJars,
             btaImplJars = btaImplJars,
-            daemonDir = paths.daemonDir(projectHash),
-            socketPath = paths.daemonSocketPath(projectHash),
-            logPath = paths.daemonLogPath(projectHash),
+            daemonDir = paths.daemonDir(projectHash, kotlincVersion),
+            socketPath = paths.daemonSocketPath(projectHash, kotlincVersion),
+            logPath = paths.daemonLogPath(projectHash, kotlincVersion),
         ),
     )
 }
@@ -113,8 +165,19 @@ internal fun formatDaemonPreconditionWarning(err: DaemonPreconditionError): Stri
         "warning: no compiler jars found in ${err.kotlincLibDir} — falling back to subprocess compile"
     is DaemonPreconditionError.BtaImplJarsMissing ->
         "warning: kotlin-build-tools-impl jars not found in ${err.probedDir} — falling back to subprocess compile"
-    is DaemonPreconditionError.KotlinVersionMismatch ->
-        "warning: kolt daemon currently bundles Kotlin ${err.bundled}; your kolt.toml requests ${err.requested} — " +
-            "falling back to subprocess compile. This is a temporary restriction; " +
-            "per-version daemon support is tracked in #138."
+    is DaemonPreconditionError.KotlinVersionBelowFloor ->
+        "warning: kolt daemon supports Kotlin >= ${err.floor}; your kolt.toml requests ${err.requested} — " +
+            "falling back to subprocess compile. Pass --no-daemon to silence this warning."
+    is DaemonPreconditionError.BtaImplFetchFailed ->
+        "warning: could not fetch kotlin-build-tools-impl ${err.version} from Maven Central " +
+            "(${formatBtaImplFetchError(err.cause)}) — falling back to subprocess compile"
+    is DaemonPreconditionError.PluginsRequireMinKotlinVersion ->
+        "warning: kolt.toml uses compiler plugins which require Kotlin >= ${err.minVersion} on the daemon path; " +
+            "your kolt.toml requests ${err.requested} — falling back to subprocess compile. " +
+            "Pass --no-daemon to silence this warning."
+}
+
+private fun formatBtaImplFetchError(err: BtaImplFetchError): String = when (err) {
+    is BtaImplFetchError.ResolveFailed -> err.cause.toString()
+    is BtaImplFetchError.ResolvedEmpty -> "resolver returned no jars"
 }

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -492,15 +492,19 @@ internal fun resolveCompilerBackend(
     absProjectPath: String,
     bundledKotlinVersion: String = BUNDLED_DAEMON_KOTLIN_VERSION,
     pluginJars: Map<String, List<String>> = emptyMap(),
-    preconditionResolver: (KoltPaths, String, String, String) -> Result<DaemonSetup, DaemonPreconditionError> =
-        { p, kotlincVersion, cwd, bundled -> resolveDaemonPreconditions(p, kotlincVersion, cwd, bundled) },
+    preconditionResolver: (KoltPaths, String, String, String, Boolean) -> Result<DaemonSetup, DaemonPreconditionError> =
+        { p, kotlincVersion, cwd, bundled, plugins ->
+            resolveDaemonPreconditions(p, kotlincVersion, cwd, bundled, plugins)
+        },
     daemonDirCreator: (String) -> Result<Unit, MkdirFailed> = ::ensureDirectoryRecursive,
     daemonBackendFactory: (DaemonSetup, Map<String, List<String>>) -> CompilerBackend = ::createDaemonBackend,
     warningSink: (String) -> Unit = ::eprintln,
 ): CompilerBackend {
     if (!useDaemon) return subprocessBackend
 
-    val setup = preconditionResolver(paths, config.kotlin, absProjectPath, bundledKotlinVersion).getOrElse { err ->
+    val setup = preconditionResolver(
+        paths, config.kotlin, absProjectPath, bundledKotlinVersion, pluginJars.isNotEmpty(),
+    ).getOrElse { err ->
         warningSink(formatDaemonPreconditionWarning(err))
         return subprocessBackend
     }
@@ -561,13 +565,7 @@ internal fun applyPluginsFingerprintToFile(path: String, fingerprint: String): S
     }
 }
 
-internal fun createResolverDeps() = object : ResolverDeps {
-    override fun fileExists(path: String): Boolean = kolt.infra.fileExists(path)
-    override fun ensureDirectoryRecursive(path: String) = kolt.infra.ensureDirectoryRecursive(path)
-    override fun downloadFile(url: String, destPath: String) = kolt.infra.downloadFile(url, destPath)
-    override fun computeSha256(filePath: String) = kolt.infra.computeSha256(filePath)
-    override fun readFileContent(path: String) = readFileAsString(path)
-}
+internal fun createResolverDeps(): ResolverDeps = defaultResolverDeps()
 
 internal data class OverlappingDep(
     val groupArtifact: String,

--- a/src/nativeMain/kotlin/kolt/cli/BundledKotlinVersion.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BundledKotlinVersion.kt
@@ -2,7 +2,12 @@
 // `KOLT_DAEMON_KOTLIN_VERSION` (kolt-compiler-daemon Main.kt). All three,
 // plus the four kotlinc/BTA artifact pins in kolt-compiler-daemon's build
 // scripts, must move together per ADR 0019 §1. `verifyDaemonKotlinVersion`
-// asserts all seven at build time. #138 will collapse the manual sync.
+// asserts all seven at build time.
+//
+// Per ADR 0022 §8 this constant is the *tested default baseline*, not
+// the only daemon-supported version: other 2.3.x patches resolve via
+// `BtaImplFetcher`. The libexec bundle exists so a fresh kolt install
+// pays no Maven Central round trip on the baseline version's first build.
 //
 // Committed as source (rather than generated) so the self-host path
 // (`kolt.kexe build` driven by `kolt.toml`) compiles without depending on a

--- a/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
@@ -47,15 +47,34 @@ private fun doDaemonStop(args: List<String>): Result<Unit, Int> {
             return Err(EXIT_CONFIG_ERROR)
         }
         val hash = projectHashOf(cwd)
-        val socketPath = paths.daemonSocketPath(hash)
-        if (!fileExists(socketPath)) {
-            println("no daemon running for this project")
-            return Ok(Unit)
+        val projectDir = "${paths.daemonBaseDir}/$hash"
+        val stopped = stopProjectDaemons(projectDir)
+        when (stopped) {
+            0 -> println("no daemon running for this project")
+            1 -> println("daemon stopped")
+            else -> println("stopped $stopped daemons")
         }
-        val stopped = sendShutdown(socketPath)
-        if (stopped) println("daemon stopped") else println("no daemon running for this project")
     }
     return Ok(Unit)
+}
+
+private fun stopProjectDaemons(projectDir: String): Int {
+    if (!fileExists(projectDir)) return 0
+    var stopped = 0
+    // Pre-#138 layout: socket sat directly under <projectHash>/. Probe first
+    // so a still-running pre-upgrade daemon can be shut down cleanly.
+    val legacySocket = "$projectDir/daemon.sock"
+    if (fileExists(legacySocket) && sendShutdown(legacySocket)) {
+        stopped++
+    }
+    val versionDirs = listSubdirectories(projectDir).getOrElse { return stopped }
+    for (versionDir in versionDirs) {
+        val socketPath = "$projectDir/$versionDir/daemon.sock"
+        if (fileExists(socketPath) && sendShutdown(socketPath)) {
+            stopped++
+        }
+    }
+    return stopped
 }
 
 private fun stopAllDaemons(daemonBaseDir: String) {
@@ -68,11 +87,8 @@ private fun stopAllDaemons(daemonBaseDir: String) {
         return
     }
     var stopped = 0
-    for (dir in projectDirs) {
-        val socketPath = "$daemonBaseDir/$dir/daemon.sock"
-        if (fileExists(socketPath) && sendShutdown(socketPath)) {
-            stopped++
-        }
+    for (projectDir in projectDirs) {
+        stopped += stopProjectDaemons("$daemonBaseDir/$projectDir")
     }
     if (stopped == 0) println("no daemons running")
     else println("stopped $stopped daemon${if (stopped > 1) "s" else ""}")

--- a/src/nativeMain/kotlin/kolt/cli/DaemonReaper.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonReaper.kt
@@ -8,32 +8,64 @@ import kolt.infra.removeDirectoryRecursive
 
 data class ReapResult(val reaped: Int, val alive: Int, val failed: Int)
 
-// Probe-based reaper for orphaned daemon sockets under `daemonBaseDir`.
-// A daemon directory is reaped when: (a) no `daemon.sock` exists, or
-// (b) `daemon.sock` exists but connect fails (daemon already exited).
+// Sibling of <projectHash> dirs under daemonBaseDir; holds incremental
+// compile state, not daemon sockets. Never touched by the reaper.
+private const val IC_STATE_DIR_NAME = "ic"
+
+// Probe-based reaper for orphaned daemon sockets. Layout per ADR 0022:
+// `<base>/<projectHash>/<kotlinVersion>/daemon.sock`. A version dir is
+// reaped when: (a) no `daemon.sock` exists, or (b) connect fails. A
+// project dir is removed only after all of its version subdirs are reaped.
 // Invariant: a live daemon is never touched.
 internal fun reapStaleDaemons(daemonBaseDir: String): ReapResult {
     if (!fileExists(daemonBaseDir)) return ReapResult(0, 0, 0)
-    val dirs = listSubdirectories(daemonBaseDir).getOrElse { return ReapResult(0, 0, 0) }
+    val projectDirs = listSubdirectories(daemonBaseDir).getOrElse { return ReapResult(0, 0, 0) }
 
     var reaped = 0
     var alive = 0
     var failed = 0
-    for (dir in dirs) {
-        val fullDir = "$daemonBaseDir/$dir"
-        val socketPath = "$fullDir/daemon.sock"
-        if (fileExists(socketPath)) {
-            val socket = UnixSocket.connect(socketPath)
+    for (projectDir in projectDirs) {
+        if (projectDir == IC_STATE_DIR_NAME) continue
+        val projectFullDir = "$daemonBaseDir/$projectDir"
+
+        // Pre-#138 layout: socket lived directly at <projectHash>/daemon.sock.
+        // Probe before removing — a daemon spawned by an older kolt build may
+        // still be alive and serving requests.
+        val legacySocket = "$projectFullDir/daemon.sock"
+        if (fileExists(legacySocket)) {
+            val socket = UnixSocket.connect(legacySocket)
             if (socket.isOk) {
                 socket.getOrElse { null }?.close()
                 alive++
                 continue
             }
+            if (removeDirectoryRecursive(projectFullDir).isOk) reaped++ else failed++
+            continue
         }
-        if (removeDirectoryRecursive(fullDir).isOk) {
-            reaped++
-        } else {
-            failed++
+
+        val versionDirs = listSubdirectories(projectFullDir).getOrElse { continue }
+        var versionsRemaining = 0
+        for (versionDir in versionDirs) {
+            val versionFullDir = "$projectFullDir/$versionDir"
+            val socketPath = "$versionFullDir/daemon.sock"
+            if (fileExists(socketPath)) {
+                val socket = UnixSocket.connect(socketPath)
+                if (socket.isOk) {
+                    socket.getOrElse { null }?.close()
+                    alive++
+                    versionsRemaining++
+                    continue
+                }
+            }
+            if (removeDirectoryRecursive(versionFullDir).isOk) {
+                reaped++
+            } else {
+                failed++
+                versionsRemaining++
+            }
+        }
+        if (versionsRemaining == 0) {
+            removeDirectoryRecursive(projectFullDir)
         }
     }
     return ReapResult(reaped, alive, failed)

--- a/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
+++ b/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
@@ -12,9 +12,12 @@ internal data class KoltPaths(val home: String) {
     val daemonBaseDir: String = "$home/.kolt/daemon"
     val daemonIcDir: String = "$daemonBaseDir/ic"
 
-    fun daemonDir(projectHash: String): String = "$daemonBaseDir/$projectHash"
-    fun daemonSocketPath(projectHash: String): String = "${daemonDir(projectHash)}/daemon.sock"
-    fun daemonLogPath(projectHash: String): String = "${daemonDir(projectHash)}/daemon.log"
+    fun daemonDir(projectHash: String, kotlinVersion: String): String =
+        "$daemonBaseDir/$projectHash/$kotlinVersion"
+    fun daemonSocketPath(projectHash: String, kotlinVersion: String): String =
+        "${daemonDir(projectHash, kotlinVersion)}/daemon.sock"
+    fun daemonLogPath(projectHash: String, kotlinVersion: String): String =
+        "${daemonDir(projectHash, kotlinVersion)}/daemon.log"
 
     fun kotlincPath(version: String): String = "$toolchainsDir/kotlinc/$version"
     fun kotlincBin(version: String): String = "${kotlincPath(version)}/bin/kotlinc"

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -61,6 +61,17 @@ interface ResolverDeps {
     fun readFileContent(path: String): Result<String, OpenFailed>
 }
 
+// Real-IO ResolverDeps wired to kolt.infra. Lives here (rather than in
+// kolt.cli) so non-CLI callers — currently kolt.build.daemon.BtaImplFetcher
+// — can use it without an upward import.
+internal fun defaultResolverDeps(): ResolverDeps = object : ResolverDeps {
+    override fun fileExists(path: String): Boolean = kolt.infra.fileExists(path)
+    override fun ensureDirectoryRecursive(path: String) = kolt.infra.ensureDirectoryRecursive(path)
+    override fun downloadFile(url: String, destPath: String) = kolt.infra.downloadFile(url, destPath)
+    override fun computeSha256(filePath: String) = kolt.infra.computeSha256(filePath)
+    override fun readFileContent(path: String) = kolt.infra.readFileAsString(path)
+}
+
 fun resolve(
     config: KoltConfig,
     existingLock: Lockfile?,

--- a/src/nativeTest/kotlin/kolt/build/daemon/BtaImplFetcherTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/BtaImplFetcherTest.kt
@@ -1,0 +1,157 @@
+package kolt.build.daemon
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.config.KoltConfig
+import kolt.config.MAVEN_CENTRAL_BASE
+import kolt.infra.DownloadError
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kolt.resolve.Lockfile
+import kolt.resolve.ResolveError
+import kolt.resolve.ResolveResult
+import kolt.resolve.ResolvedDep
+import kolt.resolve.ResolverDeps
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+class BtaImplFetcherTest {
+
+    private val cacheBase = "/fake/home/.kolt/cache"
+    private val unusedDeps = object : ResolverDeps {
+        override fun fileExists(path: String): Boolean = error("must not be called")
+        override fun ensureDirectoryRecursive(path: String) = error("must not be called")
+        override fun downloadFile(url: String, destPath: String) = error("must not be called")
+        override fun computeSha256(filePath: String) = error("must not be called")
+        override fun readFileContent(path: String) = error("must not be called")
+    }
+
+    @Test
+    fun returnsResolvedJarPathsOnSuccess() {
+        val resolved = listOf(
+            ResolvedDep("org.jetbrains.kotlin:kotlin-build-tools-impl", "2.3.10", "h1", "$cacheBase/a.jar"),
+            ResolvedDep("org.jetbrains.kotlin:kotlin-build-tools-api", "2.3.10", "h2", "$cacheBase/b.jar", transitive = true),
+        )
+        val result = ensureBtaImplJars(
+            version = "2.3.10",
+            cacheBase = cacheBase,
+            deps = unusedDeps,
+            resolver = { _, _, _, _ -> Ok(ResolveResult(resolved, lockChanged = true)) },
+        )
+        assertEquals(listOf("$cacheBase/a.jar", "$cacheBase/b.jar"), assertNotNull(result.get()))
+    }
+
+    @Test
+    fun synthesizedConfigHasKotlinBuildToolsImplDep() {
+        var captured: KoltConfig? = null
+        ensureBtaImplJars(
+            version = "2.3.10",
+            cacheBase = cacheBase,
+            deps = unusedDeps,
+            resolver = { config, _, _, _ ->
+                captured = config
+                Ok(ResolveResult(emptyList(), lockChanged = false))
+            },
+        )
+        val config = assertNotNull(captured)
+        assertEquals(
+            mapOf("org.jetbrains.kotlin:kotlin-build-tools-impl" to "2.3.10"),
+            config.dependencies,
+        )
+        assertEquals("jvm", config.target)
+        assertEquals(MAVEN_CENTRAL_BASE, config.repositories["central"])
+    }
+
+    @Test
+    fun synthesizedConfigPassesRequestedVersionAsKotlinField() {
+        var captured: KoltConfig? = null
+        ensureBtaImplJars(
+            version = "2.3.0",
+            cacheBase = cacheBase,
+            deps = unusedDeps,
+            resolver = { config, _, _, _ ->
+                captured = config
+                Ok(ResolveResult(emptyList(), lockChanged = false))
+            },
+        )
+        assertEquals("2.3.0", assertNotNull(captured).kotlin)
+    }
+
+    @Test
+    fun resolverErrorMapsToFetchError() {
+        val cause = ResolveError.DownloadFailed(
+            "org.jetbrains.kotlin:kotlin-build-tools-impl",
+            DownloadError.HttpFailed("http://example/", 503),
+        )
+        val result = ensureBtaImplJars(
+            version = "2.3.10",
+            cacheBase = cacheBase,
+            deps = unusedDeps,
+            resolver = { _, _, _, _ -> Err(cause) },
+        )
+        val err = assertIs<BtaImplFetchError.ResolveFailed>(result.getError())
+        assertEquals("2.3.10", err.version)
+        assertEquals(cause, err.cause)
+    }
+
+    @Test
+    fun emptyResolverResultMapsToResolvedEmpty() {
+        val result = ensureBtaImplJars(
+            version = "2.3.10",
+            cacheBase = cacheBase,
+            deps = unusedDeps,
+            resolver = { _, _, _, _ -> Ok(ResolveResult(emptyList(), lockChanged = false)) },
+        )
+        val err = assertIs<BtaImplFetchError.ResolvedEmpty>(result.getError())
+        assertEquals("2.3.10", err.version)
+    }
+
+    @Test
+    fun resolverInvokedWithoutExistingLockfile() {
+        var capturedLock: Lockfile? = Lockfile(0, "x", "x", emptyMap())
+        ensureBtaImplJars(
+            version = "2.3.10",
+            cacheBase = cacheBase,
+            deps = unusedDeps,
+            resolver = { _, lock, _, _ ->
+                capturedLock = lock
+                Ok(ResolveResult(emptyList(), lockChanged = false))
+            },
+        )
+        assertEquals(null, capturedLock)
+    }
+
+    @Test
+    fun resolverInvokedWithProvidedCacheBaseAndDeps() {
+        var capturedCache: String? = null
+        var capturedDeps: ResolverDeps? = null
+        val realDeps = stubDeps()
+        ensureBtaImplJars(
+            version = "2.3.10",
+            cacheBase = cacheBase,
+            deps = realDeps,
+            resolver = { _, _, c, d ->
+                capturedCache = c
+                capturedDeps = d
+                Ok(ResolveResult(emptyList(), lockChanged = false))
+            },
+        )
+        assertEquals(cacheBase, capturedCache)
+        assertEquals(realDeps, capturedDeps)
+    }
+
+    private fun stubDeps() = object : ResolverDeps {
+        override fun fileExists(path: String): Boolean = false
+        override fun ensureDirectoryRecursive(path: String) = Ok(Unit)
+        override fun downloadFile(url: String, destPath: String) =
+            Err(DownloadError.NetworkError(url, "stub"))
+        override fun computeSha256(filePath: String) =
+            Err(Sha256Error(filePath))
+        override fun readFileContent(path: String) =
+            Err(OpenFailed(path))
+    }
+}

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
@@ -5,6 +5,8 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import kolt.config.KoltPaths
+import kolt.infra.DownloadError
+import kolt.resolve.ResolveError
 import kolt.tool.ToolchainError
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -16,24 +18,28 @@ import kotlin.test.assertTrue
 class DaemonPreconditionsTest {
 
     private val paths = KoltPaths(home = "/fake/home")
-    private val kotlincVersion = "2.1.0"
+    private val bundledVersion = "2.3.20"
     private val absProject = "/fake/project"
     private val okJar = DaemonJarResolution.Resolved("/fake/libexec/daemon.jar", DaemonJarResolution.Source.Libexec)
-    private val fakeJars = listOf("/fake/home/.kolt/toolchains/kotlinc/2.1.0/lib/a.jar")
+    private val fakeJars = listOf("/fake/home/.kolt/toolchains/kotlinc/$bundledVersion/lib/a.jar")
     private val fakeBtaJars = listOf("/fake/libexec/kolt-bta-impl/kotlin-build-tools-impl.jar")
     private val okBtaImpl = BtaImplJarsResolution.Resolved(fakeBtaJars, BtaImplJarsResolution.Source.Libexec)
+    private val mustNotFetch: (String, String) -> Nothing = { _, _ ->
+        error("must not call fetcher when bundled libexec is in use")
+    }
 
     @Test
     fun resolveReturnsCompleteSetupWhenAllInputsPresent() {
         val result = resolveDaemonPreconditions(
             paths = paths,
-            kotlincVersion = kotlincVersion,
+            kotlincVersion = bundledVersion,
             absProjectPath = absProject,
-            bundledKotlinVersion = kotlincVersion,
+            bundledKotlinVersion = bundledVersion,
             ensureJavaBin = { Ok("/fake/home/.kolt/toolchains/jdk/21/bin/java") },
             resolveDaemonJar = { okJar },
             listCompilerJars = { fakeJars },
-            resolveBtaImplJars = { okBtaImpl },
+            resolveBundledBtaImplJars = { okBtaImpl },
+            fetchBtaImplJars = mustNotFetch,
         )
 
         val setup = assertNotNull(result.get())
@@ -42,30 +48,158 @@ class DaemonPreconditionsTest {
         assertEquals(fakeJars, setup.compilerJars)
         assertEquals(fakeBtaJars, setup.btaImplJars)
         val expectedHash = projectHashOf(absProject)
-        assertEquals("/fake/home/.kolt/daemon/$expectedHash", setup.daemonDir)
-        assertEquals("/fake/home/.kolt/daemon/$expectedHash/daemon.sock", setup.socketPath)
-        assertEquals("/fake/home/.kolt/daemon/$expectedHash/daemon.log", setup.logPath)
+        assertEquals("/fake/home/.kolt/daemon/$expectedHash/$bundledVersion", setup.daemonDir)
+        assertEquals("/fake/home/.kolt/daemon/$expectedHash/$bundledVersion/daemon.sock", setup.socketPath)
+        assertEquals("/fake/home/.kolt/daemon/$expectedHash/$bundledVersion/daemon.log", setup.logPath)
     }
 
-    // Stop-gap for #136: until per-version daemon spawn lands (#138), a
-    // `kotlincVersion` that differs from the bundled daemon version must
-    // short-circuit before any on-disk probing.
     @Test
-    fun kotlinVersionMismatchShortCircuitsBeforeAnyProbing() {
+    fun versionBelowFloorShortCircuitsBeforeAnyProbing() {
         val result = resolveDaemonPreconditions(
             paths = paths,
-            kotlincVersion = "2.1.0",
+            kotlincVersion = "2.2.20",
             absProjectPath = absProject,
-            bundledKotlinVersion = "2.3.20",
-            ensureJavaBin = { error("must not probe JDK on version mismatch") },
-            resolveDaemonJar = { error("must not probe daemon jar on version mismatch") },
-            listCompilerJars = { error("must not list compiler jars on version mismatch") },
-            resolveBtaImplJars = { error("must not probe BTA-impl jars on version mismatch") },
+            bundledKotlinVersion = bundledVersion,
+            ensureJavaBin = { error("must not probe JDK below floor") },
+            resolveDaemonJar = { error("must not probe daemon jar below floor") },
+            listCompilerJars = { error("must not list compiler jars below floor") },
+            resolveBundledBtaImplJars = { error("must not probe BTA-impl jars below floor") },
+            fetchBtaImplJars = mustNotFetch,
         )
 
-        val err = assertIs<DaemonPreconditionError.KotlinVersionMismatch>(result.getError())
-        assertEquals("2.1.0", err.requested)
-        assertEquals("2.3.20", err.bundled)
+        val err = assertIs<DaemonPreconditionError.KotlinVersionBelowFloor>(result.getError())
+        assertEquals("2.2.20", err.requested)
+        assertEquals(KOTLIN_VERSION_FLOOR, err.floor)
+    }
+
+    @Test
+    fun pluginsRequestedBelow2_3_20ShortCircuitsBeforeAnyProbing() {
+        val result = resolveDaemonPreconditions(
+            paths = paths,
+            kotlincVersion = "2.3.10",
+            absProjectPath = absProject,
+            bundledKotlinVersion = bundledVersion,
+            pluginsRequested = true,
+            ensureJavaBin = { error("must not probe JDK when plugins gate fails") },
+            resolveDaemonJar = { error("must not probe daemon jar when plugins gate fails") },
+            listCompilerJars = { error("must not list compiler jars when plugins gate fails") },
+            resolveBundledBtaImplJars = { error("must not probe BTA-impl jars when plugins gate fails") },
+            fetchBtaImplJars = mustNotFetch,
+        )
+
+        val err = assertIs<DaemonPreconditionError.PluginsRequireMinKotlinVersion>(result.getError())
+        assertEquals("2.3.10", err.requested)
+        assertEquals(KOTLIN_VERSION_FOR_PLUGINS, err.minVersion)
+    }
+
+    @Test
+    fun pluginsRequestedAtMinVersionIsAccepted() {
+        val result = resolveDaemonPreconditions(
+            paths = paths,
+            kotlincVersion = KOTLIN_VERSION_FOR_PLUGINS,
+            absProjectPath = absProject,
+            bundledKotlinVersion = KOTLIN_VERSION_FOR_PLUGINS,
+            pluginsRequested = true,
+            ensureJavaBin = { Ok("/fake/java") },
+            resolveDaemonJar = { okJar },
+            listCompilerJars = { fakeJars },
+            resolveBundledBtaImplJars = { okBtaImpl },
+            fetchBtaImplJars = mustNotFetch,
+        )
+        assertNotNull(result.get())
+    }
+
+    @Test
+    fun pluginsNotRequestedBelow2_3_20IsAcceptedThroughFetcher() {
+        var fetchedVersion: String? = null
+        val result = resolveDaemonPreconditions(
+            paths = paths,
+            kotlincVersion = "2.3.10",
+            absProjectPath = absProject,
+            bundledKotlinVersion = bundledVersion,
+            pluginsRequested = false,
+            ensureJavaBin = { Ok("/fake/java") },
+            resolveDaemonJar = { okJar },
+            listCompilerJars = { fakeJars },
+            resolveBundledBtaImplJars = { error("must not use libexec for non-bundled version") },
+            fetchBtaImplJars = { v, _ ->
+                fetchedVersion = v
+                Ok(listOf("/cache/impl-$v.jar"))
+            },
+        )
+        assertNotNull(result.get())
+        assertEquals("2.3.10", fetchedVersion)
+    }
+
+    @Test
+    fun versionAtFloorIsAccepted() {
+        var fetchedVersion: String? = null
+        val result = resolveDaemonPreconditions(
+            paths = paths,
+            kotlincVersion = KOTLIN_VERSION_FLOOR,
+            absProjectPath = absProject,
+            bundledKotlinVersion = bundledVersion,
+            ensureJavaBin = { Ok("/fake/java") },
+            resolveDaemonJar = { okJar },
+            listCompilerJars = { fakeJars },
+            resolveBundledBtaImplJars = { error("must not use libexec for non-bundled version") },
+            fetchBtaImplJars = { v, _ ->
+                fetchedVersion = v
+                Ok(listOf("/cache/impl-$v.jar"))
+            },
+        )
+
+        assertNotNull(result.get())
+        assertEquals(KOTLIN_VERSION_FLOOR, fetchedVersion)
+    }
+
+    @Test
+    fun nonBundledVersionGoesThroughFetcher() {
+        val fetched = listOf("/cache/impl-2.3.10.jar", "/cache/api-2.3.10.jar")
+        val result = resolveDaemonPreconditions(
+            paths = paths,
+            kotlincVersion = "2.3.10",
+            absProjectPath = absProject,
+            bundledKotlinVersion = bundledVersion,
+            ensureJavaBin = { Ok("/fake/java") },
+            resolveDaemonJar = { okJar },
+            listCompilerJars = { fakeJars },
+            resolveBundledBtaImplJars = { error("must not call libexec resolver when version != bundled") },
+            fetchBtaImplJars = { v, base ->
+                assertEquals("2.3.10", v)
+                assertEquals(paths.cacheBase, base)
+                Ok(fetched)
+            },
+        )
+
+        val setup = assertNotNull(result.get())
+        assertEquals(fetched, setup.btaImplJars)
+    }
+
+    @Test
+    fun fetcherFailureMapsToBtaImplFetchFailed() {
+        val cause = BtaImplFetchError.ResolveFailed(
+            "2.3.10",
+            ResolveError.DownloadFailed(
+                "org.jetbrains.kotlin:kotlin-build-tools-impl",
+                DownloadError.HttpFailed("http://example", 503),
+            ),
+        )
+        val result = resolveDaemonPreconditions(
+            paths = paths,
+            kotlincVersion = "2.3.10",
+            absProjectPath = absProject,
+            bundledKotlinVersion = bundledVersion,
+            ensureJavaBin = { Ok("/fake/java") },
+            resolveDaemonJar = { okJar },
+            listCompilerJars = { fakeJars },
+            resolveBundledBtaImplJars = { error("must not call libexec resolver when version != bundled") },
+            fetchBtaImplJars = { _, _ -> Err(cause) },
+        )
+
+        val err = assertIs<DaemonPreconditionError.BtaImplFetchFailed>(result.getError())
+        assertEquals("2.3.10", err.version)
+        assertEquals(cause, err.cause)
     }
 
     @Test
@@ -73,15 +207,16 @@ class DaemonPreconditionsTest {
         val installDir = "/fake/home/.kolt/toolchains/jdk/$BOOTSTRAP_JDK_VERSION"
         val result = resolveDaemonPreconditions(
             paths = paths,
-            kotlincVersion = kotlincVersion,
+            kotlincVersion = bundledVersion,
             absProjectPath = absProject,
-            bundledKotlinVersion = kotlincVersion,
+            bundledKotlinVersion = bundledVersion,
             ensureJavaBin = {
                 Err(BootstrapJdkError(installDir, ToolchainError("network error downloading jdk 21: connection refused")))
             },
             resolveDaemonJar = { error("must not run after BootstrapJdkInstallFailed") },
             listCompilerJars = { error("must not run after BootstrapJdkInstallFailed") },
-            resolveBtaImplJars = { error("must not run after BootstrapJdkInstallFailed") },
+            resolveBundledBtaImplJars = { error("must not run after BootstrapJdkInstallFailed") },
+            fetchBtaImplJars = mustNotFetch,
         )
 
         assertNull(result.get())
@@ -94,13 +229,14 @@ class DaemonPreconditionsTest {
     fun daemonJarMissingShortCircuits() {
         val result = resolveDaemonPreconditions(
             paths = paths,
-            kotlincVersion = kotlincVersion,
+            kotlincVersion = bundledVersion,
             absProjectPath = absProject,
-            bundledKotlinVersion = kotlincVersion,
+            bundledKotlinVersion = bundledVersion,
             ensureJavaBin = { Ok("/fake/java") },
             resolveDaemonJar = { DaemonJarResolution.NotFound },
             listCompilerJars = { error("must not run after DaemonJarMissing") },
-            resolveBtaImplJars = { error("must not run after DaemonJarMissing") },
+            resolveBundledBtaImplJars = { error("must not run after DaemonJarMissing") },
+            fetchBtaImplJars = mustNotFetch,
         )
 
         assertEquals(DaemonPreconditionError.DaemonJarMissing, result.getError())
@@ -110,46 +246,49 @@ class DaemonPreconditionsTest {
     fun compilerJarsMissingWhenDirAbsent() {
         val result = resolveDaemonPreconditions(
             paths = paths,
-            kotlincVersion = kotlincVersion,
+            kotlincVersion = bundledVersion,
             absProjectPath = absProject,
-            bundledKotlinVersion = kotlincVersion,
+            bundledKotlinVersion = bundledVersion,
             ensureJavaBin = { Ok("/fake/java") },
             resolveDaemonJar = { okJar },
             listCompilerJars = { null },
-            resolveBtaImplJars = { error("must not run after CompilerJarsMissing") },
+            resolveBundledBtaImplJars = { error("must not run after CompilerJarsMissing") },
+            fetchBtaImplJars = mustNotFetch,
         )
 
         val err = assertIs<DaemonPreconditionError.CompilerJarsMissing>(result.getError())
-        assertEquals("/fake/home/.kolt/toolchains/kotlinc/2.1.0/lib", err.kotlincLibDir)
+        assertEquals("/fake/home/.kolt/toolchains/kotlinc/$bundledVersion/lib", err.kotlincLibDir)
     }
 
     @Test
     fun compilerJarsMissingWhenDirEmpty() {
         val result = resolveDaemonPreconditions(
             paths = paths,
-            kotlincVersion = kotlincVersion,
+            kotlincVersion = bundledVersion,
             absProjectPath = absProject,
-            bundledKotlinVersion = kotlincVersion,
+            bundledKotlinVersion = bundledVersion,
             ensureJavaBin = { Ok("/fake/java") },
             resolveDaemonJar = { okJar },
             listCompilerJars = { emptyList() },
-            resolveBtaImplJars = { error("must not run after CompilerJarsMissing") },
+            resolveBundledBtaImplJars = { error("must not run after CompilerJarsMissing") },
+            fetchBtaImplJars = mustNotFetch,
         )
 
         assertIs<DaemonPreconditionError.CompilerJarsMissing>(result.getError())
     }
 
     @Test
-    fun btaImplJarsMissingShortCircuitsAfterCompilerJarsPass() {
+    fun bundledBtaImplJarsMissingShortCircuitsAfterCompilerJarsPass() {
         val result = resolveDaemonPreconditions(
             paths = paths,
-            kotlincVersion = kotlincVersion,
+            kotlincVersion = bundledVersion,
             absProjectPath = absProject,
-            bundledKotlinVersion = kotlincVersion,
+            bundledKotlinVersion = bundledVersion,
             ensureJavaBin = { Ok("/fake/java") },
             resolveDaemonJar = { okJar },
             listCompilerJars = { fakeJars },
-            resolveBtaImplJars = { BtaImplJarsResolution.NotFound("/fake/libexec/kolt-bta-impl") },
+            resolveBundledBtaImplJars = { BtaImplJarsResolution.NotFound("/fake/libexec/kolt-bta-impl") },
+            fetchBtaImplJars = mustNotFetch,
         )
 
         val err = assertIs<DaemonPreconditionError.BtaImplJarsMissing>(result.getError())
@@ -178,16 +317,58 @@ class DaemonPreconditionsTest {
                 DaemonPreconditionError.BtaImplJarsMissing("/x/libexec/kolt-bta-impl"),
             ),
         )
-        val mismatchWarning = formatDaemonPreconditionWarning(
-            DaemonPreconditionError.KotlinVersionMismatch(requested = "2.1.0", bundled = "2.3.20"),
+        val belowFloor = formatDaemonPreconditionWarning(
+            DaemonPreconditionError.KotlinVersionBelowFloor(requested = "2.2.20", floor = "2.3.0"),
         )
         assertTrue(
-            mismatchWarning.contains("2.1.0") &&
-                mismatchWarning.contains("2.3.20") &&
-                mismatchWarning.contains("falling back to subprocess compile") &&
-                mismatchWarning.contains("temporary") &&
-                mismatchWarning.contains("#138"),
-            "unexpected mismatch warning: $mismatchWarning",
+            belowFloor.contains("2.2.20") &&
+                belowFloor.contains("2.3.0") &&
+                belowFloor.contains("falling back to subprocess compile") &&
+                belowFloor.contains("--no-daemon"),
+            "unexpected below-floor warning: $belowFloor",
+        )
+        val fetchFailed = formatDaemonPreconditionWarning(
+            DaemonPreconditionError.BtaImplFetchFailed(
+                version = "2.3.10",
+                cause = BtaImplFetchError.ResolveFailed(
+                    "2.3.10",
+                    ResolveError.DownloadFailed(
+                        "org.jetbrains.kotlin:kotlin-build-tools-impl",
+                        DownloadError.HttpFailed("http://example", 503),
+                    ),
+                ),
+            ),
+        )
+        assertTrue(
+            fetchFailed.contains("2.3.10") &&
+                fetchFailed.contains("falling back to subprocess compile"),
+            "unexpected fetch-failed warning: $fetchFailed",
+        )
+        val resolvedEmpty = formatDaemonPreconditionWarning(
+            DaemonPreconditionError.BtaImplFetchFailed(
+                version = "2.3.10",
+                cause = BtaImplFetchError.ResolvedEmpty("2.3.10"),
+            ),
+        )
+        assertTrue(
+            resolvedEmpty.contains("2.3.10") &&
+                resolvedEmpty.contains("resolver returned no jars") &&
+                resolvedEmpty.contains("falling back to subprocess compile"),
+            "unexpected resolved-empty warning: $resolvedEmpty",
+        )
+        val pluginsGate = formatDaemonPreconditionWarning(
+            DaemonPreconditionError.PluginsRequireMinKotlinVersion(
+                requested = "2.3.10",
+                minVersion = "2.3.20",
+            ),
+        )
+        assertTrue(
+            pluginsGate.contains("2.3.10") &&
+                pluginsGate.contains("2.3.20") &&
+                pluginsGate.contains("compiler plugins") &&
+                pluginsGate.contains("falling back to subprocess compile") &&
+                pluginsGate.contains("--no-daemon"),
+            "unexpected plugins-gate warning: $pluginsGate",
         )
     }
 }

--- a/src/nativeTest/kotlin/kolt/cli/DaemonReaperTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DaemonReaperTest.kt
@@ -3,7 +3,7 @@
 package kolt.cli
 
 import com.github.michaelbull.result.getOrElse
-import kolt.infra.ensureDirectory
+import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.fileExists
 import kolt.infra.net.SUN_PATH_CAPACITY
 import kolt.infra.net.fillSockaddrUn
@@ -37,24 +37,28 @@ class DaemonReaperTest {
     fun directoryWithoutSocketIsReaped() {
         val base = createTempDir("reaper-nosock-")
         val projectDir = "$base/abc123"
-        ensureDirectory(projectDir).getOrElse { error("mkdir failed") }
-        writeFileAsString("$projectDir/daemon.log", "some log").getOrElse { error("write failed") }
+        val versionDir = "$projectDir/2.3.20"
+        ensureDirectoryRecursive(versionDir).getOrElse { error("mkdir failed") }
+        writeFileAsString("$versionDir/daemon.log", "some log").getOrElse { error("write failed") }
 
         val result = reapStaleDaemons(base)
         assertEquals(1, result.reaped)
-        assertFalse(fileExists(projectDir))
+        assertFalse(fileExists(versionDir))
+        assertFalse(fileExists(projectDir), "empty project dir should be removed")
     }
 
     @Test
     fun directoryWithOrphanedSocketIsReaped() {
         val base = createTempDir("reaper-orphan-")
         val projectDir = "$base/def456"
-        ensureDirectory(projectDir).getOrElse { error("mkdir failed") }
+        val versionDir = "$projectDir/2.3.20"
+        ensureDirectoryRecursive(versionDir).getOrElse { error("mkdir failed") }
         // A regular file named daemon.sock — connect will fail (not a real socket)
-        writeFileAsString("$projectDir/daemon.sock", "").getOrElse { error("write failed") }
+        writeFileAsString("$versionDir/daemon.sock", "").getOrElse { error("write failed") }
 
         val result = reapStaleDaemons(base)
         assertEquals(1, result.reaped)
+        assertFalse(fileExists(versionDir))
         assertFalse(fileExists(projectDir))
     }
 
@@ -63,15 +67,17 @@ class DaemonReaperTest {
     fun liveDaemonIsPreserved() {
         val base = createTempDir("reaper-alive-")
         val projectDir = "$base/live123"
-        ensureDirectory(projectDir).getOrElse { error("mkdir failed") }
+        val versionDir = "$projectDir/2.3.20"
+        ensureDirectoryRecursive(versionDir).getOrElse { error("mkdir failed") }
 
-        val socketPath = "$projectDir/daemon.sock"
+        val socketPath = "$versionDir/daemon.sock"
         val listenFd = bindAndListen(socketPath)
         try {
             val result = reapStaleDaemons(base)
             assertEquals(0, result.reaped)
             assertEquals(1, result.alive)
-            assertTrue(fileExists(projectDir), "live daemon dir must not be deleted")
+            assertTrue(fileExists(versionDir), "live daemon dir must not be deleted")
+            assertTrue(fileExists(projectDir))
         } finally {
             close(listenFd)
             unlink(socketPath)
@@ -83,20 +89,24 @@ class DaemonReaperTest {
     fun mixedAliveAndStale() {
         val base = createTempDir("reaper-mixed-")
 
-        val staleDir = "$base/stale111"
-        ensureDirectory(staleDir).getOrElse { error("mkdir failed") }
-        writeFileAsString("$staleDir/daemon.sock", "").getOrElse { error("write failed") }
+        val staleProjectDir = "$base/stale111"
+        val staleVersionDir = "$staleProjectDir/2.3.0"
+        ensureDirectoryRecursive(staleVersionDir).getOrElse { error("mkdir failed") }
+        writeFileAsString("$staleVersionDir/daemon.sock", "").getOrElse { error("write failed") }
 
-        val aliveDir = "$base/alive222"
-        ensureDirectory(aliveDir).getOrElse { error("mkdir failed") }
-        val socketPath = "$aliveDir/daemon.sock"
+        val aliveProjectDir = "$base/alive222"
+        val aliveVersionDir = "$aliveProjectDir/2.3.20"
+        ensureDirectoryRecursive(aliveVersionDir).getOrElse { error("mkdir failed") }
+        val socketPath = "$aliveVersionDir/daemon.sock"
         val listenFd = bindAndListen(socketPath)
         try {
             val result = reapStaleDaemons(base)
             assertEquals(1, result.reaped)
             assertEquals(1, result.alive)
-            assertFalse(fileExists(staleDir))
-            assertTrue(fileExists(aliveDir))
+            assertFalse(fileExists(staleVersionDir))
+            assertFalse(fileExists(staleProjectDir))
+            assertTrue(fileExists(aliveVersionDir))
+            assertTrue(fileExists(aliveProjectDir))
         } finally {
             close(listenFd)
             unlink(socketPath)
@@ -119,6 +129,52 @@ class DaemonReaperTest {
         val result = reapStaleDaemons("/tmp/kolt-reaper-nonexistent-${kotlin.random.Random.nextLong()}")
         assertEquals(0, result.reaped)
         assertEquals(0, result.alive)
+    }
+
+    @Test
+    fun legacyLayoutOrphanedSocketIsReapedAndCounted() {
+        val base = createTempDir("reaper-legacy-stale-")
+        val projectDir = "$base/legacy111"
+        ensureDirectoryRecursive(projectDir).getOrElse { error("mkdir failed") }
+        // Pre-#138 layout: socket sat directly under <projectHash>/.
+        writeFileAsString("$projectDir/daemon.sock", "").getOrElse { error("write failed") }
+        writeFileAsString("$projectDir/daemon.log", "old log").getOrElse { error("write failed") }
+
+        val result = reapStaleDaemons(base)
+        assertEquals(1, result.reaped)
+        assertEquals(0, result.alive)
+        assertFalse(fileExists(projectDir))
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun legacyLayoutLiveDaemonIsPreserved() {
+        val base = createTempDir("reaper-legacy-alive-")
+        val projectDir = "$base/legacy222"
+        ensureDirectoryRecursive(projectDir).getOrElse { error("mkdir failed") }
+        val socketPath = "$projectDir/daemon.sock"
+        val listenFd = bindAndListen(socketPath)
+        try {
+            val result = reapStaleDaemons(base)
+            assertEquals(0, result.reaped)
+            assertEquals(1, result.alive)
+            assertTrue(fileExists(projectDir), "live legacy daemon dir must not be deleted")
+        } finally {
+            close(listenFd)
+            unlink(socketPath)
+        }
+    }
+
+    @Test
+    fun icSiblingIsNotReaped() {
+        val base = createTempDir("reaper-ic-")
+        val icDir = "$base/ic/2.3.20/somehash"
+        ensureDirectoryRecursive(icDir).getOrElse { error("mkdir failed") }
+        writeFileAsString("$icDir/state.bin", "ic state").getOrElse { error("write failed") }
+
+        val result = reapStaleDaemons(base)
+        assertEquals(0, result.reaped)
+        assertTrue(fileExists(icDir), "ic state must not be touched by daemon reaper")
     }
 
     private fun createTempDir(prefix: String): String {

--- a/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
@@ -10,6 +10,7 @@ import kolt.build.CompilerBackend
 import kolt.build.FallbackCompilerBackend
 import kolt.build.daemon.DaemonPreconditionError
 import kolt.build.daemon.DaemonSetup
+import kolt.build.daemon.KOTLIN_VERSION_FLOOR
 import kolt.config.KoltConfig
 import kolt.config.KoltPaths
 import kolt.infra.MkdirFailed
@@ -47,7 +48,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = false,
             absProjectPath = absProject,
-            preconditionResolver = { _, _, _, _ -> error("must not resolve preconditions when useDaemon=false") },
+            preconditionResolver = { _, _, _, _, _ -> error("must not resolve preconditions when useDaemon=false") },
             daemonDirCreator = { error("must not create daemon dir when useDaemon=false") },
             daemonBackendFactory = { _, _ -> error("must not construct daemon backend when useDaemon=false") },
             warningSink = { warnings.add(it) },
@@ -57,13 +58,13 @@ class ResolveCompilerBackendTest {
         assertEquals(emptyList(), warnings)
     }
 
-    // #136 stop-gap: bundled-vs-requested Kotlin version mismatch enters the
-    // same "precondition error" warning rail as every other daemon-probe
+    // ADR 0022 floor (#138): a Kotlin version below 2.3.0 enters the same
+    // "precondition error" warning rail as every other daemon-probe
     // failure (ADR 0016 §5). DaemonPreconditionsTest covers that the real
-    // resolver surfaces this error without any probing; this test pins that
-    // resolveCompilerBackend routes the variant into the warning sink.
+    // resolver surfaces this error without any probing; this test pins
+    // that resolveCompilerBackend routes the variant into the warning sink.
     @Test
-    fun kotlinVersionMismatchFromResolverFallsBackWithVersionsAndFollowUpInWarning() {
+    fun kotlinVersionBelowFloorFallsBackWithVersionsInWarning() {
         val warnings = mutableListOf<String>()
         val backend = resolveCompilerBackend(
             config = minimalConfig(kotlincVersion = "2.1.0"),
@@ -72,11 +73,11 @@ class ResolveCompilerBackendTest {
             useDaemon = true,
             absProjectPath = absProject,
             bundledKotlinVersion = "2.3.20",
-            preconditionResolver = { _, requested, _, bundled ->
+            preconditionResolver = { _, requested, _, _, _ ->
                 Err(
-                    DaemonPreconditionError.KotlinVersionMismatch(
+                    DaemonPreconditionError.KotlinVersionBelowFloor(
                         requested = requested,
-                        bundled = bundled,
+                        floor = KOTLIN_VERSION_FLOOR,
                     ),
                 )
             },
@@ -88,12 +89,12 @@ class ResolveCompilerBackendTest {
         assertSame(subprocess, backend)
         val warning = warnings.single()
         assertTrue(warning.contains("2.1.0"), "warning should cite the requested version: $warning")
-        assertTrue(warning.contains("2.3.20"), "warning should cite the bundled daemon version: $warning")
+        assertTrue(warning.contains(KOTLIN_VERSION_FLOOR), "warning should cite the floor: $warning")
         assertTrue(
             warning.contains("falling back to subprocess compile"),
             "warning should say the build is falling back: $warning",
         )
-        assertTrue(warning.contains("temporary"), "warning should flag the restriction as temporary: $warning")
+        assertTrue(warning.contains("--no-daemon"), "warning should point at --no-daemon: $warning")
     }
 
     @Test
@@ -106,7 +107,7 @@ class ResolveCompilerBackendTest {
             useDaemon = true,
             absProjectPath = absProject,
             bundledKotlinVersion = "2.3.20",
-            preconditionResolver = { _, _, _, bundled ->
+            preconditionResolver = { _, _, _, bundled, _ ->
                 seenBundled = bundled
                 Ok(okSetup)
             },
@@ -128,7 +129,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = true,
             absProjectPath = absProject,
-            preconditionResolver = { _, _, _, _ ->
+            preconditionResolver = { _, _, _, _, _ ->
                 Err(DaemonPreconditionError.DaemonJarMissing)
             },
             daemonDirCreator = { error("must not create daemon dir after precondition failure") },
@@ -154,7 +155,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = true,
             absProjectPath = absProject,
-            preconditionResolver = { _, _, _, _ ->
+            preconditionResolver = { _, _, _, _, _ ->
                 Err(
                     DaemonPreconditionError.BootstrapJdkInstallFailed(
                         jdkInstallDir = "/fake/home/.kolt/toolchains/jdk/21",
@@ -193,7 +194,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = true,
             absProjectPath = absProject,
-            preconditionResolver = { _, _, _, _ -> Ok(okSetup) },
+            preconditionResolver = { _, _, _, _, _ -> Ok(okSetup) },
             daemonDirCreator = { Err(MkdirFailed(okSetup.daemonDir)) },
             daemonBackendFactory = { _, _ -> error("must not construct daemon backend after mkdir failure") },
             warningSink = { warnings.add(it) },
@@ -217,7 +218,7 @@ class ResolveCompilerBackendTest {
             useDaemon = true,
             absProjectPath = absProject,
             pluginJars = pluginJars,
-            preconditionResolver = { _, _, _, _ -> Ok(okSetup) },
+            preconditionResolver = { _, _, _, _, _ -> Ok(okSetup) },
             daemonDirCreator = { Ok(Unit) },
             daemonBackendFactory = { _, jars ->
                 capturedPluginJars = jars
@@ -241,7 +242,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = true,
             absProjectPath = absProject,
-            preconditionResolver = { _, kotlincVersion, cwd, _ ->
+            preconditionResolver = { _, kotlincVersion, cwd, _, _ ->
                 assertEquals("2.1.0", kotlincVersion)
                 assertEquals(absProject, cwd)
                 Ok(okSetup)

--- a/src/nativeTest/kotlin/kolt/config/KoltPathsTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/KoltPathsTest.kt
@@ -155,4 +155,39 @@ class KoltPathsTest {
         val konancDir = paths.konancPath(version)
         assertEquals("$konancDir/bin/cinterop", paths.cinteropBin(version))
     }
+
+    @Test
+    fun daemonDirSegmentedByProjectHashAndKotlinVersion() {
+        val paths = KoltPaths("/home/user")
+        assertEquals(
+            "/home/user/.kolt/daemon/abc123/2.3.20",
+            paths.daemonDir("abc123", "2.3.20"),
+        )
+    }
+
+    @Test
+    fun daemonSocketPathSegmentedByKotlinVersion() {
+        val paths = KoltPaths("/home/user")
+        assertEquals(
+            "/home/user/.kolt/daemon/abc123/2.3.10/daemon.sock",
+            paths.daemonSocketPath("abc123", "2.3.10"),
+        )
+    }
+
+    @Test
+    fun daemonLogPathSegmentedByKotlinVersion() {
+        val paths = KoltPaths("/home/user")
+        assertEquals(
+            "/home/user/.kolt/daemon/abc123/2.3.0/daemon.log",
+            paths.daemonLogPath("abc123", "2.3.0"),
+        )
+    }
+
+    @Test
+    fun differentKotlinVersionsProduceDifferentSocketPaths() {
+        val paths = KoltPaths("/home/user")
+        val a = paths.daemonSocketPath("hash", "2.3.0")
+        val b = paths.daemonSocketPath("hash", "2.3.20")
+        kotlin.test.assertNotEquals(a, b)
+    }
 }


### PR DESCRIPTION
Closes #138.

`config.kotlin` in the 2.3.x range now runs through the daemon (per ADR 0022). Below the floor (2.3.0) and plugin-using projects below 2.3.20 fall back to subprocess on the standard warning rail.

## Where to look

**`BtaImplFetcher` (NEW, src/nativeMain/kotlin/kolt/build/daemon/)** — synthesises a one-dependency `KoltConfig` and delegates to `resolveTransitive`. The synthetic-config path was preferred over a resolver refactor; the comment names the resolver fields actually consumed (today: `dependencies`, `repositories`, `kotlin`, `jvmTarget`). Future `KoltConfig` additions could silently widen what the resolver inspects — worth a glance.

**`DaemonPreconditions` flow** — gate ordering is floor → plugins-vs-min-version → JDK → daemon jar → compiler jars → BTA-impl (libexec for bundled, fetcher otherwise). The plugins-vs-min-version gate is new (M2 below).

**`BtaIncrementalCompiler.kt:159` `COMPILER_PLUGINS` conditional** — smoke against `kolt = "2.3.10"` revealed BTA 2.3.0–2.3.10 reject the `COMPILER_PLUGINS` argument key even with an empty list. The spike harness (#140) did not exercise this; the family-binary-compat claim in ADR 0022 §3 turns out to be partial. The conditional only addresses the empty-list case; plugin-using projects on < 2.3.20 are routed to subprocess by the new precondition gate.

**Plugins gate (M2)** — `pluginsRequested: Boolean` on `resolveDaemonPreconditions` plus `PluginsRequireMinKotlinVersion` error variant. Signal comes from `pluginJars.isNotEmpty()` in `resolveCompilerBackend`. Trade-off discussed in chat: the contract becomes "2.3.0 if no plugins, 2.3.20 if plugins" — fragmented, but more honest than a blanket floor bump.

**Reaper / `daemon stop`** — both learned the new 2-level layout and a legacy-flat-layout probe so a still-running pre-upgrade daemon can be detected and stopped/preserved correctly.

**Smoke results** — plugin-free `kolt = "2.3.10"` builds cold in 6.5s (incl. fetch) / warm 0.0s; `[plugins] serialization = true` on the same project produces the dedicated subprocess-fallback warning and builds in 4.1s.

## Deferred to follow-ups

- Audit production adapter for other 2.3.20-only API uses; spike `freeArgs`-based plugin passthrough so plugin-using projects on 2.3.0/2.3.10 can also run via the daemon.
- `sun_path` length budget shrank by 7 chars; a long `$HOME` could cross 108 — pre-existing concern, but #138 makes it likelier.
- Reaper concurrent race: `daemon reap` + first-build-after-upgrade could nuke a freshly-spawned new-layout subdir alongside a stale legacy socket.
- `ResolvedEmpty` defensive guard is effectively dead code today (synthetic config always carries one dep).