### PR TITLE
Don't wipe new-layout version subdirs when reaping stale legacy socket (#145)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/DaemonReaper.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonReaper.kt
@@ -1,6 +1,7 @@
 package kolt.cli
 
 import com.github.michaelbull.result.getOrElse
+import kolt.infra.deleteFile
 import kolt.infra.fileExists
 import kolt.infra.listSubdirectories
 import kolt.infra.net.UnixSocket
@@ -28,10 +29,11 @@ internal fun reapStaleDaemons(daemonBaseDir: String): ReapResult {
         if (projectDir == IC_STATE_DIR_NAME) continue
         val projectFullDir = "$daemonBaseDir/$projectDir"
 
-        // Pre-#138 layout: socket lived directly at <projectHash>/daemon.sock.
+        // Pre-#142 layout: socket lived directly at <projectHash>/daemon.sock.
         // Probe before removing — a daemon spawned by an older kolt build may
         // still be alive and serving requests.
         val legacySocket = "$projectFullDir/daemon.sock"
+        val legacyLog = "$projectFullDir/daemon.log"
         if (fileExists(legacySocket)) {
             val socket = UnixSocket.connect(legacySocket)
             if (socket.isOk) {
@@ -39,8 +41,16 @@ internal fun reapStaleDaemons(daemonBaseDir: String): ReapResult {
                 alive++
                 continue
             }
-            if (removeDirectoryRecursive(projectFullDir).isOk) reaped++ else failed++
-            continue
+            // #145: stale legacy socket. Do not `removeDirectoryRecursive`
+            // the project dir — a freshly-spawned new-layout daemon may be
+            // living under `<projectHash>/<kotlinVersion>/` after an
+            // upgrade, and wiping the parent unlinks its live socket.
+            // Unlink only the legacy file pair and fall through to the
+            // version-dirs loop, which handles both the post-upgrade mix
+            // and the pre-#142 "no version subdirs exist at all" case.
+            deleteFile(legacySocket)
+            if (fileExists(legacySocket)) failed++ else reaped++
+            if (fileExists(legacyLog)) deleteFile(legacyLog)
         }
 
         val versionDirs = listSubdirectories(projectFullDir).getOrElse { continue }

--- a/src/nativeTest/kotlin/kolt/cli/DaemonReaperTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DaemonReaperTest.kt
@@ -165,6 +165,40 @@ class DaemonReaperTest {
         }
     }
 
+    // #145: first build after an upgrade from a pre-#142 kolt leaves a stale
+    // legacy `<projectHash>/daemon.sock` next to a freshly-spawned new-layout
+    // `<projectHash>/<kotlinVersion>/daemon.sock`. The reaper used to see the
+    // stale legacy socket and `removeDirectoryRecursive` the whole project
+    // tree, unlinking the live new-layout socket alongside it. Post-fix the
+    // legacy file pair is swept but the version subdir with the live socket
+    // is preserved.
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun postUpgradeLegacyStalePlusNewLayoutLivePreservesVersionDir() {
+        val base = createTempDir("reaper-post-upgrade-")
+        val projectDir = "$base/mix333"
+        val versionDir = "$projectDir/2.3.20"
+        ensureDirectoryRecursive(versionDir).getOrElse { error("mkdir failed") }
+        // Stale legacy files at project root (not bound — connect will fail).
+        writeFileAsString("$projectDir/daemon.sock", "").getOrElse { error("write failed") }
+        writeFileAsString("$projectDir/daemon.log", "old log").getOrElse { error("write failed") }
+        // Live new-layout socket under the version subdir.
+        val liveSocket = "$versionDir/daemon.sock"
+        val listenFd = bindAndListen(liveSocket)
+        try {
+            val result = reapStaleDaemons(base)
+            assertTrue(result.reaped >= 1, "stale legacy socket should be reaped, got: $result")
+            assertEquals(1, result.alive, "live new-layout daemon must be counted, got: $result")
+            assertTrue(fileExists(liveSocket), "live new-layout socket must not be unlinked")
+            assertTrue(fileExists(versionDir), "live version dir must not be wiped")
+            assertTrue(fileExists(projectDir), "project dir must survive while a version is alive")
+            assertFalse(fileExists("$projectDir/daemon.sock"), "stale legacy socket should be gone")
+        } finally {
+            close(listenFd)
+            unlink(liveSocket)
+        }
+    }
+
     @Test
     fun icSiblingIsNotReaped() {
         val base = createTempDir("reaper-ic-")


### PR DESCRIPTION
Post-upgrade from a pre-#142 kolt, a single project dir briefly holds both a stale legacy `<projectHash>/daemon.sock` (from the old layout) and a live `<projectHash>/<kotlinVersion>/daemon.sock` (spawned by the upgraded kolt). The reaper's stale-legacy branch called `removeDirectoryRecursive(projectFullDir)`, which took the live new-layout socket down with it — the daemon process kept running but clients could no longer `connect()`. Closes #145.

## Reviewer focus

- **Chose selective unlink, not skip-and-leak.** Could have left the legacy files in place when version subdirs exist, but that means they'd pile up forever (`listSubdirectories` doesn't see them; they only get swept when every version is gone and the tail wipes the dir). Unlinking the known legacy file pair (`daemon.sock` + `daemon.log`) is cleaner and preserves the existing pre-#142 test behaviour.
- **`failed++` accounting.** The old code incremented `reaped` or `failed` once per project dir. New code does the same but keyed on the legacy socket unlink outcome (via `fileExists` post-check), not the whole directory wipe — so the counts mean the same thing at a project-level granularity.
- **Tail `if versionsRemaining == 0` wipe still runs after the fall-through.** That covers the pre-#142 "no version subdirs" case (same behaviour as before — `legacyLayoutOrphanedSocketIsReapedAndCounted` still asserts `fileExists(projectDir) == false`). The new mix test asserts that version dirs DO survive when at least one live daemon is present.

## Not in this PR

- Reaper-races-own-daemon detection during fresh daemon startup (pre-bind window). Different class of race, not this issue's scope.