### PR TITLE
Reserve [build.targets.X] schema and accept ADR 0023 (#167)

### DIFF
--- a/docs/adr/0023-target-and-kind-schema.md
+++ b/docs/adr/0023-target-and-kind-schema.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed (2026-04-19).
+Accepted (2026-04-19).
 
 ## Context
 

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -6,6 +6,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
 import kolt.resolve.compareVersions
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -65,6 +66,10 @@ data class BuildSection(
     @SerialName("test_resources") val testResources: List<String> = emptyList()
 )
 
+// Per-target fields deferred per ADR 0023 §3.
+@Serializable
+private data class BuildTargetEntry(val unused: String? = null)
+
 @Serializable
 data class FmtSection(
     val style: String = "google"
@@ -86,6 +91,38 @@ data class KoltConfig(
 
 private val toml = Toml(
     inputConfig = TomlInputConfig(ignoreUnknownNames = true)
+)
+
+// Two-tier parse: ktoml deserializes into the Raw* classes (target/main/sources
+// optional, plus `targets` map for `[build.targets.X]`). parseConfig then
+// validates and de-sugars into the public KoltConfig/BuildSection where
+// `target` is non-null. Keeping the public schema unchanged lets the 22-odd
+// `config.build.target` consumers stay typed as String.
+@Serializable
+private data class RawBuildSection(
+    val target: String? = null,
+    @SerialName("jvm_target") val jvmTarget: String = "17",
+    val jdk: String? = null,
+    val main: String,
+    val sources: List<String>,
+    @SerialName("test_sources") val testSources: List<String> = listOf("test"),
+    val resources: List<String> = emptyList(),
+    @SerialName("test_resources") val testResources: List<String> = emptyList(),
+    val targets: Map<String, BuildTargetEntry>? = null
+)
+
+@Serializable
+private data class RawKoltConfig(
+    val name: String,
+    val version: String,
+    val kind: String = "app",
+    val kotlin: KotlinSection,
+    val build: RawBuildSection,
+    val fmt: FmtSection = FmtSection(),
+    val dependencies: Map<String, String> = emptyMap(),
+    @SerialName("test-dependencies") val testDependencies: Map<String, String> = emptyMap(),
+    val repositories: Map<String, String> = mapOf("central" to MAVEN_CENTRAL_BASE),
+    val cinterop: List<CinteropConfig> = emptyList()
 )
 
 private fun validateKind(kind: String): Result<Unit, ConfigError> {
@@ -117,27 +154,77 @@ private fun validateTarget(target: String): Result<Unit, ConfigError> {
     return Ok(Unit)
 }
 
+// ADR 0023 §3: scalar `[build] target = "X"` and `[build.targets.X]` are
+// mutually exclusive. Multi-target form is reserved — exactly one entry
+// is de-sugared into the scalar form, two or more are rejected.
+private fun resolveEffectiveTarget(raw: RawBuildSection): Result<String, ConfigError> {
+    val scalar = raw.target
+    val tables = raw.targets
+        ?.mapKeys { (key, _) -> key.removeSurrounding("\"") }
+
+    if (scalar != null && !tables.isNullOrEmpty()) {
+        return Err(ConfigError.ParseFailed(
+            "[build] target = \"...\" and [build.targets.X] cannot both be specified"
+        ))
+    }
+    if (!tables.isNullOrEmpty()) {
+        if (tables.size > 1) {
+            return Err(ConfigError.ParseFailed(
+                "multi-target builds are not yet implemented " +
+                    "(found [build.targets]: ${tables.keys.joinToString(", ")}). " +
+                    "Pick one target until multi-target ships."
+            ))
+        }
+        return Ok(tables.keys.first())
+    }
+    if (scalar == null) {
+        return Err(ConfigError.ParseFailed("[build] target is required"))
+    }
+    return Ok(scalar)
+}
+
 fun parseConfig(tomlString: String): Result<KoltConfig, ConfigError> {
     return try {
-        val config = toml.decodeFromString(KoltConfig.serializer(), tomlString)
-        validateKind(config.kind).getError()?.let { return Err(it) }
-        validateTarget(config.build.target).getError()?.let { return Err(it) }
-        validateMainFqn(config.build.main).getError()?.let { return Err(it) }
-        config.kotlin.compiler?.let { compiler ->
-            if (compareVersions(compiler, config.kotlin.version) < 0) {
+        val raw = toml.decodeFromString(RawKoltConfig.serializer(), tomlString)
+        validateKind(raw.kind).getError()?.let { return Err(it) }
+        val effectiveTarget = resolveEffectiveTarget(raw.build).getOrElse { return Err(it) }
+        validateTarget(effectiveTarget).getError()?.let { return Err(it) }
+        validateMainFqn(raw.build.main).getError()?.let { return Err(it) }
+        raw.kotlin.compiler?.let { compiler ->
+            if (compareVersions(compiler, raw.kotlin.version) < 0) {
                 return Err(ConfigError.ParseFailed(
-                    "[kotlin] compiler '$compiler' is lower than version '${config.kotlin.version}' " +
+                    "[kotlin] compiler '$compiler' is lower than version '${raw.kotlin.version}' " +
                         "(a compiler cannot target a newer language than itself)"
                 ))
             }
         }
         // ktoml preserves quotes in map keys; strip them.
-        val cleanedDeps = config.dependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }
-        val cleanedTestDeps = config.testDependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }
-        val cleanedRepos = config.repositories
+        val cleanedDeps = raw.dependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }
+        val cleanedTestDeps = raw.testDependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }
+        val cleanedRepos = raw.repositories
             .mapKeys { (key, _) -> key.removeSurrounding("\"") }
             .mapValues { (_, url) -> url.trimEnd('/') }
-        Ok(config.copy(dependencies = cleanedDeps, testDependencies = cleanedTestDeps, repositories = cleanedRepos))
+        Ok(KoltConfig(
+            name = raw.name,
+            version = raw.version,
+            kind = raw.kind,
+            kotlin = raw.kotlin,
+            build = BuildSection(
+                target = effectiveTarget,
+                jvmTarget = raw.build.jvmTarget,
+                jdk = raw.build.jdk,
+                main = raw.build.main,
+                sources = raw.build.sources,
+                testSources = raw.build.testSources,
+                resources = raw.build.resources,
+                testResources = raw.build.testResources
+            ),
+            fmt = raw.fmt,
+            dependencies = cleanedDeps,
+            testDependencies = cleanedTestDeps,
+            repositories = cleanedRepos,
+            cinterop = raw.cinterop
+        ))
     } catch (e: SerializationException) {
         Err(ConfigError.ParseFailed("failed to parse kolt.toml: ${e.message}"))
     } catch (e: IllegalArgumentException) {

--- a/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
@@ -359,6 +359,167 @@ class ConfigTest {
     }
 
     @Test
+    fun parseConfigWithSingleTargetTableDesugars() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            main = "com.example.main"
+            sources = ["src"]
+
+            [build.targets.linuxX64]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals("linuxX64", config.build.target)
+    }
+
+    @Test
+    fun parseConfigWithSingleJvmTargetTableDesugars() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            main = "com.example.main"
+            sources = ["src"]
+
+            [build.targets.jvm]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals("jvm", config.build.target)
+    }
+
+    @Test
+    fun multipleTargetTablesRejectedAsMultiTargetNotYetImplemented() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            main = "com.example.main"
+            sources = ["src"]
+
+            [build.targets.jvm]
+            [build.targets.linuxX64]
+        """.trimIndent()
+
+        val result = parseConfig(toml)
+
+        assertNull(result.get())
+        val error = assertIs<ConfigError.ParseFailed>(result.getError())
+        assertTrue(
+            error.message.contains("multi-target") && error.message.contains("not yet implemented"),
+            "expected multi-target rejection, got: ${error.message}"
+        )
+    }
+
+    @Test
+    fun scalarTargetAndTargetTableTogetherIsSchemaError() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            main = "com.example.main"
+            sources = ["src"]
+
+            [build.targets.linuxX64]
+        """.trimIndent()
+
+        val result = parseConfig(toml)
+
+        assertNull(result.get())
+        val error = assertIs<ConfigError.ParseFailed>(result.getError())
+        assertTrue(
+            error.message.contains("[build] target") && error.message.contains("[build.targets"),
+            "expected mutual-exclusion error, got: ${error.message}"
+        )
+    }
+
+    @Test
+    fun parseConfigWithQuotedTargetTableKeyDesugars() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            main = "com.example.main"
+            sources = ["src"]
+
+            [build.targets."linuxX64"]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals("linuxX64", config.build.target)
+    }
+
+    @Test
+    fun bogusTargetTableKeyFallsThroughToTargetValidation() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            main = "com.example.main"
+            sources = ["src"]
+
+            [build.targets.wasm]
+        """.trimIndent()
+
+        val result = parseConfig(toml)
+
+        assertNull(result.get())
+        val error = assertIs<ConfigError.ParseFailed>(result.getError())
+        assertTrue(error.message.contains("wasm"), "missing 'wasm' in: ${error.message}")
+    }
+
+    @Test
+    fun nativeInTargetTableIsRejectedWithMigrationHint() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            main = "com.example.main"
+            sources = ["src"]
+
+            [build.targets.native]
+        """.trimIndent()
+
+        val result = parseConfig(toml)
+
+        assertNull(result.get())
+        val error = assertIs<ConfigError.ParseFailed>(result.getError())
+        assertTrue(error.message.contains("native"), "missing 'native' in: ${error.message}")
+        assertTrue(error.message.contains("linuxX64"), "missing migration hint in: ${error.message}")
+    }
+
+    @Test
     fun unknownFieldsAreIgnored() {
         val toml = """
             name = "my-app"

--- a/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -449,6 +450,33 @@ class ConfigTest {
         assertTrue(
             error.message.contains("[build] target") && error.message.contains("[build.targets"),
             "expected mutual-exclusion error, got: ${error.message}"
+        )
+    }
+
+    @Test
+    fun emptyBuildTargetsTableWithoutScalarReportsTargetRequired() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            main = "com.example.main"
+            sources = ["src"]
+
+            [build.targets]
+        """.trimIndent()
+
+        val result = parseConfig(toml)
+
+        assertNull(result.get())
+        val error = assertIs<ConfigError.ParseFailed>(result.getError())
+        assertTrue(error.message.contains("target"), "missing 'target' in: ${error.message}")
+        assertFalse(
+            error.message.contains("multi-target"),
+            "should not report multi-target for empty table, got: ${error.message}"
         )
     }
 


