### PR TITLE
Bump init template Kotlin version from 2.1.0 to 2.3.20

### DIFF
--- a/src/nativeMain/kotlin/kolt/config/Init.kt
+++ b/src/nativeMain/kotlin/kolt/config/Init.kt
@@ -1,9 +1,15 @@
 package kolt.config
 
+// Pinned to match `BUNDLED_DAEMON_KOTLIN_VERSION` in `kolt.cli` so a fresh
+// `kolt init` project hits the libexec BTA-impl bundle on first build (no
+// Maven Central round trip). Drift from the bundled version only costs
+// new users a one-time download; it does not break the daemon path.
+private const val INIT_TEMPLATE_KOTLIN_VERSION = "2.3.20"
+
 fun generateKoltToml(projectName: String): String = buildString {
     appendLine("""name = "$projectName"""")
     appendLine("""version = "0.1.0"""")
-    appendLine("""kotlin = "2.1.0"""")
+    appendLine("""kotlin = "$INIT_TEMPLATE_KOTLIN_VERSION"""")
     appendLine("""target = "jvm"""")
     appendLine("""jvm_target = "17"""")
     appendLine("""main = "main"""")


### PR DESCRIPTION
The `kolt init` template still pinned `kotlin = "2.1.0"`, which (a) sits below the ADR 0022 soft floor and routes every fresh project to the subprocess fallback with a warning on the very first build, and (b) predates the daemon by a long way. Bumped to match `BUNDLED_DAEMON_KOTLIN_VERSION` so a freshly-init'd project hits the libexec BTA-impl bundle and never makes a Maven Central round trip on first build.

## Reviewer focus

- **Hand-pinned constant, not imported from `kolt.cli`.** `kolt.config` should not depend on `kolt.cli`. Drift only costs a one-time BTA-impl download for newly-init'd projects and does not break the daemon path — that's in the source comment.
- **No new test.** `InitTest.generateTomlContainsRequiredFields` checks the `kotlin = ` key exists but not its value; that assertion continues to pass. A value-pinning test would couple the test file to whichever version we ship this release.

Doc-only: the README's `kotlin = "2.3.20"` example and the kolt-usage skill already reference 2.3.20 as the bundled default.