### PR TITLE
Wire native daemon into doNativeBuild (#170)

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/NativeFallbackReporter.kt
+++ b/src/nativeMain/kotlin/kolt/build/NativeFallbackReporter.kt
@@ -1,0 +1,25 @@
+package kolt.build
+
+import kolt.infra.eprintln
+
+// Parallel to `reportFallback` in FallbackReporter.kt, but for the native
+// compiler daemon's error surface. ADR 0024 §7: a daemon failure is a
+// warning, never a build-blocker — except InternalMisuse, which is a kolt
+// bug (bubbles as error-level so nobody's silent-reporting a latent issue).
+// CompilationFailed and NoCommand never take the fallback branch (ADR 0024
+// §7 + `isNativeFallbackEligible`), so they stay silent here: the caller
+// has already printed the konanc diagnostics.
+fun reportNativeFallback(err: NativeCompileError, sink: (String) -> Unit = ::eprintln) {
+    when (err) {
+        is NativeCompileError.BackendUnavailable.ForkFailed,
+        is NativeCompileError.BackendUnavailable.WaitFailed,
+        is NativeCompileError.BackendUnavailable.SignalKilled,
+        is NativeCompileError.BackendUnavailable.PopenFailed,
+        -> sink("warning: native compiler daemon unavailable, falling back to subprocess compile")
+        is NativeCompileError.BackendUnavailable.Other ->
+            sink("warning: native compiler daemon unavailable (${err.detail}), falling back to subprocess compile")
+        is NativeCompileError.InternalMisuse ->
+            sink("error: native compiler daemon hit an internal kolt bug (${err.detail}); falling back to subprocess compile — please report this")
+        is NativeCompileError.CompilationFailed, NativeCompileError.NoCommand -> {}
+    }
+}

--- a/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonPreconditions.kt
+++ b/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonPreconditions.kt
@@ -1,0 +1,155 @@
+package kolt.build.nativedaemon
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.build.daemon.BootstrapJdkError
+import kolt.build.daemon.ensureBootstrapJavaBin
+import kolt.build.daemon.projectHashOf
+import kolt.config.KoltPaths
+import kolt.infra.fileExists as infraFileExists
+import kolt.resolve.compareVersions
+
+// Parallel to `kolt.build.daemon.DaemonSetup` but tailored for ADR 0024:
+// no compilerJars list (one jar is passed to the daemon via `--konanc-jar`),
+// no btaImplJars (BTA has no native equivalent per §6), a distinct socket
+// filename (`native-daemon.sock`) co-located under the same project/version
+// directory as the JVM daemon so `daemon stop` enumerates both in one pass.
+internal data class NativeDaemonSetup(
+    val javaBin: String,
+    val daemonJarPath: String,
+    val konancJar: String,
+    val konanHome: String,
+    val daemonDir: String,
+    val socketPath: String,
+    val logPath: String,
+)
+
+// Shape of spike #166: K2Native's reflective CLI surface
+// (`CLICompiler.exec(PrintStream, String[])`) was validated at 100
+// invocations on Kotlin 2.3.x with no state leakage. Earlier 2.2.x and
+// below have different `K2Native` internals and are not exercised on
+// this path. Unlike the JVM daemon's floor (ADR 0022, BTA-impl V1 shim
+// classloader split), the native floor is about K2Native version drift,
+// not BTA — there is no BTA for native (ADR 0024 §6).
+internal const val NATIVE_KOTLIN_VERSION_FLOOR = "2.3.0"
+
+// Linux AF_UNIX sun_path capacity. Fail fast if the projected socket path
+// would overflow; the native daemon does not apply a plugin-fingerprint
+// suffix (ADR 0024 §6: no daemon-side plugin plumbing), so the projected
+// path is simply the raw socket path. Same rationale as the JVM daemon
+// precondition minus the fingerprint over-estimate.
+private const val NATIVE_SUN_PATH_CAPACITY: Int = 108
+
+// `konan/lib/kotlin-native-compiler-embeddable.jar` is the single jar the
+// daemon loads reflectively (ADR 0024 §8). It sits under the managed
+// konanc toolchain root next to `bin/konanc`.
+private const val KONANC_EMBEDDABLE_RELATIVE_PATH = "konan/lib/kotlin-native-compiler-embeddable.jar"
+
+// None of these are build failures — ADR 0024 §7.
+internal sealed interface NativeDaemonPreconditionError {
+    data class BootstrapJdkInstallFailed(
+        val jdkInstallDir: String,
+        val cause: String,
+    ) : NativeDaemonPreconditionError
+
+    data object NativeDaemonJarMissing : NativeDaemonPreconditionError
+
+    // The managed konanc install is missing its embeddable jar — usually
+    // an incomplete download or a manual delete. Subprocess still works
+    // because it invokes the konanc shell script, not the jar.
+    data class KonancJarMissing(val path: String) : NativeDaemonPreconditionError
+
+    data class KotlinVersionBelowFloor(
+        val requested: String,
+        val floor: String,
+    ) : NativeDaemonPreconditionError
+
+    data class SocketPathTooLong(
+        val socketPath: String,
+        val projectedBytes: Int,
+        val maxBytes: Int,
+    ) : NativeDaemonPreconditionError
+}
+
+internal fun resolveNativeDaemonPreconditions(
+    paths: KoltPaths,
+    kotlincVersion: String,
+    absProjectPath: String,
+    ensureJavaBin: (KoltPaths) -> Result<String, BootstrapJdkError> = ::ensureBootstrapJavaBin,
+    resolveNativeDaemonJar: () -> NativeDaemonJarResolution = ::resolveNativeDaemonJar,
+    fileExists: (String) -> Boolean = ::infraFileExists,
+): Result<NativeDaemonSetup, NativeDaemonPreconditionError> {
+    // No `bundledKotlinVersion` parameter here — unlike the JVM resolver,
+    // nothing on the native path branches on bundled vs non-bundled today
+    // (no BTA fetch per ADR 0024 §6). Add it back when a caller needs it.
+    if (compareVersions(kotlincVersion, NATIVE_KOTLIN_VERSION_FLOOR) < 0) {
+        return Err(
+            NativeDaemonPreconditionError.KotlinVersionBelowFloor(
+                requested = kotlincVersion,
+                floor = NATIVE_KOTLIN_VERSION_FLOOR,
+            ),
+        )
+    }
+
+    val projectHash = projectHashOf(absProjectPath)
+    val socketPath = paths.nativeDaemonSocketPath(projectHash, kotlincVersion)
+    if (socketPath.length > NATIVE_SUN_PATH_CAPACITY) {
+        return Err(
+            NativeDaemonPreconditionError.SocketPathTooLong(
+                socketPath = socketPath,
+                projectedBytes = socketPath.length,
+                maxBytes = NATIVE_SUN_PATH_CAPACITY,
+            ),
+        )
+    }
+
+    val javaBin = ensureJavaBin(paths).getOrElse { err ->
+        return Err(
+            NativeDaemonPreconditionError.BootstrapJdkInstallFailed(
+                jdkInstallDir = err.jdkInstallDir,
+                cause = err.cause.message,
+            ),
+        )
+    }
+
+    val daemonJar = when (val res = resolveNativeDaemonJar()) {
+        is NativeDaemonJarResolution.Resolved -> res.path
+        NativeDaemonJarResolution.NotFound -> return Err(NativeDaemonPreconditionError.NativeDaemonJarMissing)
+    }
+
+    val konanHome = paths.konancPath(kotlincVersion)
+    val konancJar = "$konanHome/$KONANC_EMBEDDABLE_RELATIVE_PATH"
+    if (!fileExists(konancJar)) {
+        return Err(NativeDaemonPreconditionError.KonancJarMissing(konancJar))
+    }
+
+    return Ok(
+        NativeDaemonSetup(
+            javaBin = javaBin,
+            daemonJarPath = daemonJar,
+            konancJar = konancJar,
+            konanHome = konanHome,
+            daemonDir = paths.daemonDir(projectHash, kotlincVersion),
+            socketPath = socketPath,
+            logPath = paths.nativeDaemonLogPath(projectHash, kotlincVersion),
+        ),
+    )
+}
+
+internal fun formatNativeDaemonPreconditionWarning(err: NativeDaemonPreconditionError): String = when (err) {
+    is NativeDaemonPreconditionError.BootstrapJdkInstallFailed ->
+        "warning: could not install bootstrap JDK at ${err.jdkInstallDir} (${err.cause}) — falling back to subprocess compile"
+    NativeDaemonPreconditionError.NativeDaemonJarMissing ->
+        "warning: kolt-native-daemon jar not found — falling back to subprocess compile"
+    is NativeDaemonPreconditionError.KonancJarMissing ->
+        "warning: konanc embeddable jar not found at ${err.path} — falling back to subprocess compile"
+    is NativeDaemonPreconditionError.KotlinVersionBelowFloor ->
+        "warning: kolt native daemon supports Kotlin >= ${err.floor}; your kolt.toml requests ${err.requested} — " +
+            "falling back to subprocess compile. Pass --no-daemon to silence this warning."
+    is NativeDaemonPreconditionError.SocketPathTooLong ->
+        "warning: native daemon socket path ${err.socketPath} would be ${err.projectedBytes} bytes, " +
+            "exceeding the Linux AF_UNIX ${err.maxBytes}-byte limit — falling back to subprocess compile. " +
+            "Move the project under a shorter \$HOME, or pass --no-daemon to silence this warning."
+}

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -13,6 +13,11 @@ import kolt.build.daemon.DaemonSetup
 import kolt.build.daemon.cleanDaemonIcStateForProject
 import kolt.build.daemon.formatDaemonPreconditionWarning
 import kolt.build.daemon.resolveDaemonPreconditions
+import kolt.build.nativedaemon.NativeDaemonBackend
+import kolt.build.nativedaemon.NativeDaemonPreconditionError
+import kolt.build.nativedaemon.NativeDaemonSetup
+import kolt.build.nativedaemon.formatNativeDaemonPreconditionWarning
+import kolt.build.nativedaemon.resolveNativeDaemonPreconditions
 import kolt.config.*
 import kolt.infra.*
 import kolt.resolve.*
@@ -112,7 +117,7 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
     val config = loadProjectConfig().getOrElse { return Err(it) }
 
     if (config.build.target in NATIVE_TARGETS) {
-        return doNativeBuild(config)
+        return doNativeBuild(config, useDaemon)
     }
 
     val currentState = BuildState(
@@ -221,7 +226,7 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
     return Ok(BuildResult(config, classpath, managedJavaBin))
 }
 
-private fun doNativeBuild(config: KoltConfig): Result<BuildResult, Int> {
+private fun doNativeBuild(config: KoltConfig, useDaemon: Boolean): Result<BuildResult, Int> {
     val startMark = TimeSource.Monotonic.markNow()
 
     val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_BUILD_ERROR) }
@@ -258,10 +263,27 @@ private fun doNativeBuild(config: KoltConfig): Result<BuildResult, Int> {
     val cinteropKlibs = runCinterop(config, paths).getOrElse { return Err(it) }
     val klibs = depKlibs + cinteropKlibs
 
+    val cwd = currentWorkingDirectory() ?: run {
+        eprintln("error: could not determine current working directory")
+        return Err(EXIT_BUILD_ERROR)
+    }
+    val subprocessBackend = NativeSubprocessBackend(konancBin = managedKonancBin)
+    val backend: NativeCompilerBackend = resolveNativeCompilerBackend(
+        config = config,
+        paths = paths,
+        subprocessBackend = subprocessBackend,
+        useDaemon = useDaemon,
+        absProjectPath = cwd,
+    )
+
     val libraryCmd = nativeLibraryCommand(config, pluginArgs = nativePluginArgs, konancPath = managedKonancBin, klibs = klibs)
     println("compiling ${config.name} (native)...")
-    executeCommand(libraryCmd.args).getOrElse { error ->
-        eprintln("error: " + formatProcessError(error, "compilation"))
+    // ADR 0024 §4: backend.compile takes konanc args *after* the binary.
+    // `nativeLibraryCommand` / `nativeLinkCommand` put the binary at [0]
+    // for the subprocess call site; strip it when handing off to the
+    // backend so the daemon and subprocess paths share the same argv shape.
+    backend.compile(libraryCmd.args.drop(1)).getOrElse { error ->
+        reportNativeCompileError(error, "compilation")
         return Err(EXIT_BUILD_ERROR)
     }
 
@@ -272,8 +294,8 @@ private fun doNativeBuild(config: KoltConfig): Result<BuildResult, Int> {
 
     val linkCmd = nativeLinkCommand(config, konancPath = managedKonancBin, klibs = klibs)
     println("linking ${config.name} (native)...")
-    runNativeLinkWithIcFallback(linkCmd.args).getOrElse { error ->
-        eprintln("error: " + formatProcessError(error, "linking"))
+    runNativeLinkWithIcFallback(backend, linkCmd.args.drop(1)).getOrElse { error ->
+        reportNativeCompileError(error, "linking")
         return Err(EXIT_BUILD_ERROR)
     }
 
@@ -292,6 +314,16 @@ private fun doNativeBuild(config: KoltConfig): Result<BuildResult, Int> {
     return Ok(BuildResult(config, classpath = null, javaPath = null))
 }
 
+// Surface konanc stderr before the one-line fallback/error summary so the
+// user sees the actual diagnostic. CompilationFailed rides the
+// backend-supplied stderr; other variants don't have diagnostic content.
+private fun reportNativeCompileError(error: NativeCompileError, context: String) {
+    if (error is NativeCompileError.CompilationFailed && error.stderr.isNotEmpty()) {
+        eprintln(error.stderr.trimEnd('\n'))
+    }
+    eprintln(formatNativeCompileError(error, context))
+}
+
 // On konanc non-zero exit, retry once after wiping the IC cache — konanc
 // can't distinguish "stale cache" from "real compile error" in its exit
 // code, so we treat every non-zero exit as potentially cache-induced.
@@ -299,20 +331,23 @@ private fun doNativeBuild(config: KoltConfig): Result<BuildResult, Int> {
 // errors are caught at stage 1 (library), not stage 2 (link). Spike #160
 // confirmed konanc handles a missing .ic-cache gracefully.
 //
-// Fork/wait/signal failures are outside the cache-corruption hypothesis
-// (the konanc process never ran to completion), so they surface as-is.
+// After PR 4: the execute step goes through `NativeCompilerBackend`, so
+// BackendUnavailable variants (daemon unreachable, subprocess fork/wait
+// failures) surface directly — they are outside the cache-corruption
+// hypothesis. Only `CompilationFailed` (konanc returned non-zero) is
+// retry-eligible. InternalMisuse and NoCommand likewise skip retry.
 // If wipe itself fails, the retry would hit the same stale cache — skip
 // the retry and return the original error instead.
 internal fun runNativeLinkWithIcFallback(
+    backend: NativeCompilerBackend,
     args: List<String>,
-    execute: (List<String>) -> Result<Int, ProcessError> = ::executeCommand,
-    wipeCache: () -> Boolean = ::wipeNativeIcCache
-): Result<Int, ProcessError> {
-    val first = execute(args)
+    wipeCache: () -> Boolean = ::wipeNativeIcCache,
+): Result<NativeCompileOutcome, NativeCompileError> {
+    val first = backend.compile(args)
     val firstError = first.getError() ?: return first
-    if (firstError !is ProcessError.NonZeroExit) return first
+    if (firstError !is NativeCompileError.CompilationFailed) return first
     if (!wipeCache()) return first
-    return execute(args)
+    return backend.compile(args)
 }
 
 private fun wipeNativeIcCache(): Boolean {
@@ -572,6 +607,61 @@ internal fun resolveCompilerBackend(
         onFallback = ::reportFallback,
     )
 }
+
+// ADR 0024 §7: native daemon is never load-bearing either. Same fallback
+// shape as `resolveCompilerBackend`, but simpler: no plugin fingerprinting
+// (no daemon-side plugin channel per §6) and a different precondition
+// resolver.
+internal fun resolveNativeCompilerBackend(
+    config: KoltConfig,
+    paths: KoltPaths,
+    subprocessBackend: NativeCompilerBackend,
+    useDaemon: Boolean,
+    absProjectPath: String,
+    preconditionResolver: (KoltPaths, String, String) -> Result<NativeDaemonSetup, NativeDaemonPreconditionError> =
+        { p, kotlincVersion, cwd ->
+            resolveNativeDaemonPreconditions(p, kotlincVersion, cwd)
+        },
+    daemonDirCreator: (String) -> Result<Unit, MkdirFailed> = ::ensureDirectoryRecursive,
+    daemonBackendFactory: (NativeDaemonSetup) -> NativeCompilerBackend = ::createNativeDaemonBackend,
+    warningSink: (String) -> Unit = ::eprintln,
+): NativeCompilerBackend {
+    if (!useDaemon) return subprocessBackend
+
+    val setup = preconditionResolver(
+        paths, config.kotlin.effectiveCompiler, absProjectPath,
+    ).getOrElse { err ->
+        warningSink(formatNativeDaemonPreconditionWarning(err))
+        return subprocessBackend
+    }
+
+    // spawnDetached opens the log with O_CREAT but not the parent dir;
+    // create it before the daemon tries to bind the socket. Mirrors the
+    // JVM daemon wiring.
+    if (daemonDirCreator(setup.daemonDir).getError() != null) {
+        warningSink(WARNING_DAEMON_DIR_UNWRITABLE)
+        return subprocessBackend
+    }
+
+    return FallbackNativeCompilerBackend(
+        primary = daemonBackendFactory(setup),
+        fallback = subprocessBackend,
+        onFallback = ::reportNativeFallback,
+    )
+}
+
+internal fun createNativeDaemonBackend(
+    setup: NativeDaemonSetup,
+): NativeCompilerBackend =
+    NativeDaemonBackend(
+        javaBin = setup.javaBin,
+        daemonJarPath = setup.daemonJarPath,
+        konancJar = setup.konancJar,
+        konanHome = setup.konanHome,
+        socketPath = setup.socketPath,
+        logPath = setup.logPath,
+        onSpawn = { eprintln("starting native compiler daemon...") },
+    )
 
 internal fun createDaemonBackend(
     setup: DaemonSetup,

--- a/src/nativeTest/kotlin/kolt/build/NativeFallbackReporterTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/NativeFallbackReporterTest.kt
@@ -1,0 +1,54 @@
+package kolt.build
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NativeFallbackReporterTest {
+
+    private fun capture(err: NativeCompileError): List<String> {
+        val messages = mutableListOf<String>()
+        reportNativeFallback(err) { messages += it }
+        return messages
+    }
+
+    @Test
+    fun backendUnavailableVariantsEmitGenericWarning() {
+        for (err in listOf(
+            NativeCompileError.BackendUnavailable.ForkFailed,
+            NativeCompileError.BackendUnavailable.WaitFailed,
+            NativeCompileError.BackendUnavailable.SignalKilled,
+            NativeCompileError.BackendUnavailable.PopenFailed,
+        )) {
+            val out = capture(err).single()
+            assertTrue(
+                out.startsWith("warning:") && out.contains("native compiler daemon unavailable"),
+                "unexpected message for $err: $out",
+            )
+        }
+    }
+
+    @Test
+    fun backendUnavailableOtherIncludesDetail() {
+        val out = capture(
+            NativeCompileError.BackendUnavailable.Other("connect refused"),
+        ).single()
+        assertTrue(out.contains("connect refused"), "expected detail in warning: $out")
+    }
+
+    @Test
+    fun internalMisuseEscalatesToError() {
+        val out = capture(NativeCompileError.InternalMisuse("socket path too long")).single()
+        assertTrue(out.startsWith("error:"), "expected error-level, got: $out")
+        assertTrue(out.contains("socket path too long"))
+    }
+
+    @Test
+    fun compilationFailedAndNoCommandAreSilent() {
+        // Real compile errors pass through without a fallback notice — the
+        // caller has already seen the konanc diagnostics. NoCommand is
+        // non-eligible and also silent.
+        assertEquals(emptyList(), capture(NativeCompileError.CompilationFailed(exitCode = 1, stderr = "error: ...")))
+        assertEquals(emptyList(), capture(NativeCompileError.NoCommand))
+    }
+}

--- a/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonPreconditionsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonPreconditionsTest.kt
@@ -1,0 +1,137 @@
+package kolt.build.nativedaemon
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.build.daemon.BootstrapJdkError
+import kolt.config.KoltPaths
+import kolt.tool.ToolchainError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class NativeDaemonPreconditionsTest {
+
+    private val paths = KoltPaths(home = "/home/test")
+    private val kotlinVersion = "2.3.20"
+    private val project = "/tmp/myproject"
+
+    private fun run(
+        kotlincVersion: String = kotlinVersion,
+        ensureJavaBin: (KoltPaths) -> Result<String, BootstrapJdkError> = { Ok("/opt/jdk/bin/java") },
+        resolveNativeJar: () -> NativeDaemonJarResolution =
+            { NativeDaemonJarResolution.Resolved("/opt/kolt/libexec/kolt-native-daemon-all.jar", NativeDaemonJarResolution.Source.Libexec) },
+        konancLayoutExists: (String) -> Boolean = { true },
+        absProjectPath: String = project,
+    ): Result<NativeDaemonSetup, NativeDaemonPreconditionError> =
+        resolveNativeDaemonPreconditions(
+            paths = paths,
+            kotlincVersion = kotlincVersion,
+            absProjectPath = absProjectPath,
+            ensureJavaBin = ensureJavaBin,
+            resolveNativeDaemonJar = resolveNativeJar,
+            fileExists = konancLayoutExists,
+        )
+
+    @Test
+    fun happyPathReturnsSetupWithDerivedKonancJarAndHome() {
+        val setup = assertNotNull(run().get())
+
+        assertEquals("/opt/jdk/bin/java", setup.javaBin)
+        assertEquals("/opt/kolt/libexec/kolt-native-daemon-all.jar", setup.daemonJarPath)
+        // konanHome is the managed toolchain root for the Kotlin version.
+        assertEquals("/home/test/.kolt/toolchains/konanc/2.3.20", setup.konanHome)
+        // konancJar is the single embeddable under `konan/lib/` — the same
+        // path the spike (#166) used.
+        assertEquals(
+            "/home/test/.kolt/toolchains/konanc/2.3.20/konan/lib/kotlin-native-compiler-embeddable.jar",
+            setup.konancJar,
+        )
+        assertTrue(setup.socketPath.endsWith("/native-daemon.sock"))
+        assertTrue(setup.logPath.endsWith("/native-daemon.log"))
+    }
+
+    @Test
+    fun kotlinVersionBelowFloorShortCircuits() {
+        // Floor check runs before any disk probe (cheap) — no filesystem
+        // fakes need to stub true to satisfy it.
+        val err = run(kotlincVersion = "2.2.10").getError()
+
+        val below = assertIs<NativeDaemonPreconditionError.KotlinVersionBelowFloor>(err)
+        assertEquals("2.2.10", below.requested)
+        assertTrue(below.floor.isNotEmpty())
+    }
+
+    @Test
+    fun nativeDaemonJarMissingShortCircuits() {
+        val err = run(resolveNativeJar = { NativeDaemonJarResolution.NotFound }).getError()
+        assertEquals(NativeDaemonPreconditionError.NativeDaemonJarMissing, err)
+    }
+
+    @Test
+    fun bootstrapJdkFailureSurfaces() {
+        val err = run(
+            ensureJavaBin = { Err(BootstrapJdkError(jdkInstallDir = "/x/jdk", cause = ToolchainError("fetch failed"))) },
+        ).getError()
+
+        val jdkErr = assertIs<NativeDaemonPreconditionError.BootstrapJdkInstallFailed>(err)
+        assertEquals("/x/jdk", jdkErr.jdkInstallDir)
+        assertTrue(jdkErr.cause.contains("fetch failed"))
+    }
+
+    @Test
+    fun konancLayoutMissingSurfacesAsKonancJarMissing() {
+        // The konanc jar sits at konan/lib/kotlin-native-compiler-embeddable.jar
+        // under the managed toolchain. If the jar is absent (incomplete
+        // install, manual tamper), the daemon will not start — fall back.
+        val err = run(konancLayoutExists = { false }).getError()
+
+        val missing = assertIs<NativeDaemonPreconditionError.KonancJarMissing>(err)
+        assertTrue(missing.path.endsWith("/konan/lib/kotlin-native-compiler-embeddable.jar"))
+    }
+
+    @Test
+    fun socketPathTooLongSurfaces() {
+        // An extreme HOME path forces the projected socket path past the
+        // Linux AF_UNIX sun_path capacity. Mirrors the JVM-side check.
+        val longHome = "/home/" + "x".repeat(128)
+        val err = resolveNativeDaemonPreconditions(
+            paths = KoltPaths(home = longHome),
+            kotlincVersion = kotlinVersion,
+            absProjectPath = project,
+            ensureJavaBin = { Ok("/opt/jdk/bin/java") },
+            resolveNativeDaemonJar = { NativeDaemonJarResolution.NotFound },
+            fileExists = { true },
+        ).getError()
+
+        val tooLong = assertIs<NativeDaemonPreconditionError.SocketPathTooLong>(err)
+        assertTrue(tooLong.projectedBytes > tooLong.maxBytes)
+    }
+
+    @Test
+    fun formatWarningMentionsFallbackForEveryVariant() {
+        val errors: List<NativeDaemonPreconditionError> = listOf(
+            NativeDaemonPreconditionError.BootstrapJdkInstallFailed("/x/jdk", "fetch failed"),
+            NativeDaemonPreconditionError.NativeDaemonJarMissing,
+            NativeDaemonPreconditionError.KonancJarMissing("/.../kotlin-native-compiler-embeddable.jar"),
+            NativeDaemonPreconditionError.KotlinVersionBelowFloor("2.2.0", "2.3.0"),
+            NativeDaemonPreconditionError.SocketPathTooLong("/too/long", 120, 108),
+        )
+
+        for (err in errors) {
+            val msg = formatNativeDaemonPreconditionWarning(err)
+            assertTrue(
+                msg.startsWith("warning:"),
+                "expected warning: prefix, got: $msg",
+            )
+            assertTrue(
+                msg.contains("falling back to subprocess"),
+                "expected fallback mention, got: $msg",
+            )
+        }
+    }
+}

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
@@ -2,9 +2,13 @@ package kolt.cli
 
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import kolt.testConfig
+import kolt.build.NativeCompileError
+import kolt.build.NativeCompileOutcome
+import kolt.build.NativeCompilerBackend
 import kolt.build.cinteropCommand
 import kolt.build.cinteropOutputKlibPath
 import kolt.build.nativeLibraryCommand
@@ -19,6 +23,7 @@ import kolt.tool.JdkBins
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -260,107 +265,118 @@ class CinteropNativeBuildIntegrationTest {
 
 class RunNativeLinkWithIcFallbackTest {
 
+    private class StubBackend(
+        private val replies: List<Result<NativeCompileOutcome, NativeCompileError>>,
+    ) : NativeCompilerBackend {
+        var calls: Int = 0
+            private set
+        override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> {
+            val reply = replies[calls.coerceAtMost(replies.size - 1)]
+            calls++
+            return reply
+        }
+    }
+
     @Test
     fun successOnFirstCallSkipsWipeAndRetry() {
-        var executeCalls = 0
+        val backend = StubBackend(listOf(Ok(NativeCompileOutcome(stderr = ""))))
         var wipeCalls = 0
 
         val result = runNativeLinkWithIcFallback(
-            args = listOf("konanc"),
-            execute = { executeCalls++; Ok(0) },
-            wipeCache = { wipeCalls++; true }
+            backend = backend,
+            args = listOf("-target", "linux_x64"),
+            wipeCache = { wipeCalls++; true },
         )
 
         assertTrue(result.isOk)
-        assertEquals(0, result.get())
-        assertEquals(1, executeCalls)
+        assertEquals(1, backend.calls)
         assertEquals(0, wipeCalls)
     }
 
     @Test
-    fun nonZeroExitTriggersWipeAndSingleRetrySucceeds() {
-        var executeCalls = 0
+    fun compilationFailedTriggersWipeAndSingleRetrySucceeds() {
+        val backend = StubBackend(
+            listOf(
+                Err(NativeCompileError.CompilationFailed(exitCode = 1, stderr = "stale cache")),
+                Ok(NativeCompileOutcome(stderr = "")),
+            ),
+        )
         var wipeCalls = 0
 
         val result = runNativeLinkWithIcFallback(
-            args = listOf("konanc"),
-            execute = {
-                executeCalls++
-                if (executeCalls == 1) Err(ProcessError.NonZeroExit(1)) else Ok(0)
-            },
-            wipeCache = { wipeCalls++; true }
+            backend = backend,
+            args = listOf("-target", "linux_x64"),
+            wipeCache = { wipeCalls++; true },
         )
 
-        assertEquals(0, result.get() ?: -1)
-        assertEquals(2, executeCalls)
+        assertTrue(result.isOk)
+        assertEquals(2, backend.calls)
         assertEquals(1, wipeCalls)
     }
 
     @Test
     fun retryFailureSurfacesRetryErrorNotOriginal() {
-        var executeCalls = 0
-        var wipeCalls = 0
+        val backend = StubBackend(
+            listOf(
+                Err(NativeCompileError.CompilationFailed(exitCode = 1, stderr = "first")),
+                Err(NativeCompileError.CompilationFailed(exitCode = 2, stderr = "second")),
+            ),
+        )
 
         val result = runNativeLinkWithIcFallback(
-            args = listOf("konanc"),
-            execute = {
-                executeCalls++
-                Err(ProcessError.NonZeroExit(if (executeCalls == 1) 1 else 2))
-            },
-            wipeCache = { wipeCalls++; true }
+            backend = backend,
+            args = listOf("-target", "linux_x64"),
+            wipeCache = { true },
         )
 
-        assertFalse(result.isOk)
-        val err = result.getError()
-        assertTrue(err is ProcessError.NonZeroExit && err.exitCode == 2)
-        assertEquals(2, executeCalls)
-        assertEquals(1, wipeCalls)
+        val err = assertIs<NativeCompileError.CompilationFailed>(result.getError())
+        assertEquals(2, err.exitCode)
+        assertEquals(2, backend.calls)
     }
 
-    // Fork/wait/signal failures mean konanc never ran. Retry cannot help
-    // (the cache had no chance to become corrupt), so surface the error.
+    // BackendUnavailable / InternalMisuse / NoCommand never reach here as
+    // the retry target, because they are either fallback-eligible (and
+    // handled by FallbackNativeCompilerBackend upstream) or genuinely
+    // unrecoverable. Only CompilationFailed can be cache-stale.
     @Test
-    fun nonExitProcessErrorsSkipWipeAndRetry() {
-        val nonExitErrors = listOf(
-            ProcessError.ForkFailed,
-            ProcessError.WaitFailed,
-            ProcessError.SignalKilled,
-            ProcessError.EmptyArgs,
+    fun nonCompilationFailedErrorsSkipWipeAndRetry() {
+        val errors: List<NativeCompileError> = listOf(
+            NativeCompileError.BackendUnavailable.ForkFailed,
+            NativeCompileError.BackendUnavailable.Other("subprocess popen failed"),
+            NativeCompileError.NoCommand,
+            NativeCompileError.InternalMisuse("socket path too long"),
         )
-        for (err in nonExitErrors) {
-            var executeCalls = 0
+        for (err in errors) {
+            val backend = StubBackend(listOf(Err(err)))
             var wipeCalls = 0
 
             val result = runNativeLinkWithIcFallback(
-                args = listOf("konanc"),
-                execute = { executeCalls++; Err(err) },
-                wipeCache = { wipeCalls++; true }
+                backend = backend,
+                args = listOf("-target", "linux_x64"),
+                wipeCache = { wipeCalls++; true },
             )
 
             assertEquals(err, result.getError(), "error=$err")
-            assertEquals(1, executeCalls, "error=$err")
+            assertEquals(1, backend.calls, "error=$err")
             assertEquals(0, wipeCalls, "error=$err")
         }
     }
 
-    // If the wipe fails, the retry would hit the same stale cache and
-    // produce an identical error — skip it and surface the first error.
     @Test
     fun wipeFailureSkipsRetryAndReturnsOriginalError() {
-        var executeCalls = 0
-        var wipeCalls = 0
-
-        val result = runNativeLinkWithIcFallback(
-            args = listOf("konanc"),
-            execute = { executeCalls++; Err(ProcessError.NonZeroExit(1)) },
-            wipeCache = { wipeCalls++; false }
+        val backend = StubBackend(
+            listOf(Err(NativeCompileError.CompilationFailed(exitCode = 1, stderr = "stale cache"))),
         )
 
-        assertFalse(result.isOk)
-        val err = result.getError()
-        assertTrue(err is ProcessError.NonZeroExit && err.exitCode == 1)
-        assertEquals(1, executeCalls)
-        assertEquals(1, wipeCalls)
+        val result = runNativeLinkWithIcFallback(
+            backend = backend,
+            args = listOf("-target", "linux_x64"),
+            wipeCache = { false },
+        )
+
+        val err = assertIs<NativeCompileError.CompilationFailed>(result.getError())
+        assertEquals(1, err.exitCode)
+        assertEquals(1, backend.calls)
     }
 }
 

--- a/src/nativeTest/kotlin/kolt/cli/ResolveNativeCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ResolveNativeCompilerBackendTest.kt
@@ -1,0 +1,179 @@
+package kolt.cli
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import kolt.build.FallbackNativeCompilerBackend
+import kolt.build.NativeCompileError
+import kolt.build.NativeCompileOutcome
+import kolt.build.NativeCompilerBackend
+import kolt.build.nativedaemon.NATIVE_KOTLIN_VERSION_FLOOR
+import kolt.build.nativedaemon.NativeDaemonPreconditionError
+import kolt.build.nativedaemon.NativeDaemonSetup
+import kolt.config.BuildSection
+import kolt.config.KoltConfig
+import kolt.config.KoltPaths
+import kolt.config.KotlinSection
+import kolt.infra.MkdirFailed
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class ResolveNativeCompilerBackendTest {
+
+    private val paths = KoltPaths(home = "/fake/home")
+    private val config = minimalConfig(kotlincVersion = "2.3.20")
+    private val subprocess = SentinelNativeBackend("subprocess")
+    private val daemonSentinel = SentinelNativeBackend("daemon")
+
+    private val okSetup = NativeDaemonSetup(
+        javaBin = "/fake/java",
+        daemonJarPath = "/fake/kolt-native-daemon-all.jar",
+        konancJar = "/fake/konanc/konan/lib/kotlin-native-compiler-embeddable.jar",
+        konanHome = "/fake/konanc",
+        daemonDir = "/fake/daemon/dir",
+        socketPath = "/fake/daemon/dir/native-daemon.sock",
+        logPath = "/fake/daemon/dir/native-daemon.log",
+    )
+
+    private val absProject = "/fake/project"
+
+    @Test
+    fun useDaemonFalseReturnsSubprocessWithoutProbingAnything() {
+        val warnings = mutableListOf<String>()
+        val backend = resolveNativeCompilerBackend(
+            config = config,
+            paths = paths,
+            subprocessBackend = subprocess,
+            useDaemon = false,
+            absProjectPath = absProject,
+            preconditionResolver = { _, _, _ -> error("must not probe preconditions when useDaemon=false") },
+            daemonDirCreator = { error("must not create daemon dir when useDaemon=false") },
+            daemonBackendFactory = { error("must not construct daemon backend when useDaemon=false") },
+            warningSink = { warnings.add(it) },
+        )
+
+        assertSame(subprocess, backend)
+        assertEquals(emptyList(), warnings)
+    }
+
+    @Test
+    fun kotlinVersionBelowFloorFallsBackWithVersionsInWarning() {
+        val warnings = mutableListOf<String>()
+        val backend = resolveNativeCompilerBackend(
+            config = minimalConfig(kotlincVersion = "2.1.0"),
+            paths = paths,
+            subprocessBackend = subprocess,
+            useDaemon = true,
+            absProjectPath = absProject,
+            preconditionResolver = { _, requested, _ ->
+                Err(
+                    NativeDaemonPreconditionError.KotlinVersionBelowFloor(
+                        requested = requested,
+                        floor = NATIVE_KOTLIN_VERSION_FLOOR,
+                    ),
+                )
+            },
+            daemonDirCreator = { error("must not create daemon dir when precondition failed") },
+            daemonBackendFactory = { error("must not construct daemon backend when precondition failed") },
+            warningSink = { warnings.add(it) },
+        )
+
+        assertSame(subprocess, backend)
+        assertEquals(1, warnings.size)
+        assertTrue(warnings.single().contains("2.3.0"), "warning should cite the floor")
+        assertTrue(warnings.single().contains("2.1.0"), "warning should cite the requested version")
+    }
+
+    @Test
+    fun nativeDaemonJarMissingFallsBack() {
+        val warnings = mutableListOf<String>()
+        val backend = resolveNativeCompilerBackend(
+            config = config,
+            paths = paths,
+            subprocessBackend = subprocess,
+            useDaemon = true,
+            absProjectPath = absProject,
+            preconditionResolver = { _, _, _ ->
+                Err(NativeDaemonPreconditionError.NativeDaemonJarMissing)
+            },
+            daemonDirCreator = { error("must not create daemon dir when precondition failed") },
+            daemonBackendFactory = { error("must not construct daemon backend when precondition failed") },
+            warningSink = { warnings.add(it) },
+        )
+
+        assertSame(subprocess, backend)
+        assertTrue(warnings.single().contains("kolt-native-daemon"))
+    }
+
+    @Test
+    fun daemonDirCreationFailureWarnsAndFallsBack() {
+        val warnings = mutableListOf<String>()
+        val backend = resolveNativeCompilerBackend(
+            config = config,
+            paths = paths,
+            subprocessBackend = subprocess,
+            useDaemon = true,
+            absProjectPath = absProject,
+            preconditionResolver = { _, _, _ -> Ok(okSetup) },
+            daemonDirCreator = { Err(MkdirFailed(it)) },
+            daemonBackendFactory = { error("must not construct daemon backend when mkdir failed") },
+            warningSink = { warnings.add(it) },
+        )
+
+        assertSame(subprocess, backend)
+        assertEquals(1, warnings.size)
+        assertTrue(warnings.single().contains("daemon state directory"))
+    }
+
+    @Test
+    fun happyPathWrapsDaemonPrimaryAndSubprocessFallback() {
+        val warnings = mutableListOf<String>()
+        var createdFrom: NativeDaemonSetup? = null
+        val backend = resolveNativeCompilerBackend(
+            config = config,
+            paths = paths,
+            subprocessBackend = subprocess,
+            useDaemon = true,
+            absProjectPath = absProject,
+            preconditionResolver = { _, kotlincVersion, cwd ->
+                assertEquals("2.3.20", kotlincVersion)
+                assertEquals(absProject, cwd)
+                Ok(okSetup)
+            },
+            daemonDirCreator = { dir ->
+                assertEquals(okSetup.daemonDir, dir)
+                Ok(Unit)
+            },
+            daemonBackendFactory = { setup ->
+                createdFrom = setup
+                daemonSentinel
+            },
+            warningSink = { warnings.add(it) },
+        )
+
+        assertEquals(emptyList(), warnings)
+        val fallback = assertNotNull(backend as? FallbackNativeCompilerBackend)
+        assertSame(daemonSentinel, fallback.primary)
+        assertSame(subprocess, fallback.fallback)
+        assertEquals(okSetup, createdFrom)
+    }
+
+    private class SentinelNativeBackend(val tag: String) : NativeCompilerBackend {
+        override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> =
+            Err(NativeCompileError.InternalMisuse("sentinel:$tag"))
+    }
+
+    private fun minimalConfig(kotlincVersion: String) = KoltConfig(
+        name = "it",
+        version = "0.0.0",
+        kotlin = KotlinSection(version = kotlincVersion),
+        build = BuildSection(
+            target = "linuxX64",
+            main = "itMainKt",
+            sources = emptyList(),
+        ),
+    )
+}


### PR DESCRIPTION
PR 4 of the native compiler daemon series. Routes both stages of `doNativeBuild` through `NativeCompilerBackend`, so `kolt build` on a `linuxX64` target now uses the native daemon by default. `--no-daemon` opts out (same flag as the JVM path). `kolt daemon stop` enumeration of the new `native-daemon.sock` and end-to-end integration tests follow in PRs 5–6.

## Places to double-check

**`args.drop(1)` at the backend seam.** `nativeLibraryCommand` / `nativeLinkCommand` return `BuildCommand.args` with the konanc binary at `args[0]` so the old subprocess call sites could `executeCommand(cmd.args)` directly. `NativeCompilerBackend.compile` expects args *after* the binary (ADR 0024 §4), so the wiring drops `.first()` at the two seams. `NativeSubprocessBackend` then re-prepends the same `managedKonancBin` the command builder put at `[0]`, so the subprocess argv is byte-identical to before. `BuilderTest` pins `args.first() == managedKonanc`; the `.drop(1)` is guarded indirectly by that. If you'd rather split `BuildCommand` into `binary + args`, this is the right time to push back.

**Kotlin version floor for native is 2.3.0, but the rationale differs from the JVM floor.** The JVM floor exists because kotlin-build-tools-impl's V1 compat shim lives in a package the daemon classloader doesn't share. There is no BTA on the native path (ADR 0024 §6), so that argument does not apply. The native floor is about K2Native reflective-surface version drift, validated by spike #166 at 2.3.x. The rewritten comment in `NativeDaemonPreconditions.kt` says so explicitly.

**Retry narrowing in `runNativeLinkWithIcFallback`.** Old version retried on `ProcessError.NonZeroExit`; new version retries on `NativeCompileError.CompilationFailed` only. `BackendUnavailable` from the primary (daemon) is consumed upstream by `FallbackNativeCompilerBackend` before reaching the IC-retry seam, so it cannot trigger the wipe. `NoCommand` and `InternalMisuse` are genuinely unrecoverable. The only residual risk is a daemon bug that routes its own failure as `CompilationFailed`; in that case the wipe+retry returns the same error (one extra JVM cold start, no data loss).

**Precondition shape asymmetries.** The native resolver has no `bundledKotlinVersion` parameter (removed in review — see below), no plugin fingerprint in the socket path (ADR 0024 §6), and a single `--konanc-jar` instead of a compiler-jars list + BTA-impl list. Socket filename is 7 bytes longer (`native-daemon.sock` vs `daemon.sock`) but there is no `-noplugins` suffix, so net projected path length is 3 bytes shorter — any path the JVM daemon accepts the native daemon accepts too.

**User-visible output.** Two new strings: `"starting native compiler daemon..."` (onSpawn) and `"warning: native compiler daemon unavailable ..."` (onFallback). The "native" qualifier earns its place the first time a user hits both rails in the same session and asks why the daemon started twice.

## Review fixes applied

- Rewrote `NATIVE_KOTLIN_VERSION_FLOOR` rationale comment to cite spike #166 (native's reason), not ADR 0022 (JVM's BTA reason).
- Dropped the unused `bundledKotlinVersion` parameter from `resolveNativeDaemonPreconditions` and `resolveNativeCompilerBackend`. Non-breaking to add back when a caller needs it.
- Moved the "no plugin-fingerprint suffix" comment to sit adjacent to the sun_path capacity check it qualifies.

## Tests

25 cases across preconditions (happy path + each error variant + warning formatter), fallback reporter (6 error shapes), `resolveNativeCompilerBackend` (`useDaemon=false` short-circuit, floor warning, daemon-jar-missing, mkdir failure, happy-path composition), and the refactored `runNativeLinkWithIcFallback` (backend-aware retry matrix).

`./gradlew build` green. Manual smoke: a local `kolt build` on a linuxX64 fixture will try the daemon path, fall back to subprocess on precondition miss, and emit the new warnings. End-to-end live daemon validation is PR 6.