### PR TITLE
Preflight sun_path 108-byte budget before daemon spawn (#146)

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
@@ -27,6 +27,21 @@ internal data class DaemonSetup(
 // SharedApiClassesClassLoader exposes.
 internal const val KOTLIN_VERSION_FLOOR = "2.3.0"
 
+// Linux AF_UNIX `sun_path` field is a 108-byte char array. `bind()` on a
+// longer path fails with `ENAMETOOLONG` / `EINVAL` at daemon spawn —
+// *after* we have already spent money installing toolchains and launching
+// the JVM. Checked up front as a precondition so the fallback rail catches
+// the miss cleanly instead. See #146.
+internal const val SUN_PATH_CAPACITY: Int = 108
+
+// `applyPluginsFingerprintToFile` (in BuildCommands.kt) injects either
+// `-noplugins` (10 bytes) or `-<8hex>` (9 bytes) before `.sock`. The
+// no-plugins case is the worst case; use it as a conservative upper bound
+// so the precondition stays independent of the plugin set. Over-estimating
+// by 1 byte is fine — sun_path is a hard kernel limit, and we'd rather
+// fall back to subprocess one byte early than crash at bind().
+private const val MAX_FINGERPRINT_SUFFIX_BYTES: Int = "-noplugins".length
+
 // None of these are build failures — ADR 0016 §5.
 internal sealed interface DaemonPreconditionError {
     data class BootstrapJdkInstallFailed(
@@ -53,6 +68,15 @@ internal sealed interface DaemonPreconditionError {
         val version: String,
         val cause: BtaImplFetchError,
     ) : DaemonPreconditionError
+
+    // #146: projected socket path would exceed Linux sun_path capacity.
+    // Caught as a precondition because the alternative — `bind()` failing
+    // mid-spawn — leaves half-initialised daemon state behind.
+    data class SocketPathTooLong(
+        val socketPath: String,
+        val projectedBytes: Int,
+        val maxBytes: Int,
+    ) : DaemonPreconditionError
 }
 
 internal fun resolveDaemonPreconditions(
@@ -75,6 +99,23 @@ internal fun resolveDaemonPreconditions(
             DaemonPreconditionError.KotlinVersionBelowFloor(
                 requested = kotlincVersion,
                 floor = KOTLIN_VERSION_FLOOR,
+            ),
+        )
+    }
+
+    // sun_path length check is pure string math, do it before any disk
+    // probe. `setup.socketPath` gets a `-<fingerprint>` suffix added later
+    // by `applyPluginsFingerprintToFile`; we over-estimate with the
+    // longer `-noplugins` variant so the gate is plugin-set-agnostic.
+    val projectHash = projectHashOf(absProjectPath)
+    val baseSocketPath = paths.daemonSocketPath(projectHash, kotlincVersion)
+    val projectedSocketBytes = baseSocketPath.length + MAX_FINGERPRINT_SUFFIX_BYTES
+    if (projectedSocketBytes > SUN_PATH_CAPACITY) {
+        return Err(
+            DaemonPreconditionError.SocketPathTooLong(
+                socketPath = baseSocketPath,
+                projectedBytes = projectedSocketBytes,
+                maxBytes = SUN_PATH_CAPACITY,
             ),
         )
     }
@@ -115,7 +156,6 @@ internal fun resolveDaemonPreconditions(
         }
     }
 
-    val projectHash = projectHashOf(absProjectPath)
     return Ok(
         DaemonSetup(
             javaBin = javaBin,
@@ -123,7 +163,7 @@ internal fun resolveDaemonPreconditions(
             compilerJars = compilerJars,
             btaImplJars = btaImplJars,
             daemonDir = paths.daemonDir(projectHash, kotlincVersion),
-            socketPath = paths.daemonSocketPath(projectHash, kotlincVersion),
+            socketPath = baseSocketPath,
             logPath = paths.daemonLogPath(projectHash, kotlincVersion),
         ),
     )
@@ -144,6 +184,10 @@ internal fun formatDaemonPreconditionWarning(err: DaemonPreconditionError): Stri
     is DaemonPreconditionError.BtaImplFetchFailed ->
         "warning: could not fetch kotlin-build-tools-impl ${err.version} from Maven Central " +
             "(${formatBtaImplFetchError(err.cause)}) — falling back to subprocess compile"
+    is DaemonPreconditionError.SocketPathTooLong ->
+        "warning: daemon socket path ${err.socketPath} would be ${err.projectedBytes} bytes, " +
+            "exceeding the Linux AF_UNIX ${err.maxBytes}-byte limit — falling back to subprocess compile. " +
+            "Move the project under a shorter \$HOME, or pass --no-daemon to silence this warning."
 }
 
 private fun formatBtaImplFetchError(err: BtaImplFetchError): String = when (err) {

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
@@ -72,6 +72,53 @@ class DaemonPreconditionsTest {
         assertEquals(KOTLIN_VERSION_FLOOR, err.floor)
     }
 
+    // #146: Linux `sun_path` tops out at 108 bytes. A deep `$HOME` (CI runner,
+    // NFS mount) can push the projected socket path past the cap before
+    // any daemon spawn. The precondition check catches this upfront so the
+    // fallback rail handles it instead of surfacing as `bind() ENAMETOOLONG`.
+    @Test
+    fun socketPathAboveSunPathCapShortCircuits() {
+        // Synthesise a `$HOME` that, after the full `<home>/.kolt/daemon/<16hex>/<version>/daemon-noplugins.sock`
+        // build-up, exceeds 108 bytes. The tail for `2.3.20` is 59 bytes; so any
+        // `$HOME` of 50+ chars reliably overflows.
+        val longHome = "/home/" + "x".repeat(96)
+        val longPaths = KoltPaths(home = longHome)
+        val result = resolveDaemonPreconditions(
+            paths = longPaths,
+            kotlincVersion = bundledVersion,
+            absProjectPath = absProject,
+            bundledKotlinVersion = bundledVersion,
+            ensureJavaBin = { error("must not probe JDK when socket path exceeds sun_path") },
+            resolveDaemonJar = { error("must not probe daemon jar when socket path exceeds sun_path") },
+            listCompilerJars = { error("must not list compiler jars when socket path exceeds sun_path") },
+            resolveBundledBtaImplJars = { error("must not probe BTA-impl jars when socket path exceeds sun_path") },
+            fetchBtaImplJars = mustNotFetch,
+        )
+
+        val err = assertIs<DaemonPreconditionError.SocketPathTooLong>(result.getError())
+        assertEquals(SUN_PATH_CAPACITY, err.maxBytes)
+        assertTrue(err.projectedBytes > SUN_PATH_CAPACITY, "projected should exceed cap: $err")
+        assertTrue(err.socketPath.startsWith(longHome), "socket path should be rooted at home: ${err.socketPath}")
+    }
+
+    @Test
+    fun socketPathInsideSunPathCapPasses() {
+        // `/home/makino` + typical 16-hex hash + `2.3.20` + `daemon-noplugins.sock`
+        // ≈ 71 bytes; well under the 108-byte cap.
+        val result = resolveDaemonPreconditions(
+            paths = paths,
+            kotlincVersion = bundledVersion,
+            absProjectPath = absProject,
+            bundledKotlinVersion = bundledVersion,
+            ensureJavaBin = { Ok("/fake/java") },
+            resolveDaemonJar = { okJar },
+            listCompilerJars = { fakeJars },
+            resolveBundledBtaImplJars = { okBtaImpl },
+            fetchBtaImplJars = mustNotFetch,
+        )
+        assertNotNull(result.get())
+    }
+
     // Post-#148: `[plugins]` on the floor (2.3.0) is accepted through the
     // fetcher — the daemon routes plugins via `-Xplugin=` passthrough which
     // works across the full 2.3.x family, so there is no version carve-out
@@ -321,6 +368,20 @@ class DaemonPreconditionsTest {
                 resolvedEmpty.contains("resolver returned no jars") &&
                 resolvedEmpty.contains("falling back to subprocess compile"),
             "unexpected resolved-empty warning: $resolvedEmpty",
+        )
+        val tooLong = formatDaemonPreconditionWarning(
+            DaemonPreconditionError.SocketPathTooLong(
+                socketPath = "/very/long/path/to/daemon.sock",
+                projectedBytes = 120,
+                maxBytes = 108,
+            ),
+        )
+        assertTrue(
+            tooLong.contains("108") &&
+                tooLong.contains("/very/long/path/to/daemon.sock") &&
+                tooLong.contains("falling back to subprocess compile") &&
+                tooLong.contains("--no-daemon"),
+            "unexpected socket-path-too-long warning: $tooLong",
         )
     }
 }


### PR DESCRIPTION
Linux `AF_UNIX.sun_path` is 108 bytes. Our daemon socket layout is `<home>/.kolt/daemon/<16hex>/<kotlinVersion>/daemon-<fp>.sock`; the tail runs ~60 bytes (kotlinVersion + 16-hex project hash + \"daemon-noplugins.sock\"), so any `$HOME` of ~50 chars or more blows the cap. CI runners (`/home/runner/work/<org>/<repo>/...`) and NFS-mounted homes hit it today. Without the preflight, the failure surfaces as `bind() ENAMETOOLONG` mid-spawn with half-initialised daemon state on disk. Closes #146.

## Reviewer focus

- **`MAX_FINGERPRINT_SUFFIX_BYTES` is `"-noplugins".length` (10), not the shorter `-<8hex>` (9).** `applyPluginsFingerprintToFile` chooses between the two based on whether `pluginJars` is empty — we don't know that inside `resolveDaemonPreconditions` and threading it through just to know one byte seemed worse than over-estimating. Over-estimating by 1 byte means we fall back to subprocess one byte early rather than crashing at `bind()` — conservative in the right direction.
- **Error variant shape.** `SocketPathTooLong(socketPath, projectedBytes, maxBytes)` carries all three because the warning text needs the computed projection and the cap, and `socketPath` is what the user would move if they wanted to fix it.
- **Check ordering.** Floor check runs first (cheapest string compare), then sun_path (still pure string math), then all the disk probes. Fails-fast on both cheap checks before we touch the filesystem.