### PR TITLE
Wire native daemon server + reflective K2Native (#170)

### DIFF
--- a/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/Main.kt
+++ b/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/Main.kt
@@ -1,5 +1,14 @@
 package kolt.nativedaemon
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.mapBoth
+import kolt.nativedaemon.compiler.ReflectiveK2NativeCompiler
+import kolt.nativedaemon.compiler.SetupError
+import kolt.nativedaemon.server.DaemonConfig
+import kolt.nativedaemon.server.DaemonServer
+import java.nio.file.Path
 import kotlin.system.exitProcess
 
 // Kotlin version pin for the native daemon. Must move in lockstep with the
@@ -8,15 +17,115 @@ import kotlin.system.exitProcess
 // `KOLT_DAEMON_KOTLIN_VERSION` in kolt-compiler-daemon/.../Main.kt.
 internal const val KOLT_NATIVE_DAEMON_KOTLIN_VERSION: String = "2.3.20"
 
-// Stub entry point. This PR lands the module scaffolding + wire protocol
-// only; the daemon server (ADR 0024 §2: URLClassLoader load of
-// kotlin-native-compiler-embeddable.jar, reflective K2Native.exec) arrives
-// in a follow-up PR. Invoking this jar today exits with status 2 and a
-// hint so nobody mistakes the scaffolding for a working daemon.
+// ADR 0024 §8: --konanc-jar and --konan-home are the two paths the daemon
+// needs to locate and drive `kotlin-native-compiler-embeddable.jar`. They
+// are supplied by the native client spawn argv; the daemon itself has no
+// other way to discover them (the client knows `~/.konan/<version>/` from
+// the project's toolchain pin).
+internal data class CliArgs(
+    val socketPath: Path,
+    val konancJar: Path,
+    val konanHome: Path,
+)
+
+internal sealed interface CliError {
+    data class UnknownFlag(val flag: String) : CliError
+    data object MissingSocket : CliError
+    data object MissingKonancJar : CliError
+    data object MissingKonanHome : CliError
+    data object EmptySocket : CliError
+    data object EmptyKonancJar : CliError
+    data object EmptyKonanHome : CliError
+}
+
 fun main(args: Array<String>) {
-    System.err.println(
-        "kolt-native-daemon: server implementation not yet wired (ADR 0024, issue #170). " +
-            "Received ${args.size} args; refusing to start.",
+    val cli = parseArgs(args).mapBoth(
+        success = { it },
+        failure = { err ->
+            System.err.println("kolt-native-daemon: ${formatCliError(err)}")
+            System.err.println(
+                "usage: kolt-native-daemon --socket <path> --konanc-jar <path> --konan-home <path>",
+            )
+            exitProcess(64)
+        },
     )
-    exitProcess(2)
+
+    // ADR 0024 §8: `konan.home` is set as a JVM-global system property before
+    // any K2Native reflection runs. konanc reads it via `System.getProperty`
+    // to locate its own runtime libraries (distribution libs, stdlib klib,
+    // platform klibs). ADR 0020 §2 / §1 of ADR 0024 make the native daemon a
+    // separate JVM precisely so this JVM-global is safe to set — the JVM
+    // compiler daemon does not share the process.
+    System.setProperty("konan.home", cli.konanHome.toString())
+
+    val compiler = ReflectiveK2NativeCompiler.create(cli.konancJar).mapBoth(
+        success = { it },
+        failure = { err ->
+            System.err.println("kolt-native-daemon: failed to initialise compiler: ${formatSetupError(err)}")
+            exitProcess(70)
+        },
+    )
+
+    val server = DaemonServer(
+        socketPath = cli.socketPath,
+        compiler = compiler,
+        config = DaemonConfig(),
+    )
+    val reason = server.serve().mapBoth(
+        success = { it },
+        failure = { err ->
+            System.err.println("kolt-native-daemon: serve failed: $err")
+            exitProcess(71)
+        },
+    )
+    System.err.println("kolt-native-daemon: exiting (${reason::class.simpleName})")
+    exitProcess(0)
+}
+
+internal fun parseArgs(args: Array<String>): Result<CliArgs, CliError> {
+    var socketPath: String? = null
+    var konancJar: String? = null
+    var konanHome: String? = null
+    var i = 0
+    while (i < args.size) {
+        when (args[i]) {
+            "--socket" -> { socketPath = args.getOrNull(i + 1); i += 2 }
+            "--konanc-jar" -> { konancJar = args.getOrNull(i + 1); i += 2 }
+            "--konan-home" -> { konanHome = args.getOrNull(i + 1); i += 2 }
+            else -> return Err(CliError.UnknownFlag(args[i]))
+        }
+    }
+    if (socketPath == null) return Err(CliError.MissingSocket)
+    if (konancJar == null) return Err(CliError.MissingKonancJar)
+    if (konanHome == null) return Err(CliError.MissingKonanHome)
+    if (socketPath.isBlank()) return Err(CliError.EmptySocket)
+    if (konancJar.isBlank()) return Err(CliError.EmptyKonancJar)
+    if (konanHome.isBlank()) return Err(CliError.EmptyKonanHome)
+    return Ok(
+        CliArgs(
+            socketPath = Path.of(socketPath),
+            konancJar = Path.of(konancJar),
+            konanHome = Path.of(konanHome),
+        ),
+    )
+}
+
+private fun formatCliError(err: CliError): String = when (err) {
+    is CliError.UnknownFlag -> "unknown flag: ${err.flag}"
+    CliError.MissingSocket -> "--socket is required"
+    CliError.MissingKonancJar -> "--konanc-jar is required"
+    CliError.MissingKonanHome -> "--konan-home is required"
+    CliError.EmptySocket -> "--socket value is empty"
+    CliError.EmptyKonancJar -> "--konanc-jar value is empty"
+    CliError.EmptyKonanHome -> "--konan-home value is empty"
+}
+
+private fun formatSetupError(err: SetupError): String = when (err) {
+    is SetupError.KonancJarNotFound -> "konanc jar not found at ${err.path}"
+    is SetupError.KonancJarUnreadable -> "konanc jar at ${err.path} is unreadable: ${err.cause.message ?: err.cause.javaClass.name}"
+    is SetupError.K2NativeClassNotFound ->
+        "K2Native class not found in konanc jar: ${err.cause.message ?: err.cause.javaClass.name}"
+    is SetupError.K2NativeInstantiationFailed ->
+        "failed to instantiate K2Native: ${err.cause.message ?: err.cause.javaClass.name}"
+    SetupError.ExecMethodNotFound -> "exec(PrintStream, String[]) method not found on K2Native"
 }

--- a/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/compiler/NativeCompiler.kt
+++ b/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/compiler/NativeCompiler.kt
@@ -1,0 +1,33 @@
+package kolt.nativedaemon.compiler
+
+import com.github.michaelbull.result.Result
+
+// Server-side abstraction over the konanc invocation path. The production
+// implementation is ReflectiveK2NativeCompiler (ADR 0024 §2); tests
+// substitute a fake so DaemonServer can be exercised without a real
+// kotlin-native-compiler-embeddable.jar on disk.
+//
+// Non-zero exitCode is a normal compilation outcome (source errors live
+// here) and rides the Ok side of the Result. Only genuinely unexpected
+// failures — the reflective call threw, the classloader cracked, etc. —
+// become NativeCompileError. Client-side fallback (ADR 0024 §7) keys off
+// whether the daemon returned at all; once a NativeCompileResult reaches
+// the client the exitCode passes through untouched.
+//
+// Thread-safety contract: implementations MAY be single-threaded (the
+// production ReflectiveK2NativeCompiler is — see its type doc). DaemonServer
+// serves one request at a time, so this is sufficient today. A future
+// worker-pool change in DaemonServer must replace the compiler with a
+// thread-safe variant before it can fan out.
+interface NativeCompiler {
+    fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError>
+}
+
+data class NativeCompileOutcome(
+    val exitCode: Int,
+    val stderr: String,
+)
+
+sealed interface NativeCompileError {
+    data class InvocationFailed(val cause: Throwable) : NativeCompileError
+}

--- a/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/compiler/ReflectiveK2NativeCompiler.kt
+++ b/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/compiler/ReflectiveK2NativeCompiler.kt
@@ -1,0 +1,161 @@
+package kolt.nativedaemon.compiler
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.net.URLClassLoader
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+sealed interface SetupError {
+    data class KonancJarNotFound(val path: Path) : SetupError
+    // A path that exists but is not a readable jar — e.g., a directory, a
+    // permission error, or a malformed URI. The native client should refuse
+    // to spawn the daemon and fall back to the subprocess path.
+    data class KonancJarUnreadable(val path: Path, val cause: Throwable) : SetupError
+    // The jar loaded but does not contain `org.jetbrains.kotlin.cli.bc.K2Native`.
+    // Usually means the wrong jar was resolved (not the native embeddable),
+    // or a Kotlin version in which the class moved — ADR 0022 pinning should
+    // prevent the latter.
+    data class K2NativeClassNotFound(val cause: Throwable) : SetupError
+    data class K2NativeInstantiationFailed(val cause: Throwable) : SetupError
+    // Exec method shape changed between Kotlin versions; ADR 0024 §2 notes
+    // `MainKt.daemonMain` as the alternative entry point if this shows up.
+    data object ExecMethodNotFound : SetupError
+}
+
+// ADR 0024 §2: loads `kotlin-native-compiler-embeddable.jar` via a dedicated
+// URLClassLoader and invokes `K2Native.exec(PrintStream, String[])`
+// reflectively. A single K2Native instance is reused for the daemon's
+// lifetime — spike #166 validated this at 100 invocations with no state
+// leakage.
+//
+// Thread-safety: this class is single-threaded by contract. `DaemonServer`
+// serves one request at a time from its accept loop; K2Native's CLI backend
+// almost certainly reuses mutable buffers internally, so introducing a
+// worker pool here without replacing the instance-per-call model would be a
+// latent crash.
+//
+// Classloader parenting: we use `URLClassLoader(arrayOf(url), null)` —
+// bootstrap parent — so the daemon's own classpath (kotlin-result,
+// kotlinx-serialization-json, daemon-core classes) is NOT visible to
+// konanc's classloader. kotlin-native-compiler-embeddable.jar ships its
+// own Kotlin stdlib / kotlinx-serialization, and parent-first delegation
+// would otherwise let the daemon's versions win and risk LinkageError.
+// NOTE: this differs from spike #166's arrangement, which used a flat
+// `-cp .:konanc.jar` (system-parent) classloader. The 100-invocation
+// stability proof therefore does NOT transfer directly to this topology;
+// end-to-end validation of null-parent behaviour is deferred to the PR 6
+// integration test. If konanc turns out to need classes beyond
+// `java.*`/`javax.*`, fall back to a shared-API parent similar to
+// `SharedApiClassesClassLoader` in the JVM daemon.
+class ReflectiveK2NativeCompiler private constructor(
+    private val k2NativeInstance: Any,
+    private val execMethod: Method,
+    @Suppress("unused") // retained so the classloader outlives the compiler instance
+    private val classLoader: URLClassLoader,
+) : NativeCompiler {
+
+    override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> {
+        val stderrBuf = ByteArrayOutputStream()
+        val printStream = PrintStream(stderrBuf, true, StandardCharsets.UTF_8)
+        val argsArray = args.toTypedArray()
+        val exitValue = try {
+            execMethod.invoke(k2NativeInstance, printStream, argsArray)
+        } catch (e: InvocationTargetException) {
+            // The reflective call wraps any Throwable the compiler threw —
+            // unwrap once so the client sees the root cause, not the
+            // boilerplate wrapper.
+            return Err(NativeCompileError.InvocationFailed(e.cause ?: e))
+        } catch (e: Throwable) {
+            return Err(NativeCompileError.InvocationFailed(e))
+        }
+        printStream.flush()
+        return Ok(
+            NativeCompileOutcome(
+                exitCode = extractExitCode(exitValue),
+                stderr = stderrBuf.toString(StandardCharsets.UTF_8),
+            ),
+        )
+    }
+
+    companion object {
+        fun create(konancJar: Path): Result<ReflectiveK2NativeCompiler, SetupError> {
+            if (!Files.isRegularFile(konancJar)) {
+                return if (Files.exists(konancJar)) {
+                    Err(SetupError.KonancJarUnreadable(konancJar, IllegalArgumentException("not a regular file")))
+                } else {
+                    Err(SetupError.KonancJarNotFound(konancJar))
+                }
+            }
+            val url = try {
+                konancJar.toUri().toURL()
+            } catch (e: Throwable) {
+                return Err(SetupError.KonancJarUnreadable(konancJar, e))
+            }
+            val loader = URLClassLoader(arrayOf(url), null)
+            val k2NativeClass = try {
+                Class.forName("org.jetbrains.kotlin.cli.bc.K2Native", true, loader)
+            } catch (e: Throwable) {
+                runCatching { loader.close() }
+                return Err(SetupError.K2NativeClassNotFound(e))
+            }
+            val instance = try {
+                k2NativeClass.getDeclaredConstructor().newInstance()
+            } catch (e: Throwable) {
+                runCatching { loader.close() }
+                return Err(SetupError.K2NativeInstantiationFailed(e))
+            }
+            val execMethod = findExecMethod(k2NativeClass)
+            if (execMethod == null) {
+                runCatching { loader.close() }
+                return Err(SetupError.ExecMethodNotFound)
+            }
+            return Ok(ReflectiveK2NativeCompiler(instance, execMethod, loader))
+        }
+
+        // Walks the class hierarchy for `exec(PrintStream, String[])`. ADR
+        // 0024 §2 / spike #166's `ReflectiveKonanc.java` both use this
+        // shape. `execImpl` is accepted as a fallback because the public
+        // `exec` has at times been an inline thunk over it; the spike code
+        // guards against that case and we keep the guard.
+        private fun findExecMethod(clazz: Class<*>): Method? {
+            var c: Class<*>? = clazz
+            while (c != null) {
+                for (m in c.declaredMethods) {
+                    if ((m.name == "exec" || m.name == "execImpl") &&
+                        m.parameterCount == 2 &&
+                        m.parameterTypes[0] == PrintStream::class.java &&
+                        m.parameterTypes[1] == Array<String>::class.java
+                    ) {
+                        m.isAccessible = true
+                        return m
+                    }
+                }
+                c = c.superclass
+            }
+            return null
+        }
+
+        // `CLICompiler.exec` returns `org.jetbrains.kotlin.cli.common.ExitCode`,
+        // a Java enum with an `int code` field (accessor: `getCode`). We read
+        // it reflectively because the enum class lives in the konanc
+        // classloader, not the daemon's. ExitCode values have `code` values
+        // that are NOT equal to ordinals (e.g. `OOM_ERROR.code = 137` at
+        // ordinal 4), so ordinal is never an acceptable fallback. Any
+        // failure to read `.code` surfaces as exitCode=2 (INTERNAL_ERROR),
+        // matching the shape the client already handles.
+        private fun extractExitCode(exitValue: Any?): Int {
+            if (exitValue == null) return 2
+            return runCatching {
+                val getCode = exitValue.javaClass.getMethod("getCode")
+                getCode.invoke(exitValue) as Int
+            }.getOrDefault(2)
+        }
+    }
+}

--- a/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/server/DaemonConfig.kt
+++ b/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/server/DaemonConfig.kt
@@ -1,0 +1,16 @@
+package kolt.nativedaemon.server
+
+// ADR 0024 §3: native daemon lifecycle defaults. Deliberately tighter than
+// the JVM daemon's (30min / 1000 / 1.5GB) because native builds are less
+// frequent and stage 2 linking consumes more LLVM-backend heap per call.
+data class DaemonConfig(
+    val idleTimeoutMillis: Long = DEFAULT_IDLE_TIMEOUT_MILLIS,
+    val maxCompiles: Int = DEFAULT_MAX_COMPILES,
+    val heapWatermarkBytes: Long = DEFAULT_HEAP_WATERMARK_BYTES,
+) {
+    companion object {
+        const val DEFAULT_IDLE_TIMEOUT_MILLIS: Long = 10 * 60 * 1000L
+        const val DEFAULT_MAX_COMPILES: Int = 500
+        const val DEFAULT_HEAP_WATERMARK_BYTES: Long = 2L * 1024 * 1024 * 1024
+    }
+}

--- a/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/server/DaemonServer.kt
+++ b/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/server/DaemonServer.kt
@@ -1,0 +1,217 @@
+package kolt.nativedaemon.server
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import com.github.michaelbull.result.mapBoth
+import kolt.nativedaemon.compiler.NativeCompileError
+import kolt.nativedaemon.compiler.NativeCompileOutcome
+import kolt.nativedaemon.compiler.NativeCompiler
+import kolt.nativedaemon.protocol.FrameCodec
+import kolt.nativedaemon.protocol.FrameError
+import kolt.nativedaemon.protocol.Message
+import java.io.IOException
+import java.io.OutputStream
+import java.lang.management.ManagementFactory
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.ClosedChannelException
+import java.nio.channels.ServerSocketChannel
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+sealed interface ExitReason {
+    data object Shutdown : ExitReason
+    data object MaxCompilesReached : ExitReason
+    data object IdleTimeout : ExitReason
+    data object HeapWatermarkReached : ExitReason
+}
+
+sealed interface DaemonError {
+    data class BindFailed(val reason: String) : DaemonError
+}
+
+// Native compiler daemon server. Structurally parallels
+// `kolt.daemon.server.DaemonServer` (ADR 0016): bind a Unix domain socket,
+// run a single-threaded accept loop, dispatch one frame at a time, enforce
+// idle / max-compiles / heap-watermark thresholds via a watchdog thread.
+//
+// ADR 0024 departure points from the JVM daemon:
+// - No IC state management / preServeHook (§6 — konanc owns its own IC
+//   cache on disk; there is no daemon-owned state to reap).
+// - NativeCompile carries a flat args list; the server does not decompose
+//   into structured fields because K2Native.exec's API is CLI-shaped (§4).
+// - NativeCompileResult returns { exitCode, stderr } only — no stdout or
+//   structured diagnostics (§4, "stderr blob").
+class DaemonServer(
+    private val socketPath: Path,
+    private val compiler: NativeCompiler,
+    private val config: DaemonConfig = DaemonConfig(),
+) {
+    private val stopRequested = AtomicBoolean(false)
+    private val compilesServed = AtomicInteger(0)
+    private val lastActivityNanos = AtomicLong(System.nanoTime())
+    @Volatile private var serverChannel: ServerSocketChannel? = null
+    @Volatile private var exitReason: ExitReason? = null
+
+    fun serve(): Result<ExitReason, DaemonError> {
+        val parent = socketPath.parent
+        if (parent != null) {
+            try {
+                Files.createDirectories(parent)
+            } catch (e: IOException) {
+                return Err(DaemonError.BindFailed("createDirectories($parent) failed: ${e.message}"))
+            }
+        }
+        try {
+            Files.deleteIfExists(socketPath)
+        } catch (e: IOException) {
+            return Err(DaemonError.BindFailed("deleteIfExists($socketPath) failed: ${e.message}"))
+        }
+
+        val server = try {
+            ServerSocketChannel.open(StandardProtocolFamily.UNIX).also {
+                it.bind(UnixDomainSocketAddress.of(socketPath))
+            }
+        } catch (e: IOException) {
+            return Err(DaemonError.BindFailed("bind($socketPath) failed: ${e.message}"))
+        }
+
+        serverChannel = server
+        val watchdog = startWatchdog()
+        try {
+            server.use {
+                while (!stopRequested.get()) {
+                    val client = try {
+                        server.accept()
+                    } catch (_: ClosedChannelException) {
+                        break
+                    }
+                    lastActivityNanos.set(System.nanoTime())
+                    client.use { handleConnection(it) }
+                    lastActivityNanos.set(System.nanoTime())
+                }
+            }
+        } finally {
+            watchdog.interrupt()
+            runCatching { Files.deleteIfExists(socketPath) }
+        }
+        return Ok(exitReason ?: ExitReason.Shutdown)
+    }
+
+    fun stop() {
+        requestExit(ExitReason.Shutdown)
+    }
+
+    private fun requestExit(reason: ExitReason) {
+        if (stopRequested.compareAndSet(false, true)) {
+            exitReason = reason
+        }
+        runCatching { serverChannel?.close() }
+    }
+
+    private fun startWatchdog(): Thread =
+        Thread({
+            while (!stopRequested.get()) {
+                val idleMs = (System.nanoTime() - lastActivityNanos.get()) / 1_000_000
+                if (idleMs >= config.idleTimeoutMillis) {
+                    requestExit(ExitReason.IdleTimeout)
+                    return@Thread
+                }
+                val sleepMs = (config.idleTimeoutMillis - idleMs).coerceAtLeast(10).coerceAtMost(500)
+                try {
+                    Thread.sleep(sleepMs)
+                } catch (_: InterruptedException) {
+                    return@Thread
+                }
+            }
+        }, "native-daemon-watchdog").apply {
+            isDaemon = true
+            start()
+        }
+
+    private fun handleConnection(client: SocketChannel) {
+        val input = Channels.newInputStream(client)
+        val output = Channels.newOutputStream(client)
+        while (!stopRequested.get()) {
+            val message = FrameCodec.readFrame(input).getOrElse { err ->
+                if (err !is FrameError.Eof) {
+                    writeProtocolError(output, "protocol error: $err")
+                }
+                return
+            }
+            when (message) {
+                is Message.Ping -> {
+                    if (FrameCodec.writeFrame(output, Message.Pong).isErr) return
+                }
+                is Message.Shutdown -> {
+                    requestExit(ExitReason.Shutdown)
+                    return
+                }
+                is Message.NativeCompile -> {
+                    if (handleNativeCompile(message, output).isErr) return
+                    val served = compilesServed.incrementAndGet()
+                    if (served >= config.maxCompiles) {
+                        requestExit(ExitReason.MaxCompilesReached)
+                        return
+                    }
+                    if (heapUsedBytes() >= config.heapWatermarkBytes) {
+                        requestExit(ExitReason.HeapWatermarkReached)
+                        return
+                    }
+                }
+                is Message.Pong, is Message.NativeCompileResult -> {
+                    writeProtocolError(
+                        output,
+                        "protocol error: client sent server-only message ${message::class.simpleName}",
+                    )
+                    return
+                }
+            }
+        }
+    }
+
+    private fun writeProtocolError(output: OutputStream, stderr: String) {
+        FrameCodec.writeFrame(
+            output,
+            Message.NativeCompileResult(exitCode = 2, stderr = stderr),
+        )
+    }
+
+    private fun handleNativeCompile(
+        request: Message.NativeCompile,
+        output: OutputStream,
+    ): Result<Unit, FrameError> {
+        val reply: Message = compiler.compile(request.args).mapBoth(
+            success = { outcome -> outcomeToReply(outcome) },
+            failure = { error -> errorToReply(error) },
+        )
+        return FrameCodec.writeFrame(output, reply)
+    }
+
+    private fun outcomeToReply(outcome: NativeCompileOutcome): Message.NativeCompileResult =
+        Message.NativeCompileResult(exitCode = outcome.exitCode, stderr = outcome.stderr)
+
+    // ADR 0024 §7: genuine reflective failures (the URLClassLoader cracked,
+    // K2Native.exec threw an uncaught exception) are surfaced to the client
+    // as exitCode=2 with a descriptive stderr. This keeps the wire contract
+    // uniform — every request gets a NativeCompileResult. Client-side fallback
+    // (ADR 0024 §7, implemented in PR 3) keys off whether the daemon replied
+    // at all, not off the exitCode; a reflective-error reply does NOT trigger
+    // the subprocess fallback because the daemon itself is healthy.
+    private fun errorToReply(error: NativeCompileError): Message.NativeCompileResult = when (error) {
+        is NativeCompileError.InvocationFailed -> Message.NativeCompileResult(
+            exitCode = 2,
+            stderr = "native compiler invocation failed: ${error.cause.message ?: error.cause.javaClass.name}",
+        )
+    }
+
+    private fun heapUsedBytes(): Long =
+        ManagementFactory.getMemoryMXBean().heapMemoryUsage.used
+}

--- a/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/MainCliArgsTest.kt
+++ b/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/MainCliArgsTest.kt
@@ -1,0 +1,152 @@
+package kolt.nativedaemon
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+// Pins the native daemon's CLI parser shape. All three flags — --socket,
+// --konanc-jar, --konan-home — are load-bearing at the native client spawn
+// boundary (arrives in PR 3). Removing any of them at the daemon without
+// updating the spawn argv would turn every fresh daemon launch into a hard
+// CliError.MissingXyz, which is silent at unit-test time and only visible as
+// a field regression.
+class MainCliArgsTest {
+
+    @Test
+    fun parseAcceptsAllThreeRequiredFlags() {
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/kolt-native-daemon.sock",
+                "--konanc-jar", "/home/u/.konan/kotlin-native/konan/lib/kotlin-native-compiler-embeddable.jar",
+                "--konan-home", "/home/u/.konan/kotlin-native",
+            ),
+        )
+
+        val cli = assertNotNull(result.get())
+        assertEquals(Path.of("/tmp/kolt-native-daemon.sock"), cli.socketPath)
+        assertEquals(Path.of("/home/u/.konan/kotlin-native/konan/lib/kotlin-native-compiler-embeddable.jar"), cli.konancJar)
+        assertEquals(Path.of("/home/u/.konan/kotlin-native"), cli.konanHome)
+    }
+
+    @Test
+    fun socketFlagIsRequired() {
+        val result = parseArgs(
+            arrayOf(
+                "--konanc-jar", "/a.jar",
+                "--konan-home", "/k",
+            ),
+        )
+        assertEquals(CliError.MissingSocket, result.getError())
+    }
+
+    @Test
+    fun konancJarFlagIsRequired() {
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--konan-home", "/k",
+            ),
+        )
+        assertEquals(CliError.MissingKonancJar, result.getError())
+    }
+
+    @Test
+    fun konanHomeFlagIsRequired() {
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--konanc-jar", "/a.jar",
+            ),
+        )
+        assertEquals(CliError.MissingKonanHome, result.getError())
+    }
+
+    @Test
+    fun unknownFlagRejected() {
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--konanc-jar", "/a.jar",
+                "--konan-home", "/k",
+                "--frobnicate",
+            ),
+        )
+        val err = assertNotNull(result.getError()) as CliError.UnknownFlag
+        assertEquals("--frobnicate", err.flag)
+    }
+
+    @Test
+    fun emptyValueForSocketRejected() {
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "",
+                "--konanc-jar", "/a.jar",
+                "--konan-home", "/k",
+            ),
+        )
+        assertEquals(CliError.EmptySocket, result.getError())
+    }
+
+    @Test
+    fun emptyValueForKonancJarRejected() {
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--konanc-jar", "",
+                "--konan-home", "/k",
+            ),
+        )
+        assertEquals(CliError.EmptyKonancJar, result.getError())
+    }
+
+    @Test
+    fun emptyValueForKonanHomeRejected() {
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--konanc-jar", "/a.jar",
+                "--konan-home", "",
+            ),
+        )
+        assertEquals(CliError.EmptyKonanHome, result.getError())
+    }
+
+    // The three tests below pin the current behaviour where a flag at the
+    // end of argv with no following token collapses to MissingXyz (via
+    // `getOrNull(i+1)` returning null) rather than a dedicated
+    // "value-missing" variant. The JVM daemon parser has the same shape —
+    // adding these tests here prevents a future refactor from silently
+    // regressing the current diagnosability floor.
+
+    @Test
+    fun socketFlagAtEndOfArgvCollapsesToMissingSocket() {
+        val result = parseArgs(arrayOf("--socket"))
+        assertEquals(CliError.MissingSocket, result.getError())
+    }
+
+    @Test
+    fun konancJarFlagAtEndOfArgvCollapsesToMissingKonancJar() {
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--konanc-jar",
+            ),
+        )
+        assertEquals(CliError.MissingKonancJar, result.getError())
+    }
+
+    @Test
+    fun konanHomeFlagAtEndOfArgvCollapsesToMissingKonanHome() {
+        val result = parseArgs(
+            arrayOf(
+                "--socket", "/tmp/s",
+                "--konanc-jar", "/a.jar",
+                "--konan-home",
+            ),
+        )
+        assertEquals(CliError.MissingKonanHome, result.getError())
+    }
+}

