### PR TITLE
Enable native incremental compilation (#168)

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -6,6 +6,11 @@ import kolt.config.KoltConfig
 internal const val BUILD_DIR = "build"
 internal const val CLASSES_DIR = "$BUILD_DIR/classes"
 
+// Native IC cache. Wiped by `kolt clean` (it lives under BUILD_DIR).
+// Spike #160: touch/abi-neutral wall-time -30–39% at 25–50 files; cold
+// builds also speed up from konanc's IC strategy. Issue #168.
+internal const val NATIVE_IC_CACHE_DIR = "$BUILD_DIR/.ic-cache"
+
 // Passed explicitly so a cross-build cannot silently fall back to host default.
 internal const val NATIVE_TARGET = "linux_x64"
 
@@ -110,6 +115,8 @@ fun nativeLinkCommand(
             add(klib)
         }
         add("-Xinclude=$klibPath")
+        add("-Xenable-incremental-compilation")
+        add("-Xic-cache-dir=$NATIVE_IC_CACHE_DIR")
         add("-o")
         add(outputBase)
     }

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -265,9 +265,14 @@ private fun doNativeBuild(config: KoltConfig): Result<BuildResult, Int> {
         return Err(EXIT_BUILD_ERROR)
     }
 
+    ensureDirectoryRecursive(NATIVE_IC_CACHE_DIR).getOrElse { error ->
+        eprintln("error: could not create directory ${error.path}")
+        return Err(EXIT_BUILD_ERROR)
+    }
+
     val linkCmd = nativeLinkCommand(config, konancPath = managedKonancBin, klibs = klibs)
     println("linking ${config.name} (native)...")
