### PR TITLE
Wire native daemon client backend + fallback (#170)

### DIFF
--- a/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/server/DaemonServer.kt
+++ b/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/server/DaemonServer.kt
@@ -198,13 +198,20 @@ class DaemonServer(
     private fun outcomeToReply(outcome: NativeCompileOutcome): Message.NativeCompileResult =
         Message.NativeCompileResult(exitCode = outcome.exitCode, stderr = outcome.stderr)
 
-    // ADR 0024 §7: genuine reflective failures (the URLClassLoader cracked,
-    // K2Native.exec threw an uncaught exception) are surfaced to the client
-    // as exitCode=2 with a descriptive stderr. This keeps the wire contract
-    // uniform — every request gets a NativeCompileResult. Client-side fallback
-    // (ADR 0024 §7, implemented in PR 3) keys off whether the daemon replied
-    // at all, not off the exitCode; a reflective-error reply does NOT trigger
-    // the subprocess fallback because the daemon itself is healthy.
+    // ADR 0024 §7 (interpreted): genuine reflective failures (the
+    // URLClassLoader cracked, K2Native.exec threw an uncaught exception) are
+    // surfaced to the client as exitCode=2 with a descriptive stderr. §7
+    // names "connect refused, spawn failure, unexpected disconnect" as the
+    // explicit fallback triggers; a reflective crack is the same class of
+    // "daemon is not healthy for this request" signal and routes the same
+    // way. This keeps the wire contract uniform — every request gets a
+    // NativeCompileResult — while letting the client escape to the subprocess
+    // path when the daemon's execution vehicle is broken. The `native
+    // compiler invocation failed: ` stderr prefix is the load-bearing
+    // contract: the native client's `NativeDaemonBackend.isDaemonSideFailure`
+    // pattern-matches on it, and renaming on either side without updating
+    // the other turns daemon failures into silently-routed konanc errors
+    // and loses fallback.
     private fun errorToReply(error: NativeCompileError): Message.NativeCompileResult = when (error) {
         is NativeCompileError.InvocationFailed -> Message.NativeCompileResult(
             exitCode = 2,

--- a/src/nativeMain/kotlin/kolt/build/FallbackNativeCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/FallbackNativeCompilerBackend.kt
@@ -1,0 +1,32 @@
+package kolt.build
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
+
+// ADR 0024 §7: daemon is never load-bearing for correctness. On any
+// BackendUnavailable / InternalMisuse from the primary (daemon) path, retry
+// through the fallback (subprocess) path. Real compilation errors
+// (CompilationFailed) pass through untouched — the subprocess would fail
+// the same way and the retry would just add a cold-start tax.
+//
+// Composition contract: `primary` is the daemon path, `fallback` is the
+// subprocess path. Do NOT flip them. `NativeSubprocessBackend` maps
+// `ProcessError.SignalKilled` to `BackendUnavailable.SignalKilled`, which
+// is fallback-eligible — if the subprocess sat on the primary side, a
+// SIGKILL'd konanc would incorrectly trigger a daemon retry. The fallback
+// path is the last resort, not a peer.
+class FallbackNativeCompilerBackend(
+    internal val primary: NativeCompilerBackend,
+    internal val fallback: NativeCompilerBackend,
+    private val onFallback: (NativeCompileError) -> Unit = {},
+) : NativeCompilerBackend {
+
+    override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> {
+        val primaryResult = primary.compile(args)
+        val primaryError = primaryResult.getError() ?: return primaryResult
+        if (!isNativeFallbackEligible(primaryError)) return Err(primaryError)
+        onFallback(primaryError)
+        return fallback.compile(args)
+    }
+}

--- a/src/nativeMain/kotlin/kolt/build/NativeCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/NativeCompilerBackend.kt
@@ -1,0 +1,70 @@
+package kolt.build
+
+import com.github.michaelbull.result.Result
+
+// Separate from `CompilerBackend` on purpose: ADR 0024 §4 keeps the native
+// compilation API flat (konanc args list) rather than the JVM-side structured
+// `CompileRequest` (workingDir / classpath / sources / outputPath /
+// moduleName). K2Native's entry point is `exec(PrintStream, String[])` and
+// there is no BTA for native; a structured request would decompose only to
+// recompose on the wire. Keeping the interface args-shaped means the client,
+// the `NativeCompile` wire message, and `konanc` all see the same list.
+//
+// `args` here is the flat argv list *after* the compiler binary. The
+// subprocess backend prepends `konanc`; the daemon backend forwards the
+// list unchanged because the daemon already has the compiler loaded.
+interface NativeCompilerBackend {
+    fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError>
+}
+
+// Unlike `CompileOutcome`, no `stdout` field — ADR 0024 §4 collapses native
+// compiler output into a single `stderr` blob. konanc writes diagnostics
+// to stderr; stdout is not observed on either the daemon or subprocess
+// path.
+data class NativeCompileOutcome(
+    val stderr: String,
+)
+
+sealed interface NativeCompileError {
+    // A clean compiler run that returned non-zero: konanc reported a source
+    // error, OOM'd, etc. Not fallback-eligible — the subprocess path would
+    // fail the same way.
+    data class CompilationFailed(
+        val exitCode: Int,
+        val stderr: String,
+    ) : NativeCompileError
+
+    // The daemon process is unreachable / the subprocess fork failed — the
+    // *infrastructure* is unhealthy, not the source. FallbackNativeCompilerBackend
+    // treats this as a retry signal to the subprocess path.
+    sealed interface BackendUnavailable : NativeCompileError {
+        data object ForkFailed : BackendUnavailable
+        data object WaitFailed : BackendUnavailable
+        data object SignalKilled : BackendUnavailable
+        data object PopenFailed : BackendUnavailable
+        data class Other(val detail: String) : BackendUnavailable
+    }
+
+    data object NoCommand : NativeCompileError
+
+    data class InternalMisuse(val detail: String) : NativeCompileError
+}
+
+// Mirrors `isFallbackEligible` on the JVM side (ADR 0016 §5 / ADR 0024 §7).
+fun isNativeFallbackEligible(error: NativeCompileError): Boolean = when (error) {
+    is NativeCompileError.BackendUnavailable -> true
+    is NativeCompileError.InternalMisuse -> true
+    is NativeCompileError.CompilationFailed -> false
+    NativeCompileError.NoCommand -> false
+}
+
+fun formatNativeCompileError(error: NativeCompileError, context: String): String = when (error) {
+    is NativeCompileError.CompilationFailed -> "error: $context failed with exit code ${error.exitCode}"
+    is NativeCompileError.BackendUnavailable.ForkFailed -> "error: failed to start $context process"
+    is NativeCompileError.BackendUnavailable.PopenFailed -> "error: failed to start $context process"
+    is NativeCompileError.BackendUnavailable.WaitFailed -> "error: failed waiting for $context process"
+    is NativeCompileError.BackendUnavailable.SignalKilled -> "error: $context process was killed"
+    is NativeCompileError.BackendUnavailable.Other -> "error: $context backend unavailable: ${error.detail}"
+    is NativeCompileError.NoCommand -> "error: no command to execute"
+    is NativeCompileError.InternalMisuse -> "error: $context internal bug: ${error.detail}"
+}

--- a/src/nativeMain/kotlin/kolt/build/NativeSubprocessBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/NativeSubprocessBackend.kt
@@ -1,0 +1,45 @@
+package kolt.build
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.ProcessError
+import kolt.infra.executeCommand
+
+// Baseline native backend: invokes `konanc` as a subprocess. This is the
+// pre-ADR-0024 behaviour kept intact so FallbackNativeCompilerBackend can
+// retry here when the daemon is unreachable. stderr is not captured —
+// konanc inherits the parent process's stderr fd, same as the JVM-side
+// SubprocessCompilerBackend.
+class NativeSubprocessBackend(
+    private val konancBin: String,
+) : NativeCompilerBackend {
+
+    override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> {
+        val argv = nativeSubprocessArgv(konancBin, args)
+        executeCommand(argv).getOrElse { err ->
+            return Err(mapProcessErrorToNativeCompileError(err))
+        }
+        return Ok(NativeCompileOutcome(stderr = ""))
+    }
+}
+
+// `args` are the konanc argv AFTER the binary (ADR 0024 §4); the subprocess
+// path prepends the binary here. The daemon path forwards `args` as-is.
+internal fun nativeSubprocessArgv(konancBin: String, args: List<String>): List<String> = buildList {
+    add(konancBin)
+    addAll(args)
+}
+
+internal fun mapProcessErrorToNativeCompileError(error: ProcessError): NativeCompileError = when (error) {
+    is ProcessError.EmptyArgs -> NativeCompileError.NoCommand
+    is ProcessError.ForkFailed -> NativeCompileError.BackendUnavailable.ForkFailed
+    is ProcessError.WaitFailed -> NativeCompileError.BackendUnavailable.WaitFailed
+    is ProcessError.PopenFailed -> NativeCompileError.BackendUnavailable.PopenFailed
+    is ProcessError.NonZeroExit -> NativeCompileError.CompilationFailed(
+        exitCode = error.exitCode,
+        stderr = "",
+    )
+    is ProcessError.SignalKilled -> NativeCompileError.BackendUnavailable.SignalKilled
+}

--- a/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
@@ -1,0 +1,270 @@
+package kolt.build.nativedaemon
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.build.NativeCompileError
+import kolt.build.NativeCompileOutcome
+import kolt.build.NativeCompilerBackend
+// Shared with the JVM daemon client: `isRetryableConnectError` classifies
+// errno codes (ENOENT / ECONNREFUSED) that are expected transients in the
+// spawn window, and `monotonicMs` wraps `clock_gettime(CLOCK_MONOTONIC)`.
+// Both are genuinely generic; the import is the path of least coupling until
+// a third caller appears and a hoist to `kolt.infra` is warranted.
+import kolt.build.daemon.isRetryableConnectError
+import kolt.build.daemon.monotonicMs
+import kolt.infra.ProcessError
+import kolt.infra.net.UnixSocket
+import kolt.infra.net.UnixSocketError
+import kolt.infra.spawnDetached
+import kolt.nativedaemon.wire.FrameCodec
+import kolt.nativedaemon.wire.FrameError
+import kolt.nativedaemon.wire.Message
+import platform.posix.usleep
+
+// ADR 0024 §2/§3/§7. Parallel to `kolt.build.daemon.DaemonCompilerBackend`:
+// spawn-on-demand, exponential backoff connect (10..200ms within 3s budget),
+// wire protocol over a Unix domain socket. Not load-bearing for correctness —
+// `FallbackNativeCompilerBackend` (ADR 0024 §7) retries eligible errors on
+// `NativeSubprocessBackend`.
+//
+// Constructor asymmetry vs the JVM backend:
+// - `konancJar` (single path) replaces `compilerJars` + `btaImplJars`: the
+//   native daemon loads `kotlin-native-compiler-embeddable.jar` reflectively
+//   (ADR 0024 §8); no BTA exists for native (§6).
+// - `konanHome` is new — the daemon sets it as `-Dkonan.home` at JVM startup
+//   so konanc can locate its distribution libs (ADR 0024 §8).
+// - No `pluginJars` — compiler plugins are a JVM-path feature (ADR 0019 §9);
+//   the native path has no structured plugin channel yet.
+class NativeDaemonBackend internal constructor(
+    private val javaBin: String,
+    private val daemonJarPath: String,
+    private val konancJar: String,
+    private val konanHome: String,
+    private val socketPath: String,
+    private val logPath: String? = null,
+    private val connector: NativeDaemonConnector = defaultNativeDaemonConnector,
+    private val spawner: NativeDaemonSpawner = defaultNativeDaemonSpawner,
+    private val clockMs: () -> Long = ::monotonicMs,
+    private val sleeper: (Int) -> Unit = defaultNativeDaemonSleeper,
+    private val onSpawn: () -> Unit = {},
+) : NativeCompilerBackend {
+
+    constructor(
+        javaBin: String,
+        daemonJarPath: String,
+        konancJar: String,
+        konanHome: String,
+        socketPath: String,
+        logPath: String? = null,
+        onSpawn: () -> Unit = {},
+    ) : this(
+        javaBin = javaBin,
+        daemonJarPath = daemonJarPath,
+        konancJar = konancJar,
+        konanHome = konanHome,
+        socketPath = socketPath,
+        logPath = logPath,
+        connector = defaultNativeDaemonConnector,
+        spawner = defaultNativeDaemonSpawner,
+        onSpawn = onSpawn,
+    )
+
+    override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> {
+        val connection = connectOrSpawn().let { result ->
+            result.getError()?.let { return Err(it) }
+            result.get()!!
+        }
+        connection.use {
+            val wire = Message.NativeCompile(args = args)
+            val sendErr = it.sendRequest(wire).getError()
+            if (sendErr != null) return Err(mapFrameErrorToSendError(sendErr))
+            val reply = it.receiveReply()
+            val replyErr = reply.getError()
+            if (replyErr != null) return Err(mapFrameErrorToReceiveError(replyErr))
+            return mapReplyToOutcome(reply.get()!!)
+        }
+    }
+
+    private fun connectOrSpawn(): Result<NativeDaemonConnection, NativeCompileError> {
+        val first = connector(socketPath)
+        first.getError()?.let { err ->
+            if (!isRetryableConnectError(err)) {
+                return Err(mapFatalConnectError(err))
+            }
+        } ?: return Ok(first.get()!!)
+
+        onSpawn()
+        val spawnErr = spawner(spawnArgv(), logPath).getError()
+        if (spawnErr != null) {
+            return Err(
+                NativeCompileError.BackendUnavailable.Other(
+                    "native daemon spawn failed: $spawnErr",
+                ),
+            )
+        }
+
+        return retryConnect()
+    }
+
+    private fun retryConnect(): Result<NativeDaemonConnection, NativeCompileError> {
+        val start = clockMs()
+        var delayMs = INITIAL_BACKOFF_MS
+        var lastErr: UnixSocketError? = null
+        do {
+            sleeper(delayMs)
+            val attempt = connector(socketPath)
+            attempt.getError()?.let { err ->
+                lastErr = err
+                if (!isRetryableConnectError(err)) {
+                    return Err(mapFatalConnectError(err))
+                }
+            } ?: return Ok(attempt.get()!!)
+            delayMs = (delayMs * 2).coerceAtMost(MAX_BACKOFF_MS)
+        } while (clockMs() - start < CONNECT_TOTAL_BUDGET_MS)
+        return Err(
+            NativeCompileError.BackendUnavailable.Other(
+                "native daemon did not accept a connection on $socketPath within " +
+                    "${CONNECT_TOTAL_BUDGET_MS}ms (last: ${describe(lastErr)})",
+            ),
+        )
+    }
+
+    // ADR 0024 §3: `-Xmx4G` is load-bearing — the spike validated reflective
+    // K2Native.exec() at this ceiling. Drop it and stage 2 linking will OOM
+    // on medium-sized fixtures. ADR 0024 §8 pins the three daemon CLI flags.
+    private fun spawnArgv(): List<String> = buildList {
+        add(javaBin)
+        add("-Xmx4G")
+        add("-jar")
+        add(daemonJarPath)
+        add("--socket")
+        add(socketPath)
+        add("--konanc-jar")
+        add(konancJar)
+        add("--konan-home")
+        add(konanHome)
+    }
+
+    companion object {
+        internal const val INITIAL_BACKOFF_MS = 10
+        internal const val MAX_BACKOFF_MS = 200
+        internal const val CONNECT_TOTAL_BUDGET_MS: Long = 3000L
+    }
+}
+
+internal interface NativeDaemonConnection : AutoCloseable {
+    fun sendRequest(message: Message): Result<Unit, FrameError>
+    fun receiveReply(): Result<Message, FrameError>
+}
+
+internal class SocketNativeDaemonConnection(private val socket: UnixSocket) : NativeDaemonConnection {
+    override fun sendRequest(message: Message): Result<Unit, FrameError> =
+        FrameCodec.writeFrame(socket, message)
+
+    override fun receiveReply(): Result<Message, FrameError> =
+        FrameCodec.readFrame(socket)
+
+    override fun close() {
+        socket.close()
+    }
+}
+
+internal typealias NativeDaemonConnector = (String) -> Result<NativeDaemonConnection, UnixSocketError>
+internal typealias NativeDaemonSpawner = (List<String>, String?) -> Result<Unit, ProcessError>
+
+internal val defaultNativeDaemonConnector: NativeDaemonConnector = { path ->
+    val socketResult = UnixSocket.connect(path)
+    val err = socketResult.getError()
+    if (err != null) Err(err) else Ok(SocketNativeDaemonConnection(socketResult.get()!!))
+}
+
+internal val defaultNativeDaemonSpawner: NativeDaemonSpawner = { argv, logPath -> spawnDetached(argv, logPath) }
+
+internal val defaultNativeDaemonSleeper: (Int) -> Unit = { ms -> usleep((ms * 1000).toUInt()) }
+
+internal fun mapFatalConnectError(err: UnixSocketError): NativeCompileError = when (err) {
+    is UnixSocketError.InvalidArgument -> NativeCompileError.InternalMisuse(err.detail)
+    is UnixSocketError.ConnectFailed ->
+        NativeCompileError.BackendUnavailable.Other(
+            "connect(${err.path}) failed: errno=${err.errno} ${err.message}",
+        )
+    is UnixSocketError.SendFailed,
+    is UnixSocketError.RecvFailed,
+    is UnixSocketError.UnexpectedEof,
+    is UnixSocketError.ShutdownFailed,
+    -> NativeCompileError.BackendUnavailable.Other("unexpected connect error: $err")
+}
+
+internal fun mapFrameErrorToSendError(err: FrameError): NativeCompileError = when (err) {
+    is FrameError.Malformed -> NativeCompileError.InternalMisuse("failed to serialise NativeCompile: ${err.reason}")
+    is FrameError.Transport -> NativeCompileError.BackendUnavailable.Other("send failed: ${describe(err.cause)}")
+    is FrameError.Eof -> NativeCompileError.BackendUnavailable.Other("native daemon closed connection before request was sent")
+    is FrameError.Truncated -> NativeCompileError.BackendUnavailable.Other("truncated send: wanted=${err.wantedBytes} got=${err.gotBytes}")
+}
+
+internal fun mapFrameErrorToReceiveError(err: FrameError): NativeCompileError = when (err) {
+    is FrameError.Eof -> NativeCompileError.BackendUnavailable.Other("native daemon closed connection before replying")
+    is FrameError.Truncated -> NativeCompileError.BackendUnavailable.Other("truncated reply: wanted=${err.wantedBytes} got=${err.gotBytes}")
+    is FrameError.Malformed -> NativeCompileError.BackendUnavailable.Other("malformed reply: ${err.reason}")
+    is FrameError.Transport -> NativeCompileError.BackendUnavailable.Other("receive failed: ${describe(err.cause)}")
+}
+
+internal fun mapReplyToOutcome(reply: Message): Result<NativeCompileOutcome, NativeCompileError> = when (reply) {
+    is Message.NativeCompileResult ->
+        when {
+            reply.exitCode == 0 ->
+                Ok(NativeCompileOutcome(stderr = reply.stderr))
+            isDaemonSideFailure(reply) ->
+                Err(NativeCompileError.BackendUnavailable.Other("native daemon failure: ${reply.stderr}"))
+            else ->
+                Err(
+                    NativeCompileError.CompilationFailed(
+                        exitCode = reply.exitCode,
+                        stderr = reply.stderr,
+                    ),
+                )
+        }
+    is Message.NativeCompile,
+    is Message.Ping,
+    is Message.Pong,
+    is Message.Shutdown,
+    -> Err(
+        NativeCompileError.BackendUnavailable.Other(
+            "unexpected reply type: ${reply::class.simpleName}",
+        ),
+    )
+}
+
+// DaemonServer emits these prefixes for server-side failures (writeProtocolError
+// and NativeCompileError.InvocationFailed → exitCode=2 replies). Any other
+// exitCode=2 reply is assumed to come from konanc itself (ExitCode.INTERNAL_ERROR
+// has code=2) and rides the CompilationFailed path. Collision risk: a konanc
+// error whose stderr happens to start with one of these prefixes would be
+// mis-routed as a daemon failure. The prefixes are long and specific enough
+// that this is not a realistic concern today, but the assumption is
+// load-bearing — renaming a prefix on either side without updating the other
+// silently breaks fallback routing.
+private const val DAEMON_PROTOCOL_ERROR_PREFIX = "protocol error: "
+private const val DAEMON_INVOCATION_FAILED_PREFIX = "native compiler invocation failed: "
+
+private fun isDaemonSideFailure(reply: Message.NativeCompileResult): Boolean =
+    reply.exitCode == 2 &&
+        (reply.stderr.startsWith(DAEMON_PROTOCOL_ERROR_PREFIX) ||
+            reply.stderr.startsWith(DAEMON_INVOCATION_FAILED_PREFIX))
+
+// Duplicated from kolt.build.daemon.DaemonCompilerBackend.describe for the
+// same reason as parentDir in NativeDaemonJarResolver: keep the new package
+// free of cross-package `private` imports. If a third backend ever needs
+// the same formatter, hoist to `kolt.infra.net`.
+private fun describe(err: UnixSocketError?): String = when (err) {
+    null -> "(none)"
+    is UnixSocketError.ConnectFailed -> "ConnectFailed(errno=${err.errno}, ${err.message})"
+    is UnixSocketError.SendFailed -> "SendFailed(errno=${err.errno}, ${err.message})"
+    is UnixSocketError.RecvFailed -> "RecvFailed(errno=${err.errno}, ${err.message})"
+    is UnixSocketError.UnexpectedEof -> "UnexpectedEof(received=${err.received}, expected=${err.expected})"
+    is UnixSocketError.ShutdownFailed -> "ShutdownFailed(errno=${err.errno}, ${err.message})"
+    is UnixSocketError.InvalidArgument -> "InvalidArgument(${err.detail})"
+}

--- a/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonJarResolver.kt
+++ b/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonJarResolver.kt
@@ -1,0 +1,73 @@
+package kolt.build.nativedaemon
+
+import com.github.michaelbull.result.get
+import kolt.infra.fileExists
+import kolt.infra.readSelfExe
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+
+// Parallel to DaemonJarResolver for the JVM daemon. Structure is identical
+// (env -> libexec -> dev-fallback probe order) but the filename and env var
+// differ so a dev machine with both daemons staged doesn't cross-wire them.
+sealed interface NativeDaemonJarResolution {
+    data class Resolved(val path: String, val source: Source) : NativeDaemonJarResolution
+    data object NotFound : NativeDaemonJarResolution
+
+    enum class Source { Env, Libexec, DevFallback }
+}
+
+internal const val NATIVE_DAEMON_JAR_FILENAME = "kolt-native-daemon-all.jar"
+internal const val KOLT_NATIVE_DAEMON_JAR_ENV = "KOLT_NATIVE_DAEMON_JAR"
+
+fun resolveNativeDaemonJarPure(
+    envValue: String?,
+    selfExePath: String?,
+    fileExists: (String) -> Boolean,
+): NativeDaemonJarResolution {
+    if (envValue != null && envValue.isNotEmpty()) {
+        return NativeDaemonJarResolution.Resolved(envValue, NativeDaemonJarResolution.Source.Env)
+    }
+
+    if (selfExePath == null) return NativeDaemonJarResolution.NotFound
+
+    val binDir = parentDir(selfExePath) ?: return NativeDaemonJarResolution.NotFound
+    val prefix = parentDir(binDir) ?: return NativeDaemonJarResolution.NotFound
+    val libexec = "$prefix/libexec/$NATIVE_DAEMON_JAR_FILENAME"
+    if (fileExists(libexec)) {
+        return NativeDaemonJarResolution.Resolved(libexec, NativeDaemonJarResolution.Source.Libexec)
+    }
+
+    var repoRoot: String? = selfExePath
+    repeat(5) { repoRoot = repoRoot?.let { parentDir(it) } }
+    if (repoRoot != null) {
+        val devJar = "$repoRoot/kolt-native-daemon/build/libs/$NATIVE_DAEMON_JAR_FILENAME"
+        if (fileExists(devJar)) {
+            return NativeDaemonJarResolution.Resolved(devJar, NativeDaemonJarResolution.Source.DevFallback)
+        }
+    }
+
+    return NativeDaemonJarResolution.NotFound
+}
+
+@OptIn(ExperimentalForeignApi::class)
+fun resolveNativeDaemonJar(): NativeDaemonJarResolution {
+    val env = platform.posix.getenv(KOLT_NATIVE_DAEMON_JAR_ENV)?.toKString()
+    val selfExe = readSelfExe().get()
+    return resolveNativeDaemonJarPure(
+        envValue = env,
+        selfExePath = selfExe,
+        fileExists = ::fileExists,
+    )
+}
+
+// Duplicated from kolt.build.daemon.parentDir — kept private to avoid a
+// cross-package `internal` import chain. If a third resolver ever needs
+// the same helper, hoist it into `kolt.infra`.
+private fun parentDir(path: String): String? {
+    if (path.isEmpty()) return null
+    if (path == "/") return null
+    val lastSlash = path.lastIndexOf('/')
+    if (lastSlash < 0) return null
+    if (lastSlash == 0) return "/"
+    return path.substring(0, lastSlash)
+}

--- a/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
+++ b/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
@@ -19,6 +19,15 @@ internal data class KoltPaths(val home: String) {
     fun daemonLogPath(projectHash: String, kotlinVersion: String): String =
         "${daemonDir(projectHash, kotlinVersion)}/daemon.log"
 
+    // ADR 0024 §3: native daemon sits under the same <projectHash>/<version>
+    // directory as the JVM daemon, distinguished by its socket filename.
+    // Keeping both sockets under one directory lets `kolt daemon stop`
+    // enumerate them in a single pass (ADR 0020 §2).
+    fun nativeDaemonSocketPath(projectHash: String, kotlinVersion: String): String =
+        "${daemonDir(projectHash, kotlinVersion)}/native-daemon.sock"
+    fun nativeDaemonLogPath(projectHash: String, kotlinVersion: String): String =
+        "${daemonDir(projectHash, kotlinVersion)}/native-daemon.log"
+
     fun kotlincPath(version: String): String = "$toolchainsDir/kotlinc/$version"
     fun kotlincBin(version: String): String = "${kotlincPath(version)}/bin/kotlinc"
 

--- a/src/nativeMain/kotlin/kolt/nativedaemon/wire/FrameCodec.kt
+++ b/src/nativeMain/kotlin/kolt/nativedaemon/wire/FrameCodec.kt
@@ -1,0 +1,89 @@
+package kolt.nativedaemon.wire
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.net.UnixSocket
+import kolt.infra.net.UnixSocketError
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+sealed interface FrameError {
+    data object Eof : FrameError
+    data class Truncated(val wantedBytes: Int, val gotBytes: Int) : FrameError
+    data class Malformed(val reason: String) : FrameError
+    data class Transport(val cause: UnixSocketError) : FrameError
+}
+
+// Wire format (4-byte big-endian length + UTF-8 JSON body) is structurally
+// identical to `kolt.daemon.wire.FrameCodec` (ADR 0016 §3) but bound to this
+// module's own Message type per ADR 0024 §1. The two codecs are intentionally
+// duplicated — the ~80 LOC cost is cheaper than coupling two independent
+// protocols and their evolution paths.
+object FrameCodec {
+
+    const val MAX_BODY_BYTES: Int = 64 * 1024 * 1024
+
+    private val json = Json { classDiscriminator = "type" }
+
+    fun writeFrame(socket: UnixSocket, message: Message): Result<Unit, FrameError> {
+        val body = try {
+            json.encodeToString(Message.serializer(), message).encodeToByteArray()
+        } catch (e: SerializationException) {
+            return Err(FrameError.Malformed(e.message ?: "serialization error"))
+        }
+        val len = body.size
+        if (len > MAX_BODY_BYTES) {
+            return Err(FrameError.Malformed("frame body exceeds MAX_BODY_BYTES: $len"))
+        }
+
+        val header = ByteArray(4)
+        header[0] = ((len ushr 24) and 0xff).toByte()
+        header[1] = ((len ushr 16) and 0xff).toByte()
+        header[2] = ((len ushr 8) and 0xff).toByte()
+        header[3] = (len and 0xff).toByte()
+
+        socket.sendAll(header).getOrElse { return Err(FrameError.Transport(it)) }
+        socket.sendAll(body).getOrElse { return Err(FrameError.Transport(it)) }
+        return Ok(Unit)
+    }
+
+    fun readFrame(socket: UnixSocket): Result<Message, FrameError> {
+        val header = socket.recvExact(4).getOrElse { err ->
+            return Err(headerTransportError(err))
+        }
+
+        val len = ((header[0].toInt() and 0xff) shl 24) or
+            ((header[1].toInt() and 0xff) shl 16) or
+            ((header[2].toInt() and 0xff) shl 8) or
+            (header[3].toInt() and 0xff)
+
+        if (len < 0 || len > MAX_BODY_BYTES) {
+            return Err(FrameError.Malformed("invalid frame length: $len"))
+        }
+
+        val body = socket.recvExact(len).getOrElse { err ->
+            return Err(
+                when (err) {
+                    is UnixSocketError.UnexpectedEof ->
+                        FrameError.Truncated(wantedBytes = len, gotBytes = err.received)
+                    else -> FrameError.Transport(err)
+                },
+            )
+        }
+
+        return try {
+            Ok(json.decodeFromString(Message.serializer(), body.decodeToString()))
+        } catch (e: SerializationException) {
+            Err(FrameError.Malformed(e.message ?: "serialization error"))
+        }
+    }
+
+    private fun headerTransportError(err: UnixSocketError): FrameError = when (err) {
+        is UnixSocketError.UnexpectedEof ->
+            if (err.received == 0) FrameError.Eof
+            else FrameError.Truncated(wantedBytes = 4, gotBytes = err.received)
+        else -> FrameError.Transport(err)
+    }
+}

--- a/src/nativeMain/kotlin/kolt/nativedaemon/wire/Message.kt
+++ b/src/nativeMain/kotlin/kolt/nativedaemon/wire/Message.kt
@@ -1,0 +1,38 @@
+package kolt.nativedaemon.wire
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// Native-side mirror of kolt-native-daemon's kolt.nativedaemon.protocol.Message.
+// Field names and @SerialName values are load-bearing wire contract (ADR 0024
+// §4) — drift breaks the daemon. Kept independent from `kolt.daemon.wire.Message`
+// (the JVM daemon's mirror) per ADR 0024 §1: two daemons, two protocols, one
+// frame codec pattern shared in spirit but not in code.
+@Serializable
+sealed interface Message {
+
+    @Serializable
+    @SerialName("NativeCompile")
+    data class NativeCompile(
+        val args: List<String>,
+    ) : Message
+
+    @Serializable
+    @SerialName("NativeCompileResult")
+    data class NativeCompileResult(
+        val exitCode: Int,
+        val stderr: String,
+    ) : Message
+
+    @Serializable
+    @SerialName("Ping")
+    data object Ping : Message
+
+    @Serializable
+    @SerialName("Pong")
+    data object Pong : Message
+
+    @Serializable
+    @SerialName("Shutdown")
+    data object Shutdown : Message
+}

--- a/src/nativeTest/kotlin/kolt/build/FallbackNativeCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/FallbackNativeCompilerBackendTest.kt
@@ -1,0 +1,163 @@
+package kolt.build
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class FallbackNativeCompilerBackendTest {
+
+    @Test
+    fun primarySuccessDoesNotInvokeFallback() {
+        val primary = FakeBackend(reply = Ok(NativeCompileOutcome(stderr = "")))
+        val fallback = FakeBackend(reply = Err(NativeCompileError.NoCommand))
+
+        val fb = FallbackNativeCompilerBackend(primary = primary, fallback = fallback)
+        val result = fb.compile(listOf("-target", "linux_x64"))
+
+        assertEquals(NativeCompileOutcome(stderr = ""), result.get())
+        assertEquals(1, primary.callCount)
+        assertEquals(0, fallback.callCount, "fallback must not run when primary succeeded")
+    }
+
+    @Test
+    fun primaryBackendUnavailableRetriesOnFallback() {
+        val primary = FakeBackend(
+            reply = Err(NativeCompileError.BackendUnavailable.Other("daemon unreachable")),
+        )
+        val fallback = FakeBackend(reply = Ok(NativeCompileOutcome(stderr = "warn: foo")))
+
+        val fb = FallbackNativeCompilerBackend(primary = primary, fallback = fallback)
+        val result = fb.compile(listOf("-p", "library"))
+
+        assertEquals(NativeCompileOutcome(stderr = "warn: foo"), result.get())
+        assertEquals(1, primary.callCount)
+        assertEquals(1, fallback.callCount)
+    }
+
+    @Test
+    fun primaryCompilationFailedDoesNotFallback() {
+        val primary = FakeBackend(
+            reply = Err(
+                NativeCompileError.CompilationFailed(
+                    exitCode = 1,
+                    stderr = "error: unresolved reference: foo",
+                ),
+            ),
+        )
+        val fallback = FakeBackend(reply = Ok(NativeCompileOutcome(stderr = "")))
+
+        val fb = FallbackNativeCompilerBackend(primary = primary, fallback = fallback)
+        val err = fb.compile(emptyList()).getError()
+
+        val compilationFailed = assertIs<NativeCompileError.CompilationFailed>(err)
+        assertEquals(1, compilationFailed.exitCode)
+        assertEquals(0, fallback.callCount, "real compile errors pass through untouched")
+    }
+
+    @Test
+    fun primaryNoCommandDoesNotFallback() {
+        val primary = FakeBackend(reply = Err(NativeCompileError.NoCommand))
+        val fallback = FakeBackend(reply = Ok(NativeCompileOutcome(stderr = "")))
+
+        val fb = FallbackNativeCompilerBackend(primary = primary, fallback = fallback)
+        val err = fb.compile(emptyList()).getError()
+
+        assertEquals(NativeCompileError.NoCommand, err)
+        assertEquals(0, fallback.callCount)
+    }
+
+    @Test
+    fun primaryInternalMisuseFallsBack() {
+        val primary = FakeBackend(
+            reply = Err(NativeCompileError.InternalMisuse("socket path too long")),
+        )
+        val fallback = FakeBackend(reply = Ok(NativeCompileOutcome(stderr = "")))
+
+        val fb = FallbackNativeCompilerBackend(primary = primary, fallback = fallback)
+        val result = fb.compile(emptyList())
+
+        assertEquals(NativeCompileOutcome(stderr = ""), result.get())
+        assertEquals(1, fallback.callCount)
+    }
+
+    @Test
+    fun bothBackendsFailReturnsFallbackError() {
+        val primary = FakeBackend(
+            reply = Err(NativeCompileError.BackendUnavailable.ForkFailed),
+        )
+        val fallback = FakeBackend(
+            reply = Err(NativeCompileError.CompilationFailed(exitCode = 1, stderr = "")),
+        )
+
+        val fb = FallbackNativeCompilerBackend(primary = primary, fallback = fallback)
+        val err = fb.compile(emptyList()).getError()
+
+        val compilationFailed = assertIs<NativeCompileError.CompilationFailed>(err)
+        assertEquals(1, compilationFailed.exitCode)
+    }
+
+    @Test
+    fun argsAreForwardedUnchangedToBothBackends() {
+        val primary = FakeBackend(reply = Err(NativeCompileError.BackendUnavailable.ForkFailed))
+        val fallback = FakeBackend(reply = Ok(NativeCompileOutcome(stderr = "")))
+        val args = listOf("-target", "linux_x64", "src/Main.kt", "-p", "library")
+
+        FallbackNativeCompilerBackend(primary = primary, fallback = fallback).compile(args)
+
+        assertEquals(args, primary.lastArgs)
+        assertEquals(args, fallback.lastArgs)
+    }
+
+    @Test
+    fun onFallbackFiresWithPrimaryError() {
+        val primaryError: NativeCompileError =
+            NativeCompileError.BackendUnavailable.Other("spawn failed: daemon jar missing")
+        val primary = FakeBackend(reply = Err(primaryError))
+        val fallback = FakeBackend(reply = Ok(NativeCompileOutcome(stderr = "")))
+
+        val observed = mutableListOf<NativeCompileError>()
+        FallbackNativeCompilerBackend(
+            primary = primary,
+            fallback = fallback,
+            onFallback = { observed += it },
+        ).compile(emptyList())
+
+        assertEquals(listOf(primaryError), observed)
+    }
+
+    @Test
+    fun onFallbackDoesNotFireOnPrimarySuccess() {
+        val primary = FakeBackend(reply = Ok(NativeCompileOutcome(stderr = "")))
+        val fallback = FakeBackend(reply = Ok(NativeCompileOutcome(stderr = "")))
+
+        var observedError: NativeCompileError? = null
+        FallbackNativeCompilerBackend(
+            primary = primary,
+            fallback = fallback,
+            onFallback = { observedError = it },
+        ).compile(emptyList())
+
+        assertNull(observedError)
+    }
+
+    private class FakeBackend(
+        private val reply: Result<NativeCompileOutcome, NativeCompileError>,
+    ) : NativeCompilerBackend {
+        var callCount: Int = 0
+            private set
+        var lastArgs: List<String>? = null
+            private set
+
+        override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> {
+            callCount++
+            lastArgs = args
+            return reply
+        }
+    }
+}

--- a/src/nativeTest/kotlin/kolt/build/NativeCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/NativeCompilerBackendTest.kt
@@ -1,0 +1,46 @@
+package kolt.build
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+// Pins `isNativeFallbackEligible` — the single point of truth for which
+// error variants allow FallbackNativeCompilerBackend to retry on the
+// subprocess path. Mirrors `isFallbackEligible` on the JVM side.
+class NativeCompilerBackendTest {
+
+    @Test
+    fun backendUnavailableVariantsAreFallbackEligible() {
+        assertTrue(isNativeFallbackEligible(NativeCompileError.BackendUnavailable.ForkFailed))
+        assertTrue(isNativeFallbackEligible(NativeCompileError.BackendUnavailable.WaitFailed))
+        assertTrue(isNativeFallbackEligible(NativeCompileError.BackendUnavailable.SignalKilled))
+        assertTrue(isNativeFallbackEligible(NativeCompileError.BackendUnavailable.PopenFailed))
+        assertTrue(isNativeFallbackEligible(NativeCompileError.BackendUnavailable.Other("connect refused")))
+    }
+
+    @Test
+    fun internalMisuseIsFallbackEligible() {
+        assertTrue(isNativeFallbackEligible(NativeCompileError.InternalMisuse("socket path too long")))
+    }
+
+    @Test
+    fun compilationFailedIsNotFallbackEligible() {
+        // Real konanc compilation errors pass through untouched — the
+        // subprocess path would fail the same way, and retrying adds a
+        // cold-JVM tax.
+        assertFalse(
+            isNativeFallbackEligible(
+                NativeCompileError.CompilationFailed(
+                    exitCode = 1,
+                    stderr = "error: unresolved reference: foo",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun noCommandIsNotFallbackEligible() {
+        // If there's no konanc binary to fall back to, retrying is pointless.
+        assertFalse(isNativeFallbackEligible(NativeCompileError.NoCommand))
+    }
+}

--- a/src/nativeTest/kotlin/kolt/build/NativeSubprocessBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/NativeSubprocessBackendTest.kt
@@ -1,0 +1,77 @@
+package kolt.build
+
+import kolt.infra.ProcessError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class NativeSubprocessBackendTest {
+
+    @Test
+    fun argvPrependsKonancBin() {
+        val argv = nativeSubprocessArgv(
+            konancBin = "/opt/konanc",
+            args = listOf("-target", "linux_x64", "src/Main.kt", "-p", "library", "-o", "build/m-klib"),
+        )
+
+        assertEquals(
+            listOf("/opt/konanc", "-target", "linux_x64", "src/Main.kt", "-p", "library", "-o", "build/m-klib"),
+            argv,
+        )
+    }
+
+    @Test
+    fun argvAcceptsEmptyArgs() {
+        assertEquals(listOf("/opt/konanc"), nativeSubprocessArgv("/opt/konanc", emptyList()))
+    }
+
+    @Test
+    fun processErrorForkFailedMapsToBackendUnavailable() {
+        assertEquals(
+            NativeCompileError.BackendUnavailable.ForkFailed,
+            mapProcessErrorToNativeCompileError(ProcessError.ForkFailed),
+        )
+    }
+
+    @Test
+    fun processErrorWaitFailedMapsToBackendUnavailable() {
+        assertEquals(
+            NativeCompileError.BackendUnavailable.WaitFailed,
+            mapProcessErrorToNativeCompileError(ProcessError.WaitFailed),
+        )
+    }
+
+    @Test
+    fun processErrorPopenFailedMapsToBackendUnavailable() {
+        assertEquals(
+            NativeCompileError.BackendUnavailable.PopenFailed,
+            mapProcessErrorToNativeCompileError(ProcessError.PopenFailed),
+        )
+    }
+
+    @Test
+    fun processErrorSignalKilledMapsToBackendUnavailable() {
+        assertEquals(
+            NativeCompileError.BackendUnavailable.SignalKilled,
+            mapProcessErrorToNativeCompileError(ProcessError.SignalKilled),
+        )
+    }
+
+    @Test
+    fun processErrorNonZeroExitMapsToCompilationFailed() {
+        val err = mapProcessErrorToNativeCompileError(ProcessError.NonZeroExit(exitCode = 1))
+        val compilationFailed = assertIs<NativeCompileError.CompilationFailed>(err)
+        assertEquals(1, compilationFailed.exitCode)
+        // stderr is empty because the subprocess inherits the parent's fd;
+        // the caller never captures it. Matches the JVM subprocess backend.
+        assertEquals("", compilationFailed.stderr)
+    }
+
+    @Test
+    fun processErrorEmptyArgsMapsToNoCommand() {
+        assertEquals(
+            NativeCompileError.NoCommand,
+            mapProcessErrorToNativeCompileError(ProcessError.EmptyArgs),
+        )
+    }
+}

--- a/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
@@ -1,0 +1,440 @@
+package kolt.build.nativedaemon
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.build.NativeCompileError
+import kolt.infra.ProcessError
+import kolt.infra.net.UnixSocketError
+import kolt.nativedaemon.wire.FrameError
+import kolt.nativedaemon.wire.Message
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+private class FakeConnection(
+    val reply: Result<Message, FrameError> = Ok(
+        Message.NativeCompileResult(exitCode = 0, stderr = ""),
+    ),
+    val sendResult: Result<Unit, FrameError> = Ok(Unit),
+) : NativeDaemonConnection {
+    var lastSent: Message? = null
+    var closed = false
+
+    override fun sendRequest(message: Message): Result<Unit, FrameError> {
+        lastSent = message
+        return sendResult
+    }
+
+    override fun receiveReply(): Result<Message, FrameError> = reply
+
+    override fun close() {
+        closed = true
+    }
+}
+
+private class FakeClock(var nowMs: Long = 0) {
+    val clock: () -> Long = { nowMs }
+    val sleeper: (Int) -> Unit = { ms -> nowMs += ms.toLong() }
+}
+
+private fun newBackend(
+    connector: NativeDaemonConnector,
+    spawner: NativeDaemonSpawner = { _, _ -> Ok(Unit) },
+    clock: FakeClock = FakeClock(),
+    onSpawn: () -> Unit = {},
+): NativeDaemonBackend = NativeDaemonBackend(
+    javaBin = "/opt/jdk/bin/java",
+    daemonJarPath = "/opt/kolt/libexec/kolt-native-daemon-all.jar",
+    konancJar = "/opt/konan/konan/lib/kotlin-native-compiler-embeddable.jar",
+    konanHome = "/opt/konan",
+    socketPath = "/tmp/kolt-native-daemon-test.sock",
+    logPath = "/tmp/kolt-native-daemon-test.log",
+    connector = connector,
+    spawner = spawner,
+    clockMs = clock.clock,
+    sleeper = clock.sleeper,
+    onSpawn = onSpawn,
+)
+
+private val sampleArgs = listOf(
+    "-target", "linux_x64",
+    "src/Main.kt",
+    "-p", "library",
+    "-nopack",
+    "-Xenable-incremental-compilation",
+    "-Xic-cache-dir=build/.ic-cache",
+    "-o", "build/m-klib",
+)
+
+class NativeDaemonBackendHappyPathTest {
+
+    @Test
+    fun successfulCompileMapsResultToOutcome() {
+        val fake = FakeConnection(
+            reply = Ok(Message.NativeCompileResult(exitCode = 0, stderr = "warning: deprecated")),
+        )
+        val backend = newBackend(connector = { Ok(fake) })
+
+        val result = backend.compile(sampleArgs)
+
+        val outcome = assertNotNull(result.get())
+        assertEquals("warning: deprecated", outcome.stderr)
+        // Connection is closed even on success (AutoCloseable.use).
+        assertTrue(fake.closed)
+    }
+
+    @Test
+    fun argsAreForwardedUnchangedOnTheWire() {
+        val fake = FakeConnection()
+        val backend = newBackend(connector = { Ok(fake) })
+
+        backend.compile(sampleArgs)
+
+        val sent = assertIs<Message.NativeCompile>(fake.lastSent)
+        assertEquals(sampleArgs, sent.args)
+    }
+
+    @Test
+    fun nonZeroExitCodeMapsToCompilationFailed() {
+        val fake = FakeConnection(
+            reply = Ok(
+                Message.NativeCompileResult(
+                    exitCode = 1,
+                    stderr = "error: unresolved reference: foo",
+                ),
+            ),
+        )
+        val backend = newBackend(connector = { Ok(fake) })
+
+        val err = backend.compile(sampleArgs).getError()
+
+        val failed = assertIs<NativeCompileError.CompilationFailed>(err)
+        assertEquals(1, failed.exitCode)
+        assertTrue(failed.stderr.contains("unresolved reference"))
+    }
+
+    @Test
+    fun exitCode2WithProtocolErrorPrefixIsDaemonSideFailure() {
+        // DaemonServer.writeProtocolError emits this shape on wire-protocol
+        // violations (EOF mid-frame, client-sent server-only message). The
+        // client must treat it as BackendUnavailable so the fallback kicks in.
+        val fake = FakeConnection(
+            reply = Ok(
+                Message.NativeCompileResult(
+                    exitCode = 2,
+                    stderr = "protocol error: client sent server-only message NativeCompileResult",
+                ),
+            ),
+        )
+        val backend = newBackend(connector = { Ok(fake) })
+
+        val err = backend.compile(sampleArgs).getError()
+
+        val unavailable = assertIs<NativeCompileError.BackendUnavailable.Other>(err)
+        assertTrue(unavailable.detail.contains("native daemon failure"))
+    }
+
+    @Test
+    fun exitCode2WithInvocationFailedPrefixIsDaemonSideFailure() {
+        // DaemonServer.errorToReply emits this shape when the reflective
+        // K2Native.exec throws. Same fallback treatment as a protocol error.
+        val fake = FakeConnection(
+            reply = Ok(
+                Message.NativeCompileResult(
+                    exitCode = 2,
+                    stderr = "native compiler invocation failed: classloader cracked",
+                ),
+            ),
+        )
+        val backend = newBackend(connector = { Ok(fake) })
+
+        val err = backend.compile(sampleArgs).getError()
+
+        assertIs<NativeCompileError.BackendUnavailable.Other>(err)
+    }
+
+    @Test
+    fun exitCode2WithoutKnownPrefixIsKonancInternalError() {
+        // `ExitCode.INTERNAL_ERROR.code == 2`. If konanc itself returns it
+        // (JVM OOM, analyzer bug, etc.), the stderr will NOT start with one
+        // of our daemon-side prefixes — pass it through as CompilationFailed
+        // so the subprocess path does not waste a retry on the same bug.
+        val fake = FakeConnection(
+            reply = Ok(
+                Message.NativeCompileResult(
+                    exitCode = 2,
+                    stderr = "error: unexpected internal error: java.lang.NullPointerException at ...",
+                ),
+            ),
+        )
+        val backend = newBackend(connector = { Ok(fake) })
+
+        val err = backend.compile(sampleArgs).getError()
+
+        val failed = assertIs<NativeCompileError.CompilationFailed>(err)
+        assertEquals(2, failed.exitCode)
+    }
+
+    @Test
+    fun unexpectedReplyTypeBecomesBackendUnavailable() {
+        val fake = FakeConnection(reply = Ok(Message.Pong))
+        val backend = newBackend(connector = { Ok(fake) })
+
+        val err = backend.compile(sampleArgs).getError()
+
+        val unavailable = assertIs<NativeCompileError.BackendUnavailable.Other>(err)
+        assertTrue(unavailable.detail.contains("unexpected reply type"))
+    }
+
+    @Test
+    fun sendErrorMalformedMapsToInternalMisuse() {
+        val fake = FakeConnection(
+            sendResult = Err(FrameError.Malformed("oversize body")),
+        )
+        val backend = newBackend(connector = { Ok(fake) })
+
+        val err = backend.compile(sampleArgs).getError()
+
+        val misuse = assertIs<NativeCompileError.InternalMisuse>(err)
+        assertTrue(misuse.detail.contains("oversize body"))
+    }
+
+    @Test
+    fun receiveErrorTransportMapsToBackendUnavailable() {
+        val fake = FakeConnection(
+            reply = Err(
+                FrameError.Transport(UnixSocketError.RecvFailed(errno = 5, message = "I/O error")),
+            ),
+        )
+        val backend = newBackend(connector = { Ok(fake) })
+
+        val err = backend.compile(sampleArgs).getError()
+
+        assertIs<NativeCompileError.BackendUnavailable.Other>(err)
+    }
+}
+
+class NativeDaemonBackendConnectAndSpawnTest {
+
+    @Test
+    fun noSpawnOnFirstSuccessfulConnect() {
+        var spawnCount = 0
+        val fake = FakeConnection()
+        val backend = newBackend(
+            connector = { Ok(fake) },
+            spawner = { _, _ -> spawnCount++; Ok(Unit) },
+        )
+
+        backend.compile(sampleArgs)
+
+        assertEquals(0, spawnCount, "spawner must not fire when first connect succeeds")
+    }
+
+    @Test
+    fun enoentTriggersSpawnThenRetryConnect() {
+        var callCount = 0
+        val fake = FakeConnection()
+        val backend = newBackend(
+            connector = { _ ->
+                callCount++
+                if (callCount == 1) {
+                    Err(UnixSocketError.ConnectFailed(path = "/tmp/s", errno = 2, message = "ENOENT"))
+                } else {
+                    Ok(fake)
+                }
+            },
+        )
+
+        val result = backend.compile(sampleArgs)
+
+        assertNotNull(result.get())
+        assertEquals(2, callCount, "expected one failed + one successful connect")
+    }
+
+    @Test
+    fun econnrefusedTriggersSpawnThenRetryConnect() {
+        var callCount = 0
+        val fake = FakeConnection()
+        val backend = newBackend(
+            connector = { _ ->
+                callCount++
+                if (callCount == 1) {
+                    Err(UnixSocketError.ConnectFailed(path = "/tmp/s", errno = 111, message = "ECONNREFUSED"))
+                } else {
+                    Ok(fake)
+                }
+            },
+        )
+
+        val result = backend.compile(sampleArgs)
+
+        assertNotNull(result.get())
+    }
+
+    @Test
+    fun fatalErrnoReturnsImmediatelyWithoutSpawn() {
+        var spawnCount = 0
+        val backend = newBackend(
+            connector = { _ ->
+                Err(UnixSocketError.ConnectFailed(path = "/tmp/s", errno = 13, message = "EACCES"))
+            },
+            spawner = { _, _ -> spawnCount++; Ok(Unit) },
+        )
+
+        val err = backend.compile(sampleArgs).getError()
+
+        assertIs<NativeCompileError.BackendUnavailable.Other>(err)
+        assertEquals(0, spawnCount, "fatal errno must not trigger a spawn attempt")
+    }
+
+    @Test
+    fun invalidArgumentMapsToInternalMisuse() {
+        val backend = newBackend(
+            connector = { _ -> Err(UnixSocketError.InvalidArgument("socket path exceeds SUN_PATH_CAPACITY")) },
+        )
+
+        val err = backend.compile(sampleArgs).getError()
+
+        val misuse = assertIs<NativeCompileError.InternalMisuse>(err)
+        assertTrue(misuse.detail.contains("SUN_PATH_CAPACITY"))
+    }
+
+    @Test
+    fun spawnFailureSurfacesAsBackendUnavailable() {
+        val backend = newBackend(
+            connector = { _ ->
+                Err(UnixSocketError.ConnectFailed(path = "/tmp/s", errno = 2, message = "ENOENT"))
+            },
+            spawner = { _, _ -> Err(ProcessError.ForkFailed) },
+        )
+
+        val err = backend.compile(sampleArgs).getError()
+
+        val unavailable = assertIs<NativeCompileError.BackendUnavailable.Other>(err)
+        assertTrue(unavailable.detail.contains("spawn failed"))
+    }
+
+    @Test
+    fun retryBudgetExhaustionReportsLastError() {
+        val clock = FakeClock()
+        var calls = 0
+        val backend = newBackend(
+            connector = { _ ->
+                calls++
+                Err(UnixSocketError.ConnectFailed(path = "/tmp/s", errno = 2, message = "ENOENT"))
+            },
+            clock = clock,
+        )
+
+        val err = backend.compile(sampleArgs).getError()
+
+        val unavailable = assertIs<NativeCompileError.BackendUnavailable.Other>(err)
+        assertTrue(
+            unavailable.detail.contains("within 3000ms"),
+            "expected budget mention, got: ${unavailable.detail}",
+        )
+        assertTrue(calls > 1, "expected multiple retry attempts before giving up")
+    }
+
+    @Test
+    fun spawnArgvContainsXmx4GAndDaemonFlags() {
+        var capturedArgv: List<String>? = null
+        val backend = newBackend(
+            connector = { _ ->
+                Err(UnixSocketError.ConnectFailed(path = "/tmp/s", errno = 2, message = "ENOENT"))
+            },
+            spawner = { argv, _ -> capturedArgv = argv; Err(ProcessError.ForkFailed) },
+        )
+
+        backend.compile(sampleArgs)
+
+        val argv = assertNotNull(capturedArgv)
+        // ADR 0024 §3: -Xmx4G is load-bearing for stage 2 linking.
+        assertTrue("-Xmx4G" in argv, "missing -Xmx4G: $argv")
+        // ADR 0024 §8: the three daemon-side CLI flags are non-negotiable.
+        assertTrue("--socket" in argv)
+        assertTrue("--konanc-jar" in argv)
+        assertTrue("--konan-home" in argv)
+        assertEquals(
+            "/opt/konan/konan/lib/kotlin-native-compiler-embeddable.jar",
+            argv[argv.indexOf("--konanc-jar") + 1],
+        )
+        assertEquals("/opt/konan", argv[argv.indexOf("--konan-home") + 1])
+        assertEquals("/opt/jdk/bin/java", argv.first())
+    }
+
+    @Test
+    fun onSpawnFiresOnlyWhenSpawnIsTriggered() {
+        var hits = 0
+        val fake = FakeConnection()
+
+        // Success on first connect: no onSpawn.
+        newBackend(connector = { Ok(fake) }, onSpawn = { hits++ }).compile(sampleArgs)
+        assertEquals(0, hits)
+
+        // ENOENT first, then Ok: onSpawn fires exactly once.
+        var callCount = 0
+        newBackend(
+            connector = { _ ->
+                callCount++
+                if (callCount == 1) Err(UnixSocketError.ConnectFailed("/tmp/s", errno = 2, message = "ENOENT"))
+                else Ok(fake)
+            },
+            onSpawn = { hits++ },
+        ).compile(sampleArgs)
+        assertEquals(1, hits)
+    }
+
+    @Test
+    fun exponentialBackoffDoublesUpToMax() {
+        // Capture each sleep duration so we can pin the 10 -> 20 -> 40 -> 80
+        // -> 160 -> 200 (cap) progression from ADR 0024's spike budget.
+        val slept = mutableListOf<Int>()
+        val clock = FakeClock()
+        val budgetOverflowSleeper: (Int) -> Unit = { ms ->
+            slept += ms
+            clock.nowMs += ms.toLong()
+        }
+        val backend = NativeDaemonBackend(
+            javaBin = "/java",
+            daemonJarPath = "/d.jar",
+            konancJar = "/k.jar",
+            konanHome = "/k",
+            socketPath = "/tmp/s",
+            logPath = null,
+            connector = { _ ->
+                Err(UnixSocketError.ConnectFailed(path = "/tmp/s", errno = 2, message = "ENOENT"))
+            },
+            spawner = { _, _ -> Ok(Unit) },
+            clockMs = clock.clock,
+            sleeper = budgetOverflowSleeper,
+        )
+
+        backend.compile(sampleArgs)
+
+        // First few delays follow the doubling ladder, capped at MAX_BACKOFF_MS.
+        assertTrue(slept.isNotEmpty())
+        assertEquals(10, slept[0])
+        if (slept.size > 1) assertEquals(20, slept[1])
+        if (slept.size > 2) assertEquals(40, slept[2])
+        // Every delay must stay in [INITIAL, MAX].
+        for (ms in slept) {
+            assertTrue(ms in 10..200, "delay out of range: $ms")
+        }
+    }
+
+    @Test
+    fun connectionIsClosedEvenOnSendFailure() {
+        val fake = FakeConnection(sendResult = Err(FrameError.Malformed("bad")))
+        val backend = newBackend(connector = { Ok(fake) })
+
+        backend.compile(sampleArgs)
+
+        assertTrue(fake.closed, "connection must close on send error")
+    }
+}

--- a/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonJarResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonJarResolverTest.kt
@@ -1,0 +1,112 @@
+package kolt.build.nativedaemon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class NativeDaemonJarResolverTest {
+
+    private fun exists(vararg paths: String): (String) -> Boolean {
+        val set = paths.toSet()
+        return { it in set }
+    }
+
+    @Test
+    fun envOverrideWinsWithoutExistenceCheck() {
+        val result = resolveNativeDaemonJarPure(
+            envValue = "/nowhere/custom-native.jar",
+            selfExePath = "/opt/kolt/bin/kolt",
+            fileExists = { false },
+        )
+        val resolved = assertIs<NativeDaemonJarResolution.Resolved>(result)
+        assertEquals("/nowhere/custom-native.jar", resolved.path)
+        assertEquals(NativeDaemonJarResolution.Source.Env, resolved.source)
+    }
+
+    @Test
+    fun emptyEnvFallsThroughToLibexec() {
+        val libexec = "/opt/kolt/libexec/kolt-native-daemon-all.jar"
+        val result = resolveNativeDaemonJarPure(
+            envValue = "",
+            selfExePath = "/opt/kolt/bin/kolt",
+            fileExists = exists(libexec),
+        )
+        val resolved = assertIs<NativeDaemonJarResolution.Resolved>(result)
+        assertEquals(libexec, resolved.path)
+        assertEquals(NativeDaemonJarResolution.Source.Libexec, resolved.source)
+    }
+
+    @Test
+    fun libexecLayoutIsPickedFromInstalledPrefix() {
+        val libexec = "/usr/local/libexec/kolt-native-daemon-all.jar"
+        val result = resolveNativeDaemonJarPure(
+            envValue = null,
+            selfExePath = "/usr/local/bin/kolt",
+            fileExists = exists(libexec),
+        )
+        val resolved = assertIs<NativeDaemonJarResolution.Resolved>(result)
+        assertEquals(libexec, resolved.path)
+    }
+
+    @Test
+    fun devFallbackResolvesFromBuildBinLinuxX64() {
+        val kolt = "/home/alice/src/kolt/build/bin/linuxX64/debugExecutable/kolt.kexe"
+        val devJar = "/home/alice/src/kolt/kolt-native-daemon/build/libs/kolt-native-daemon-all.jar"
+        val result = resolveNativeDaemonJarPure(
+            envValue = null,
+            selfExePath = kolt,
+            fileExists = exists(devJar),
+        )
+        val resolved = assertIs<NativeDaemonJarResolution.Resolved>(result)
+        assertEquals(devJar, resolved.path)
+        assertEquals(NativeDaemonJarResolution.Source.DevFallback, resolved.source)
+    }
+
+    @Test
+    fun libexecWinsOverDevFallbackWhenBothExist() {
+        val libexec = "/opt/kolt/libexec/kolt-native-daemon-all.jar"
+        val devJar = "/kolt-native-daemon/build/libs/kolt-native-daemon-all.jar"
+        val result = resolveNativeDaemonJarPure(
+            envValue = null,
+            selfExePath = "/opt/kolt/bin/kolt",
+            fileExists = exists(libexec, devJar),
+        )
+        val resolved = assertIs<NativeDaemonJarResolution.Resolved>(result)
+        assertEquals(libexec, resolved.path)
+    }
+
+    @Test
+    fun noSelfExeAndNoEnvReturnsNotFound() {
+        val result = resolveNativeDaemonJarPure(
+            envValue = null,
+            selfExePath = null,
+            fileExists = { true },
+        )
+        assertEquals(NativeDaemonJarResolution.NotFound, result)
+    }
+
+    @Test
+    fun selfExePresentButNoFilesExistReturnsNotFound() {
+        val result = resolveNativeDaemonJarPure(
+            envValue = null,
+            selfExePath = "/opt/kolt/bin/kolt",
+            fileExists = { false },
+        )
+        assertEquals(NativeDaemonJarResolution.NotFound, result)
+    }
+
+    @Test
+    fun jvmDaemonJarIsNotPickedUpAsNativeDaemonJar() {
+        // Both daemons ship their jars under `libexec/`. If the native
+        // resolver ever accidentally probed the JVM jar filename, it would
+        // spawn a JVM daemon over --konanc-jar/--konan-home and explode at
+        // parse time. This test pins the filename strictness.
+        val jvmJar = "/opt/kolt/libexec/kolt-compiler-daemon-all.jar"
+        val result = resolveNativeDaemonJarPure(
+            envValue = null,
+            selfExePath = "/opt/kolt/bin/kolt",
+            fileExists = exists(jvmJar),
+        )
+        assertEquals(NativeDaemonJarResolution.NotFound, result)
+    }
+}

--- a/src/nativeTest/kotlin/kolt/nativedaemon/wire/FrameCodecTest.kt
+++ b/src/nativeTest/kotlin/kolt/nativedaemon/wire/FrameCodecTest.kt
@@ -1,0 +1,124 @@
+package kolt.nativedaemon.wire
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.net.UnixSocket
+import kolt.infra.net.testfixture.UnixEchoServer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class FrameCodecTest {
+
+    @Test
+    fun roundTripEchoPreservesNativeCompileMessage() {
+        val message = Message.NativeCompile(
+            args = listOf(
+                "-target", "linux_x64",
+                "src/Main.kt",
+                "-p", "library",
+                "-nopack",
+                "-Xenable-incremental-compilation",
+                "-Xic-cache-dir=build/.ic-cache",
+                "-o", "build/m-klib",
+            ),
+        )
+
+        val decoded = roundTripViaByteEcho(message)
+
+        assertEquals(message, decoded)
+    }
+
+    @Test
+    fun roundTripEchoPreservesNativeCompileResult() {
+        val message = Message.NativeCompileResult(
+            exitCode = 1,
+            stderr = "error: unresolved reference: foo\n    at src/Main.kt:3",
+        )
+
+        assertEquals(message, roundTripViaByteEcho(message))
+    }
+
+    @Test
+    fun roundTripEchoPreservesControlMessages() {
+        assertEquals(Message.Ping, roundTripViaByteEcho(Message.Ping))
+        assertEquals(Message.Pong, roundTripViaByteEcho(Message.Pong))
+        assertEquals(Message.Shutdown, roundTripViaByteEcho(Message.Shutdown))
+    }
+
+    @Test
+    fun readFrameReturnsEofOnCleanClose() {
+        UnixEchoServer.start(handler = { ByteArray(0) })
+            .getOrElse { fail("start failed: $it") }
+            .use { server -> withReadFrame(server) { it.shutdownWrite() } }
+            .let { err ->
+                assertEquals(FrameError.Eof, err, "expected Eof on clean close")
+            }
+    }
+
+    @Test
+    fun readFrameReturnsMalformedOnBadJsonBody() {
+        val body = "not json at all".encodeToByteArray()
+        val framed = encodeBigEndianU32(body.size) + body
+        UnixEchoServer.start(handler = { framed })
+            .getOrElse { fail("start failed: $it") }
+            .use { server -> withReadFrame(server) { it.shutdownWrite() } }
+            .let { err ->
+                assertIs<FrameError.Malformed>(err)
+            }
+    }
+
+    @Test
+    fun writeFrameRejectsBodyLargerThanMaxBodyBytes() {
+        val oversize = Message.NativeCompileResult(
+            exitCode = 1,
+            stderr = "a".repeat(FrameCodec.MAX_BODY_BYTES + 1),
+        )
+        UnixEchoServer.start().getOrElse { fail("start failed: $it") }.use { server ->
+            UnixSocket.connect(server.socketPath)
+                .getOrElse { fail("connect failed: $it") }
+                .use { client ->
+                    val result = FrameCodec.writeFrame(client, oversize)
+                    assertTrue(result.isErr, "expected oversize body to be rejected")
+                    val err = assertIs<FrameError.Malformed>(result.getError())
+                    assertTrue(
+                        err.reason.contains("MAX_BODY_BYTES"),
+                        "reason should mention MAX_BODY_BYTES: ${err.reason}",
+                    )
+                }
+        }
+    }
+
+    private fun roundTripViaByteEcho(message: Message): Message {
+        UnixEchoServer.start().getOrElse { fail("start failed: $it") }.use { server ->
+            return UnixSocket.connect(server.socketPath)
+                .getOrElse { fail("connect failed: $it") }
+                .use { client ->
+                    FrameCodec.writeFrame(client, message).getOrElse { fail("write failed: $it") }
+                    client.shutdownWrite().getOrElse { fail("shutdownWrite failed: $it") }
+                    FrameCodec.readFrame(client).getOrElse { fail("read failed: $it") }
+                }
+        }
+    }
+
+    private fun withReadFrame(
+        server: UnixEchoServer,
+        prepare: (UnixSocket) -> Unit,
+    ): FrameError {
+        val socket = UnixSocket.connect(server.socketPath).getOrElse { fail("connect failed: $it") }
+        return socket.use {
+            prepare(it)
+            val err = FrameCodec.readFrame(it).getError() ?: fail("expected read error")
+            err
+        }
+    }
+
+    private fun encodeBigEndianU32(value: Int): ByteArray = byteArrayOf(
+        ((value ushr 24) and 0xff).toByte(),
+        ((value ushr 16) and 0xff).toByte(),
+        ((value ushr 8) and 0xff).toByte(),
+        (value and 0xff).toByte(),
+    )
+}


### PR DESCRIPTION
PR 3 of the native compiler daemon series. Lands the native client side of ADR 0024: a separate `NativeCompilerBackend` interface, subprocess/daemon implementations, and the fallback wrapper that retries an unhealthy daemon on the subprocess path. `doNativeBuild` wiring, `kolt daemon stop` enumeration, and an end-to-end test against a real konanc jar follow in PR 4+.

## Places to double-check

**`NativeCompilerBackend` as a separate interface from `CompilerBackend`.** Issue #170's original Definition-of-Done said "implementing `CompilerBackend`". We deliberately diverged — ADR 0024 §4 keeps native compilation args-shaped (`compile(args: List<String>)`) rather than the JVM-side structured `CompileRequest`, because `K2Native.exec` is CLI-shaped and there's no BTA for native. The divergence means `FallbackNativeCompilerBackend` parallels `FallbackCompilerBackend` rather than reusing it. Push back if you'd rather reuse the JVM interface.

**Daemon-side-failure detection via stderr prefixes.** `NativeDaemonBackend.mapReplyToOutcome` distinguishes "daemon broke" (fallback-eligible) from "konanc INTERNAL_ERROR" (passthrough) by matching `"protocol error: "` and `"native compiler invocation failed: "` in the reply's stderr. This is a load-bearing contract with `kolt-native-daemon`'s `DaemonServer.writeProtocolError` / `errorToReply` — renaming on either side without updating the other silently breaks fallback. Both sides now carry explicit comments about this; a cross-module prefix-drift regression test is tracked as a follow-up.

**`-Xmx4G` in spawnArgv.** ADR 0024 §3 table marks 4 GB load-bearing for stage 2 LLVM backend memory. The JVM daemon's `DaemonCompilerBackend.spawnArgv` does NOT set `-Xmx`; the asymmetry is intentional. Worth a second look if you know the stage 2 linker behaves differently than the spike measured.

**Server-side comment rewrite.** This PR includes a small edit to `kolt-native-daemon/.../DaemonServer.kt` (PR 2 territory): the `errorToReply` comment used to say "reflective-error reply does NOT trigger fallback" which contradicts the client's actual behaviour. Rewritten to match the client + pin the stderr prefix as load-bearing. Flagged here so it doesn't look like scope creep.

**Classloader-internal errno reuse.** `NativeDaemonBackend` imports `isRetryableConnectError` and `monotonicMs` from `kolt.build.daemon` rather than duplicating. Comment at the import site explains when to hoist to `kolt.infra`. Similar comment on `describe(UnixSocketError?)` and `parentDir` duplications.

## Two small carryovers from review

Deferred as follow-ups (not addressed here):
- Cross-module regression test that asserts the daemon-failure stderr prefixes match between server + client.
- `-Xmx4G` source-of-truth consolidation into ADR 0024 §3 so both daemon specs can reference it.
- `NativeCompileOutcome` drops stdout permanently; if a future `-Xverbose` flow needs it, interface revisit required.

## Tests

35 cases. Interface/fallback eligibility (4), wire protocol round-trip (6), subprocess backend argv + ProcessError mapping (8), fallback composition (9), daemon backend happy-path + connect-and-spawn (~10), jar resolver (8). `./gradlew build` green end-to-end.