### PR TITLE
Document Kotlin version support policy in README + kolt-usage

### DIFF
--- a/.claude/skills/kolt-usage/SKILL.md
+++ b/.claude/skills/kolt-usage/SKILL.md
@@ -171,6 +171,10 @@ kolt toolchain install   # Download kotlinc version from kolt.toml
 
 Stored at `~/.kolt/toolchains/kotlinc/{version}/`. Used automatically when available, falls back to system `kotlinc`.
 
+## Kotlin Version Support
+
+kolt supports **Kotlin 2.3.0 and above** on the daemon path, including `[plugins]` projects. Kotlin 2.3.20 is the bundled default (no fetch on first build); other 2.3.x patches get `kotlin-build-tools-impl` fetched from Maven Central on first use. Below 2.3.0 is a soft floor — `kolt build` falls back to subprocess with a one-line warning, or silence it with `--no-daemon`. Forward support (2.4.x+) is re-evaluated at each Kotlin language release. Policy: ADR 0022.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/README.ja.md
+++ b/README.ja.md
@@ -291,6 +291,14 @@ v1.0 以降で対応予定：
 - マルチモジュールプロジェクト
 - Kotlin/Java 混合ソースのコンパイル
 
+## Kotlin バージョンサポート
+
+kolt は **Kotlin 2.3.0 以上** を daemon のファーストクラス対象としてサポートします。`kolt.toml` の `kotlin = "2.3.x"` は `[plugins]` を使うプロジェクトも含め常に warm compiler daemon を通ります。Kotlin 2.3.20 はバンドル済みなので初回ビルドでダウンロードは発生しません。他の 2.3.x パッチは初回使用時に Maven Central から取得され `~/.kolt/cache/` にキャッシュされます。
+
+2.3.0 未満は soft floor です：`kolt build` は subprocess で動作し、該当ビルドごとに 1 行の警告が出ます。`--no-daemon` を渡すと警告は消え、Kotlin バージョンによらず常に利用できます。
+
+将来の Kotlin 言語リリース（2.4.0、2.5.0 …）のサポート範囲は事前に約束せず、各リリース時点で再評価します。ポリシーの詳細は [ADR 0022](docs/adr/0022-supported-kotlin-version-policy.md) を参照してください。
+
 ## なぜ kolt？
 
 Gradle は強力ですが、シンプルな Kotlin プロジェクトには重すぎます：

--- a/README.md
+++ b/README.md
@@ -291,6 +291,14 @@ Planned post-1.0:
 - Multi-module projects
 - Mixed Kotlin/Java source compilation
 
+## Kotlin version support
+
+kolt supports Kotlin **2.3.0 and above** as a first-class daemon target. Any `kolt.toml` `kotlin = "2.3.x"` uses the warm compiler daemon, including `[plugins]` projects. Kotlin 2.3.20 ships bundled so the first build pays no download; other 2.3.x patches are fetched from Maven Central on first use and cached under `~/.kolt/cache/`.
+
+Below 2.3.0 is a soft floor: `kolt build` still works via subprocess compile and prints a one-line warning per affected build. Pass `--no-daemon` to silence the warning — it bypasses the daemon entirely and is always available regardless of Kotlin version.
+
+Support for future Kotlin language releases (2.4.0, 2.5.0, …) is re-evaluated at each release rather than promised ahead of time. See [ADR 0022](docs/adr/0022-supported-kotlin-version-policy.md) for the policy.
+
 ## Why kolt?
 
 Gradle is powerful but heavy for simple Kotlin projects. It imposes:


### PR DESCRIPTION
Covers a gap that opened up when v0.10.1 widened daemon support from `2.3.20` only to the full 2.3.x family with a soft floor at 2.3.0. Adds:

- `## Kotlin version support` section in both `README.md` and `README.ja.md` covering the supported range, bundled vs Maven-fetched BTA-impl, the soft floor + `--no-daemon` escape hatch, and the event-driven forward policy.
- Shorter user-facing summary in the `kolt-usage` skill so Claude can answer "is Kotlin X supported?" without reading the ADR.

Troubleshooting / warning-message explanations are deferred to the v1 docs pass.

Doc-only. No code changes.