--- a/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/compiler/NativeCompilerTest.kt
+++ b/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/compiler/NativeCompilerTest.kt
@@ -1,0 +1,68 @@
+package kolt.nativedaemon.compiler
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+// Exercises the NativeCompiler contract shape. The production implementation
+// (ReflectiveK2NativeCompiler) is covered separately. This test pins the
+// success / internal-error split: non-zero `exitCode` is a normal
+// *compilation* outcome (source errors), not an adapter-level failure, so it
+// rides Ok side of the Result. Only truly unexpected invocation failures
+// (e.g., reflection threw) become NativeCompileError.
+class NativeCompilerTest {
+
+    @Test
+    fun `compile returns Ok with exitCode 0 and empty stderr on success`() {
+        val compiler = FakeCompiler { args ->
+            assertEquals(listOf("-target", "linux_x64", "A.kt"), args)
+            Ok(NativeCompileOutcome(exitCode = 0, stderr = ""))
+        }
+
+        val result = compiler.compile(listOf("-target", "linux_x64", "A.kt"))
+
+        val outcome = assertNotNull(result.get())
+        assertEquals(0, outcome.exitCode)
+        assertEquals("", outcome.stderr)
+    }
+
+    @Test
+    fun `non-zero exitCode is an Ok outcome not an error`() {
+        val compiler = FakeCompiler {
+            Ok(NativeCompileOutcome(exitCode = 1, stderr = "error: unresolved reference: foo"))
+        }
+
+        val result = compiler.compile(listOf("-target", "linux_x64", "A.kt"))
+
+        val outcome = assertNotNull(result.get())
+        assertEquals(1, outcome.exitCode)
+        assertEquals("error: unresolved reference: foo", outcome.stderr)
+    }
+
+    @Test
+    fun `reflective invocation failure surfaces as InvocationFailed`() {
+        val boom = RuntimeException("K2Native.exec threw")
+        val compiler = FakeCompiler {
+            Err(NativeCompileError.InvocationFailed(boom))
+        }
+
+        val err = compiler.compile(emptyList()).getError()
+
+        assertNotNull(err)
+        assertIs<NativeCompileError.InvocationFailed>(err)
+        assertEquals(boom, err.cause)
+    }
+
+    private class FakeCompiler(
+        private val handler: (List<String>) -> Result<NativeCompileOutcome, NativeCompileError>,
+    ) : NativeCompiler {
+        override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> =
+            handler(args)
+    }
+}