-    executeCommand(linkCmd.args).getOrElse { error ->
+    runNativeLinkWithIcFallback(linkCmd.args).getOrElse { error ->
         eprintln("error: " + formatProcessError(error, "linking"))
         return Err(EXIT_BUILD_ERROR)
     }
@@ -285,6 +290,38 @@ private fun doNativeBuild(config: KoltConfig): Result<BuildResult, Int> {
     val elapsed = startMark.elapsedNow()
     println("built $kexePath in ${formatDuration(elapsed)}")
     return Ok(BuildResult(config, classpath = null, javaPath = null))
+}
+
+// On konanc non-zero exit, retry once after wiping the IC cache — konanc
+// can't distinguish "stale cache" from "real compile error" in its exit
+// code, so we treat every non-zero exit as potentially cache-induced.
+// The 2x cost on genuine source errors is acceptable because source
+// errors are caught at stage 1 (library), not stage 2 (link). Spike #160
+// confirmed konanc handles a missing .ic-cache gracefully.
+//
+// Fork/wait/signal failures are outside the cache-corruption hypothesis
+// (the konanc process never ran to completion), so they surface as-is.
+// If wipe itself fails, the retry would hit the same stale cache — skip
+// the retry and return the original error instead.
+internal fun runNativeLinkWithIcFallback(
+    args: List<String>,
+    execute: (List<String>) -> Result<Int, ProcessError> = ::executeCommand,
+    wipeCache: () -> Boolean = ::wipeNativeIcCache
+): Result<Int, ProcessError> {
+    val first = execute(args)
+    val firstError = first.getError() ?: return first
+    if (firstError !is ProcessError.NonZeroExit) return first
+    if (!wipeCache()) return first
+    return execute(args)
+}
+
+private fun wipeNativeIcCache(): Boolean {
+    if (!fileExists(NATIVE_IC_CACHE_DIR)) return true
+    val result = removeDirectoryRecursive(NATIVE_IC_CACHE_DIR)
+    if (result.isOk) return true
+    val error = result.getError()!!
+    eprintln("warning: could not remove ${error.path}")
+    return false
 }
 
 private fun newestDefMtime(config: KoltConfig): Long? {

--- a/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
@@ -232,6 +232,8 @@ class BuilderTest {
                 "-p", "program",
                 "-e", "com.example.main",
                 "-Xinclude=build/my-app-klib",
+                "-Xenable-incremental-compilation",
+                "-Xic-cache-dir=build/.ic-cache",
                 "-o", "build/my-app"
             ),
             cmd.args
@@ -251,6 +253,8 @@ class BuilderTest {
                 "-p", "program",
                 "-e", "com.example.main",
                 "-Xinclude=build/hello-klib",
+                "-Xenable-incremental-compilation",
+                "-Xic-cache-dir=build/.ic-cache",
                 "-o", "build/hello"
             ),
             cmd.args
@@ -285,6 +289,8 @@ class BuilderTest {
                 "-l", "/cache/a.klib",
                 "-l", "/cache/b.klib",
                 "-Xinclude=build/my-app-klib",
+                "-Xenable-incremental-compilation",
+                "-Xic-cache-dir=build/.ic-cache",
                 "-o", "build/my-app"
             ),
             cmd.args

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
@@ -1,6 +1,9 @@
 package kolt.cli
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
 import kolt.testConfig
 import kolt.build.cinteropCommand
 import kolt.build.cinteropOutputKlibPath
@@ -8,12 +11,14 @@ import kolt.build.nativeLibraryCommand
 import kolt.build.nativeLinkCommand
 import kolt.config.CinteropConfig
 import kolt.config.KoltPaths
+import kolt.infra.ProcessError
 import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.removeDirectoryRecursive
 import kolt.infra.writeFileAsString
 import kolt.tool.JdkBins
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -249,5 +254,125 @@ class CinteropNativeBuildIntegrationTest {
         assertEquals(2, lIndices.size)
         assertEquals("build/libcurl.klib", libraryCmd.args[lIndices[0] + 1])
         assertEquals("build/libssl.klib", libraryCmd.args[lIndices[1] + 1])
+    }
+}
+
+class RunNativeLinkWithIcFallbackTest {
+
+    @Test
+    fun successOnFirstCallSkipsWipeAndRetry() {
+        var executeCalls = 0
+        var wipeCalls = 0
+
+        val result = runNativeLinkWithIcFallback(
+            args = listOf("konanc"),
+            execute = { executeCalls++; Ok(0) },
+            wipeCache = { wipeCalls++; true }
+        )
+
+        assertTrue(result.isOk)
+        assertEquals(0, result.get())
+        assertEquals(1, executeCalls)
+        assertEquals(0, wipeCalls)
+    }
+
+    @Test
+    fun nonZeroExitTriggersWipeAndSingleRetrySucceeds() {
+        var executeCalls = 0
+        var wipeCalls = 0
+
+        val result = runNativeLinkWithIcFallback(
+            args = listOf("konanc"),
+            execute = {
+                executeCalls++
+                if (executeCalls == 1) Err(ProcessError.NonZeroExit(1)) else Ok(0)
+            },
+            wipeCache = { wipeCalls++; true }
+        )
+
+        assertEquals(0, result.get() ?: -1)
+        assertEquals(2, executeCalls)
+        assertEquals(1, wipeCalls)
+    }
+
+    @Test
+    fun retryFailureSurfacesRetryErrorNotOriginal() {
+        var executeCalls = 0
+        var wipeCalls = 0
+
+        val result = runNativeLinkWithIcFallback(
+            args = listOf("konanc"),
+            execute = {
+                executeCalls++
+                Err(ProcessError.NonZeroExit(if (executeCalls == 1) 1 else 2))
+            },
+            wipeCache = { wipeCalls++; true }
+        )
+
+        assertFalse(result.isOk)
+        val err = result.getError()
+        assertTrue(err is ProcessError.NonZeroExit && err.exitCode == 2)
+        assertEquals(2, executeCalls)
+        assertEquals(1, wipeCalls)
+    }
+
+    // Fork/wait/signal failures mean konanc never ran. Retry cannot help
+    // (the cache had no chance to become corrupt), so surface the error.
+    @Test
+    fun nonExitProcessErrorsSkipWipeAndRetry() {
+        val nonExitErrors = listOf(
+            ProcessError.ForkFailed,
+            ProcessError.WaitFailed,
+            ProcessError.SignalKilled,
+            ProcessError.EmptyArgs,
+        )
+        for (err in nonExitErrors) {
+            var executeCalls = 0
+            var wipeCalls = 0
+
+            val result = runNativeLinkWithIcFallback(
+                args = listOf("konanc"),
+                execute = { executeCalls++; Err(err) },
+                wipeCache = { wipeCalls++; true }
+            )
+
+            assertEquals(err, result.getError(), "error=$err")
+            assertEquals(1, executeCalls, "error=$err")
+            assertEquals(0, wipeCalls, "error=$err")
+        }
+    }
+
+    // If the wipe fails, the retry would hit the same stale cache and
+    // produce an identical error — skip it and surface the first error.
+    @Test
+    fun wipeFailureSkipsRetryAndReturnsOriginalError() {
+        var executeCalls = 0
+        var wipeCalls = 0
+
+        val result = runNativeLinkWithIcFallback(
+            args = listOf("konanc"),
+            execute = { executeCalls++; Err(ProcessError.NonZeroExit(1)) },
+            wipeCache = { wipeCalls++; false }
+        )
+
+        assertFalse(result.isOk)
+        val err = result.getError()
+        assertTrue(err is ProcessError.NonZeroExit && err.exitCode == 1)
+        assertEquals(1, executeCalls)
+        assertEquals(1, wipeCalls)
+    }
+}
+
+class NativeIcCacheLocationTest {
+
+    // `doClean` removes BUILD_DIR wholesale, so the IC cache is wiped
+    // transitively. A refactor that moves .ic-cache outside BUILD_DIR
+    // would silently break the "wiped by kolt clean" contract.
+    @Test
+    fun icCacheLivesUnderBuildDir() {
+        assertTrue(
+            kolt.build.NATIVE_IC_CACHE_DIR.startsWith("${kolt.build.BUILD_DIR}/"),
+            "NATIVE_IC_CACHE_DIR=${kolt.build.NATIVE_IC_CACHE_DIR} must live under BUILD_DIR=${kolt.build.BUILD_DIR}"
+        )
     }
 }


### PR DESCRIPTION
Closes #168.

Per spike #160, adopting `-Xenable-incremental-compilation -Xic-cache-dir=build/.ic-cache` on stage 2 of the native build. The cache lives under `BUILD_DIR` so `kolt clean` wipes it without special-casing.

## Review focus

- **Fallback policy** (`runNativeLinkWithIcFallback` in `BuildCommands.kt`): retries only on `ProcessError.NonZeroExit`. Fork/wait/signal errors bypass the retry (konanc never ran), and a failed wipe also skips the retry (the stale cache is still there). Judgment call — the doubled wall time on genuine source errors is acceptable because source errors surface at stage 1 (library), not stage 2 (link).
- **`NativeIcCacheLocationTest`**: invariant test that `NATIVE_IC_CACHE_DIR` starts with `BUILD_DIR/`. Cheap guard so a refactor that moves the cache elsewhere can't silently break the "wiped by `kolt clean`" contract without a failing test.
- No changes to `nativeTestLinkCommand` — test path is an explicit follow-up per the issue's scope.

## Verified

- `./gradlew build` green.
- Manual dogfood on `spike/bench-native-ic/fixtures/native-10`: cold 10s → touch 8s, `.ic-cache` grows to ~692K, `kolt clean` wipes it.