### PR DESCRIPTION
Closes #167. Second of two PRs implementing ADR 0023 (PR1 = #172).

## What changed

- `[build.targets.X]` reservation per ADR 0023 §3:
  - Exactly one table is de-sugared into `[build] target = "X"` internally.
  - Two or more rejected with "multi-target builds are not yet implemented".
  - Scalar `target` plus `[build.targets.X]` is a parse error (mutual exclusion).
- ADR 0023 Status: Proposed → Accepted (2026-04-19).

## Where to focus review

- `src/nativeMain/kotlin/kolt/config/Config.kt` — the two-tier parse pattern (`RawBuildSection`/`RawKoltConfig` private; `BuildTargetEntry` private). The duplication exists so the public `BuildSection.target: String` stays non-null and the 22-odd `config.build.target` consumer sites need no migration. Worth a glance: `resolveEffectiveTarget` covers all four states (scalar / single-table / multi-table / neither).
- The quoted-dotted-key test (`parseConfigWithQuotedTargetTableKeyDesugars`) pins `removeSurrounding("\"")` against future "looks like dead code" cleanups.

## Verification

- `./gradlew linuxX64Test --rerun-tasks` green
- Self-host build (`./build/bin/linuxX64/releaseExecutable/kolt.kexe build`) succeeds — `kolt.toml` keeps the scalar form, exercising the back-compat path

## Out of scope (future work)

- `kind = "lib"` actual implementation (ADR 0023 §1)
- multi-target build pipeline (the slot is reserved here)
- per-target field vocabulary inside `BuildTargetEntry` (a future KMP ADR will define it)