--- a/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/compiler/ReflectiveK2NativeCompilerTest.kt
+++ b/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/compiler/ReflectiveK2NativeCompilerTest.kt
@@ -1,0 +1,66 @@
+package kolt.nativedaemon.compiler
+
+import com.github.michaelbull.result.getError
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.jar.Attributes
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+// Production setup path is best validated end-to-end with a real konanc jar,
+// which is deferred to PR 6's integration test (needs KONAN_HOME / a staged
+// kotlin-native-compiler-embeddable.jar). Here we pin the setup *error*
+// shapes so the daemon can distinguish "jar missing on disk" from "jar is
+// not the konanc jar" and surface each to the native client with a
+// diagnosable message.
+class ReflectiveK2NativeCompilerTest {
+
+    @Test
+    fun `create returns KonancJarNotFound when the path does not exist`(@TempDir tmp: Path) {
+        val missing = tmp.resolve("absent-konanc.jar")
+
+        val err = ReflectiveK2NativeCompiler.create(missing).getError()
+
+        val e = assertNotNull(err)
+        assertIs<SetupError.KonancJarNotFound>(e)
+    }
+
+    @Test
+    fun `create returns K2NativeClassNotFound when the jar lacks K2Native`(@TempDir tmp: Path) {
+        // An empty jar (valid zip with only a MANIFEST.MF) resolves into a
+        // URLClassLoader fine but has no `org.jetbrains.kotlin.cli.bc.K2Native`,
+        // so the reflective Class.forName fails. This pins the "wrong jar"
+        // diagnostic as distinct from "jar missing".
+        val emptyJar = tmp.resolve("empty.jar")
+        writeEmptyJar(emptyJar)
+
+        val err = ReflectiveK2NativeCompiler.create(emptyJar).getError()
+
+        val e = assertNotNull(err)
+        assertIs<SetupError.K2NativeClassNotFound>(e)
+    }
+
+    @Test
+    fun `create returns KonancJarUnreadable when the path is a directory`(@TempDir tmp: Path) {
+        // A directory passed as `--konanc-jar` is a plausible operator
+        // mistake; we reject it explicitly rather than letting URLClassLoader
+        // produce a confusing lazy failure downstream.
+        val dir = Files.createDirectory(tmp.resolve("not-a-jar-dir"))
+
+        val err = ReflectiveK2NativeCompiler.create(dir).getError()
+
+        val e = assertNotNull(err)
+        assertIs<SetupError.KonancJarUnreadable>(e)
+    }
+
+    private fun writeEmptyJar(path: Path) {
+        val manifest = Manifest().also { it.mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0" }
+        Files.newOutputStream(path).use { out ->
+            JarOutputStream(out, manifest).use { /* close writes the manifest + EOCD */ }
+        }
+    }
+}

--- a/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonConfigTest.kt
+++ b/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonConfigTest.kt
@@ -1,0 +1,40 @@
+package kolt.nativedaemon.server
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// ADR 0024 §3 pins the native daemon's lifecycle defaults. These are
+// deliberately shorter/smaller than the JVM daemon's defaults (30min /
+// 1000 compiles / 1.5GB) because native builds are less frequent and
+// stage 2 linking uses more heap per invocation.
+class DaemonConfigTest {
+
+    @Test
+    fun `defaults match ADR 0024 section 3`() {
+        val config = DaemonConfig()
+
+        assertEquals(10 * 60 * 1000L, config.idleTimeoutMillis, "idle timeout: 10 minutes per ADR 0024 §3")
+        assertEquals(500, config.maxCompiles, "max compiles: 500 per ADR 0024 §3")
+        assertEquals(2L * 1024 * 1024 * 1024, config.heapWatermarkBytes, "heap watermark: 2 GB per ADR 0024 §3")
+    }
+
+    @Test
+    fun `companion constants expose the defaults`() {
+        assertEquals(10 * 60 * 1000L, DaemonConfig.DEFAULT_IDLE_TIMEOUT_MILLIS)
+        assertEquals(500, DaemonConfig.DEFAULT_MAX_COMPILES)
+        assertEquals(2L * 1024 * 1024 * 1024, DaemonConfig.DEFAULT_HEAP_WATERMARK_BYTES)
+    }
+
+    @Test
+    fun `values can be overridden for tests`() {
+        val config = DaemonConfig(
+            idleTimeoutMillis = 1_000,
+            maxCompiles = 3,
+            heapWatermarkBytes = 128L * 1024 * 1024,
+        )
+
+        assertEquals(1_000L, config.idleTimeoutMillis)
+        assertEquals(3, config.maxCompiles)
+        assertEquals(128L * 1024 * 1024, config.heapWatermarkBytes)
+    }
+}

--- a/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonLifecycleTest.kt
+++ b/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonLifecycleTest.kt
@@ -1,0 +1,127 @@
+package kolt.nativedaemon.server
+
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
+import kolt.nativedaemon.compiler.NativeCompileError
+import kolt.nativedaemon.compiler.NativeCompileOutcome
+import kolt.nativedaemon.compiler.NativeCompiler
+import kolt.nativedaemon.protocol.FrameCodec
+import kolt.nativedaemon.protocol.Message
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+class DaemonLifecycleTest {
+
+    private lateinit var socketDir: Path
+    private lateinit var socketPath: Path
+    private lateinit var serverThread: Thread
+    private lateinit var server: DaemonServer
+
+    @BeforeTest
+    fun setUp() {
+        socketDir = Files.createTempDirectory("kolt-native-daemon-lifecycle-")
+        socketPath = socketDir.resolve("native-daemon.sock")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        runCatching { server.stop() }
+        runCatching { serverThread.join(2_000) }
+        runCatching { Files.deleteIfExists(socketPath) }
+        runCatching { Files.deleteIfExists(socketDir) }
+    }
+
+    @Test
+    fun `server exits after serving maxCompiles compiles`() {
+        server = DaemonServer(
+            socketPath = socketPath,
+            compiler = alwaysSuccess(),
+            config = DaemonConfig(
+                idleTimeoutMillis = 60_000,
+                maxCompiles = 2,
+                heapWatermarkBytes = Long.MAX_VALUE,
+            ),
+        )
+        serverThread = Thread({ server.serve() }, "native-daemon-lifecycle").apply {
+            isDaemon = true
+            start()
+        }
+        waitForSocket()
+
+        SocketChannel.open(StandardProtocolFamily.UNIX).use { ch ->
+            ch.connect(UnixDomainSocketAddress.of(socketPath))
+            val input = Channels.newInputStream(ch)
+            val output = Channels.newOutputStream(ch)
+            repeat(2) {
+                FrameCodec.writeFrame(output, Message.NativeCompile(args = listOf("-target", "linux_x64")))
+                FrameCodec.readFrame(input)
+            }
+        }
+
+        serverThread.join(2_000)
+        assertFalse(serverThread.isAlive, "server should have exited after maxCompiles")
+    }
+
+    @Test
+    fun `idle timeout stops server when no connection arrives`() {
+        server = DaemonServer(
+            socketPath = socketPath,
+            compiler = alwaysSuccess(),
+            config = DaemonConfig(
+                idleTimeoutMillis = 1_000,
+                maxCompiles = Int.MAX_VALUE,
+                heapWatermarkBytes = Long.MAX_VALUE,
+            ),
+        )
+        serverThread = Thread({ server.serve() }, "native-daemon-idle").apply {
+            isDaemon = true
+            start()
+        }
+        waitForSocket()
+
+        serverThread.join(5_000)
+        assertFalse(serverThread.isAlive, "server should have exited after idle timeout")
+    }
+
+    @Test
+    fun `serve returns BindFailed when the parent directory cannot be created`() {
+        // `/dev/null/...` cannot be a directory — `Files.createDirectories`
+        // fails here, which is the first bind-side failure mode the native
+        // client needs to distinguish from a genuine connect-refused race.
+        val impossible = Path.of("/dev/null/kolt-native-daemon-impossible/native-daemon.sock")
+        server = DaemonServer(
+            socketPath = impossible,
+            compiler = alwaysSuccess(),
+        )
+        serverThread = Thread({}, "noop").apply { start(); join() }
+
+        val result = server.serve()
+        val err = result.getError()
+        assertNotNull(err)
+        assertIs<DaemonError.BindFailed>(err)
+    }
+
+    private fun alwaysSuccess(): NativeCompiler = object : NativeCompiler {
+        override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> =
+            Ok(NativeCompileOutcome(exitCode = 0, stderr = ""))
+    }
+
+    private fun waitForSocket() {
+        val deadline = System.currentTimeMillis() + 2_000
+        while (!Files.exists(socketPath) && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10)
+        }
+    }
+}

