### PR TITLE
Adopt KonanTarget vocabulary and reserve kind field (#167)

### DIFF
--- a/.claude/skills/kolt-usage/SKILL.md
+++ b/.claude/skills/kolt-usage/SKILL.md
@@ -117,7 +117,7 @@ package = "libcurl"
 | `[kotlin] version` | Kotlin language/API version (and the default compiler version) | (required) |
 | `[kotlin] compiler` | Override kotlinc/daemon version independently of `version`. Must be `>= version`. | `version` |
 | `[kotlin.plugins]` | Compiler plugins (`serialization`, `allopen`, `noarg`) | `{}` |
-| `[build] target` | `"jvm"` or `"native"` | (required) |
+| `[build] target` | `"jvm"` or a KonanTarget (`"linuxX64"`, `"linuxArm64"`, `"macosX64"`, `"macosArm64"`, `"mingwX64"`) | (required) |
 | `[build] jvm_target` | JVM bytecode target | `"17"` |
 | `[build] jdk` | JDK version pin for daemon/runtime | (host JDK) |
 | `[build] main` | Entry point function FQN (e.g. `"main"` or `"com.example.main"`) | (required) |
@@ -126,12 +126,12 @@ package = "libcurl"
 | `[build] resources` | Resource directories included in JAR | `[]` |
 | `[build] test_resources` | Test resource directories added to test classpath | `[]` |
 | `[fmt] style` | ktfmt style: `"google"`, `"kotlinlang"`, `"meta"` | `"google"` |
-| `[[cinterop]]` | C interop bindings for `target = "native"` (array of `.def` entries) | `[]` |
+| `[[cinterop]]` | C interop bindings for native targets (array of `.def` entries) | `[]` |
 | `[repositories]` | Maven repositories (name = URL, tried in order) | Maven Central only |
 
 ### C Interop
 
-For `target = "native"` projects, declare one `[[cinterop]]` entry per `.def` file. kolt invokes the konan `cinterop` tool, caches `build/<name>.klib`, and links it via `konanc -l`. Fields: `name` (klib base), `def` (.def path), `package` (optional Kotlin package). Compiler and linker flags belong inside the `.def` file itself via the Kotlin/Native standard `compilerOpts.<platform>` / `linkerOpts.<platform>` keys — kolt does not duplicate them in `kolt.toml`. Klibs are regenerated when the `.def` file's mtime changes.
+For native target projects, declare one `[[cinterop]]` entry per `.def` file. kolt invokes the konan `cinterop` tool, caches `build/<name>.klib`, and links it via `konanc -l`. Fields: `name` (klib base), `def` (.def path), `package` (optional Kotlin package). Compiler and linker flags belong inside the `.def` file itself via the Kotlin/Native standard `compilerOpts.<platform>` / `linkerOpts.<platform>` keys — kolt does not duplicate them in `kolt.toml`. Klibs are regenerated when the `.def` file's mtime changes.
 
 ## Dependencies
 
@@ -169,7 +169,7 @@ kolt test -- <extra runner args>
 
 **JVM target (`target = "jvm"`):** kolt auto-injects `kotlin-test-junit5` matching the Kotlin version and runs via JUnit Platform Console Standalone. Supports kotlin.test, JUnit 5, and Kotest. Extra args are forwarded to the console launcher, e.g. `kolt test -- --include-classname ".*IntegrationTest"`.
 
-**Native target (`target = "native"`):** kolt compiles main + test sources into an intermediate klib (`build/<name>-test-klib`) with any enabled compiler plugins applied, then links that klib into `build/<name>-test.kexe` via `konanc -p program -generate-test-runner -Xinclude=...`. `kolt build` uses the same two-stage shape (`build/<name>-klib` → `build/<name>.kexe`). `kotlin.test` is provided by the bundled Kotlin/Native stdlib — no test dependency needs to be declared. Extra args are forwarded to the native test runner, e.g. `kolt test -- --ktest_filter=MyTest.*` or `--ktest_logger=SIMPLE`. The test executable exits non-zero on any failed test.
+**Native target (e.g. `target = "linuxX64"`):** kolt compiles main + test sources into an intermediate klib (`build/<name>-test-klib`) with any enabled compiler plugins applied, then links that klib into `build/<name>-test.kexe` via `konanc -p program -generate-test-runner -Xinclude=...`. `kolt build` uses the same two-stage shape (`build/<name>-klib` → `build/<name>.kexe`). `kotlin.test` is provided by the bundled Kotlin/Native stdlib — no test dependency needs to be declared. Extra args are forwarded to the native test runner, e.g. `kolt test -- --ktest_filter=MyTest.*` or `--ktest_logger=SIMPLE`. The test executable exits non-zero on any failed test.
 
 ## Toolchain Management
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -133,7 +133,7 @@ jitpack = "https://jitpack.io"
 | `[kotlin] version` | Kotlin 言語／API バージョン（`compiler` 未指定時はコンパイラバージョンも兼ねる） | （必須） |
 | `[kotlin] compiler` | `version` と独立して kotlinc / daemon のバージョンを固定（`>= version` 必須） | `version` |
 | `[kotlin.plugins]` | コンパイラプラグイン（`serialization`、`allopen`、`noarg`） | `{}` |
-| `[build] target` | `"jvm"` または `"native"` | （必須） |
+| `[build] target` | `"jvm"` または KonanTarget（`"linuxX64"`, `"linuxArm64"`, `"macosX64"`, `"macosArm64"`, `"mingwX64"`） | （必須） |
 | `[build] jvm_target` | JVM バイトコードターゲット | `"17"` |
 | `[build] jdk` | daemon/runtime 用の JDK バージョン | （ホスト JDK） |
 | `[build] main` | エントリポイント関数の FQN（例：`"main"` または `"com.example.main"`） | （必須） |
@@ -142,7 +142,7 @@ jitpack = "https://jitpack.io"
 | `[build] resources` | ビルド出力に含めるリソースディレクトリ | `[]` |
 | `[build] test_resources` | テスト時のクラスパスに追加するリソースディレクトリ | `[]` |
 | `[fmt] style` | ktfmt スタイル：`"google"`、`"kotlinlang"`、`"meta"` | `"google"` |
-| `[[cinterop]]` | `target = "native"` 用の C interop バインディング（`.def` ごとに 1 エントリ） | `[]` |
+| `[[cinterop]]` | native target 用の C interop バインディング（`.def` ごとに 1 エントリ） | `[]` |
 | `[repositories]` | Maven リポジトリ（名前 = URL） | Maven Central のみ |
 
 ### 依存関係
@@ -190,11 +190,11 @@ serialization = true
 
 対応プラグイン：`serialization`、`allopen`、`noarg`。プラグイン JAR は Kotlin コンパイラディストリビューションから解決されます。
 
-プラグインは `target = "jvm"` と `target = "native"` の両方で動作します。Native では、konanc の 2 段階コンパイル（`-p library` → `-p program -Xinclude=...`）でプラグインレジストラをライブラリ段階で実行します。これは、konanc の単一ステップ `-p program` がコンパイラプラグインを暗黙にスキップする問題への回避策です。詳細は ADR 0014 を参照してください。Native プロジェクトでプラグインを有効にすると、現在は `<kotlincHome>/lib/` からプラグイン JAR を借用するために kotlinc ディストリビューションをサイドカーとしてプロビジョニングします。将来的に Maven Central からの直接解決に切り替え予定です。
+プラグインは `target = "jvm"` と native target（`"linuxX64"` など）の両方で動作します。Native では、konanc の 2 段階コンパイル（`-p library` → `-p program -Xinclude=...`）でプラグインレジストラをライブラリ段階で実行します。これは、konanc の単一ステップ `-p program` がコンパイラプラグインを暗黙にスキップする問題への回避策です。詳細は ADR 0014 を参照してください。Native プロジェクトでプラグインを有効にすると、現在は `<kotlincHome>/lib/` からプラグイン JAR を借用するために kotlinc ディストリビューションをサイドカーとしてプロビジョニングします。将来的に Maven Central からの直接解決に切り替え予定です。
 
 ### C Interop（native ターゲット）
 
-C ライブラリを呼び出す `target = "native"` プロジェクトでは、`.def` ファイルごとに `[[cinterop]]` エントリを宣言します。kolt は各エントリに対して konan の `cinterop` ツールを呼び出し、生成された `.klib` を `build/` にキャッシュして、ライブラリおよびリンク段階で `-l` を通じて `konanc` に渡します。
+C ライブラリを呼び出す native target プロジェクトでは、`.def` ファイルごとに `[[cinterop]]` エントリを宣言します。kolt は各エントリに対して konan の `cinterop` ツールを呼び出し、生成された `.klib` を `build/` にキャッシュして、ライブラリおよびリンク段階で `-l` を通じて `konanc` に渡します。
 
 ```toml
 [[cinterop]]

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ jitpack = "https://jitpack.io"
 | `[kotlin] version` | Kotlin language/API version (also the default compiler version) | (required) |
 | `[kotlin] compiler` | Override kotlinc/daemon version independently of `version`. Must be `>= version`. | `version` |
 | `[kotlin.plugins]` | Compiler plugins (`serialization`, `allopen`, `noarg`) | `{}` |
-| `[build] target` | `"jvm"` or `"native"` | (required) |
+| `[build] target` | `"jvm"` or a KonanTarget (`"linuxX64"`, `"linuxArm64"`, `"macosX64"`, `"macosArm64"`, `"mingwX64"`) | (required) |
 | `[build] jvm_target` | JVM bytecode target | `"17"` |
 | `[build] jdk` | JDK version pin for daemon/runtime | (host JDK) |
 | `[build] main` | Entry point function FQN (e.g. `"main"` or `"com.example.main"`) | (required) |
@@ -142,7 +142,7 @@ jitpack = "https://jitpack.io"
 | `[build] resources` | Resource directories to include in build output | `[]` |
 | `[build] test_resources` | Test resource directories added to test classpath | `[]` |
 | `[fmt] style` | ktfmt style: `"google"`, `"kotlinlang"`, `"meta"` | `"google"` |
-| `[[cinterop]]` | C interop bindings for `target = "native"` (one array entry per `.def`) | `[]` |
+| `[[cinterop]]` | C interop bindings for native targets (one array entry per `.def`) | `[]` |
 | `[repositories]` | Maven repositories (name = URL) | Maven Central only |
 
 ### Dependencies
@@ -190,11 +190,11 @@ serialization = true
 
 Supported plugins: `serialization`, `allopen`, `noarg`. Plugin JARs are resolved from the Kotlin compiler distribution.
 
-Plugins work for both `target = "jvm"` and `target = "native"`. On native, kolt compiles the project in two konanc stages (`-p library` then `-p program -Xinclude=...`) so the plugin registrars run on the library stage; this is a workaround for a konanc quirk where single-step `-p program` invocations silently skip compiler plugins. See ADR 0014 for details. Enabling a plugin on a native project currently provisions the kotlinc distribution as a sidecar purely to borrow plugin jars from `<kotlincHome>/lib/`; a follow-up will switch to resolving them from Maven Central directly.
+Plugins work for both `target = "jvm"` and native targets (`"linuxX64"`, etc.). On native, kolt compiles the project in two konanc stages (`-p library` then `-p program -Xinclude=...`) so the plugin registrars run on the library stage; this is a workaround for a konanc quirk where single-step `-p program` invocations silently skip compiler plugins. See ADR 0014 for details. Enabling a plugin on a native project currently provisions the kotlinc distribution as a sidecar purely to borrow plugin jars from `<kotlincHome>/lib/`; a follow-up will switch to resolving them from Maven Central directly.
 
 ### C Interop (native target)
 
-For `target = "native"` projects that need to call C libraries, declare one `[[cinterop]]` entry per `.def` file. kolt invokes the konan `cinterop` tool for each entry, caches the generated `.klib` under `build/`, and passes it to `konanc` via `-l` on both the library and link stages.
+For native targets that need to call C libraries, declare one `[[cinterop]]` entry per `.def` file. kolt invokes the konan `cinterop` tool for each entry, caches the generated `.klib` under `build/`, and passes it to `konanc` via `-l` on both the library and link stages.
 
 ```toml
 [[cinterop]]

--- a/docs/adr/0023-target-and-kind-schema.md
+++ b/docs/adr/0023-target-and-kind-schema.md
@@ -53,10 +53,12 @@ by this ADR but rejected at build time with a "not yet implemented"
 error; the slot exists so library support is a localized follow-up,
 not a schema revision.
 
-The `[build] main` field becomes conditional: required for
-`kind = "app"`, rejected for `kind = "lib"` ("`main` has no meaning
-for a library; remove it"). `kolt run` against a library is a usage
-error.
+When `kind = "lib"` is eventually implemented, `[build] main` will
+be rejected for libraries ("`main` has no meaning for a library;
+remove it") and `kolt run` against a library will be a usage error.
+Until then, `kind = "lib"` itself is rejected at parse time, so the
+`main` rule is reserved schema semantics rather than active
+validation.
 
 ### 2. `target` uses `KonanTarget` identifiers
 

--- a/kolt.toml
+++ b/kolt.toml
@@ -8,7 +8,7 @@ version = "2.3.20"
 serialization = true
 
 [build]
-target = "native"
+target = "linuxX64"
 main = "kolt.cli.main"
 sources = ["src/nativeMain/kotlin"]
 test_sources = ["src/nativeTest/kotlin"]

--- a/spike/bench-native-ic/gen.sh
+++ b/spike/bench-native-ic/gen.sh
@@ -23,7 +23,7 @@ version = "0.1.0"
 version = "$KOTLIN_VERSION"
 
 [build]
-target = "native"
+target = "linuxX64"
 main = "bench.main"
 sources = ["src"]
 EOF

--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -2,6 +2,7 @@ package kolt.build
 
 import kolt.config.CinteropConfig
 import kolt.config.KoltConfig
+import kolt.config.konanTargetGradleName
 
 internal const val BUILD_DIR = "build"
 internal const val CLASSES_DIR = "$BUILD_DIR/classes"
@@ -10,9 +11,6 @@ internal const val CLASSES_DIR = "$BUILD_DIR/classes"
 // Spike #160: touch/abi-neutral wall-time -30–39% at 25–50 files; cold
 // builds also speed up from konanc's IC strategy. Issue #168.
 internal const val NATIVE_IC_CACHE_DIR = "$BUILD_DIR/.ic-cache"
-
-// Passed explicitly so a cross-build cannot silently fall back to host default.
-internal const val NATIVE_TARGET = "linux_x64"
 
 internal fun outputJarPath(config: KoltConfig): String = "$BUILD_DIR/${config.name}.jar"
 
@@ -74,10 +72,11 @@ fun nativeLibraryCommand(
     klibs: List<String> = emptyList()
 ): BuildCommand {
     val outputBase = outputNativeKlibPath(config)
+    val nativeTarget = konanTargetGradleName(config.build.target)
     val args = buildList {
         add(konancPath ?: "konanc")
         add("-target")
-        add(NATIVE_TARGET)
+        add(nativeTarget)
         addAll(config.build.sources)
         add("-p")
         add("library")
@@ -102,10 +101,11 @@ fun nativeLinkCommand(
     val outputPath = outputKexePath(config)
     val outputBase = "$BUILD_DIR/${config.name}"
     val klibPath = outputNativeKlibPath(config)
+    val nativeTarget = konanTargetGradleName(config.build.target)
     val args = buildList {
         add(konancPath ?: "konanc")
         add("-target")
-        add(NATIVE_TARGET)
+        add(nativeTarget)
         add("-p")
         add("program")
         add("-e")
@@ -130,10 +130,11 @@ fun nativeTestLibraryCommand(
     klibs: List<String> = emptyList()
 ): BuildCommand {
     val outputBase = outputNativeTestKlibPath(config)
+    val nativeTarget = konanTargetGradleName(config.build.target)
     val args = buildList {
         add(konancPath ?: "konanc")
         add("-target")
-        add(NATIVE_TARGET)
+        add(nativeTarget)
         addAll(config.build.sources)
         addAll(config.build.testSources)
         add("-p")
@@ -159,10 +160,11 @@ fun nativeTestLinkCommand(
     val outputPath = outputNativeTestKexePath(config)
     val outputBase = "$BUILD_DIR/${config.name}-test"
     val klibPath = outputNativeTestKlibPath(config)
+    val nativeTarget = konanTargetGradleName(config.build.target)
     val args = buildList {
         add(konancPath ?: "konanc")
         add("-target")
-        add(NATIVE_TARGET)
+        add(nativeTarget)
         add("-p")
         add("program")
         add("-generate-test-runner")
@@ -180,6 +182,7 @@ fun nativeTestLinkCommand(
 // cinterop appends .klib to the -o path, so outputPath omits the extension.
 fun cinteropCommand(
     entry: CinteropConfig,
+    target: String,
     cinteropPath: String? = null,
     outputDir: String = BUILD_DIR
 ): BuildCommand {
@@ -187,7 +190,7 @@ fun cinteropCommand(
     val args = buildList {
         add(cinteropPath ?: "cinterop")
         add("-target")
-        add(NATIVE_TARGET)
+        add(konanTargetGradleName(target))
         add("-def")
         add(entry.def)
         add("-o")

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -60,7 +60,7 @@ internal fun doCheck(useDaemon: Boolean = true): Result<Unit, Int> {
     val startMark = TimeSource.Monotonic.markNow()
     val config = loadProjectConfig().getOrElse { return Err(it) }
     // konanc has no syntax-only mode; a full build is the only option.
-    if (config.build.target == "native") {
+    if (config.build.target in NATIVE_TARGETS) {
         doBuild(useDaemon = useDaemon).getOrElse { return Err(it) }
         return Ok(Unit)
     }
@@ -111,7 +111,7 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
     val startMark = TimeSource.Monotonic.markNow()
     val config = loadProjectConfig().getOrElse { return Err(it) }
 
-    if (config.build.target == "native") {
+    if (config.build.target in NATIVE_TARGETS) {
         return doNativeBuild(config)
     }
 
@@ -348,7 +348,7 @@ private fun runCinterop(config: KoltConfig, paths: KoltPaths): Result<List<Strin
             }
         }
 
-        val cmd = cinteropCommand(entry, cinteropPath = managedCinteropBin)
+        val cmd = cinteropCommand(entry, target = config.build.target, cinteropPath = managedCinteropBin)
         println("generating cinterop klib for ${entry.name}...")
         executeCommand(cmd.args).getOrElse { error ->
             eprintln("error: " + formatProcessError(error, "cinterop (${entry.name})"))
@@ -376,7 +376,7 @@ private fun resolveNativeDependencies(config: KoltConfig, paths: KoltPaths): Res
 }
 
 internal fun doRun(config: KoltConfig, classpath: String?, appArgs: List<String> = emptyList(), javaPath: String? = null): Result<Unit, Int> {
-    if (config.build.target == "native") {
+    if (config.build.target in NATIVE_TARGETS) {
         val kexePath = outputKexePath(config)
         if (!fileExists(kexePath)) {
             eprintln("error: $kexePath not found. Run 'kolt build' first.")
@@ -408,7 +408,7 @@ internal fun doRun(config: KoltConfig, classpath: String?, appArgs: List<String>
 
 internal fun doTest(testArgs: List<String> = emptyList(), useDaemon: Boolean = true): Result<Unit, Int> {
     val config = loadProjectConfig().getOrElse { return Err(it) }
-    if (config.build.target == "native") {
+    if (config.build.target in NATIVE_TARGETS) {
         return doNativeTest(config, testArgs)
     }
     val (_, classpath, javaPath) = doBuild(useDaemon = useDaemon).getOrElse { return Err(it) }

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -228,11 +228,12 @@ internal fun doTree(): Result<Unit, Int> {
 
     val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_DEPENDENCY_ERROR) }
 
-    if (config.build.target == "native") {
+    if (config.build.target in NATIVE_TARGETS) {
         val nativeLookup = createNativeLookup(
             config.repositories.values.toList(),
             paths.cacheBase,
-            createResolverDeps()
+            createResolverDeps(),
+            nativeTarget = konanTargetGradleName(config.build.target)
         )
         if (config.dependencies.isNotEmpty()) {
             val tree = buildNativeDependencyTree(config.dependencies, nativeLookup)

--- a/src/nativeMain/kotlin/kolt/cli/ToolchainCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/ToolchainCommands.kt
@@ -44,7 +44,7 @@ private fun doToolchainInstall(): Result<Unit, Int> {
     if (config.build.jdk != null) {
         installJdkToolchain(config.build.jdk, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
     }
-    if (config.build.target == "native") {
+    if (config.build.target in NATIVE_TARGETS) {
         installKonancToolchain(config.kotlin.effectiveCompiler, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
     }
     return Ok(Unit)

--- a/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
+++ b/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.getOrElse
 import kolt.build.nativeRunCommand
 import kolt.build.runCommand
 import kolt.config.KoltConfig
+import kolt.config.NATIVE_TARGETS
 import kolt.infra.*
 import kotlinx.cinterop.*
 import platform.linux.IN_CREATE
@@ -280,7 +281,7 @@ internal fun watchRunLoop(
             continue
         }
 
-        val runCmd = if (buildResult.config.build.target == "native") {
+        val runCmd = if (buildResult.config.build.target in NATIVE_TARGETS) {
             nativeRunCommand(buildResult.config, appArgs)
         } else {
             runCommand(buildResult.config, buildResult.classpath, appArgs, javaPath = buildResult.javaPath)

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -13,7 +13,22 @@ import kotlinx.serialization.SerializationException
 
 const val MAVEN_CENTRAL_BASE = "https://repo1.maven.org/maven2"
 
-val VALID_TARGETS = setOf("jvm", "native")
+// Kotlin/Native target identifiers, matching `KonanTarget.<n>.name`. Gradle
+// Module Metadata uses snake_case variants of these (`linux_x64` etc.); the
+// schema-to-metadata mapping lives inside NativeResolver.
+val NATIVE_TARGETS = setOf("linuxX64", "linuxArm64", "macosX64", "macosArm64", "mingwX64")
+
+val VALID_TARGETS = setOf("jvm") + NATIVE_TARGETS
+
+val VALID_KINDS = setOf("app", "lib")
+
+// Maps a schema-level KonanTarget identifier (camelCase, e.g. `linuxX64`) to
+// the snake_case form used by both konanc CLI (`-target linux_x64`) and the
+// `org.jetbrains.kotlin.native.target` attribute in Gradle Module Metadata.
+// Precondition: `target in NATIVE_TARGETS`. The regex form is total so it
+// never throws; callers are responsible for validating the input first.
+fun konanTargetGradleName(target: String): String =
+    target.replace(Regex("([a-z])([A-Z])"), "$1_$2").lowercase()
 
 sealed class ConfigError {
     data class ParseFailed(val message: String) : ConfigError()
@@ -59,6 +74,7 @@ data class FmtSection(
 data class KoltConfig(
     val name: String,
     val version: String,
+    val kind: String = "app",
     val kotlin: KotlinSection,
     val build: BuildSection,
     val fmt: FmtSection = FmtSection(),
@@ -72,14 +88,40 @@ private val toml = Toml(
     inputConfig = TomlInputConfig(ignoreUnknownNames = true)
 )
 
+private fun validateKind(kind: String): Result<Unit, ConfigError> {
+    if (kind == "lib") {
+        return Err(ConfigError.ParseFailed(
+            "kind = \"lib\" is reserved but not yet implemented (ADR 0023)"
+        ))
+    }
+    if (kind !in VALID_KINDS) {
+        return Err(ConfigError.ParseFailed(
+            "invalid kind '$kind' (valid kinds: ${VALID_KINDS.joinToString(", ")})"
+        ))
+    }
+    return Ok(Unit)
+}
+
+private fun validateTarget(target: String): Result<Unit, ConfigError> {
+    if (target == "native") {
+        return Err(ConfigError.ParseFailed(
+            "target = \"native\" is no longer accepted. " +
+                "Use a specific Konan target, e.g. target = \"linuxX64\""
+        ))
+    }
+    if (target !in VALID_TARGETS) {
+        return Err(ConfigError.ParseFailed(
+            "invalid target '$target' (valid targets: ${VALID_TARGETS.joinToString(", ")})"
+        ))
+    }
+    return Ok(Unit)
+}
+
 fun parseConfig(tomlString: String): Result<KoltConfig, ConfigError> {
     return try {
         val config = toml.decodeFromString(KoltConfig.serializer(), tomlString)
-        if (config.build.target !in VALID_TARGETS) {
-            return Err(ConfigError.ParseFailed(
-                "invalid target '${config.build.target}' (valid targets: ${VALID_TARGETS.joinToString(", ")})"
-            ))
-        }
+        validateKind(config.kind).getError()?.let { return Err(it) }
+        validateTarget(config.build.target).getError()?.let { return Err(it) }
         validateMainFqn(config.build.main).getError()?.let { return Err(it) }
         config.kotlin.compiler?.let { compiler ->
             if (compareVersions(compiler, config.kotlin.version) < 0) {

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -5,9 +5,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltConfig
-
-// Phase B is linuxX64-only. Cross-platform support lands in a later phase.
-internal const val NATIVE_TARGET_LINUX_X64 = "linux_x64"
+import kolt.config.konanTargetGradleName
 
 // Kotlin/Native bundles the stdlib in the konanc distribution — it must be
 // skipped during dependency resolution even though Gradle module metadata
@@ -49,7 +47,7 @@ fun resolveNative(
     cacheBase: String,
     deps: ResolverDeps
 ): Result<ResolveResult, ResolveError> {
-    val nativeTarget = NATIVE_TARGET_LINUX_X64
+    val nativeTarget = konanTargetGradleName(config.build.target)
     val repos = config.repositories.values.toList()
 
     // Validate direct coords up front (mirrors jvm resolver)
@@ -172,7 +170,7 @@ fun createNativeLookup(
     repos: List<String>,
     cacheBase: String,
     deps: ResolverDeps,
-    nativeTarget: String = NATIVE_TARGET_LINUX_X64
+    nativeTarget: String
 ): (String, String) -> NativeNodeInfo? {
     val cache = mutableMapOf<String, NativeNodeInfo?>()
 

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -2,6 +2,7 @@ package kolt.resolve
 
 import com.github.michaelbull.result.Result
 import kolt.config.KoltConfig
+import kolt.config.NATIVE_TARGETS
 import kolt.infra.DownloadError
 import kolt.infra.MkdirFailed
 import kolt.infra.OpenFailed
@@ -78,7 +79,7 @@ fun resolve(
     cacheBase: String,
     deps: ResolverDeps
 ): Result<ResolveResult, ResolveError> =
-    if (config.build.target == "native") resolveNative(config, cacheBase, deps)
+    if (config.build.target in NATIVE_TARGETS) resolveNative(config, cacheBase, deps)
     else resolveTransitive(config, existingLock, cacheBase, deps)
 
 fun buildLockfileFromResolved(config: KoltConfig, deps: List<ResolvedDep>): Lockfile {

--- a/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
@@ -136,7 +136,7 @@ class BuilderTest {
 
     @Test
     fun nativeLibraryCommandProducesKlibDirectory() {
-        val cmd = nativeLibraryCommand(testConfig(target = "native"))
+        val cmd = nativeLibraryCommand(testConfig(target = "linuxX64"))
 
         assertEquals(
             listOf("konanc", "-target", "linux_x64", "src", "-p", "library", "-nopack", "-o", "build/my-app-klib"),
@@ -148,7 +148,7 @@ class BuilderTest {
     @Test
     fun nativeLibraryCommandMultipleSources() {
         val cmd = nativeLibraryCommand(
-            testConfig(sources = listOf("src", "generated"), target = "native")
+            testConfig(sources = listOf("src", "generated"), target = "linuxX64")
         )
 
         assertEquals(
@@ -159,7 +159,7 @@ class BuilderTest {
 
     @Test
     fun nativeLibraryCommandWithProjectName() {
-        val cmd = nativeLibraryCommand(testConfig(name = "hello", target = "native"))
+        val cmd = nativeLibraryCommand(testConfig(name = "hello", target = "linuxX64"))
 
         assertEquals("build/hello-klib", cmd.outputPath)
         assertEquals(
@@ -171,7 +171,7 @@ class BuilderTest {
     @Test
     fun nativeLibraryCommandWithManagedKonancPath() {
         val managedKonanc = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/konanc"
-        val cmd = nativeLibraryCommand(testConfig(target = "native"), konancPath = managedKonanc)
+        val cmd = nativeLibraryCommand(testConfig(target = "linuxX64"), konancPath = managedKonanc)
 
         assertEquals(managedKonanc, cmd.args.first())
     }
@@ -179,7 +179,7 @@ class BuilderTest {
     @Test
     fun nativeLibraryCommandWithPluginArgs() {
         val cmd = nativeLibraryCommand(
-            testConfig(target = "native"),
+            testConfig(target = "linuxX64"),
             pluginArgs = listOf("-Xplugin=foo.jar")
         )
 
@@ -197,7 +197,7 @@ class BuilderTest {
     @Test
     fun nativeLibraryCommandWithMultipleKlibsRepeatsLFlag() {
         val cmd = nativeLibraryCommand(
-            testConfig(target = "native"),
+            testConfig(target = "linuxX64"),
             klibs = listOf("/cache/a.klib", "/cache/b.klib", "/cache/c.klib")
         )
 
@@ -216,14 +216,14 @@ class BuilderTest {
 
     @Test
     fun nativeLibraryCommandEmptyKlibsOmitsLibraryFlag() {
-        val cmd = nativeLibraryCommand(testConfig(target = "native"), klibs = emptyList())
+        val cmd = nativeLibraryCommand(testConfig(target = "linuxX64"), klibs = emptyList())
 
         assertFalse(cmd.args.contains("-l"))
     }
 
     @Test
     fun nativeLinkCommandLinksKlibToProgramKexe() {
-        val cmd = nativeLinkCommand(testConfig(target = "native"))
+        val cmd = nativeLinkCommand(testConfig(target = "linuxX64"))
 
         assertEquals(
             listOf(
@@ -243,7 +243,7 @@ class BuilderTest {
 
     @Test
     fun nativeLinkCommandWithProjectName() {
-        val cmd = nativeLinkCommand(testConfig(name = "hello", target = "native"))
+        val cmd = nativeLinkCommand(testConfig(name = "hello", target = "linuxX64"))
 
         assertEquals("build/hello.kexe", cmd.outputPath)
         assertEquals(
@@ -264,7 +264,7 @@ class BuilderTest {
     @Test
     fun nativeLinkCommandWithManagedKonancPath() {
         val managedKonanc = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/konanc"
-        val cmd = nativeLinkCommand(testConfig(target = "native"), konancPath = managedKonanc)
+        val cmd = nativeLinkCommand(testConfig(target = "linuxX64"), konancPath = managedKonanc)
 
         assertEquals(managedKonanc, cmd.args.first())
     }
@@ -276,7 +276,7 @@ class BuilderTest {
         // by plugin-generated code) are still unresolved and need the
         // transitive klibs on the library path at link time.
         val cmd = nativeLinkCommand(
-            testConfig(target = "native"),
+            testConfig(target = "linuxX64"),
             klibs = listOf("/cache/a.klib", "/cache/b.klib")
         )
 
@@ -299,7 +299,7 @@ class BuilderTest {
 
     @Test
     fun nativeLinkCommandEmptyKlibsOmitsLibraryFlag() {
-        val cmd = nativeLinkCommand(testConfig(target = "native"), klibs = emptyList())
+        val cmd = nativeLinkCommand(testConfig(target = "linuxX64"), klibs = emptyList())
 
         assertFalse(cmd.args.contains("-l"))
     }
@@ -309,7 +309,7 @@ class BuilderTest {
         // config.main is already a Kotlin function FQN (validated by parseConfig),
         // so konanc -e consumes it verbatim. Without -e, konanc looks for `main`
         // in the root package and fails when the function lives in a named package.
-        val cmd = nativeLinkCommand(testConfig(target = "native"))
+        val cmd = nativeLinkCommand(testConfig(target = "linuxX64"))
 
         val eIndex = cmd.args.indexOf("-e")
         assertTrue(eIndex >= 0, "Expected -e in: ${cmd.args}")
@@ -318,7 +318,7 @@ class BuilderTest {
 
     @Test
     fun nativeLinkCommandEmitsRootPackageEntryPoint() {
-        val base = testConfig(target = "native")
+        val base = testConfig(target = "linuxX64")
         val cmd = nativeLinkCommand(base.copy(build = base.build.copy(main = "main")))
 
         val eIndex = cmd.args.indexOf("-e")
@@ -328,7 +328,7 @@ class BuilderTest {
 
     @Test
     fun nativeTestLibraryCommandIncludesMainAndTestSources() {
-        val cmd = nativeTestLibraryCommand(testConfig(target = "native"))
+        val cmd = nativeTestLibraryCommand(testConfig(target = "linuxX64"))
 
         assertEquals(
             listOf(
@@ -349,7 +349,7 @@ class BuilderTest {
             testConfig(
                 sources = listOf("src", "generated"),
                 testSources = listOf("test", "integration-test"),
-                target = "native"
+                target = "linuxX64"
             )
         )
 
@@ -368,7 +368,7 @@ class BuilderTest {
     @Test
     fun nativeTestLibraryCommandWithPluginArgs() {
         val cmd = nativeTestLibraryCommand(
-            testConfig(target = "native"),
+            testConfig(target = "linuxX64"),
             pluginArgs = listOf("-Xplugin=foo.jar", "-Xplugin=bar.jar")
         )
 
@@ -388,7 +388,7 @@ class BuilderTest {
     @Test
     fun nativeTestLibraryCommandWithMultipleKlibsRepeatsLFlag() {
         val cmd = nativeTestLibraryCommand(
-            testConfig(target = "native"),
+            testConfig(target = "linuxX64"),
             klibs = listOf("/cache/a.klib", "/cache/b.klib")
         )
 
@@ -409,14 +409,14 @@ class BuilderTest {
     @Test
     fun nativeTestLibraryCommandWithManagedKonancPath() {
         val managedKonanc = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/konanc"
-        val cmd = nativeTestLibraryCommand(testConfig(target = "native"), konancPath = managedKonanc)
+        val cmd = nativeTestLibraryCommand(testConfig(target = "linuxX64"), konancPath = managedKonanc)
 
         assertEquals(managedKonanc, cmd.args.first())
     }
 
     @Test
     fun nativeTestLinkCommandLinksWithGeneratedRunner() {
-        val cmd = nativeTestLinkCommand(testConfig(target = "native"))
+        val cmd = nativeTestLinkCommand(testConfig(target = "linuxX64"))
 
         assertEquals(
             listOf(
@@ -434,14 +434,14 @@ class BuilderTest {
 
     @Test
     fun nativeTestLinkCommandDoesNotEmitEntryPointFlag() {
-        val cmd = nativeTestLinkCommand(testConfig(target = "native"))
+        val cmd = nativeTestLinkCommand(testConfig(target = "linuxX64"))
 
         assertFalse(cmd.args.contains("-e"))
     }
 
     @Test
     fun nativeTestLinkCommandWithProjectName() {
-        val cmd = nativeTestLinkCommand(testConfig(name = "hello", target = "native"))
+        val cmd = nativeTestLinkCommand(testConfig(name = "hello", target = "linuxX64"))
 
         assertEquals("build/hello-test.kexe", cmd.outputPath)
         assertEquals(
@@ -460,7 +460,7 @@ class BuilderTest {
     @Test
     fun nativeTestLinkCommandWithMultipleKlibsRepeatsLFlag() {
         val cmd = nativeTestLinkCommand(
-            testConfig(target = "native"),
+            testConfig(target = "linuxX64"),
             klibs = listOf("/cache/a.klib", "/cache/b.klib")
         )
 
@@ -482,7 +482,7 @@ class BuilderTest {
     @Test
     fun nativeTestLinkCommandWithManagedKonancPath() {
         val managedKonanc = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/konanc"
-        val cmd = nativeTestLinkCommand(testConfig(target = "native"), konancPath = managedKonanc)
+        val cmd = nativeTestLinkCommand(testConfig(target = "linuxX64"), konancPath = managedKonanc)
 
         assertEquals(managedKonanc, cmd.args.first())
     }
@@ -522,7 +522,7 @@ class BuilderTest {
 
     @Test
     fun nativeLibraryCommandInjectsLanguageVersionWhenCompilerHigherThanVersion() {
-        val cmd = nativeLibraryCommand(testConfig(target = "native", kotlinVersion = "2.1.0", kotlinCompiler = "2.3.20"))
+        val cmd = nativeLibraryCommand(testConfig(target = "linuxX64", kotlinVersion = "2.1.0", kotlinCompiler = "2.3.20"))
 
         val langIdx = cmd.args.indexOf("-language-version")
         val apiIdx = cmd.args.indexOf("-api-version")
@@ -533,7 +533,7 @@ class BuilderTest {
 
     @Test
     fun nativeLibraryCommandOmitsLanguageVersionWhenCompilerUnset() {
-        val cmd = nativeLibraryCommand(testConfig(target = "native"))
+        val cmd = nativeLibraryCommand(testConfig(target = "linuxX64"))
 
         assertFalse(cmd.args.contains("-language-version"))
         assertFalse(cmd.args.contains("-api-version"))
@@ -541,7 +541,7 @@ class BuilderTest {
 
     @Test
     fun nativeTestLibraryCommandInjectsLanguageVersionWhenCompilerHigherThanVersion() {
-        val cmd = nativeTestLibraryCommand(testConfig(target = "native", kotlinVersion = "2.1.0", kotlinCompiler = "2.3.20"))
+        val cmd = nativeTestLibraryCommand(testConfig(target = "linuxX64", kotlinVersion = "2.1.0", kotlinCompiler = "2.3.20"))
 
         val langIdx = cmd.args.indexOf("-language-version")
         val apiIdx = cmd.args.indexOf("-api-version")
@@ -552,7 +552,7 @@ class BuilderTest {
 
     @Test
     fun nativeTestLibraryCommandOmitsLanguageVersionWhenCompilerUnset() {
-        val cmd = nativeTestLibraryCommand(testConfig(target = "native"))
+        val cmd = nativeTestLibraryCommand(testConfig(target = "linuxX64"))
 
         assertFalse(cmd.args.contains("-language-version"))
         assertFalse(cmd.args.contains("-api-version"))

--- a/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CinteropTest.kt
@@ -16,7 +16,7 @@ class CinteropTest {
             def = "src/nativeInterop/cinterop/libcurl.def"
         )
 
-        val cmd = cinteropCommand(entry)
+        val cmd = cinteropCommand(entry, target = "linuxX64")
 
         assertEquals(
             listOf("cinterop", "-target", "linux_x64", "-def", "src/nativeInterop/cinterop/libcurl.def", "-o", "build/libcurl"),
@@ -28,7 +28,7 @@ class CinteropTest {
     fun cinteropCommandOutputPathIsInBuildDir() {
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
-        val cmd = cinteropCommand(entry)
+        val cmd = cinteropCommand(entry, target = "linuxX64")
 
         assertEquals("build/libcurl", cmd.outputPath)
     }
@@ -41,7 +41,7 @@ class CinteropTest {
             packageName = "libcurl"
         )
 
-        val cmd = cinteropCommand(entry)
+        val cmd = cinteropCommand(entry, target = "linuxX64")
 
         assertTrue(cmd.args.contains("-pkg"), "Expected -pkg flag in: ${cmd.args}")
         val pkgIndex = cmd.args.indexOf("-pkg")
@@ -52,7 +52,7 @@ class CinteropTest {
     fun cinteropCommandWithoutPackageNameOmitsPkgFlag() {
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def", packageName = null)
 
-        val cmd = cinteropCommand(entry)
+        val cmd = cinteropCommand(entry, target = "linuxX64")
 
         assertFalse(cmd.args.contains("-pkg"), "Unexpected -pkg flag in: ${cmd.args}")
     }
@@ -65,7 +65,7 @@ class CinteropTest {
             packageName = "libcurl"
         )
 
-        val cmd = cinteropCommand(entry)
+        val cmd = cinteropCommand(entry, target = "linuxX64")
 
         assertEquals(
             listOf(
@@ -84,7 +84,7 @@ class CinteropTest {
         val managedPath = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/cinterop"
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
-        val cmd = cinteropCommand(entry, cinteropPath = managedPath)
+        val cmd = cinteropCommand(entry, target = "linuxX64", cinteropPath = managedPath)
 
         assertEquals(managedPath, cmd.args.first())
     }
@@ -93,7 +93,7 @@ class CinteropTest {
     fun cinteropCommandWithNullCinteropPathDefaultsToSystemCinterop() {
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
-        val cmd = cinteropCommand(entry, cinteropPath = null)
+        val cmd = cinteropCommand(entry, target = "linuxX64", cinteropPath = null)
 
         assertEquals("cinterop", cmd.args.first())
     }
@@ -102,7 +102,7 @@ class CinteropTest {
     fun cinteropCommandWithCustomOutputDir() {
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
-        val cmd = cinteropCommand(entry, outputDir = "custom/build")
+        val cmd = cinteropCommand(entry, target = "linuxX64", outputDir = "custom/build")
 
         val outputIndex = cmd.args.indexOf("-o")
         assertEquals("custom/build/libcurl", cmd.args[outputIndex + 1])
@@ -113,7 +113,7 @@ class CinteropTest {
     fun cinteropCommandOutputPathDoesNotIncludeKlibExtension() {
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
-        val cmd = cinteropCommand(entry)
+        val cmd = cinteropCommand(entry, target = "linuxX64")
 
         assertFalse(cmd.outputPath.endsWith(".klib.klib"), "outputPath must not double .klib: ${cmd.outputPath}")
         assertFalse(cmd.args.any { it.endsWith(".klib") }, "No .klib suffix expected in args: ${cmd.args}")

--- a/src/nativeTest/kotlin/kolt/build/RunnerTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/RunnerTest.kt
@@ -75,38 +75,38 @@ class RunnerTest {
 
     @Test
     fun nativeRunCommandExecutesKexeBinary() {
-        val cmd = nativeRunCommand(testConfig(target = "native"))
+        val cmd = nativeRunCommand(testConfig(target = "linuxX64"))
         assertEquals(listOf("build/my-app.kexe"), cmd.args)
     }
 
     @Test
     fun nativeRunCommandAppendsAppArgs() {
-        val cmd = nativeRunCommand(testConfig(target = "native"), listOf("--port", "8080"))
+        val cmd = nativeRunCommand(testConfig(target = "linuxX64"), listOf("--port", "8080"))
         assertEquals(listOf("build/my-app.kexe", "--port", "8080"), cmd.args)
     }
 
     @Test
     fun nativeRunCommandUsesProjectName() {
-        val cmd = nativeRunCommand(testConfig(name = "hello", target = "native"))
+        val cmd = nativeRunCommand(testConfig(name = "hello", target = "linuxX64"))
         assertEquals(listOf("build/hello.kexe"), cmd.args)
     }
 
     @Test
     fun nativeTestRunCommandExecutesTestKexeBinary() {
-        val cmd = nativeTestRunCommand(testConfig(target = "native"))
+        val cmd = nativeTestRunCommand(testConfig(target = "linuxX64"))
         assertEquals(listOf("build/my-app-test.kexe"), cmd.args)
     }
 
     @Test
     fun nativeTestRunCommandUsesProjectName() {
-        val cmd = nativeTestRunCommand(testConfig(name = "hello", target = "native"))
+        val cmd = nativeTestRunCommand(testConfig(name = "hello", target = "linuxX64"))
         assertEquals(listOf("build/hello-test.kexe"), cmd.args)
     }
 
     @Test
     fun nativeTestRunCommandAppendsTestArgs() {
         val cmd = nativeTestRunCommand(
-            testConfig(target = "native"),
+            testConfig(target = "linuxX64"),
             testArgs = listOf("--ktest_filter=MyTest.*", "--ktest_logger=SIMPLE")
         )
         assertEquals(

--- a/src/nativeTest/kotlin/kolt/build/TestDepsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/TestDepsTest.kt
@@ -25,7 +25,7 @@ class TestDepsTest {
         val config = KoltConfig(
             name = "my-app", version = "0.1.0",
             kotlin = KotlinSection(version = "2.1.0"),
-            build = BuildSection(target = "native", main = "main", sources = listOf("src")),
+            build = BuildSection(target = "linuxX64", main = "main", sources = listOf("src")),
         )
         val injected = autoInjectedTestDeps(config)
 
@@ -98,7 +98,7 @@ class TestDepsTest {
         val config = KoltConfig(
             name = "my-app", version = "0.1.0",
             kotlin = KotlinSection(version = "2.1.0"),
-            build = BuildSection(target = "native", main = "main", sources = listOf("src")),
+            build = BuildSection(target = "linuxX64", main = "main", sources = listOf("src")),
             dependencies = mapOf("com.example:lib" to "1.0.0"),
         )
         val allDeps = mergeAllDeps(config)

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
@@ -202,13 +202,14 @@ class CinteropNativeBuildIntegrationTest {
         )
         val config = testConfig(
             name = "myapp",
-            target = "native",
+            target = "linuxX64",
             cinterop = listOf(libcurlEntry)
         )
         val paths = KoltPaths("/home/testuser")
 
         val cinteropCmd = cinteropCommand(
             entry = libcurlEntry,
+            target = config.build.target,
             cinteropPath = paths.cinteropBin(config.kotlin.effectiveCompiler)
         )
         val klibPath = cinteropOutputKlibPath(libcurlEntry)
@@ -231,7 +232,7 @@ class CinteropNativeBuildIntegrationTest {
         // cinterop tool appends .klib to -o automatically; cinteropCommand.outputPath omits it.
         val entry = CinteropConfig(name = "libcurl", def = "libcurl.def")
 
-        val cmd = cinteropCommand(entry)
+        val cmd = cinteropCommand(entry, target = "linuxX64")
         val klibPath = cinteropOutputKlibPath(entry)
 
         assertEquals("${cmd.outputPath}.klib", klibPath)
@@ -242,7 +243,7 @@ class CinteropNativeBuildIntegrationTest {
         val libcurlEntry = CinteropConfig(name = "libcurl", def = "libcurl.def")
         val libsslEntry = CinteropConfig(name = "libssl", def = "libssl.def")
         val config = testConfig(
-            target = "native",
+            target = "linuxX64",
             cinterop = listOf(libcurlEntry, libsslEntry)
         )
 

--- a/src/nativeTest/kotlin/kolt/cli/PluginSupportTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/PluginSupportTest.kt
@@ -58,7 +58,7 @@ class PluginSupportTest {
 
     @Test
     fun resolvePluginArgsNativeTargetSharesTheSameShortCircuit() {
-        val config = testConfig(plugins = emptyMap(), target = "native")
+        val config = testConfig(plugins = emptyMap(), target = "linuxX64")
 
         val result = assertNotNull(resolvePluginArgs(config, bogusPaths, operationalExitCode = 999).get())
 

--- a/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
@@ -196,7 +196,46 @@ class ConfigTest {
     }
 
     @Test
-    fun parseConfigWithNativeTarget() {
+    fun parseConfigWithLinuxX64Target() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "linuxX64"
+            main = "com.example.main"
+            sources = ["src"]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals("linuxX64", config.build.target)
+    }
+
+    @Test
+    fun parseConfigAcceptsAllKonanTargets() {
+        for (target in listOf("linuxX64", "linuxArm64", "macosX64", "macosArm64", "mingwX64")) {
+            val toml = """
+                name = "my-app"
+                version = "0.1.0"
+
+                [kotlin]
+                version = "2.1.0"
+
+                [build]
+                target = "$target"
+                main = "com.example.main"
+                sources = ["src"]
+            """.trimIndent()
+            val config = assertNotNull(parseConfig(toml).get(), "expected $target to parse")
+            assertEquals(target, config.build.target)
+        }
+    }
+
+    @Test
+    fun nativeTargetIsRejectedWithMigrationHint() {
         val toml = """
             name = "my-app"
             version = "0.1.0"
@@ -210,8 +249,12 @@ class ConfigTest {
             sources = ["src"]
         """.trimIndent()
 
-        val config = assertNotNull(parseConfig(toml).get())
-        assertEquals("native", config.build.target)
+        val result = parseConfig(toml)
+
+        assertNull(result.get())
+        val error = assertIs<ConfigError.ParseFailed>(result.getError())
+        assertTrue(error.message.contains("native"), "missing 'native' in: ${error.message}")
+        assertTrue(error.message.contains("linuxX64"), "missing migration hint in: ${error.message}")
     }
 
     @Test
@@ -233,9 +276,86 @@ class ConfigTest {
 
         assertNull(result.get())
         val error = assertIs<ConfigError.ParseFailed>(result.getError())
-        kotlin.test.assertTrue(error.message.contains("target"))
-        kotlin.test.assertTrue(error.message.contains("jvm"))
-        kotlin.test.assertTrue(error.message.contains("native"))
+        assertTrue(error.message.contains("target"))
+        assertTrue(error.message.contains("jvm"))
+        assertTrue(error.message.contains("linuxX64"))
+    }
+
+    @Test
+    fun parseConfigDefaultsKindToApp() {
+        val config = assertNotNull(parseConfig(minimalToml).get())
+        assertEquals("app", config.kind)
+    }
+
+    @Test
+    fun parseConfigAcceptsExplicitKindApp() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kind = "app"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            main = "com.example.main"
+            sources = ["src"]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals("app", config.kind)
+    }
+
+    @Test
+    fun kindLibIsRejectedAsNotYetImplemented() {
+        val toml = """
+            name = "my-lib"
+            version = "0.1.0"
+            kind = "lib"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            main = "com.example.main"
+            sources = ["src"]
+        """.trimIndent()
+
+        val result = parseConfig(toml)
+
+        assertNull(result.get())
+        val error = assertIs<ConfigError.ParseFailed>(result.getError())
+        assertTrue(error.message.contains("kind"), "missing 'kind' in: ${error.message}")
+        assertTrue(error.message.contains("lib"), "missing 'lib' in: ${error.message}")
+        assertTrue(
+            error.message.contains("not yet implemented"),
+            "missing 'not yet implemented' in: ${error.message}"
+        )
+    }
+
+    @Test
+    fun unknownKindReturnsErr() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kind = "service"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            main = "com.example.main"
+            sources = ["src"]
+        """.trimIndent()
+
+        val result = parseConfig(toml)
+
+        assertNull(result.get())
+        val error = assertIs<ConfigError.ParseFailed>(result.getError())
+        assertTrue(error.message.contains("kind"), "missing 'kind' in: ${error.message}")
     }
 
     @Test
@@ -757,7 +877,7 @@ class ConfigTest {
             version = "2.1.0"
 
             [build]
-            target = "native"
+            target = "linuxX64"
             main = "com.example.main"
             sources = ["src"]
 
@@ -785,7 +905,7 @@ class ConfigTest {
             version = "2.1.0"
 
             [build]
-            target = "native"
+            target = "linuxX64"
             main = "com.example.main"
             sources = ["src"]
 
@@ -814,7 +934,7 @@ class ConfigTest {
             version = "2.1.0"
 
             [build]
-            target = "native"
+            target = "linuxX64"
             main = "com.example.main"
             sources = ["src"]
 
@@ -847,7 +967,7 @@ class ConfigTest {
             version = "2.1.0"
 
             [build]
-            target = "native"
+            target = "linuxX64"
             main = "com.example.main"
             sources = ["src"]
 
@@ -940,5 +1060,14 @@ class ConfigTest {
             parseFailed.message.contains("compiler") && parseFailed.message.contains("2.1.0") && parseFailed.message.contains("2.3.20"),
             "expected message to name both versions, got: ${parseFailed.message}",
         )
+    }
+
+    @Test
+    fun konanTargetGradleNameMapsAllKonanTargets() {
+        assertEquals("linux_x64", konanTargetGradleName("linuxX64"))
+        assertEquals("linux_arm64", konanTargetGradleName("linuxArm64"))
+        assertEquals("macos_x64", konanTargetGradleName("macosX64"))
+        assertEquals("macos_arm64", konanTargetGradleName("macosArm64"))
+        assertEquals("mingw_x64", konanTargetGradleName("mingwX64"))
     }
 }

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -21,7 +21,7 @@ class NativeResolverTest {
 
     @Test
     fun resolvesDirectDepWithNoTransitives() {
-        val config = testConfig(target = "native").copy(
+        val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf("com.example:lib" to "1.0.0")
         )
 
@@ -62,7 +62,7 @@ class NativeResolverTest {
 
     @Test
     fun resolvesSingleTransitiveDep() {
-        val config = testConfig(target = "native").copy(
+        val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf("com.example:lib" to "1.0.0")
         )
 
@@ -108,7 +108,7 @@ class NativeResolverTest {
 
     @Test
     fun skipsKotlinStdlibFromTransitives() {
-        val config = testConfig(target = "native").copy(
+        val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf("com.example:lib" to "1.0.0")
         )
 
@@ -140,7 +140,7 @@ class NativeResolverTest {
     @Test
     fun skipsKotlinStdlibCommonFromTransitives() {
         // kotlin-stdlib-common has no Gradle module metadata (pre-GMM artifact).
-        val config = testConfig(target = "native").copy(
+        val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf("com.example:lib" to "1.0.0")
         )
 
@@ -171,7 +171,7 @@ class NativeResolverTest {
 
     @Test
     fun skipsKotlinStdlibCommonAsDirectDependencyToo() {
-        val config = testConfig(target = "native").copy(
+        val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf(
                 "com.example:lib" to "1.0.0",
                 "org.jetbrains.kotlin:kotlin-stdlib-common" to "1.8.21"
@@ -199,7 +199,7 @@ class NativeResolverTest {
 
     @Test
     fun skipsKotlinStdlibAsDirectDependencyToo() {
-        val config = testConfig(target = "native").copy(
+        val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf(
                 "com.example:lib" to "1.0.0",
                 "org.jetbrains.kotlin:kotlin-stdlib" to "2.0.0"
@@ -227,7 +227,7 @@ class NativeResolverTest {
 
     @Test
     fun returnsEmptyWhenNoDependencies() {
-        val config = testConfig(target = "native").copy(dependencies = emptyMap())
+        val config = testConfig(target = "linuxX64").copy(dependencies = emptyMap())
         val deps = fakeDeps()
 
         val result = resolveNative(config, "/cache", deps)
@@ -238,7 +238,7 @@ class NativeResolverTest {
 
     @Test
     fun failsWhenNoNativeVariantAvailable() {
-        val config = testConfig(target = "native").copy(
+        val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf("com.example:jvmonly" to "1.0.0")
         )
 
@@ -276,7 +276,7 @@ class NativeResolverTest {
 
     @Test
     fun failsOnSha256Mismatch() {
-        val config = testConfig(target = "native").copy(
+        val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf("com.example:lib" to "1.0.0")
         )
 
@@ -302,7 +302,7 @@ class NativeResolverTest {
 
     @Test
     fun diamondDependencyHighestVersionWins() {
-        val config = testConfig(target = "native").copy(
+        val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf(
                 "com.example:a" to "1.0.0",
                 "com.example:b" to "1.0.0"
@@ -349,7 +349,7 @@ class NativeResolverTest {
 
     @Test
     fun directDepVersionWinsOverTransitive() {
-        val config = testConfig(target = "native").copy(
+        val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf(
                 "com.example:a" to "1.0.0",
                 "com.example:shared" to "1.0.0"
@@ -386,7 +386,7 @@ class NativeResolverTest {
 
     @Test
     fun failsOnInvalidCoordinate() {
-        val config = testConfig(target = "native").copy(
+        val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf("invalid-no-colon" to "1.0.0")
         )
         val deps = fakeDeps()
@@ -398,7 +398,7 @@ class NativeResolverTest {
 
     @Test
     fun failsOnInvalidJsonWithMetadataParseFailed() {
-        val config = testConfig(target = "native").copy(
+        val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf("com.example:lib" to "1.0.0")
         )
 


### PR DESCRIPTION
First of two PRs implementing ADR 0023 (#167). Schema-only — no build pipeline changes for non-linuxX64 targets.

## What changed

- `target` accepts `jvm` + 5 KonanTarget identifiers (`linuxX64`, `linuxArm64`, `macosX64`, `macosArm64`, `mingwX64`); `target = "native"` becomes a parse-time error with a migration hint.
- New top-level `kind` field, default `"app"`. `kind = "lib"` is reserved at the schema level but rejected with "not yet implemented" so the slot exists for a future library-support PR.
- `konanTargetGradleName` maps the schema-level camelCase to the snake_case form that konanc CLI and Gradle Module Metadata both expect. Used by `Builder` and `NativeResolver`.
- Eight dispatch sites migrated from `target == "native"` to `target in NATIVE_TARGETS`.
- Fixtures, README (en/ja), `kolt-usage` skill, and the project's own `kolt.toml` migrated. Self-host build verified (kolt builds kolt).

## Where to focus review

- `src/nativeMain/kotlin/kolt/config/Config.kt` — `validateKind` / `validateTarget` ordering and error message wording (the migration hint and the "reserved" framing for `kind = "lib"`).
- `konanTargetGradleName` regex — total by design; precondition is enforced by `validateTarget` upstream. Direct unit test pins the mapping for all five targets.
- `cinteropCommand` gained a required `target` parameter (no default). All call sites — including tests — pass it explicitly. Worth a glance to confirm nothing leaks the previously-hardcoded `linux_x64`.

## Out of scope (PR2)

- `[build.targets.X]` reservation + mutual exclusion with scalar `target`
- Promoting ADR 0023 from Proposed to Accepted