### PR TITLE
Add kolt-native-daemon module skeleton + wire protocol (#170)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,13 +7,15 @@ group = "com.github.snicmakino"
 
 // Canonical kotlinc version pin for the whole project. Sister constants live in
 // `src/nativeMain/kotlin/kolt/cli/BundledKotlinVersion.kt` (native client),
-// `kolt-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt` (daemon), and four
-// kotlinc/BTA artifact coordinates in kolt-compiler-daemon's build scripts.
-// ADR 0019 §1 requires all six to move in lockstep with this value. They are
-// hand-pinned rather than generated so the self-host path (`kolt.kexe build`
-// driven by `kolt.toml`) compiles without a prior Gradle step populating
-// `build/generated/`; `verifyDaemonKotlinVersion` asserts the sync at build
-// time. #138 will collapse the manual-sync requirement.
+// `kolt-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt` (JVM daemon),
+// `kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/Main.kt` (native
+// daemon, ADR 0024), and four kotlinc/BTA artifact coordinates in
+// kolt-compiler-daemon's build scripts. ADR 0019 §1 requires all seven to
+// move in lockstep with this value. They are hand-pinned rather than
+// generated so the self-host path (`kolt.kexe build` driven by `kolt.toml`)
+// compiles without a prior Gradle step populating `build/generated/`;
+// `verifyDaemonKotlinVersion` asserts the sync at build time. #138 will
+// collapse the manual-sync requirement.
 val daemonKotlinVersion = "2.3.20"
 
 repositories {
@@ -35,11 +37,15 @@ val verifyDaemonKotlinVersion = tasks.register("verifyDaemonKotlinVersion") {
     val icBuildScript = layout.projectDirectory.file(
         "kolt-compiler-daemon/ic/build.gradle.kts",
     )
+    val nativeDaemonMain = layout.projectDirectory.file(
+        "kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/Main.kt",
+    )
     val expected = daemonKotlinVersion
     inputs.file(nativeBundled)
     inputs.file(daemonMain)
     inputs.file(daemonBuildScript)
     inputs.file(icBuildScript)
+    inputs.file(nativeDaemonMain)
     inputs.property("expected", expected)
     doLast {
         data class Pin(val label: String, val file: java.io.File, val regex: Regex, val fixHint: String)
@@ -89,6 +95,14 @@ val verifyDaemonKotlinVersion = tasks.register("verifyDaemonKotlinVersion") {
                 file = icBuildScript.asFile,
                 regex = Regex("kotlin-build-tools-impl:([^\"\\s]+)\""),
                 fixHint = "pin `org.jetbrains.kotlin:kotlin-build-tools-impl:<version>` with a literal version",
+            ),
+            Pin(
+                label = "kolt-native-daemon Main.kt `KOLT_NATIVE_DAEMON_KOTLIN_VERSION`",
+                file = nativeDaemonMain.asFile,
+                regex = Regex(
+                    """const\s+val\s+KOLT_NATIVE_DAEMON_KOTLIN_VERSION\s*:\s*String\s*=\s*"([^"]+)"""",
+                ),
+                fixHint = "keep the declaration as `internal const val KOLT_NATIVE_DAEMON_KOTLIN_VERSION: String = \"<version>\"`",
             ),
         )
 
@@ -152,30 +166,34 @@ tasks.withType<Wrapper> {
     distributionType = Wrapper.DistributionType.BIN
 }
 
-// Keep the existing "./gradlew build rebuilds the daemon fat jar too" DX after
-// the kolt-compiler-daemon split into an independent Gradle build. Without this
-// wiring, the dev-fallback path in DaemonJarResolver.kt could pick up a stale
-// jar produced before a local protocol change.
+// Keep the existing "./gradlew build rebuilds the daemon fat jars too" DX
+// after the kolt-compiler-daemon and kolt-native-daemon splits into
+// independent Gradle builds. Without this wiring, the dev-fallback paths in
+// DaemonJarResolver.kt (and the forthcoming native counterpart per ADR
+// 0024) could pick up stale jars produced before a local protocol change.
 tasks.named("build") {
     dependsOn(gradle.includedBuild("kolt-compiler-daemon").task(":build"))
+    dependsOn(gradle.includedBuild("kolt-native-daemon").task(":build"))
 }
 
-// Propagate `check` to the included build as well, so that ADR 0016's
-// `verifyShadowJar` regression guard (which rejects kotlin-compiler-embeddable
-// being baked into the fat jar) stays on the root `./gradlew check` path.
-// Without this, the silent-fallback footgun that ADR 0018 flags loses its
-// first line of defense.
+// Propagate `check` to both included builds as well, so that ADR 0016's and
+// ADR 0024's `verifyShadowJar` regression guards (which reject
+// kotlin-compiler-embeddable and kotlin-native-compiler-embeddable from
+// being baked into their respective fat jars) stay on the root
+// `./gradlew check` path.
 tasks.named("check") {
     dependsOn(gradle.includedBuild("kolt-compiler-daemon").task(":check"))
+    dependsOn(gradle.includedBuild("kolt-native-daemon").task(":check"))
     dependsOn(verifyDaemonKotlinVersion)
 }
 
 // Same rationale for `clean`: without this wiring, `./gradlew clean` at the
-// root leaves the daemon fat jar behind, and the dev-fallback path in
-// DaemonJarResolver.kt can keep resolving it across local protocol changes
-// until someone manually wipes kolt-compiler-daemon/build/.
+// root leaves the daemon fat jars behind, and the dev-fallback resolvers can
+// keep reading them across local protocol changes until someone manually
+// wipes the daemon build dirs.
 tasks.named("clean") {
     dependsOn(gradle.includedBuild("kolt-compiler-daemon").task(":clean"))
+    dependsOn(gradle.includedBuild("kolt-native-daemon").task(":clean"))
 }
 
 // Force `stageBtaImplJars` before any `linuxX64Test` run. Without this

--- a/kolt-native-daemon/build.gradle.kts
+++ b/kolt-native-daemon/build.gradle.kts
@@ -1,0 +1,97 @@
+import java.util.zip.ZipFile
+
+plugins {
+    kotlin("jvm") version "2.3.20"
+    kotlin("plugin.serialization") version "2.3.20"
+    application
+    id("com.gradleup.shadow") version "8.3.5"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // kotlin-native-compiler-embeddable.jar is NOT declared here. ADR 0024 §8:
+    // the native daemon receives its path on the CLI via `--konanc-jar <path>`
+    // and loads it through a dedicated URLClassLoader at request-handling time.
+    // Bundling it would defeat the reflective-load contract and drag a ~60MB
+    // artifact into the fat jar. `verifyShadowJar` below enforces the exclusion.
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation("com.michael-bull.kotlin-result:kotlin-result-jvm:2.3.1")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.3")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+application {
+    mainClass.set("kolt.nativedaemon.MainKt")
+}
+
+tasks.shadowJar {
+    // Pin Main-Class explicitly — mirrors the rationale in
+    // kolt-compiler-daemon/build.gradle.kts: a future removal of the
+    // `application` plugin would otherwise produce a jar that silently
+    // fails at `java -jar` time instead of at build time.
+    manifest {
+        attributes("Main-Class" to "kolt.nativedaemon.MainKt")
+    }
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+}
+
+// Regression guard parallel to the one in kolt-compiler-daemon/build.gradle.kts:
+// ADR 0024 §8 requires kotlin-native-compiler-embeddable.jar to be passed via
+// --konanc-jar and loaded reflectively — it MUST NOT be baked into the fat jar.
+// kotlinx-serialization-json and kotlin-result must be bundled since the native
+// client spawns the daemon with a bare `java -jar` and there is no other source
+// for those classes.
+tasks.register("verifyShadowJar") {
+    group = "verification"
+    description = "Verifies the native daemon fat jar bundles required libs and excludes kotlin-native-compiler-embeddable."
+    dependsOn(tasks.shadowJar)
+    doLast {
+        val jarFile = tasks.shadowJar.get().archiveFile.get().asFile
+        val entries = ZipFile(jarFile).use { zip ->
+            zip.entries().asSequence().map { entry -> entry.name }.toList()
+        }
+        // Markers unique to kotlin-native-compiler-embeddable: K2Native and the
+        // `cli/bc` package it sits in are native-specific; `cli/common` is shared
+        // with the JVM compiler, so we anchor on the native-only subtree.
+        val mustExclude = listOf(
+            "org/jetbrains/kotlin/cli/bc/",
+            "org/jetbrains/kotlin/cli/utilities/MainKt",
+        )
+        val mustInclude = listOf(
+            "kotlinx/serialization/json/Json",
+            "com/github/michaelbull/result/Result",
+        )
+        val forbidden = mustExclude.filter { prefix -> entries.any { name -> name.startsWith(prefix) } }
+        if (forbidden.isNotEmpty()) {
+            throw GradleException(
+                "shadowJar contains forbidden entries (ADR 0024 §8 violation): $forbidden. " +
+                    "kotlin-native-compiler-embeddable must be passed via --konanc-jar and loaded reflectively.",
+            )
+        }
+        val missing = mustInclude.filter { needle -> entries.none { name -> name.startsWith(needle) } }
+        if (missing.isNotEmpty()) {
+            throw GradleException(
+                "shadowJar is missing required entries: $missing. " +
+                    "The native client spawns the daemon with `java -jar` and has no other source for these classes.",
+            )
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn("verifyShadowJar")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/kolt-native-daemon/settings.gradle.kts
+++ b/kolt-native-daemon/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "kolt-native-daemon"

--- a/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/Main.kt
+++ b/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/Main.kt
@@ -1,0 +1,22 @@
+package kolt.nativedaemon
+
+import kotlin.system.exitProcess
+
+// Kotlin version pin for the native daemon. Must move in lockstep with the
+// root `daemonKotlinVersion` in the top-level build.gradle.kts; the root
+// `verifyDaemonKotlinVersion` task guards against drift. Mirrors
+// `KOLT_DAEMON_KOTLIN_VERSION` in kolt-compiler-daemon/.../Main.kt.
+internal const val KOLT_NATIVE_DAEMON_KOTLIN_VERSION: String = "2.3.20"
+
+// Stub entry point. This PR lands the module scaffolding + wire protocol
+// only; the daemon server (ADR 0024 §2: URLClassLoader load of
+// kotlin-native-compiler-embeddable.jar, reflective K2Native.exec) arrives
+// in a follow-up PR. Invoking this jar today exits with status 2 and a
+// hint so nobody mistakes the scaffolding for a working daemon.
+fun main(args: Array<String>) {
+    System.err.println(
+        "kolt-native-daemon: server implementation not yet wired (ADR 0024, issue #170). " +
+            "Received ${args.size} args; refusing to start.",
+    )
+    exitProcess(2)
+}

--- a/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/protocol/FrameCodec.kt
+++ b/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/protocol/FrameCodec.kt
@@ -1,0 +1,93 @@
+package kolt.nativedaemon.protocol
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+sealed interface FrameError {
+    data object Eof : FrameError
+    data class Truncated(val wantedBytes: Int, val gotBytes: Int) : FrameError
+    data class Malformed(val reason: String) : FrameError
+    data class Io(val reason: String) : FrameError
+}
+
+// Wire envelope for the native compiler daemon. Identical frame format to
+// `kolt.daemon.protocol.FrameCodec` (ADR 0016) — 4-byte big-endian length
+// prefix + UTF-8 JSON body — but bound to this module's own Message type per
+// ADR 0024 §1. Keeping the codec local avoids a build dependency from
+// kolt-native-daemon on kolt-compiler-daemon and lets the two protocols
+// evolve independently.
+object FrameCodec {
+
+    private val json = Json { classDiscriminator = "type" }
+
+    const val MAX_BODY_BYTES: Int = 64 * 1024 * 1024
+
+    fun writeFrame(out: OutputStream, message: Message): Result<Unit, FrameError> {
+        val body = json.encodeToString(Message.serializer(), message).toByteArray(Charsets.UTF_8)
+        val len = body.size
+        if (len > MAX_BODY_BYTES) {
+            return Err(FrameError.Malformed("frame body exceeds MAX_BODY_BYTES: $len"))
+        }
+        return try {
+            out.write((len ushr 24) and 0xff)
+            out.write((len ushr 16) and 0xff)
+            out.write((len ushr 8) and 0xff)
+            out.write(len and 0xff)
+            out.write(body)
+            out.flush()
+            Ok(Unit)
+        } catch (e: IOException) {
+            Err(FrameError.Io(e.message ?: "write failed"))
+        }
+    }
+
+    fun readFrame(input: InputStream): Result<Message, FrameError> {
+        val header = ByteArray(4)
+        val headerRead = try {
+            readFully(input, header)
+        } catch (e: IOException) {
+            return Err(FrameError.Io(e.message ?: "read failed"))
+        }
+        if (headerRead == 0) return Err(FrameError.Eof)
+        if (headerRead < 4) return Err(FrameError.Truncated(wantedBytes = 4, gotBytes = headerRead))
+
+        val len = ((header[0].toInt() and 0xff) shl 24) or
+            ((header[1].toInt() and 0xff) shl 16) or
+            ((header[2].toInt() and 0xff) shl 8) or
+            (header[3].toInt() and 0xff)
+
+        if (len < 0 || len > MAX_BODY_BYTES) {
+            return Err(FrameError.Malformed("invalid frame length: $len"))
+        }
+
+        val body = ByteArray(len)
+        val bodyRead = try {
+            readFully(input, body)
+        } catch (e: IOException) {
+            return Err(FrameError.Io(e.message ?: "read failed"))
+        }
+        if (bodyRead < len) return Err(FrameError.Truncated(wantedBytes = len, gotBytes = bodyRead))
+
+        return try {
+            Ok(json.decodeFromString(Message.serializer(), body.toString(Charsets.UTF_8)))
+        } catch (e: SerializationException) {
+            Err(FrameError.Malformed(e.message ?: "serialization error"))
+        }
+    }
+
+    private fun readFully(input: InputStream, buf: ByteArray): Int {
+        var total = 0
+        while (total < buf.size) {
+            val n = input.read(buf, total, buf.size - total)
+            if (n < 0) return total
+            total += n
+        }
+        return total
+    }
+}

--- a/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/protocol/Message.kt
+++ b/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/protocol/Message.kt
@@ -1,0 +1,44 @@
+package kolt.nativedaemon.protocol
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// ADR 0024 §4: native daemon carries konanc args as a flat list rather than
+// the structured fields used by the JVM daemon's Message.Compile. K2Native's
+// entry point is `exec(PrintStream, String[])` and there is no BTA equivalent
+// for native, so decomposing into structured fields adds complexity with no
+// downstream benefit. The native daemon's Message sealed interface is
+// intentionally separate from `kolt.daemon.protocol.Message` per ADR 0020 §2
+// (separate daemon processes) and §1 here — the two wire formats evolve
+// independently and share only the frame envelope format.
+@Serializable
+sealed interface Message {
+
+    @Serializable
+    @SerialName("NativeCompile")
+    data class NativeCompile(
+        val args: List<String>,
+    ) : Message
+
+    // ADR 0024 §4: stderr is a blob, same shape as the subprocess fallback path.
+    // Structured diagnostic parsing is out of scope (see `kolt.daemon.protocol.Diagnostic`
+    // on the JVM side — not mirrored here).
+    @Serializable
+    @SerialName("NativeCompileResult")
+    data class NativeCompileResult(
+        val exitCode: Int,
+        val stderr: String,
+    ) : Message
+
+    @Serializable
+    @SerialName("Ping")
+    data object Ping : Message
+
+    @Serializable
+    @SerialName("Pong")
+    data object Pong : Message
+
+    @Serializable
+    @SerialName("Shutdown")
+    data object Shutdown : Message
+}

--- a/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/protocol/FrameCodecTest.kt
+++ b/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/protocol/FrameCodecTest.kt
@@ -1,0 +1,146 @@
+package kolt.nativedaemon.protocol
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.OutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+class FrameCodecTest {
+
+    @Test
+    fun `round-trips a Ping frame`() {
+        val out = ByteArrayOutputStream()
+        FrameCodec.writeFrame(out, Message.Ping)
+
+        val decoded = FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get()
+        assertEquals(Message.Ping, decoded)
+    }
+
+    @Test
+    fun `round-trips a NativeCompile frame`() {
+        val msg: Message = Message.NativeCompile(
+            args = listOf("-target", "linux_x64", "src/Main.kt", "-p", "library", "-nopack", "-o", "build/main-klib"),
+        )
+        val out = ByteArrayOutputStream()
+        FrameCodec.writeFrame(out, msg)
+
+        assertEquals(msg, FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get())
+    }
+
+    @Test
+    fun `round-trips a NativeCompileResult frame`() {
+        val msg: Message = Message.NativeCompileResult(
+            exitCode = 1,
+            stderr = "error: unresolved reference: foo",
+        )
+        val out = ByteArrayOutputStream()
+        FrameCodec.writeFrame(out, msg)
+
+        assertEquals(msg, FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get())
+    }
+
+    @Test
+    fun `reads multiple frames back to back`() {
+        val out = ByteArrayOutputStream()
+        FrameCodec.writeFrame(out, Message.Ping)
+        FrameCodec.writeFrame(out, Message.Pong)
+        FrameCodec.writeFrame(out, Message.Shutdown)
+
+        val input = ByteArrayInputStream(out.toByteArray())
+        assertEquals(Message.Ping, FrameCodec.readFrame(input).get())
+        assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
+        assertEquals(Message.Shutdown, FrameCodec.readFrame(input).get())
+    }
+
+    @Test
+    fun `empty stream returns Eof`() {
+        val err = FrameCodec.readFrame(ByteArrayInputStream(ByteArray(0))).getError()
+        assertEquals(FrameError.Eof, err)
+    }
+
+    @Test
+    fun `truncated length prefix returns Truncated`() {
+        val err = FrameCodec.readFrame(ByteArrayInputStream(byteArrayOf(0, 0))).getError()
+        assertNotNull(err)
+        assertIs<FrameError.Truncated>(err)
+    }
+
+    @Test
+    fun `truncated body returns Truncated`() {
+        val out = ByteArrayOutputStream()
+        FrameCodec.writeFrame(out, Message.Ping)
+        val full = out.toByteArray()
+        val cut = full.copyOf(full.size - 2)
+
+        val err = FrameCodec.readFrame(ByteArrayInputStream(cut)).getError()
+        assertNotNull(err)
+        assertIs<FrameError.Truncated>(err)
+    }
+
+    @Test
+    fun `malformed JSON body returns Malformed`() {
+        val body = "not json".toByteArray(Charsets.UTF_8)
+        val out = ByteArrayOutputStream()
+        out.write(byteArrayOf(0, 0, 0, body.size.toByte()))
+        out.write(body)
+
+        val err = FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).getError()
+        assertNotNull(err)
+        assertIs<FrameError.Malformed>(err)
+    }
+
+    @Test
+    fun `writeFrame returns Io error when the stream throws`() {
+        val failing = object : OutputStream() {
+            override fun write(b: Int) { throw IOException("broken pipe") }
+        }
+        val err = FrameCodec.writeFrame(failing, Message.Ping).getError()
+        assertNotNull(err)
+        assertIs<FrameError.Io>(err)
+    }
+
+    @Test
+    fun `negative length returns Malformed`() {
+        val bytes = byteArrayOf(-1, -1, -1, -1)
+        val err = FrameCodec.readFrame(ByteArrayInputStream(bytes)).getError()
+        assertNotNull(err)
+        assertIs<FrameError.Malformed>(err)
+    }
+
+    @Test
+    fun `writeFrame returns Malformed when body exceeds MAX_BODY_BYTES`() {
+        // One arg whose JSON-encoded length alone overflows the cap. The actual
+        // body grows slightly past the arg size (type discriminator, field name,
+        // quotes), guaranteeing we cross the threshold.
+        val oversized = "x".repeat(FrameCodec.MAX_BODY_BYTES + 1)
+        val msg: Message = Message.NativeCompile(args = listOf(oversized))
+
+        val err = FrameCodec.writeFrame(ByteArrayOutputStream(), msg).getError()
+        assertNotNull(err)
+        assertIs<FrameError.Malformed>(err)
+    }
+
+    @Test
+    fun `reads a NativeCompile NativeCompileResult pair back to back`() {
+        val request: Message = Message.NativeCompile(
+            args = listOf("-target", "linux_x64", "src/Main.kt", "-p", "library", "-nopack"),
+        )
+        val response: Message = Message.NativeCompileResult(
+            exitCode = 0,
+            stderr = "warning: deprecated API usage at src/Main.kt:3",
+        )
+        val out = ByteArrayOutputStream()
+        FrameCodec.writeFrame(out, request)
+        FrameCodec.writeFrame(out, response)
+
+        val input = ByteArrayInputStream(out.toByteArray())
+        assertEquals(request, FrameCodec.readFrame(input).get())
+        assertEquals(response, FrameCodec.readFrame(input).get())
+    }
+}

--- a/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/protocol/MessageTest.kt
+++ b/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/protocol/MessageTest.kt
@@ -1,0 +1,83 @@
+package kolt.nativedaemon.protocol
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MessageTest {
+
+    private val json = Json { classDiscriminator = "type" }
+
+    @Test
+    fun `NativeCompile carries a flat args list`() {
+        val msg: Message = Message.NativeCompile(
+            args = listOf("-target", "linux_x64", "src/Main.kt", "-p", "library", "-nopack", "-o", "build/main-klib"),
+        )
+
+        val encoded = json.encodeToString(Message.serializer(), msg)
+        val decoded = json.decodeFromString(Message.serializer(), encoded)
+
+        assertEquals(msg, decoded)
+    }
+
+    @Test
+    fun `NativeCompile serializes with type discriminator NativeCompile`() {
+        val msg: Message = Message.NativeCompile(args = listOf("-target", "linux_x64"))
+
+        val encoded = json.encodeToString(Message.serializer(), msg)
+
+        assertTrue(encoded.contains("\"type\":\"NativeCompile\""), "expected type discriminator, got: $encoded")
+    }
+
+    @Test
+    fun `NativeCompileResult round-trips with exitCode and stderr`() {
+        val msg: Message = Message.NativeCompileResult(
+            exitCode = 0,
+            stderr = "warning: deprecated API usage",
+        )
+
+        val encoded = json.encodeToString(Message.serializer(), msg)
+        val decoded = json.decodeFromString(Message.serializer(), encoded)
+
+        assertEquals(msg, decoded)
+    }
+
+    @Test
+    fun `NativeCompileResult with non-zero exit code preserves stderr blob`() {
+        val msg: Message = Message.NativeCompileResult(
+            exitCode = 1,
+            stderr = "error: unresolved reference: foo\n    at src/Main.kt:3",
+        )
+
+        val decoded = json.decodeFromString(
+            Message.serializer(),
+            json.encodeToString(Message.serializer(), msg),
+        )
+
+        assertEquals(msg, decoded)
+    }
+
+    @Test
+    fun `control messages Ping Pong Shutdown round-trip`() {
+        for (msg in listOf<Message>(Message.Ping, Message.Pong, Message.Shutdown)) {
+            val decoded = json.decodeFromString(
+                Message.serializer(),
+                json.encodeToString(Message.serializer(), msg),
+            )
+            assertEquals(msg, decoded)
+        }
+    }
+
+    @Test
+    fun `NativeCompile accepts empty args list`() {
+        val msg: Message = Message.NativeCompile(args = emptyList())
+
+        val decoded = json.decodeFromString(
+            Message.serializer(),
+            json.encodeToString(Message.serializer(), msg),
+        )
+
+        assertEquals(msg, decoded)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,3 +8,12 @@ rootProject.name = "kolt"
 // root build.gradle.kts, so there is no stale-jar risk for the dev-fallback path
 // in DaemonJarResolver.
 includeBuild("kolt-compiler-daemon")
+
+// kolt-native-daemon is the sidecar JVM process for konanc compilation, per
+// ADR 0024. Same includeBuild rationale as kolt-compiler-daemon: independent
+// release cadence, separate classpath (kotlin-native-compiler-embeddable.jar),
+// and distinct lifecycle from the JVM daemon. Wired into `./gradlew
+// build/check/clean` via dependsOn in the root build.gradle.kts so the
+// dev-fallback jar resolver never reads a stale fat jar across protocol
+// changes.
+includeBuild("kolt-native-daemon")


### PR DESCRIPTION
First PR in the native compiler daemon series (issue #170, ADR 0024). Lands the `kolt-native-daemon/` Gradle module scaffolding, the wire protocol types, and root-level `includeBuild`/drift-guard wiring. **No server logic yet** — `Main.kt` is a deliberate stub that exits with status 2. Daemon server (reflective `K2Native.exec`), native client backend, `doNativeBuild` wiring, `kolt daemon stop` enumeration, and integration test follow in separate PRs.

## Places to double-check

**Protocol independence (ADR 0024 §1).** I chose to give the native daemon its own `kolt.nativedaemon.protocol.Message` sealed interface rather than extend `kolt.daemon.protocol.Message`. Rationale: the two daemons are already separate processes per ADR 0020 §2, their classpaths and lifecycles diverge, and coupling the protocols would force co-evolution of two independent `includeBuild`s. The cost is a duplicated ~80-line `FrameCodec`; that seemed cheaper than cross-module build dependencies. Worth pushback if you disagree.

**Shadow jar exclusion markers.** `verifyShadowJar` anchors ADR 0024 §8 on `org/jetbrains/kotlin/cli/bc/` and `org/jetbrains/kotlin/cli/utilities/MainKt` — the native-only subtrees. `cli/common/` is shared with the JVM compiler and would false-positive, so I avoided it. Please sanity-check that `cli/bc/` is actually the right marker for `kotlin-native-compiler-embeddable.jar` going forward.

**Stub exit code.** `Main.kt` prints a hint and exits 2 so the scaffolding can't be mistaken for a working daemon. Any scenario where this fails confusingly?

**`verifyDaemonKotlinVersion` extension.** Added a fifth pin (`KOLT_NATIVE_DAEMON_KOTLIN_VERSION`). Empirically verified the drift guard fires on a corrupted value (temporarily wrote `"9.9.9"`, got the expected failure, restored). The regex follows the existing closing-quote anchor pattern.

## Tests

18 cases: `MessageTest` (type discriminator, empty args, large stderr blob, round-trip of all variants) + `FrameCodecTest` (multi-frame, truncation, malformed JSON, oversize body write guard, `NativeCompile` / `NativeCompileResult` pair back-to-back). Two of the tests (oversize guard, NativeCompile pair) were added in response to pre-commit review — the existing JVM daemon tests don't cover those edges either, but this is wire-protocol code so erring on the side of coverage.

`./gradlew build` green end-to-end; the new `kolt-native-daemon-all.jar` is produced and wired into `build`/`check`/`clean`.