--- a/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonServerTest.kt
+++ b/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonServerTest.kt
@@ -1,0 +1,177 @@
+package kolt.nativedaemon.server
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import kolt.nativedaemon.compiler.NativeCompileError
+import kolt.nativedaemon.compiler.NativeCompileOutcome
+import kolt.nativedaemon.compiler.NativeCompiler
+import kolt.nativedaemon.protocol.FrameCodec
+import kolt.nativedaemon.protocol.Message
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DaemonServerTest {
+
+    private lateinit var socketDir: Path
+    private lateinit var socketPath: Path
+    private lateinit var server: DaemonServer
+    private lateinit var serverThread: Thread
+
+    @BeforeTest
+    fun setUp() {
+        socketDir = Files.createTempDirectory("kolt-native-daemon-server-")
+        socketPath = socketDir.resolve("native-daemon.sock")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        runCatching { server.stop() }
+        runCatching { serverThread.join(2_000) }
+        runCatching { Files.deleteIfExists(socketPath) }
+        runCatching { Files.deleteIfExists(socketDir) }
+    }
+
+    private fun startServer(compiler: NativeCompiler) {
+        server = DaemonServer(socketPath = socketPath, compiler = compiler)
+        serverThread = Thread({ server.serve() }, "native-daemon-server-test").apply {
+            isDaemon = true
+            start()
+        }
+        val deadline = System.currentTimeMillis() + 2_000
+        while (!Files.exists(socketPath) && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10)
+        }
+    }
+
+    private fun connect(): SocketChannel =
+        SocketChannel.open(StandardProtocolFamily.UNIX).also {
+            it.connect(UnixDomainSocketAddress.of(socketPath))
+        }
+
+    @Test
+    fun `responds to Ping with Pong`() {
+        startServer(FakeCompiler())
+        connect().use { ch ->
+            val input = Channels.newInputStream(ch)
+            val output = Channels.newOutputStream(ch)
+            FrameCodec.writeFrame(output, Message.Ping)
+            assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
+        }
+    }
+
+    @Test
+    fun `delegates NativeCompile to the compiler and returns NativeCompileResult`() {
+        val observedArgs = mutableListOf<List<String>>()
+        val compiler = FakeCompiler { args ->
+            observedArgs += args
+            Ok(NativeCompileOutcome(exitCode = 0, stderr = ""))
+        }
+        startServer(compiler)
+
+        connect().use { ch ->
+            val input = Channels.newInputStream(ch)
+            val output = Channels.newOutputStream(ch)
+            val argv = listOf("-target", "linux_x64", "src/Main.kt", "-p", "library", "-nopack", "-o", "build/m-klib")
+            FrameCodec.writeFrame(output, Message.NativeCompile(args = argv))
+            val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
+            assertEquals(0, response.exitCode)
+            assertEquals("", response.stderr)
+            assertEquals(argv, observedArgs.single())
+        }
+    }
+
+    @Test
+    fun `non-zero exit code from compiler passes through to client`() {
+        val compiler = FakeCompiler {
+            Ok(NativeCompileOutcome(exitCode = 1, stderr = "error: unresolved reference: foo"))
+        }
+        startServer(compiler)
+
+        connect().use { ch ->
+            val input = Channels.newInputStream(ch)
+            val output = Channels.newOutputStream(ch)
+            FrameCodec.writeFrame(output, Message.NativeCompile(args = listOf("-target", "linux_x64", "Bad.kt")))
+            val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
+            assertEquals(1, response.exitCode)
+            assertTrue(response.stderr.contains("unresolved reference"))
+        }
+    }
+
+    @Test
+    fun `InvocationFailed from the compiler becomes exitCode 2 with stderr`() {
+        val compiler = FakeCompiler {
+            Err(NativeCompileError.InvocationFailed(RuntimeException("K2Native.exec threw: classloader broken")))
+        }
+        startServer(compiler)
+
+        connect().use { ch ->
+            val input = Channels.newInputStream(ch)
+            val output = Channels.newOutputStream(ch)
+            FrameCodec.writeFrame(output, Message.NativeCompile(args = listOf("-target", "linux_x64")))
+            val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
+            assertEquals(2, response.exitCode)
+            assertTrue(response.stderr.contains("K2Native.exec threw"))
+        }
+    }
+
+    @Test
+    fun `handles multiple frames on the same connection`() {
+        startServer(FakeCompiler())
+        connect().use { ch ->
+            val input = Channels.newInputStream(ch)
+            val output = Channels.newOutputStream(ch)
+            repeat(3) {
+                FrameCodec.writeFrame(output, Message.Ping)
+                assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
+            }
+        }
+    }
+
+    @Test
+    fun `Shutdown message stops the server and cleans up the socket file`() {
+        startServer(FakeCompiler())
+        connect().use { ch ->
+            FrameCodec.writeFrame(Channels.newOutputStream(ch), Message.Shutdown)
+        }
+        serverThread.join(2_000)
+        assertEquals(false, serverThread.isAlive, "server thread should have exited")
+        assertEquals(false, Files.exists(socketPath), "socket file should have been removed on exit")
+    }
+
+    @Test
+    fun `rejects server-only messages with a protocol error reply`() {
+        startServer(FakeCompiler())
+        connect().use { ch ->
+            val input = Channels.newInputStream(ch)
+            val output = Channels.newOutputStream(ch)
+            FrameCodec.writeFrame(output, Message.Pong)
+            val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
+            assertEquals(2, response.exitCode)
+            assertTrue(
+                response.stderr.contains("protocol error"),
+                "expected protocol error in stderr, got: ${response.stderr}",
+            )
+        }
+    }
+
+    private class FakeCompiler(
+        private val handler: (List<String>) -> Result<NativeCompileOutcome, NativeCompileError> = { _ ->
+            Ok(NativeCompileOutcome(exitCode = 0, stderr = ""))
+        },
+    ) : NativeCompiler {
+        override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> =
+            handler(args)
+    }
+}


