### PR TITLE
Route plugin-using projects through daemon via -Xplugin= passthrough (#148)

### DIFF
--- a/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
+++ b/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
@@ -324,6 +324,19 @@ hierarchy that holds `kotlin-build-tools-impl`. The
 `SharedLoaderCompileDriver` pattern from compile-bench spike #86 is the
 working template for the classloader topology.
 
+**Post-#148 mechanism note.** The translator emits `-Xplugin=<jar>`
+tokens and the adapter pushes them through
+`CommonToolArguments.applyArgumentStrings`, not the structured
+`CommonCompilerArguments.COMPILER_PLUGINS` key. The structured key was
+only added in BTA 2.3.20 and rejects assignment on 2.3.0 / 2.3.10
+impls even with an empty list; `applyArgumentStrings` is the one
+passthrough surface present across the full 2.3.x family the daemon
+supports (ADR 0022 §3). Ordering is load-bearing: the passthrough
+call must precede any structured `set(...)` on the builder, because
+`applyArgumentStrings` resets every non-mentioned argument to the
+parser default. See `spike/bta-compat-138/REPORT.md` for the empirical
+verdict.
+
 Rationale: the alternative (option (b), passing plugin settings from
 daemon core via an `IcRequest` field) would force daemon core to carry
 a `pluginClasspaths: List<Path>` and a `compilerOptions: Map<String, String>`

--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
 import org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader
 import org.jetbrains.kotlin.buildtools.api.SourcesChanges
-import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.JvmCompilerArguments
 import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain.Companion.jvm
 import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperation
@@ -141,24 +140,32 @@ class BtaIncrementalCompiler private constructor(
             .onFailure { metrics.record(METRIC_REAPER_LOCK_FAILED) }
 
         val builder = toolchain.jvm.jvmCompilationOperationBuilder(request.sources, request.outputDir)
+
+        // ADR 0019 §9 + #148: kolt.toml [plugins] → `-Xplugin=<jar>` freeArgs
+        // translation happens inside the adapter, not in daemon core. The
+        // translated list is pushed through `applyArgumentStrings` rather
+        // than the structured `COMPILER_PLUGINS` key: the structured key is
+        // BTA 2.3.20 only and rejects even an empty list on 2.3.0 / 2.3.10
+        // impls, whereas `-Xplugin=` passthrough is accepted across the whole
+        // 2.3.x family (verified by spike/bta-compat-138/REPORT.md §"Plugin-passthrough spike: GREEN").
+        //
+        // **Ordering is load-bearing.** `applyArgumentStrings` resets every
+        // argument it does not mention back to the parser default — observed
+        // failure: running it after `MODULE_NAME` was assigned via the
+        // structured setter nulls out `moduleName` and BTA fails the compile
+        // with `'moduleName' is null!` at `IncrementalJvmCompilerRunnerBase.makeServices`.
+        // The structured `set(...)` calls therefore come AFTER the
+        // passthrough so their values survive into the final compile.
+        val translatedPluginArgs = PluginTranslator.translate(request.projectRoot, pluginJarResolver)
+        if (translatedPluginArgs.isNotEmpty()) {
+            builder.compilerArguments.applyArgumentStrings(translatedPluginArgs)
+        }
+
         if (request.classpath.isNotEmpty()) {
             builder.compilerArguments[JvmCompilerArguments.CLASSPATH] =
                 request.classpath.joinToString(File.pathSeparator) { it.toString() }
         }
         builder.compilerArguments[JvmCompilerArguments.MODULE_NAME] = moduleNameFor(request)
-
-        // ADR 0019 §9: kolt.toml [plugins] → List<CompilerPlugin> translation
-        // happens inside the adapter, not in daemon core. The COMPILER_PLUGINS
-        // structured argument key was introduced in BTA 2.3.20; setting it
-        // against a 2.3.0–2.3.10 impl raises "available only since 2.3.20"
-        // even with an empty list (#138 follow-up audit). Skip the assignment
-        // when there are no plugins so plugin-free projects build on the full
-        // 2.3.x family. Plugin-using projects still need 2.3.20+ daemon, or
-        // --no-daemon, until a freeArgs-based pre-2.3.20 path lands.
-        val translatedPlugins = PluginTranslator.translate(request.projectRoot, pluginJarResolver)
-        if (translatedPlugins.isNotEmpty()) {
-            builder.compilerArguments[CommonCompilerArguments.COMPILER_PLUGINS] = translatedPlugins
-        }
 
         // #127: cached by ClasspathSnapshotCache; see class doc for key/error policy.
         val dependenciesSnapshotFiles = classpathSnapshotCache.getOrComputeSnapshots(request.classpath)
@@ -372,12 +379,11 @@ class BtaIncrementalCompiler private constructor(
         fun create(
             btaImplJars: List<Path>,
             // Defaults to an empty-result resolver: every plugin alias maps to
-            // an empty classpath. Production daemon startup overrides this with
-            // a resolver that walks a known plugin-jars directory. B-2a's
-            // acceptance criterion 4 requires the translation path to be
-            // exercised, not for plugins to actually compile — so even this
-            // default still attaches `COMPILER_PLUGINS` when kolt.toml lists
-            // enabled entries.
+            // an empty classpath, which collapses to no `-Xplugin=` freeArg
+            // emitted. Production daemon startup overrides this with a
+            // resolver that looks up the `pluginJars` map passed through
+            // `--plugin-jars`; tests that do not exercise plugin delivery
+            // rely on this default.
             pluginJarResolver: (alias: String) -> List<Path> = { _ -> emptyList() },
             metrics: IcMetricsSink = NoopIcMetricsSink,
             // ADR 0019 §Negative follow-up (#127): shared directory for cached

--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/PluginTranslator.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/PluginTranslator.kt
@@ -1,85 +1,57 @@
-@file:OptIn(ExperimentalBuildToolsApi::class)
-
 package kolt.daemon.ic
 
 import com.akuleshov7.ktoml.Toml
 import com.akuleshov7.ktoml.TomlInputConfig
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
-import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPlugin
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.Collections
 
-// Translates a project's `kolt.toml` [plugins] section into the BTA-shaped
-// `List<CompilerPlugin>` that BtaIncrementalCompiler attaches to
-// `COMPILER_PLUGINS` on the JvmCompilerArguments builder. Lives inside the
-// adapter per ADR 0019 §9 so daemon core never has to carry a `pluginClasspaths:
-// List<Path>` field whose shape is dictated by BTA.
+// Translates a project's `kolt.toml` [plugins] section into the `-Xplugin=<path>`
+// freeArgs list that `BtaIncrementalCompiler` pushes through
+// `CommonToolArguments.applyArgumentStrings`. Lives inside the adapter per
+// ADR 0019 §9 so daemon core never carries a BTA-shaped `pluginClasspaths`
+// field.
 //
-// The translator is a pure function over (projectRoot, jarResolver). Making the
-// jar resolver injectable keeps the unit tests independent of any real plugin
-// jars on disk, and lets daemon startup wire in a real resolver (e.g. one that
-// walks a plugin-jars directory delivered alongside --compiler-jars). B-2a
-// ships with a trivial `NoopJarResolver` that returns empty classpaths so the
-// BtaIncrementalCompiler call site can still exercise the translation path; a
-// real resolver is a B-2c / daemon-core concern.
+// Why freeArgs and not the structured `COMPILER_PLUGINS` key: the structured
+// key was introduced in BTA 2.3.20. The daemon supports the full 2.3.x line
+// per ADR 0022 §3; `-Xplugin=` + `applyArgumentStrings` is the one passthrough
+// mechanism present across the family (the same mechanism 2.3.20's own
+// `Kotlin230AndBelowWrapper` uses internally to shuttle arguments into a
+// pre-2.3.20 impl). Verdict source: `spike/bta-compat-138/REPORT.md` §"Plugin-passthrough spike: GREEN".
+//
+// Plugin-id aliasing dropped: with `-Xplugin=`, kotlinc reads the plugin
+// identity from the jar's `META-INF/services/org.jetbrains.kotlin.compiler.
+// plugin.CompilerPluginRegistrar` descriptor. The translator only needs to
+// forward resolved jar paths; the alias→id map the 2.3.20 adapter needed is
+// no longer load-bearing.
+//
+// The translator is a pure function over (projectRoot, jarResolver). Making
+// the jar resolver injectable keeps the unit tests independent of any real
+// plugin jars on disk, and lets daemon startup wire in a real resolver that
+// reads from `pluginJars: Map<alias, List<path>>` delivered alongside
+// `--compiler-jars`.
 object PluginTranslator {
 
-    // Kotlin compiler plugin IDs are stable strings the compiler itself uses to
-    // route -P options. `kotlinx-serialization` is the canonical ID for the
-    // serialization plugin across Kotlin 1.x/2.x; the `allopen` / `noarg` IDs
-    // are read from `AllOpenPluginNames.PLUGIN_ID` / `NoArgPluginNames.PLUGIN_ID`
-    // in the Kotlin source tree (verified against v2.3.20). Changing any of
-    // these would break every build that depends on the plugin, so they are
-    // safe to hard-code.
-    const val SERIALIZATION_PLUGIN_ID = "org.jetbrains.kotlinx.serialization"
-    const val ALLOPEN_PLUGIN_ID = "org.jetbrains.kotlin.allopen"
-    const val NOARG_PLUGIN_ID = "org.jetbrains.kotlin.noarg"
-
-    // Alias that kolt.toml users type. The set of accepted aliases is
-    // kept in lock-step with the native client's plugin jar fetcher
-    // (`kolt.resolve.PluginJarFetcher`, the `serialization` / `allopen`
-    // / `noarg` alias map) so a project's `[plugins]` section means the
-    // same thing on the daemon, the subprocess fallback, and the native
-    // konanc path. There is no cross-module test pinning the two sides
-    // together today; adding one is filed as a #65 follow-up nit.
-    private val aliasToPluginId: Map<String, String> = mapOf(
-        "serialization" to SERIALIZATION_PLUGIN_ID,
-        "allopen" to ALLOPEN_PLUGIN_ID,
-        "noarg" to NOARG_PLUGIN_ID,
-    )
-
     /**
-     * Parse `projectRoot/kolt.toml`, project its [plugins] map to the enabled
-     * entries, and ask [jarResolver] for the classpath of each. Returns the
-     * list of `CompilerPlugin` instances to attach to the compile operation.
+     * Parse `projectRoot/kolt.toml`, pick the enabled `[plugins]` entries, ask
+     * [jarResolver] for the classpath of each, and emit one `-Xplugin=<path>`
+     * argument per resolved jar. Resolver order is preserved.
      *
-     * Non-existent `kolt.toml`, absent `[plugins]` section, and plugin entries
-     * set to `false` all collapse to an empty output — the resolver is never
-     * called in those cases, which makes the common "no plugins" path free.
+     * Non-existent `kolt.toml`, absent `[plugins]` section, entries set to
+     * `false`, and resolver returns that are empty for an enabled alias all
+     * collapse to an empty output. The resolver is not called when the
+     * parsed map is empty.
      */
     fun translate(
         projectRoot: Path,
         jarResolver: (alias: String) -> List<Path>,
-    ): List<CompilerPlugin> {
+    ): List<String> {
         val tomlFile = projectRoot.resolve("kolt.toml")
         if (!Files.isRegularFile(tomlFile)) return emptyList()
         val enabledAliases = parseEnabledPluginAliases(tomlFile)
-        if (enabledAliases.isEmpty()) return emptyList()
-        return enabledAliases.map { alias ->
-            val pluginId = aliasToPluginId[alias]
-                // Unknown alias: still emit a CompilerPlugin keyed by the raw
-                // alias string so the BTA layer surfaces a plugin-not-found
-                // error rather than silently dropping the user's request.
-                ?: alias
-            CompilerPlugin(
-                pluginId,
-                jarResolver(alias),
-                /* rawArguments = */ emptyList(),
-                /* orderingRequirements = */ Collections.emptySet(),
-            )
+        return enabledAliases.flatMap { alias ->
+            jarResolver(alias).map { jar -> "-Xplugin=$jar" }
         }
     }
 

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
@@ -184,10 +184,10 @@ class BtaIncrementalCompilerColdPathTest {
                 resolverCalls += alias
                 // Return an empty classpath on purpose: the point of this test is
                 // to prove the translation path is reached, not to successfully
-                // load a real plugin. Empty classpath means BTA is asked to
-                // attach a plugin id without a jar, which may or may not produce
-                // a compile-time error depending on how eagerly BTA validates
-                // COMPILER_PLUGINS — either outcome is acceptable here.
+                // load a real plugin. Post-#148 the translator collapses an
+                // empty resolution to zero `-Xplugin=` freeArgs, so the compile
+                // simply proceeds without the plugin attached. The assertion
+                // that matters here is that the resolver was consulted at all.
                 emptyList()
             },
         ).getOrElse { fail("failed to load BTA toolchain: $it") }

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/PluginTranslatorTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/PluginTranslatorTest.kt
@@ -1,5 +1,3 @@
-@file:OptIn(org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi::class)
-
 package kolt.daemon.ic
 
 import java.nio.file.Files
@@ -9,26 +7,25 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-// Unit tests for the kolt.toml [plugins] → CompilerPlugin translation path
-// defined by ADR 0019 §9. PluginTranslator is a pure function: given a
-// projectRoot and a jar resolver, it parses kolt.toml and emits the list of
-// CompilerPlugin instances that BtaIncrementalCompiler will attach to the
-// `COMPILER_PLUGINS` compiler argument on the JvmCompilationOperation.
+// Unit tests for the kolt.toml [plugins] → freeArgs translation path. Issue
+// #148 flipped the translator output from the structured `COMPILER_PLUGINS`
+// shape (2.3.20-only) to CLI-style `-Xplugin=<jar>` strings fed through
+// `CommonToolArguments.applyArgumentStrings`. The latter works against every
+// 2.3.x BTA impl the daemon supports — see spike/bta-compat-138/REPORT.md.
 //
-// The resolver is injected so these tests can run without any real plugin
-// jars on disk — B-2a only needs to prove the translation path exists and is
-// exercised from the compile path. Actual plugin jar delivery (e.g. real
-// kotlinx-serialization-compiler-plugin.jar) is a B-2b / daemon-core concern.
+// Plugin-id aliasing is no longer needed: kotlinc discovers the plugin via
+// the jar's `META-INF/services/.../CompilerPluginRegistrar` service
+// descriptor, so the translator just passes through resolved jar paths.
 class PluginTranslatorTest {
 
     @Test
     fun `missing kolt_toml yields an empty plugin list`() {
         val projectRoot = Files.createTempDirectory("plugin-translator-empty-")
-        val plugins = PluginTranslator.translate(
+        val args = PluginTranslator.translate(
             projectRoot = projectRoot,
             jarResolver = { _ -> error("resolver must not be called when no plugins section") },
         )
-        assertTrue(plugins.isEmpty(), "no kolt.toml → no plugins, got $plugins")
+        assertTrue(args.isEmpty(), "no kolt.toml → no plugin args, got $args")
     }
 
     @Test
@@ -44,15 +41,15 @@ class PluginTranslatorTest {
             sources = ["src/main/kotlin"]
             """.trimIndent(),
         )
-        val plugins = PluginTranslator.translate(
+        val args = PluginTranslator.translate(
             projectRoot = projectRoot,
             jarResolver = { _ -> error("resolver must not be called when plugins map is empty") },
         )
-        assertTrue(plugins.isEmpty())
+        assertTrue(args.isEmpty())
     }
 
     @Test
-    fun `serialization plugin entry is translated to a CompilerPlugin`() {
+    fun `serialization plugin entry emits one -Xplugin= arg per resolved jar`() {
         val projectRoot = Files.createTempDirectory("plugin-translator-serialization-")
         projectRoot.resolve("kolt.toml").writeText(
             """
@@ -70,7 +67,7 @@ class PluginTranslatorTest {
         val fakeJar = Path.of("/fake/kotlinx-serialization-compiler-plugin.jar")
         val resolved = mutableListOf<String>()
 
-        val plugins = PluginTranslator.translate(
+        val args = PluginTranslator.translate(
             projectRoot = projectRoot,
             jarResolver = { name ->
                 resolved += name
@@ -79,10 +76,7 @@ class PluginTranslatorTest {
         )
 
         assertEquals(listOf("serialization"), resolved, "resolver should be asked once for the serialization plugin")
-        assertEquals(1, plugins.size, "expected exactly one translated plugin, got $plugins")
-        val plugin = plugins.single()
-        assertEquals(PluginTranslator.SERIALIZATION_PLUGIN_ID, plugin.pluginId)
-        assertEquals(listOf(fakeJar), plugin.classpath)
+        assertEquals(listOf("-Xplugin=$fakeJar"), args)
     }
 
     @Test
@@ -101,21 +95,19 @@ class PluginTranslatorTest {
             serialization = false
             """.trimIndent(),
         )
-        val plugins = PluginTranslator.translate(
+        val args = PluginTranslator.translate(
             projectRoot = projectRoot,
             jarResolver = { _ -> error("resolver must not be called for disabled plugin") },
         )
-        assertTrue(plugins.isEmpty())
+        assertTrue(args.isEmpty())
     }
 
-    // #65 native client wiring: allopen / noarg join serialization in the
-    // alias map so the JVM build path can enable them via kolt.toml. The
-    // plugin IDs are the stock Kotlin compiler ones (`org.jetbrains.kotlin.
-    // allopen`, `org.jetbrains.kotlin.noarg`) — not vendor-renamed — so a
-    // future bump of the kolt-compiler-daemon kotlin version does not need
-    // to revisit this map.
+    // #65 native client wiring: allopen / noarg must also translate through
+    // the same passthrough path. The translator is alias-agnostic now — it
+    // only trusts the resolver — so this test pins the "resolver gets asked"
+    // behaviour for all three known aliases.
     @Test
-    fun `allopen plugin entry is translated to the stock allopen CompilerPlugin id`() {
+    fun `allopen plugin entry emits -Xplugin= passthrough args`() {
         val projectRoot = Files.createTempDirectory("plugin-translator-allopen-")
         projectRoot.resolve("kolt.toml").writeText(
             """
@@ -131,17 +123,15 @@ class PluginTranslatorTest {
             """.trimIndent(),
         )
         val fakeJar = Path.of("/fake/allopen-compiler-plugin.jar")
-        val plugins = PluginTranslator.translate(
+        val args = PluginTranslator.translate(
             projectRoot = projectRoot,
             jarResolver = { name -> if (name == "allopen") listOf(fakeJar) else emptyList() },
         )
-        assertEquals(1, plugins.size)
-        assertEquals(PluginTranslator.ALLOPEN_PLUGIN_ID, plugins.single().pluginId)
-        assertEquals(listOf(fakeJar), plugins.single().classpath)
+        assertEquals(listOf("-Xplugin=$fakeJar"), args)
     }
 
     @Test
-    fun `noarg plugin entry is translated to the stock noarg CompilerPlugin id`() {
+    fun `noarg plugin entry emits -Xplugin= passthrough args`() {
         val projectRoot = Files.createTempDirectory("plugin-translator-noarg-")
         projectRoot.resolve("kolt.toml").writeText(
             """
@@ -157,24 +147,48 @@ class PluginTranslatorTest {
             """.trimIndent(),
         )
         val fakeJar = Path.of("/fake/noarg-compiler-plugin.jar")
-        val plugins = PluginTranslator.translate(
+        val args = PluginTranslator.translate(
             projectRoot = projectRoot,
             jarResolver = { name -> if (name == "noarg") listOf(fakeJar) else emptyList() },
         )
-        assertEquals(1, plugins.size)
-        assertEquals(PluginTranslator.NOARG_PLUGIN_ID, plugins.single().pluginId)
-        assertEquals(listOf(fakeJar), plugins.single().classpath)
+        assertEquals(listOf("-Xplugin=$fakeJar"), args)
     }
 
     @Test
-    fun `unresolved plugin jar produces an empty classpath but still emits a CompilerPlugin`() {
-        // An empty classpath from the resolver does not mean "skip this plugin":
-        // B-2a's plugin-jar delivery path is not wired yet, so the resolver
-        // legitimately returns emptyList() for every known id. The translator
-        // still emits a CompilerPlugin so the attached COMPILER_PLUGINS list is
-        // non-empty and the BTA layer sees the plugin request. This matches the
-        // #112 acceptance criterion 4 wording: "a compile failure that reaches
-        // the BTA layer with the plugin classpath attached is sufficient".
+    fun `multi-jar resolution emits one arg per jar preserving resolver order`() {
+        val projectRoot = Files.createTempDirectory("plugin-translator-multijar-")
+        projectRoot.resolve("kolt.toml").writeText(
+            """
+            name = "demo"
+            version = "0.1.0"
+            kotlin = "2.3.20"
+            target = "jvm"
+            main = "demo.Main"
+            sources = ["src/main/kotlin"]
+
+            [plugins]
+            serialization = true
+            """.trimIndent(),
+        )
+        val jars = listOf(
+            Path.of("/fake/kotlinx-serialization-compiler-plugin.jar"),
+            Path.of("/fake/kotlinx-serialization-compiler-plugin-embeddable.jar"),
+        )
+        val args = PluginTranslator.translate(
+            projectRoot = projectRoot,
+            jarResolver = { _ -> jars },
+        )
+        assertEquals(jars.map { "-Xplugin=$it" }, args)
+    }
+
+    @Test
+    fun `empty resolver result for an enabled plugin produces no args`() {
+        // Production upstream (`PluginJarFetcher` in the CLI) fails before the
+        // daemon request is built if a plugin jar cannot be fetched, so the
+        // resolver never returns an empty list for an enabled alias in
+        // practice. This test pins the boundary case: if it does happen
+        // (test mocks, future resolver rewiring) the translator emits no
+        // `-Xplugin=` entries rather than a malformed one.
         val projectRoot = Files.createTempDirectory("plugin-translator-unresolved-")
         projectRoot.resolve("kolt.toml").writeText(
             """
@@ -189,11 +203,10 @@ class PluginTranslatorTest {
             serialization = true
             """.trimIndent(),
         )
-        val plugins = PluginTranslator.translate(
+        val args = PluginTranslator.translate(
             projectRoot = projectRoot,
             jarResolver = { _ -> emptyList() },
         )
-        assertEquals(1, plugins.size)
-        assertTrue(plugins.single().classpath.isEmpty())
+        assertTrue(args.isEmpty())
     }
 }

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
@@ -27,15 +27,6 @@ internal data class DaemonSetup(
 // SharedApiClassesClassLoader exposes.
 internal const val KOTLIN_VERSION_FLOOR = "2.3.0"
 
-// BTA's structured `COMPILER_PLUGINS` argument key was introduced in 2.3.20.
-// Before that, the impl rejects the key even with an empty list, so a
-// project that actually has plugins configured cannot run on the daemon
-// against a pre-2.3.20 BTA-impl. The gap is recoverable in principle via
-// `freeArgs` passthrough (`-Xplugin=...`) but that path is unimplemented;
-// for now, plugin-using projects on 2.3.0–2.3.10 take the subprocess
-// fallback rail with a dedicated warning. Tracked as a #138 follow-up.
-internal const val KOTLIN_VERSION_FOR_PLUGINS = "2.3.20"
-
 // None of these are build failures — ADR 0016 §5.
 internal sealed interface DaemonPreconditionError {
     data class BootstrapJdkInstallFailed(
@@ -62,14 +53,6 @@ internal sealed interface DaemonPreconditionError {
         val version: String,
         val cause: BtaImplFetchError,
     ) : DaemonPreconditionError
-
-    // Plugins requested but the requested Kotlin version pre-dates
-    // BTA's structured COMPILER_PLUGINS argument (2.3.20). See the
-    // KOTLIN_VERSION_FOR_PLUGINS const for context.
-    data class PluginsRequireMinKotlinVersion(
-        val requested: String,
-        val minVersion: String,
-    ) : DaemonPreconditionError
 }
 
 internal fun resolveDaemonPreconditions(
@@ -77,7 +60,6 @@ internal fun resolveDaemonPreconditions(
     kotlincVersion: String,
     absProjectPath: String,
     bundledKotlinVersion: String,
-    pluginsRequested: Boolean = false,
     ensureJavaBin: (KoltPaths) -> Result<String, BootstrapJdkError> = ::ensureBootstrapJavaBin,
     resolveDaemonJar: () -> DaemonJarResolution = ::resolveDaemonJar,
     listCompilerJars: (String) -> List<String>? = { dir -> listJarFiles(dir).getOrElse { null } },
@@ -93,15 +75,6 @@ internal fun resolveDaemonPreconditions(
             DaemonPreconditionError.KotlinVersionBelowFloor(
                 requested = kotlincVersion,
                 floor = KOTLIN_VERSION_FLOOR,
-            ),
-        )
-    }
-
-    if (pluginsRequested && compareVersions(kotlincVersion, KOTLIN_VERSION_FOR_PLUGINS) < 0) {
-        return Err(
-            DaemonPreconditionError.PluginsRequireMinKotlinVersion(
-                requested = kotlincVersion,
-                minVersion = KOTLIN_VERSION_FOR_PLUGINS,
             ),
         )
     }
@@ -171,10 +144,6 @@ internal fun formatDaemonPreconditionWarning(err: DaemonPreconditionError): Stri
     is DaemonPreconditionError.BtaImplFetchFailed ->
         "warning: could not fetch kotlin-build-tools-impl ${err.version} from Maven Central " +
             "(${formatBtaImplFetchError(err.cause)}) — falling back to subprocess compile"
-    is DaemonPreconditionError.PluginsRequireMinKotlinVersion ->
-        "warning: kolt.toml uses compiler plugins which require Kotlin >= ${err.minVersion} on the daemon path; " +
-            "your kolt.toml requests ${err.requested} — falling back to subprocess compile. " +
-            "Pass --no-daemon to silence this warning."
 }
 
 private fun formatBtaImplFetchError(err: BtaImplFetchError): String = when (err) {

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -492,9 +492,9 @@ internal fun resolveCompilerBackend(
     absProjectPath: String,
     bundledKotlinVersion: String = BUNDLED_DAEMON_KOTLIN_VERSION,
     pluginJars: Map<String, List<String>> = emptyMap(),
-    preconditionResolver: (KoltPaths, String, String, String, Boolean) -> Result<DaemonSetup, DaemonPreconditionError> =
-        { p, kotlincVersion, cwd, bundled, plugins ->
-            resolveDaemonPreconditions(p, kotlincVersion, cwd, bundled, plugins)
+    preconditionResolver: (KoltPaths, String, String, String) -> Result<DaemonSetup, DaemonPreconditionError> =
+        { p, kotlincVersion, cwd, bundled ->
+            resolveDaemonPreconditions(p, kotlincVersion, cwd, bundled)
         },
     daemonDirCreator: (String) -> Result<Unit, MkdirFailed> = ::ensureDirectoryRecursive,
     daemonBackendFactory: (DaemonSetup, Map<String, List<String>>) -> CompilerBackend = ::createDaemonBackend,
@@ -503,7 +503,7 @@ internal fun resolveCompilerBackend(
     if (!useDaemon) return subprocessBackend
 
     val setup = preconditionResolver(
-        paths, config.kotlin, absProjectPath, bundledKotlinVersion, pluginJars.isNotEmpty(),
+        paths, config.kotlin, absProjectPath, bundledKotlinVersion,
     ).getOrElse { err ->
         warningSink(formatDaemonPreconditionWarning(err))
         return subprocessBackend

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
@@ -72,52 +72,18 @@ class DaemonPreconditionsTest {
         assertEquals(KOTLIN_VERSION_FLOOR, err.floor)
     }
 
+    // Post-#148: `[plugins]` on the floor (2.3.0) is accepted through the
+    // fetcher — the daemon routes plugins via `-Xplugin=` passthrough which
+    // works across the full 2.3.x family, so there is no version carve-out
+    // for plugin-using projects inside the family.
     @Test
-    fun pluginsRequestedBelow2_3_20ShortCircuitsBeforeAnyProbing() {
-        val result = resolveDaemonPreconditions(
-            paths = paths,
-            kotlincVersion = "2.3.10",
-            absProjectPath = absProject,
-            bundledKotlinVersion = bundledVersion,
-            pluginsRequested = true,
-            ensureJavaBin = { error("must not probe JDK when plugins gate fails") },
-            resolveDaemonJar = { error("must not probe daemon jar when plugins gate fails") },
-            listCompilerJars = { error("must not list compiler jars when plugins gate fails") },
-            resolveBundledBtaImplJars = { error("must not probe BTA-impl jars when plugins gate fails") },
-            fetchBtaImplJars = mustNotFetch,
-        )
-
-        val err = assertIs<DaemonPreconditionError.PluginsRequireMinKotlinVersion>(result.getError())
-        assertEquals("2.3.10", err.requested)
-        assertEquals(KOTLIN_VERSION_FOR_PLUGINS, err.minVersion)
-    }
-
-    @Test
-    fun pluginsRequestedAtMinVersionIsAccepted() {
-        val result = resolveDaemonPreconditions(
-            paths = paths,
-            kotlincVersion = KOTLIN_VERSION_FOR_PLUGINS,
-            absProjectPath = absProject,
-            bundledKotlinVersion = KOTLIN_VERSION_FOR_PLUGINS,
-            pluginsRequested = true,
-            ensureJavaBin = { Ok("/fake/java") },
-            resolveDaemonJar = { okJar },
-            listCompilerJars = { fakeJars },
-            resolveBundledBtaImplJars = { okBtaImpl },
-            fetchBtaImplJars = mustNotFetch,
-        )
-        assertNotNull(result.get())
-    }
-
-    @Test
-    fun pluginsNotRequestedBelow2_3_20IsAcceptedThroughFetcher() {
+    fun pluginsAtFloorIsAcceptedThroughFetcher() {
         var fetchedVersion: String? = null
         val result = resolveDaemonPreconditions(
             paths = paths,
-            kotlincVersion = "2.3.10",
+            kotlincVersion = KOTLIN_VERSION_FLOOR,
             absProjectPath = absProject,
             bundledKotlinVersion = bundledVersion,
-            pluginsRequested = false,
             ensureJavaBin = { Ok("/fake/java") },
             resolveDaemonJar = { okJar },
             listCompilerJars = { fakeJars },
@@ -128,7 +94,7 @@ class DaemonPreconditionsTest {
             },
         )
         assertNotNull(result.get())
-        assertEquals("2.3.10", fetchedVersion)
+        assertEquals(KOTLIN_VERSION_FLOOR, fetchedVersion)
     }
 
     @Test
@@ -355,20 +321,6 @@ class DaemonPreconditionsTest {
                 resolvedEmpty.contains("resolver returned no jars") &&
                 resolvedEmpty.contains("falling back to subprocess compile"),
             "unexpected resolved-empty warning: $resolvedEmpty",
-        )
-        val pluginsGate = formatDaemonPreconditionWarning(
-            DaemonPreconditionError.PluginsRequireMinKotlinVersion(
-                requested = "2.3.10",
-                minVersion = "2.3.20",
-            ),
-        )
-        assertTrue(
-            pluginsGate.contains("2.3.10") &&
-                pluginsGate.contains("2.3.20") &&
-                pluginsGate.contains("compiler plugins") &&
-                pluginsGate.contains("falling back to subprocess compile") &&
-                pluginsGate.contains("--no-daemon"),
-            "unexpected plugins-gate warning: $pluginsGate",
         )
     }
 }

--- a/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
@@ -48,7 +48,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = false,
             absProjectPath = absProject,
-            preconditionResolver = { _, _, _, _, _ -> error("must not resolve preconditions when useDaemon=false") },
+            preconditionResolver = { _, _, _, _ -> error("must not resolve preconditions when useDaemon=false") },
             daemonDirCreator = { error("must not create daemon dir when useDaemon=false") },
             daemonBackendFactory = { _, _ -> error("must not construct daemon backend when useDaemon=false") },
             warningSink = { warnings.add(it) },
@@ -73,7 +73,7 @@ class ResolveCompilerBackendTest {
             useDaemon = true,
             absProjectPath = absProject,
             bundledKotlinVersion = "2.3.20",
-            preconditionResolver = { _, requested, _, _, _ ->
+            preconditionResolver = { _, requested, _, _ ->
                 Err(
                     DaemonPreconditionError.KotlinVersionBelowFloor(
                         requested = requested,
@@ -107,7 +107,7 @@ class ResolveCompilerBackendTest {
             useDaemon = true,
             absProjectPath = absProject,
             bundledKotlinVersion = "2.3.20",
-            preconditionResolver = { _, _, _, bundled, _ ->
+            preconditionResolver = { _, _, _, bundled ->
                 seenBundled = bundled
                 Ok(okSetup)
             },
@@ -129,7 +129,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = true,
             absProjectPath = absProject,
-            preconditionResolver = { _, _, _, _, _ ->
+            preconditionResolver = { _, _, _, _ ->
                 Err(DaemonPreconditionError.DaemonJarMissing)
             },
             daemonDirCreator = { error("must not create daemon dir after precondition failure") },
@@ -155,7 +155,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = true,
             absProjectPath = absProject,
-            preconditionResolver = { _, _, _, _, _ ->
+            preconditionResolver = { _, _, _, _ ->
                 Err(
                     DaemonPreconditionError.BootstrapJdkInstallFailed(
                         jdkInstallDir = "/fake/home/.kolt/toolchains/jdk/21",
@@ -194,7 +194,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = true,
             absProjectPath = absProject,
-            preconditionResolver = { _, _, _, _, _ -> Ok(okSetup) },
+            preconditionResolver = { _, _, _, _ -> Ok(okSetup) },
             daemonDirCreator = { Err(MkdirFailed(okSetup.daemonDir)) },
             daemonBackendFactory = { _, _ -> error("must not construct daemon backend after mkdir failure") },
             warningSink = { warnings.add(it) },
@@ -218,7 +218,7 @@ class ResolveCompilerBackendTest {
             useDaemon = true,
             absProjectPath = absProject,
             pluginJars = pluginJars,
-            preconditionResolver = { _, _, _, _, _ -> Ok(okSetup) },
+            preconditionResolver = { _, _, _, _ -> Ok(okSetup) },
             daemonDirCreator = { Ok(Unit) },
             daemonBackendFactory = { _, jars ->
                 capturedPluginJars = jars
@@ -242,7 +242,7 @@ class ResolveCompilerBackendTest {
             subprocessBackend = subprocess,
             useDaemon = true,
             absProjectPath = absProject,
-            preconditionResolver = { _, kotlincVersion, cwd, _, _ ->
+            preconditionResolver = { _, kotlincVersion, cwd, _ ->
                 assertEquals("2.1.0", kotlincVersion)
                 assertEquals(absProject, cwd)
                 Ok(okSetup)


### PR DESCRIPTION
Flips the plugin delivery mechanism in `BtaIncrementalCompiler` from the 2.3.20-only structured `COMPILER_PLUGINS` key to `applyArgumentStrings(listOf("-Xplugin=<jar>"))`. The passthrough surface is present across the full 2.3.x family the daemon supports (empirical verdict: `spike/bta-compat-138/REPORT.md` plugin-smoke matrix — GREEN on 2.3.0 / 2.3.10 / 2.3.20). With that, the `KOTLIN_VERSION_FOR_PLUGINS = 2.3.20` precondition is gone and plugin-using projects on 2.3.0 / 2.3.10 also take the daemon rail instead of falling through to subprocess. Closes #148.

## Reviewer focus

- **Ordering invariant in `BtaIncrementalCompiler.executeCompile`.** `applyArgumentStrings` resets every non-mentioned argument to the parser default. Running it after `MODULE_NAME` was set via the structured setter reproducibly nulls `moduleName` and the compile fails with `'moduleName' is null!` at `IncrementalJvmCompilerRunnerBase.makeServices`. The passthrough call therefore has to come BEFORE the structured `set(...)` calls; the comment on the code is the anchor. First place to check if something regresses.
- **`PluginTranslator` is simpler now.** The 2.3.20 `CompilerPlugin` constructor required `(pluginId, classpath, rawArguments, orderingRequirements)` — with `-Xplugin=` kotlinc reads the plugin id from the jar's `META-INF/services/.../CompilerPluginRegistrar` service descriptor, so the whole `aliasToPluginId` map and the three `*_PLUGIN_ID` constants go away. Resolver order is preserved (`flatMap` over aliases → jars). Tests updated to match.
- **Behaviour change on empty resolver result.** The old `PluginTranslator` emitted a `CompilerPlugin(id, classpath=[])` for "enabled alias, resolver returned empty" as a B-2a workaround to surface "plugin-not-found" at the BTA layer. The new translator emits zero `-Xplugin=` entries in that case — the plugin is silently not attached. Production: this case doesn't arise because `PluginJarFetcher` upstream errors before the daemon request is built. Tests: the old "empty classpath still emits a plugin" assertion is now "empty resolver produces no args". Flag if the new semantics feel wrong.
- **Dogfood pass.** `kolt.toml` with `kotlin = "2.3.0"` + `[plugins] serialization = true` built via the daemon and the output jar contains `fixture/Payload$$serializer.class` — the canonical "plugin actually ran" signal. `BtaSerializationPluginTest` (existing end-to-end against a real `@Serializable` fixture, runs against the bundled 2.3.20 BTA-impl) is the regression safety net.
- **`DaemonPreconditionError.PluginsRequireMinKotlinVersion` removed.** Not kept as a safety-net variant — the precondition is load-bearing precisely when the gate fires, and there is no scenario now where `[plugins]` + 2.3.x should block the daemon path. The warning text and its test are also gone.

## Not in this PR

- Plugin options (`-P plugin:...:key=value`). Serialization needs none and the old translator already passed `rawArguments = emptyList()` — adding options is a separate issue if any future plugin needs them.
- Per-plugin classpath isolation. `-Xplugin=` shares a flat classpath across all plugins, same as kotlinc CLI; adequate for the three aliases (`serialization` / `allopen` / `noarg`) the native client fetches.