### PR TITLE
Audit BTA-API call sites and spike plugin passthrough for 2.3.0 / 2.3.10 (#143)

### DIFF
--- a/spike/bta-compat-138/README.md
+++ b/spike/bta-compat-138/README.md
@@ -2,31 +2,49 @@
 
 **Throwaway. Not production code.**
 
-Prerequisite spike for issue #138 (per-kotlinVersion daemon spawn). Answers:
+Two spikes sharing the same matrix + classloader topology:
 
-> Is `kotlin-build-tools-api` binary-stable enough that an adapter compiled
-> against API 2.3.20 can load API+impl pairs at 2.1.0 / 2.2.x at runtime
-> through the daemon's `SharedApiClassesClassLoader` + `URLClassLoader`
-> topology?
+1. **`bta-compat`** (issue #138) — is `kotlin-build-tools-api` binary-stable
+   enough that an adapter compiled against API 2.3.20 can load API+impl pairs
+   at 2.1.0 / 2.2.x at runtime through the daemon's
+   `SharedApiClassesClassLoader` + `URLClassLoader` topology?
+2. **`plugin-smoke`** (issue #143) — can the CLI-style `-Xplugin=<path>`
+   passthrough (via `applyArgumentStrings`) deliver compiler plugins to
+   pre-2.3.20 impls without using the 2.3.20-only structured `COMPILER_PLUGINS`
+   key?
 
-See `REPORT.md` for the verdict.
+See `REPORT.md` for both verdicts.
 
 ## Usage
 
 ```
-./gradlew -p spike/bta-compat-138 run --args="fixtures/linear-10 /tmp/bta-compat-work"
+# #138 BTA compat matrix
+./gradlew -p spike/bta-compat-138 run --args="bta-compat fixtures/linear-10 /tmp/bta-compat-work"
+
+# #143 plugin passthrough
+./gradlew -p spike/bta-compat-138 run --args="plugin-smoke fixtures/plugin-serialization /tmp/bta-compat-plugin-work"
 ```
 
 The matrix (`2.1.0`, `2.2.20`, `2.3.0`, `2.3.10`, `2.3.20`) is hard-coded in
-`build.gradle.kts`. Each impl version ships with a matching `kotlin-stdlib` in
-its own resolvable configuration so the fixture classpath matches the impl.
+`build.gradle.kts`. Each impl version ships with a matching `kotlin-stdlib`,
+a `kotlinx-serialization-core` runtime, and a matching
+`kotlin-serialization-compiler-plugin-embeddable` jar in its own resolvable
+configuration so the plugin-smoke fixture matches the impl.
 
-For each impl version the harness:
+For each impl version the `bta-compat` harness:
 
 1. Builds `URLClassLoader(impl jars, parent = SharedApiClassesClassLoader())`
 2. Calls `KotlinToolchains.loadImplementation(loader)`
 3. Runs a cold compile on `fixtures/linear-10`, touches `F2.kt`, runs an incremental compile
 4. Classifies the outcome (`GREEN` / `RED_LINKAGE` / `RED_METHOD` / `RED_OTHER` / `COMPILE_ERROR`)
+
+The `plugin-smoke` harness additionally:
+
+1. Compiles `fixtures/plugin-serialization/Foo.kt` (a single `@Serializable`
+   data class) with `applyArgumentStrings(listOf("-Xplugin=<serialization-plugin>.jar"))`
+2. Inspects the output directory for `Foo$$serializer.class` — the class
+   kotlinc synthesises only when the serialization compiler plugin actually ran
+3. Classifies the outcome (`GREEN` / `RED_COMPILE` / `RED_NO_GEN` / `RED_METHOD` / `RED_LINKAGE` / `RED_OTHER`)
 
 Every phase is wrapped so a thrown `LinkageError` / `NoSuchMethodError` does
 not abort the matrix — we want to see *which* versions break and *how*.

--- a/spike/bta-compat-138/REPORT.md
+++ b/spike/bta-compat-138/REPORT.md
@@ -1,9 +1,9 @@
 # BTA-API binary-compat spike — verdict
 
-**Issue:** #138
+**Issue:** #138 (initial); #143 (follow-up audit + plugin-passthrough spike)
 **Adapter compile-time API:** `kotlin-build-tools-api:2.3.20`
 **Topology under test:** `URLClassLoader(impl jars, parent = SharedApiClassesClassLoader())` (matches `BtaIncrementalCompiler.create` in `kolt-compiler-daemon/ic`).
-**Date:** 2026-04-17
+**Dates:** 2026-04-17 (initial), 2026-04-18 (#143 audit + plugin spike)
 
 ## Verdict: RED across the 2.x line, GREEN within 2.3.x
 
@@ -100,12 +100,150 @@ binary-compat family for daemon-spawn purposes.
   the input to the forward-policy judgement call. Keep the spike
   checked in for that reason rather than deleting after #138 merges.
 
+---
+
+# #143 follow-up: BTA-API call-site audit and plugin-passthrough spike
+
+Context: PR #142's smoke invalidated ADR 0022 §3's "2.3.x is one
+binary-compat family" claim for the plugin path — `BtaIncrementalCompiler`
+sets the structured `COMPILER_PLUGINS` key which only exists in BTA-API
+2.3.20. Issue #143 asks two things:
+
+1. **Audit** every BTA-API call site in `kolt-compiler-daemon/ic/` against the
+   v2.3.0 API surface.
+2. **Spike** whether CLI-style `-Xplugin=<path>` passthrough can carry plugins
+   to pre-2.3.20 impls. GREEN → file an implementation issue. RED → make the
+   2.3.20 plugin gate a documented permanent contract.
+
+## Audit verdict: only the `COMPILER_PLUGINS` path is non-portable
+
+v2.3.0 and v2.3.10 `.api` dumps are **byte-identical** (625 lines each); 2.3.20
+adds 193 lines, chiefly the builder-style surface (`JvmCompilationOperation.Builder`,
+`JvmClasspathSnapshottingOperation.Builder`, `JvmSnapshotBasedIncrementalCompilationConfiguration.Builder`)
+and the structured-plugin surface (`COMPILER_PLUGINS`, `CompilerPlugin`,
+`CompilerPluginOption`, `CompilerPluginPartialOrder`).
+
+The builder-style surface is *not* a regression risk for pre-2.3.20 impls
+because 2.3.20 ships `Kotlin230AndBelowWrapper`
+(`compiler/build-tools/kotlin-build-tools-api/.../internal/wrappers/Kotlin230AndBelowWrapper.kt`)
+inside the API jar. `KotlinToolchains.loadImplementation` detects impls
+whose `getCompilerVersion() < "2.3.20"` and wraps them in this class, which
+synthesises `jvmCompilationOperationBuilder` (delegating to the old
+`createJvmCompilationOperation`) and `snapshotBasedIcConfigurationBuilder`
+(constructing an ad-hoc `JvmSnapshotBasedIncrementalCompilationConfigurationWrapper`).
+The wrapper also bridges arguments via `applyArgumentStrings` /
+`toArgumentStrings`.
+
+| Call site in `kolt-compiler-daemon/ic/` | v2.3.0 status | Notes |
+|---|---|---|
+| `KotlinToolchains.loadImplementation(loader)` | portable | wraps <2.3.20 impls with `Kotlin230AndBelowWrapper` |
+| `SharedApiClassesClassLoader()` | portable | unchanged |
+| `toolchain.jvm` (extension on `KotlinToolchains`) | portable | inline val → `getToolchain<JvmPlatformToolchain>()` |
+| `jvm.jvmCompilationOperationBuilder(sources, outputDir)` | portable via wrapper | wrapper delegates to 2.3.0 `createJvmCompilationOperation` |
+| `jvm.classpathSnapshottingOperationBuilder(entry)` | portable via wrapper | wrapper delegates to 2.3.0 `createClasspathSnapshottingOperation` |
+| `builder.snapshotBasedIcConfigurationBuilder(...)` | portable via wrapper | wrapper synthesises the Builder + Configuration pair |
+| `builder[JvmCompilationOperation.INCREMENTAL_COMPILATION] = icConfig` | portable | Option key present in 2.3.0 |
+| `builder[BuildOperation.METRICS_COLLECTOR] = ...` | portable | `BuildOperation.METRICS_COLLECTOR` field present in 2.3.0 |
+| `builder.compilerArguments[JvmCompilerArguments.CLASSPATH]` | portable | CLASSPATH key present in 2.3.0 |
+| `builder.compilerArguments[JvmCompilerArguments.MODULE_NAME]` | portable | MODULE_NAME key present in 2.3.0 |
+| `builder.compilerArguments[CommonCompilerArguments.COMPILER_PLUGINS]` | **2.3.20 only** | structured key added in 2.3.20; pre-2.3.20 impls raise `"available only since 2.3.20"` even on empty list assignment |
+| `CompilerPlugin(id, classpath, rawArgs, orderingRequirements)` | **2.3.20 only** | class added in 2.3.20 API; constructed inside `PluginTranslator.translate` before the empty-list guard in `BtaIncrementalCompiler`, so construction happens whenever a user enables any `[plugins]` entry |
+| `toolchain.createInProcessExecutionPolicy()` | portable | unchanged |
+| `toolchain.createBuildSession()` | portable | unchanged |
+| `session.executeOperation(op, policy, logger)` | portable | 3-arg signature present in 2.3.0 |
+| `session.executeOperation(op)` | portable | 1-arg convenience present in 2.3.0 |
+| `snapshot.saveSnapshot(Path)` | portable | default method on `ClasspathEntrySnapshot` in 2.3.0 |
+| `KotlinLogger` implementation (isDebugEnabled, error, warn, info, debug, lifecycle) | portable | identical method surface in 2.3.0 |
+| `BuildMetricsCollector.collectMetric(name, type, value)` + `ValueType` enum | portable | identical in 2.3.0 |
+| `SourcesChanges.ToBeCalculated` | portable | unchanged |
+
+Only two call sites are non-portable, and both are in the plugin path. The
+existing `DaemonPreconditionError.PluginsRequireMinKotlinVersion` gate in
+`src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt:100` is
+sufficient to prevent both from firing on 2.3.0 / 2.3.10. ADR 0022 §3's
+family-GREEN claim therefore holds for plugin-free projects across the full
+2.3.x line; the §3 wording that needs sharpening is not the floor, but the
+conditional on `[plugins]`.
+
+## Plugin-passthrough spike: GREEN
+
+Issue #143 phrases the spike as "can `JvmCompilerArguments.FREE_ARGS` carry
+plugins for impls < 2.3.20?" — but `FREE_ARGS` is not a member of the 2.3.0
+(or 2.3.20) `JvmCompilerArguments` surface. The actual CLI-passthrough
+mechanism in 2.3.0 is `CommonToolArguments.applyArgumentStrings(List<String>)`,
+which is the method 2.3.20's `Kotlin230AndBelowWrapper` itself uses to bridge
+structured args from the new builder surface to the pre-2.3.20 impl.
+
+The plugin-smoke harness (`plugin-smoke` subcommand in `Main.kt`) extends the
+existing matrix with a `@Serializable`-annotated fixture and a serialization
+compiler-plugin jar resolved per impl version. The test attaches the plugin
+with `applyArgumentStrings(listOf("-Xplugin=<jar>"))` and inspects the
+generated `.class` tree. The `Foo$$serializer.class` output is the signal:
+that class is only synthesised when the serialization compiler plugin
+actually runs.
+
+| impl version | verdict | compile result | has `$$serializer` | notes |
+|--------------|---------|----------------|--------------------|-------|
+| 2.1.0        | RED     | —              | —                  | `NoImplementationFoundException` (same as #138 spike — pre-floor territory) |
+| 2.2.20       | RED     | —              | —                  | same as 2.1.0 |
+| 2.3.0        | **GREEN** | COMPILATION_SUCCESS | yes         | `Foo.class`, `Foo$Companion.class`, `Foo$$serializer.class` all emitted |
+| 2.3.10       | **GREEN** | COMPILATION_SUCCESS | yes         | same as 2.3.0 |
+| 2.3.20       | GREEN   | COMPILATION_SUCCESS | yes                | baseline sanity check |
+
+**Observed gotcha (not yet folded into the adapter):** `applyArgumentStrings`
+resets every non-mentioned structured argument to the parser default.
+Running `applyArgumentStrings(["-Xplugin=..."])` **after** setting
+`MODULE_NAME` via the structured key path reproducibly nulls out
+`moduleName`, failing the compile with
+`'moduleName' is null!` at `IncrementalJvmCompilerRunnerBase.makeServices`.
+The fix is trivially to call `applyArgumentStrings` *before* any structured
+`set(...)` calls, but any implementation of the passthrough path must
+preserve that ordering.
+
+## Implications for ADR 0022 §3 and #138 follow-up work
+
+- **§3 family-GREEN claim stands for plugin-free projects.** No audit finding
+  beyond `COMPILER_PLUGINS` / `CompilerPlugin`. The adapter works end-to-end
+  against 2.3.0 / 2.3.10 when `[plugins]` is empty.
+- **Plugin-using projects on 2.3.0 / 2.3.10 can also be routed through the
+  daemon** — the spike proves the plugin runs under the wrapper. The
+  implementation path is a separate issue (see below).
+- **No ADR amendment required today.** Once the passthrough is implemented,
+  §3 can drop the "plugin-using projects need 2.3.20" carve-out. Until then,
+  the existing `KOTLIN_VERSION_FOR_PLUGINS` gate remains correct — it
+  over-restricts but does not mis-route.
+
+## Follow-up to file
+
+Open a new issue: "Route plugin-using projects on 2.3.0 / 2.3.10 through the
+daemon via `-Xplugin=` passthrough."
+
+- Replace the structured `COMPILER_PLUGINS` assignment in
+  `BtaIncrementalCompiler` with a codepath that falls back to
+  `applyArgumentStrings(listOf("-Xplugin=<jar1>", "-Xplugin=<jar2>", ...))`
+  when the configured Kotlin version is < 2.3.20 (or unconditionally, once
+  the passthrough path is verified equivalent for 2.3.20 too).
+- Call `applyArgumentStrings` before the structured `set(...)` calls so the
+  parser-default reset does not wipe `MODULE_NAME` / `CLASSPATH` (observed
+  in this spike).
+- Drop the `PluginsRequireMinKotlinVersion` precondition once the above
+  lands; leave the precondition's error path in place only as a safety net
+  until the next release cycle confirms no regressions.
+- Plugin options (`-P plugin:...:key=value`) are out of scope for the initial
+  implementation — serialization needs no options, and the `PluginTranslator`
+  already passes `rawArguments = emptyList()`.
+
 ## Raw run log
 
-`/tmp/bta-compat-work/run.log` after `./gradlew -p spike/bta-compat-138 run`.
+- `/tmp/bta-compat-work/run.log` — initial #138 compat matrix.
+- `/tmp/bta-compat-plugin-work/run.log` — #143 plugin-smoke matrix.
 
 ## Reproducing
 
 ```
-./gradlew -p spike/bta-compat-138 run --args="fixtures/linear-10 /tmp/bta-compat-work"
+# #138 BTA compat matrix
+./gradlew -p spike/bta-compat-138 run --args="bta-compat fixtures/linear-10 /tmp/bta-compat-work"
+
+# #143 plugin passthrough
+./gradlew -p spike/bta-compat-138 run --args="plugin-smoke fixtures/plugin-serialization /tmp/bta-compat-plugin-work"
 ```

--- a/spike/bta-compat-138/build.gradle.kts
+++ b/spike/bta-compat-138/build.gradle.kts
@@ -29,6 +29,8 @@ val implMatrix = listOf("2.1.0", "2.2.20", "2.3.0", "2.3.10", "2.3.20")
 implMatrix.forEach { version ->
     val implName = "btaImpl_${version.replace('.', '_')}"
     val fixtureName = "fixture_${version.replace('.', '_')}"
+    val pluginFixtureName = "pluginFixture_${version.replace('.', '_')}"
+    val pluginJarName = "pluginJar_${version.replace('.', '_')}"
     configurations.create(implName) {
         isCanBeResolved = true
         isCanBeConsumed = false
@@ -37,8 +39,25 @@ implMatrix.forEach { version ->
         isCanBeResolved = true
         isCanBeConsumed = false
     }
+    configurations.create(pluginFixtureName) {
+        isCanBeResolved = true
+        isCanBeConsumed = false
+    }
+    configurations.create(pluginJarName) {
+        isCanBeResolved = true
+        isCanBeConsumed = false
+        isTransitive = false
+    }
     dependencies.add(implName, "org.jetbrains.kotlin:kotlin-build-tools-impl:$version")
     dependencies.add(fixtureName, "org.jetbrains.kotlin:kotlin-stdlib:$version")
+    // Plugin smoke test: @Serializable needs stdlib for the impl version + the
+    // serialization runtime on the classpath. `kotlinx-serialization-core` is
+    // the runtime annotation/descriptor library; the compiler plugin is a
+    // separate artefact pulled into `pluginJar_<ver>` below.
+    dependencies.add(pluginFixtureName, "org.jetbrains.kotlin:kotlin-stdlib:$version")
+    dependencies.add(pluginFixtureName, "org.jetbrains.kotlinx:kotlinx-serialization-core:1.9.0")
+    // `*-embeddable` is the shaded jar kotlinc expects for `-Xplugin=`.
+    dependencies.add(pluginJarName, "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable:$version")
 }
 
 dependencies {
@@ -57,8 +76,12 @@ tasks.named<JavaExec>("run") {
     implMatrix.forEach { version ->
         val implName = "btaImpl_${version.replace('.', '_')}"
         val fixtureName = "fixture_${version.replace('.', '_')}"
+        val pluginFixtureName = "pluginFixture_${version.replace('.', '_')}"
+        val pluginJarName = "pluginJar_${version.replace('.', '_')}"
         systemProperty("bta.impl.classpath.$version", configurations.getByName(implName).asPath)
         systemProperty("fixture.classpath.$version", configurations.getByName(fixtureName).asPath)
+        systemProperty("plugin.fixture.classpath.$version", configurations.getByName(pluginFixtureName).asPath)
+        systemProperty("plugin.jar.$version", configurations.getByName(pluginJarName).asPath)
     }
     systemProperty("bta.impl.matrix", implMatrix.joinToString(","))
 }

--- a/spike/bta-compat-138/fixtures/plugin-serialization/Foo.kt
+++ b/spike/bta-compat-138/fixtures/plugin-serialization/Foo.kt
@@ -1,0 +1,11 @@
+package fixture
+
+import kotlinx.serialization.Serializable
+
+// `@Serializable` is the canonical smoke test for the serialization compiler
+// plugin: when the plugin runs, kotlinc synthesises `Foo$$serializer` and a
+// `serializer()` method on `Foo.Companion`. When the plugin does NOT run, the
+// annotation is inert and only `Foo.class` is emitted. The harness keys off
+// the presence of the `$$serializer` class to verify plugin delivery.
+@Serializable
+data class Foo(val a: String, val b: Int)

--- a/spike/bta-compat-138/src/main/kotlin/spike/bta/compat/Main.kt
+++ b/spike/bta-compat-138/src/main/kotlin/spike/bta/compat/Main.kt
@@ -49,6 +49,15 @@ private data class RunOutcome(
 )
 
 fun main(args: Array<String>) {
+    val mode = args.firstOrNull() ?: "bta-compat"
+    when (mode) {
+        "bta-compat" -> runBtaCompat(args.drop(1))
+        "plugin-smoke" -> runPluginSmoke(args.drop(1))
+        else -> error("unknown mode '$mode' (expected 'bta-compat' or 'plugin-smoke')")
+    }
+}
+
+private fun runBtaCompat(args: List<String>) {
     val fixtureDir = Path.of(args.getOrElse(0) { "fixtures/linear-10" }).toAbsolutePath()
     val workRoot = Path.of(args.getOrElse(1) { "/tmp/bta-compat-work" }).toAbsolutePath()
     val matrix = System.getProperty("bta.impl.matrix")!!.split(",")
@@ -262,4 +271,159 @@ private fun touchSourceFile(path: Path) {
     val uniq = System.nanoTime()
     val marker = "\nfun spikeTouch$uniq(): Long = $uniq\n"
     Files.writeString(path, marker, java.nio.file.StandardOpenOption.APPEND)
+}
+
+// --- plugin-smoke mode --------------------------------------------------
+
+private enum class PluginVerdict { GREEN, RED_COMPILE, RED_NO_GEN, RED_METHOD, RED_LINKAGE, RED_OTHER }
+
+private data class PluginOutcome(
+    val implVersion: String,
+    val verdict: PluginVerdict,
+    val compilationResult: String?,
+    val generatedClasses: List<String>,
+    val hasSerializerClass: Boolean,
+    val error: Throwable?,
+)
+
+private fun runPluginSmoke(args: List<String>) {
+    val fixtureDir = Path.of(args.getOrElse(0) { "fixtures/plugin-serialization" }).toAbsolutePath()
+    val workRoot = Path.of(args.getOrElse(1) { "/tmp/bta-compat-plugin-work" }).toAbsolutePath()
+    val matrix = System.getProperty("bta.impl.matrix")!!.split(",")
+
+    println("=== BTA plugin-smoke spike (#138/#143) ===")
+    println("adapter compile-time API: 2.3.20")
+    println("mechanism: applyArgumentStrings([\"-Xplugin=<serialization-plugin>\"])")
+    println("fixture: $fixtureDir")
+    println("workdir: $workRoot")
+    println("matrix:  ${matrix.joinToString(", ")}")
+    println()
+
+    val outcomes = matrix.map { version ->
+        println("--- impl $version ---")
+        val outcome = runPluginOne(version, fixtureDir, workRoot.resolve(version))
+        printPluginOutcome(outcome)
+        println()
+        outcome
+    }
+
+    println("=== summary ===")
+    outcomes.forEach { o ->
+        val tail = o.error?.let { " :: ${it.javaClass.name}: ${it.message?.take(200)}" } ?: ""
+        val extra = " compile=${o.compilationResult ?: "-"} hasSerializer=${o.hasSerializerClass}"
+        println("${o.implVersion.padEnd(8)}  ${o.verdict}$extra$tail")
+    }
+}
+
+@OptIn(ExperimentalPathApi::class)
+private fun runPluginOne(implVersion: String, fixtureDir: Path, workDir: Path): PluginOutcome {
+    resetDir(workDir)
+    val sourcesDir = workDir.resolve("sources").also { copyFixture(fixtureDir, it) }
+    val classesDir = workDir.resolve("classes").also { it.createDirectories() }
+    val icDir = workDir.resolve("ic").also { it.createDirectories() }
+    val shrunk = workDir.resolve("snapshots").also { it.createDirectories() }
+        .resolve("shrunk-classpath-snapshot.bin")
+
+    val pluginFixtureClasspath = System.getProperty("plugin.fixture.classpath.$implVersion")
+        ?: return PluginOutcome(implVersion, PluginVerdict.RED_OTHER, null, emptyList(), false,
+            IllegalStateException("plugin.fixture.classpath.$implVersion not set"))
+    val pluginJar = System.getProperty("plugin.jar.$implVersion")
+        ?: return PluginOutcome(implVersion, PluginVerdict.RED_OTHER, null, emptyList(), false,
+            IllegalStateException("plugin.jar.$implVersion not set"))
+
+    val toolchain = try {
+        loadToolchain(implVersion)
+    } catch (t: Throwable) {
+        return PluginOutcome(implVersion, classifyPlugin(t), null, emptyList(), false, t)
+    }
+
+    val sources: List<Path> = sourcesDir.walk()
+        .filter { it.extension == "kt" || it.extension == "java" }
+        .sorted().toList()
+
+    val compilationResult = try {
+        val builder = toolchain.jvm.jvmCompilationOperationBuilder(sources, classesDir)
+        // Passthrough under test: deliver the serialization plugin via the
+        // CLI-style `-Xplugin=` argument rather than the structured
+        // `COMPILER_PLUGINS` key (which is 2.3.20-only). `applyArgumentStrings`
+        // is the only BTA-API surface present in 2.3.0 that accepts raw
+        // kotlinc CLI tokens; the 2.3.20 `Kotlin230AndBelowWrapper` itself
+        // uses this method to move arguments from the builder to the real
+        // impl, so the passthrough is load-bearing for the wrapper path.
+        //
+        // Order matters: `applyArgumentStrings` resets non-mentioned
+        // arguments to their parser defaults (observed: moduleName becomes
+        // null). Call it before the structured `set(...)` calls so the
+        // builder ends with the structured values we care about.
+        builder.compilerArguments.applyArgumentStrings(listOf("-Xplugin=$pluginJar"))
+        builder.compilerArguments[JvmCompilerArguments.CLASSPATH] = pluginFixtureClasspath
+        builder.compilerArguments[JvmCompilerArguments.MODULE_NAME] = "spike-plugin-smoke"
+        builder.compilerArguments[JvmCompilerArguments.NO_STDLIB] = true
+        builder.compilerArguments[JvmCompilerArguments.NO_REFLECT] = true
+
+        val icConfig = builder.snapshotBasedIcConfigurationBuilder(
+            workingDirectory = icDir,
+            sourcesChanges = SourcesChanges.ToBeCalculated,
+            dependenciesSnapshotFiles = emptyList(),
+            shrunkClasspathSnapshot = shrunk,
+        ).build()
+        builder[JvmCompilationOperation.INCREMENTAL_COMPILATION] = icConfig
+
+        builder[BuildOperation.METRICS_COLLECTOR] = object : BuildMetricsCollector {
+            override fun collectMetric(name: String, type: BuildMetricsCollector.ValueType, value: Long) { /* ignore */ }
+        }
+
+        val op = builder.build()
+        val policy = toolchain.createInProcessExecutionPolicy()
+        toolchain.createBuildSession().use { session -> session.executeOperation(op, policy) }
+    } catch (t: Throwable) {
+        return PluginOutcome(implVersion, classifyPlugin(t), null, emptyList(), false, t)
+    }
+
+    val generated = classesDir.walk()
+        .filter { it.extension == "class" }
+        .map { it.relativeTo(classesDir).toString() }
+        .sorted().toList()
+    // serialization plugin synthesises a `$serializer` nested class inside the
+    // annotated data class's output. Its presence is the GREEN signal.
+    val hasSerializer = generated.any { it.contains("\$\$serializer") || it.endsWith("\$serializer.class") }
+
+    val verdict = when {
+        compilationResult != CompilationResult.COMPILATION_SUCCESS -> PluginVerdict.RED_COMPILE
+        !hasSerializer -> PluginVerdict.RED_NO_GEN
+        else -> PluginVerdict.GREEN
+    }
+
+    return PluginOutcome(
+        implVersion = implVersion,
+        verdict = verdict,
+        compilationResult = compilationResult.name,
+        generatedClasses = generated,
+        hasSerializerClass = hasSerializer,
+        error = null,
+    )
+}
+
+private fun classifyPlugin(t: Throwable): PluginVerdict {
+    var cur: Throwable? = t
+    while (cur != null) {
+        when (cur) {
+            is NoSuchMethodError, is AbstractMethodError -> return PluginVerdict.RED_METHOD
+            is LinkageError, is NoClassDefFoundError -> return PluginVerdict.RED_LINKAGE
+        }
+        cur = cur.cause
+    }
+    return PluginVerdict.RED_OTHER
+}
+
+private fun printPluginOutcome(o: PluginOutcome) {
+    println("verdict: ${o.verdict}")
+    o.compilationResult?.let { println("compile: $it") }
+    println("generated classes (${o.generatedClasses.size}):")
+    o.generatedClasses.forEach { println("  $it") }
+    println("has \$serializer: ${o.hasSerializerClass}")
+    o.error?.let { t ->
+        println("error: ${t.javaClass.name}: ${t.message}")
+        t.printStackTrace(System.out)
+    }
 }


### PR DESCRIPTION
Extends `spike/bta-compat-138/` with the two #143 deliverables. Closes #143.

Key findings, both in `spike/bta-compat-138/REPORT.md` under the `#143 follow-up` section:

- **Audit**: every BTA-API symbol used in `kolt-compiler-daemon/ic/` is portable to v2.3.0 *except* the structured `COMPILER_PLUGINS` key and the `CompilerPlugin` constructor — both 2.3.20-only. The builder-style surface the adapter uses (`jvmCompilationOperationBuilder`, `snapshotBasedIcConfigurationBuilder`, `classpathSnapshottingOperationBuilder`) is adapted for pre-2.3.20 impls by `Kotlin230AndBelowWrapper`, which ships inside the 2.3.20 API jar and auto-activates from `KotlinToolchains.loadImplementation` when `getCompilerVersion() < "2.3.20"`. That wrapper also uses `applyArgumentStrings` / `toArgumentStrings` internally to shuttle arguments, so the passthrough path is already load-bearing for every daemon compile on 2.3.0 / 2.3.10 today.

- **Spike verdict: GREEN**. `applyArgumentStrings(listOf("-Xplugin=<serialization-plugin>.jar"))` delivers the plugin on 2.3.0 / 2.3.10 / 2.3.20; the fixture's `@Serializable` class compiles and kotlinc emits `Foo$$serializer.class`, which is the canonical "the plugin actually ran" signal. Routed to implementation issue #148.

## Reviewer focus

- REPORT.md's audit table is the load-bearing artefact — #148's scope (and the decision not to amend ADR 0022) rests on the claim that no non-portable call exists beyond `COMPILER_PLUGINS` / `CompilerPlugin`. Double-check anything I may have missed; the v2.3.0 `.api` dump (`/tmp/bta-audit/bta-v2.3.0.api` when reproducing, or `gh api repos/JetBrains/kotlin/contents/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api?ref=v2.3.0`) is 625 lines total.
- The issue phrased the spike as "can `JvmCompilerArguments.FREE_ARGS` carry plugins?" — `FREE_ARGS` is not a member of the 2.3.0 *or* 2.3.20 `JvmCompilerArguments` surface. The real passthrough API is `CommonToolArguments.applyArgumentStrings(List<String>)`. The spike under test uses that instead; the REPORT's #148 brief names the real API. Confirm this re-scope is acceptable.
- **Ordering gotcha, flagged in REPORT.md and in #148**: `applyArgumentStrings` resets every non-mentioned structured argument to the parser default. Running it after `builder.compilerArguments[MODULE_NAME] = ...` reproducibly nulls out `moduleName` and fails the compile with `'moduleName' is null!` at `IncrementalJvmCompilerRunnerBase.makeServices`. Fix is "call `applyArgumentStrings` before any structured `set(...)`". #148's DoD should not pass without this.
- The spike harness's mode dispatch (`args.firstOrNull() ?: "bta-compat"` in `Main.kt`) is a break from the pre-#143 CLI (`./gradlew run --args="fixtures/linear-10 ..."` no longer lands in `bta-compat` — it interprets `fixtures/linear-10` as the mode). README and REPORT's reproduce commands are updated to the explicit form; no one else should be relying on it, but flag here in case.

## Not in this PR

- Implementation of the passthrough path — issue #148.
- ADR 0022 §3 amendment — deferred until #148 lands and the family-GREEN claim is verified for plugin-using projects via CI/smoke.