### PR DESCRIPTION
PR 2 of the native compiler daemon series. Lands the server side of ADR 0024: Unix domain socket accept loop, reflective `K2Native.exec()` invocation via URLClassLoader, and `Main.kt` wiring. The native client backend (`NativeCompilerBackend` / `NativeDaemonBackend`) and `doNativeBuild` integration are PR 3; end-to-end validation against a real `kotlin-native-compiler-embeddable.jar` is PR 6.

## Places to double-check

**Classloader isolation — divergent from spike.** `ReflectiveK2NativeCompiler.create` uses `URLClassLoader(arrayOf(url), null)` (bootstrap parent) so konanc's embedded Kotlin stdlib / kotlinx-serialization cannot collide with the daemon's own copies. Spike #166 used the simpler flat `-cp .:konanc.jar` arrangement (system parent), so the 100-invocation stability proof does **not** transfer directly to this topology. The type doc calls this out and flags validation for PR 6. If konanc turns out to need classes beyond `java.*`, the fallback plan is a shared-API parent similar to `SharedApiClassesClassLoader` in the JVM daemon. Push back here if you want a smoke run against a real konanc jar before merging.

**`extractExitCode` never uses ordinal.** `ExitCode.OOM_ERROR.code = 137` ≠ ordinal 4, so any ordinal fallback would silently misreport OOM as exitCode 4. Implementation reads `.getCode` reflectively only; any failure surfaces as exitCode 2 (INTERNAL_ERROR). Look at `extractExitCode` at `ReflectiveK2NativeCompiler.kt`.

