### PR TITLE
Warn on missing test/resource source directories (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ resources = ["resources"]
 test_resources = ["test-resources"]
 ```
 
-Files in `resources` directories are copied into the build output and included in the JAR. Files in `test_resources` directories are added to the classpath during test execution. Non-existent directories are silently skipped.
+Files in `resources` directories are copied into the build output and included in the JAR. Files in `test_resources` directories are added to the classpath during test execution. Non-existent directories are skipped with a warning.
 
 ### Test Dependencies
 

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -30,6 +30,19 @@ internal data class BuildResult(
     val javaPath: String? = null,
 )
 
+internal fun filterExistingDirs(
+    paths: List<String>,
+    kind: String,
+    exists: (String) -> Boolean = ::fileExists,
+    warn: (String) -> Unit = ::eprintln
+): List<String> {
+    val (existing, missing) = paths.partition { exists(it) }
+    for (path in missing) {
+        warn("warning: $kind directory \"$path\" does not exist, skipping")
+    }
+    return existing
+}
+
 internal fun loadProjectConfig(): Result<KoltConfig, Int> {
     val tomlString = readFileAsString(KOLT_TOML).getOrElse { error ->
         eprintln("error: could not read ${error.path}")
@@ -180,8 +193,8 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
         return Err(EXIT_BUILD_ERROR)
     }
 
-    for (resourceDir in config.resources) {
-        if (!fileExists(resourceDir)) continue
+    val existingResourceDirs = filterExistingDirs(config.resources, "resource")
+    for (resourceDir in existingResourceDirs) {
         copyDirectoryContents(resourceDir, CLASSES_DIR).getOrElse { error ->
             eprintln("error: could not copy resources from ${error.path}")
             return Err(EXIT_BUILD_ERROR)
@@ -363,7 +376,7 @@ internal fun doTest(testArgs: List<String> = emptyList(), useDaemon: Boolean = t
     }
     val (_, classpath, javaPath) = doBuild(useDaemon = useDaemon).getOrElse { return Err(it) }
 
-    val existingTestSources = config.testSources.filter { fileExists(it) }
+    val existingTestSources = filterExistingDirs(config.testSources, "test source")
     if (existingTestSources.isEmpty()) {
         eprintln("error: no test sources found in ${config.testSources}")
         return Err(EXIT_TEST_ERROR)
@@ -385,7 +398,7 @@ internal fun doTest(testArgs: List<String> = emptyList(), useDaemon: Boolean = t
         return Err(EXIT_BUILD_ERROR)
     }
 
-    val existingTestResourceDirs = config.testResources.filter { fileExists(it) }
+    val existingTestResourceDirs = filterExistingDirs(config.testResources, "test resource")
     val runCmd = testRunCommand(
         classesDir = CLASSES_DIR,
         testClassesDir = testCmd.outputPath,
@@ -412,7 +425,7 @@ internal fun doTest(testArgs: List<String> = emptyList(), useDaemon: Boolean = t
 }
 
 private fun doNativeTest(config: KoltConfig, testArgs: List<String>): Result<Unit, Int> {
-    val existingTestSources = config.testSources.filter { fileExists(it) }
+    val existingTestSources = filterExistingDirs(config.testSources, "test source")
     if (existingTestSources.isEmpty()) {
         eprintln("error: no test sources found in ${config.testSources}")
         return Err(EXIT_TEST_ERROR)

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
@@ -50,6 +50,78 @@ class EnsureJdkBinsFromConfigTest {
     }
 }
 
+class FilterExistingDirsTest {
+
+    @Test
+    fun returnsAllPathsWhenAllExist() {
+        val warnings = mutableListOf<String>()
+        val result = filterExistingDirs(
+            paths = listOf("a", "b"),
+            kind = "test source",
+            exists = { true },
+            warn = { warnings.add(it) }
+        )
+
+        assertEquals(listOf("a", "b"), result)
+        assertTrue(warnings.isEmpty())
+    }
+
+    @Test
+    fun dropsMissingPathsAndWarnsForEach() {
+        val warnings = mutableListOf<String>()
+        val existing = setOf("a", "c")
+        val result = filterExistingDirs(
+            paths = listOf("a", "b", "c", "d"),
+            kind = "test source",
+            exists = { it in existing },
+            warn = { warnings.add(it) }
+        )
+
+        assertEquals(listOf("a", "c"), result)
+        assertEquals(
+            listOf(
+                "warning: test source directory \"b\" does not exist, skipping",
+                "warning: test source directory \"d\" does not exist, skipping"
+            ),
+            warnings
+        )
+    }
+
+    @Test
+    fun returnsEmptyAndWarnsForEachWhenAllMissing() {
+        val warnings = mutableListOf<String>()
+        val result = filterExistingDirs(
+            paths = listOf("a", "b"),
+            kind = "resource",
+            exists = { false },
+            warn = { warnings.add(it) }
+        )
+
+        assertTrue(result.isEmpty())
+        assertEquals(
+            listOf(
+                "warning: resource directory \"a\" does not exist, skipping",
+                "warning: resource directory \"b\" does not exist, skipping"
+            ),
+            warnings
+        )
+    }
+
+    @Test
+    fun preservesOriginalOrder() {
+        val warnings = mutableListOf<String>()
+        val existing = setOf("b", "d")
+        val result = filterExistingDirs(
+            paths = listOf("a", "b", "c", "d"),
+            kind = "test resource",
+            exists = { it in existing },
+            warn = { warnings.add(it) }
+        )
+
+        assertEquals(listOf("b", "d"), result)
+    }
+}
+
 class FindOverlappingDependenciesTest {
 
     @Test


### PR DESCRIPTION
Extract `filterExistingDirs(paths, kind)` and route three silent-filter
sites through it so dropped directories are surfaced to the user:

- `doBuild` — `config.resources` (was `if (!fileExists) continue`)
- `doTest` — `config.testSources` + `config.testResources`
- `doNativeTest` — `config.testSources`

One `warning: <kind> directory "<path>" does not exist, skipping` per
dropped path. The existing "no test sources found" error path for the
all-missing case is untouched (it still fires with `EXIT_TEST_ERROR`).

## Where to look

- `BuildCommands.filterExistingDirs` — the helper. `exists` / `warn`
  are seams with `::fileExists` / `::eprintln` defaults so the unit
  tests don't touch the filesystem or stderr.
- `BuildCommandsTest.FilterExistingDirsTest` — all-exist, partial,
  all-missing, order-preserving cases.
- `doBuild` around `copyDirectoryContents` — the resource-copy loop
  now iterates `existingResourceDirs` instead of doing its own
  `fileExists` continue.

## Notes

- The `kind` label is the user-facing noun (`"test source"`, `"test
  resource"`, `"resource"`) to keep warnings readable. No shared
  constants — three sites, three labels, not worth an enum.
- `config.resources.maxOf { newestMtimeAll(it) }` in the up-to-date
  check still runs on the original list; `newestMtimeAll` returns 0
  for non-existent dirs, so missing entries don't perturb the cache
  key beyond what they already did on main.
- `config.sources` (main sources) is out of scope — the issue
  scopes to test + resource paths and main sources have a separate
  failure mode (compile error on empty input).