**`K2Native` single-threaded contract.** A single instance is reused for the daemon's lifetime. DaemonServer is single-threaded (one accept at a time), so this works today. The `NativeCompiler` interface and `ReflectiveK2NativeCompiler` both carry a type-level invariant noting this — a future worker-pool change must either replace the compiler with a thread-safe variant or fan out per request.

**`konan.home` as JVM-global system property.** Per ADR 0024 §8, `Main.kt` calls `System.setProperty("konan.home", ...)` once at startup, before the compiler is created. ADR 0020 §2 / ADR 0024 §1 make the native daemon a separate JVM precisely so this global is safe to set.

**DaemonServer lifecycle departures from JVM daemon.** No `preServeHook` (ADR 0024 §6: no daemon-owned IC state to reap), `DaemonError` has only `BindFailed` (the JVM daemon's `SocketCleanupFailed` variant was dead code), wire rejects `Message.Pong` / `Message.NativeCompileResult` as client-sent. Intentional — worth sanity-checking.

**Exit codes.** `64` cli error / `70` compiler setup / `71` serve failure — same discipline as JVM daemon.

## Tests

30 cases. CLI parsing (8 + 3 missing-value edge cases), config defaults (3), compiler contract (3), lifecycle — maxCompiles / idle timeout / bind failure (3), wire dispatch — Ping / NativeCompile success / compile-error / invocation-failure / multi-frame / Shutdown / server-only reject (7), and setup error paths — jar-missing / jar-without-K2Native / jar-is-directory (3). The remaining setup errors (`K2NativeInstantiationFailed`, `ExecMethodNotFound`) require a synthetic jar with a stub class and are left to PR 6's integration path.

`./gradlew build` green end-to-end. Smoke-verified CLI handling manually: missing flags → exit 64, missing konanc jar → exit 70.