### PR TITLE
Enumerate native daemon sockets in kolt daemon stop (#170)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
@@ -6,13 +6,16 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.build.daemon.projectHashOf
 import kolt.config.resolveKoltPaths
-import kolt.daemon.wire.FrameCodec
-import kolt.daemon.wire.Message
+import kolt.infra.ListFilesFailed
 import kolt.infra.currentWorkingDirectory
 import kolt.infra.eprintln
-import kolt.infra.fileExists
-import kolt.infra.listSubdirectories
+import kolt.infra.fileExists as infraFileExists
+import kolt.infra.listSubdirectories as infraListSubdirectories
 import kolt.infra.net.UnixSocket
+import kolt.daemon.wire.FrameCodec as JvmFrameCodec
+import kolt.daemon.wire.Message as JvmMessage
+import kolt.nativedaemon.wire.FrameCodec as NativeFrameCodec
+import kolt.nativedaemon.wire.Message as NativeMessage
 
 private val DAEMON_SUBCOMMANDS = setOf("stop", "reap")
 
@@ -58,19 +61,34 @@ private fun doDaemonStop(args: List<String>): Result<Unit, Int> {
     return Ok(Unit)
 }
 
-private fun stopProjectDaemons(projectDir: String): Int {
+internal fun stopProjectDaemons(
+    projectDir: String,
+    fileExists: (String) -> Boolean = ::infraFileExists,
+    listSubdirectories: (String) -> Result<List<String>, ListFilesFailed> = ::infraListSubdirectories,
+    sendJvmShutdown: (String) -> Boolean = ::sendShutdown,
+    sendNativeShutdown: (String) -> Boolean = ::sendNativeShutdown,
+): Int {
     if (!fileExists(projectDir)) return 0
     var stopped = 0
-    // Pre-#138 layout: socket sat directly under <projectHash>/. Probe first
-    // so a still-running pre-upgrade daemon can be shut down cleanly.
+    // Pre-#138 layout: JVM daemon socket sat directly under <projectHash>/.
+    // The native daemon (ADR 0024, #170) post-dates the versioned layout,
+    // so it has no legacy variant — only the JVM shutdown is attempted here.
     val legacySocket = "$projectDir/daemon.sock"
-    if (fileExists(legacySocket) && sendShutdown(legacySocket)) {
+    if (fileExists(legacySocket) && sendJvmShutdown(legacySocket)) {
         stopped++
     }
     val versionDirs = listSubdirectories(projectDir).getOrElse { return stopped }
     for (versionDir in versionDirs) {
-        val socketPath = "$projectDir/$versionDir/daemon.sock"
-        if (fileExists(socketPath) && sendShutdown(socketPath)) {
+        // ADR 0024 §3: both daemons share <projectHash>/<version>/, keyed
+        // by filename. Probe each and send the protocol-appropriate
+        // Shutdown — the two wire formats are structurally similar but
+        // bound to separate Message types per ADR 0024 §1.
+        val jvmSocket = "$projectDir/$versionDir/daemon.sock"
+        if (fileExists(jvmSocket) && sendJvmShutdown(jvmSocket)) {
+            stopped++
+        }
+        val nativeSocket = "$projectDir/$versionDir/native-daemon.sock"
+        if (fileExists(nativeSocket) && sendNativeShutdown(nativeSocket)) {
             stopped++
         }
     }
@@ -78,11 +96,11 @@ private fun stopProjectDaemons(projectDir: String): Int {
 }
 
 private fun stopAllDaemons(daemonBaseDir: String) {
-    if (!fileExists(daemonBaseDir)) {
+    if (!infraFileExists(daemonBaseDir)) {
         println("no daemons running")
         return
     }
-    val projectDirs = listSubdirectories(daemonBaseDir).getOrElse {
+    val projectDirs = infraListSubdirectories(daemonBaseDir).getOrElse {
         println("no daemons running")
         return
     }
@@ -96,7 +114,18 @@ private fun stopAllDaemons(daemonBaseDir: String) {
 
 private fun sendShutdown(socketPath: String): Boolean {
     val socket = UnixSocket.connect(socketPath).getOrElse { return false }
-    val sent = FrameCodec.writeFrame(socket, Message.Shutdown).isOk
+    val sent = JvmFrameCodec.writeFrame(socket, JvmMessage.Shutdown).isOk
+    socket.close()
+    return sent
+}
+
+// ADR 0024 §1: native daemon speaks its own Message sealed interface. The
+// wire-level JSON matches the JVM daemon's today, but keeping the send
+// path typed catches a future divergence at the compiler rather than in
+// production.
+private fun sendNativeShutdown(socketPath: String): Boolean {
+    val socket = UnixSocket.connect(socketPath).getOrElse { return false }
+    val sent = NativeFrameCodec.writeFrame(socket, NativeMessage.Shutdown).isOk
     socket.close()
     return sent
 }
@@ -116,6 +145,6 @@ private fun printDaemonUsage() {
     eprintln("usage: kolt daemon <command>")
     eprintln("")
     eprintln("commands:")
-    eprintln("  stop       Stop the compiler daemon (--all for all daemons)")
+    eprintln("  stop       Stop this project's compiler daemons (JVM and native; --all for all projects)")
     eprintln("  reap       Remove stale daemon directories and orphaned sockets")
 }

--- a/src/nativeTest/kotlin/kolt/cli/DaemonStopEnumerationTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DaemonStopEnumerationTest.kt
@@ -1,0 +1,216 @@
+package kolt.cli
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import kolt.infra.ListFilesFailed
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// Pins the `stopProjectDaemons` enumeration shape. Each version directory
+// under `<daemonBaseDir>/<projectHash>/` can contain both a JVM daemon
+// socket (`daemon.sock`, ADR 0016) AND a native daemon socket
+// (`native-daemon.sock`, ADR 0024 §3). `daemon stop` must signal both.
+// The legacy pre-#138 socket (`<projectHash>/daemon.sock`, no version
+// segment) only ever held a JVM daemon — the native daemon did not exist
+// before #170 — so only the JVM shutdown helper probes it.
+class DaemonStopEnumerationTest {
+
+    private class FakeFs(
+        private val existing: Set<String> = emptySet(),
+        private val subdirs: Map<String, List<String>> = emptyMap(),
+    ) {
+        fun exists(path: String): Boolean = path in existing
+        fun list(path: String): Result<List<String>, ListFilesFailed> =
+            subdirs[path]?.let(::Ok) ?: Err(ListFilesFailed(path))
+    }
+
+    @Test
+    fun enumeratesBothJvmAndNativeSocketsUnderEachVersionDir() {
+        val projectDir = "/home/u/.kolt/daemon/abc123"
+        val fs = FakeFs(
+            existing = setOf(
+                "$projectDir",
+                "$projectDir/2.3.20/daemon.sock",
+                "$projectDir/2.3.20/native-daemon.sock",
+            ),
+            subdirs = mapOf(projectDir to listOf("2.3.20")),
+        )
+        val jvmSockets = mutableListOf<String>()
+        val nativeSockets = mutableListOf<String>()
+
+        val stopped = stopProjectDaemons(
+            projectDir = projectDir,
+            fileExists = fs::exists,
+            listSubdirectories = fs::list,
+            sendJvmShutdown = { jvmSockets += it; true },
+            sendNativeShutdown = { nativeSockets += it; true },
+        )
+
+        assertEquals(2, stopped, "both sockets should be counted")
+        assertEquals(listOf("$projectDir/2.3.20/daemon.sock"), jvmSockets)
+        assertEquals(listOf("$projectDir/2.3.20/native-daemon.sock"), nativeSockets)
+    }
+
+    @Test
+    fun versionDirWithOnlyJvmSocketCountsOnlyJvm() {
+        val projectDir = "/home/u/.kolt/daemon/hash"
+        val fs = FakeFs(
+            existing = setOf("$projectDir", "$projectDir/2.3.20/daemon.sock"),
+            subdirs = mapOf(projectDir to listOf("2.3.20")),
+        )
+        var nativeCalls = 0
+
+        val stopped = stopProjectDaemons(
+            projectDir = projectDir,
+            fileExists = fs::exists,
+            listSubdirectories = fs::list,
+            sendJvmShutdown = { true },
+            sendNativeShutdown = { nativeCalls++; true },
+        )
+
+        assertEquals(1, stopped)
+        assertEquals(0, nativeCalls, "native send must not fire when the socket is absent")
+    }
+
+    @Test
+    fun versionDirWithOnlyNativeSocketCountsOnlyNative() {
+        val projectDir = "/home/u/.kolt/daemon/hash"
+        val fs = FakeFs(
+            existing = setOf("$projectDir", "$projectDir/2.3.20/native-daemon.sock"),
+            subdirs = mapOf(projectDir to listOf("2.3.20")),
+        )
+        var jvmCalls = 0
+
+        val stopped = stopProjectDaemons(
+            projectDir = projectDir,
+            fileExists = fs::exists,
+            listSubdirectories = fs::list,
+            sendJvmShutdown = { jvmCalls++; true },
+            sendNativeShutdown = { true },
+        )
+
+        assertEquals(1, stopped)
+        assertEquals(0, jvmCalls, "jvm send must not fire when the socket is absent")
+    }
+
+    @Test
+    fun multipleVersionDirsEnumerateAllSockets() {
+        val projectDir = "/home/u/.kolt/daemon/hash"
+        val fs = FakeFs(
+            existing = setOf(
+                "$projectDir",
+                "$projectDir/2.3.20/daemon.sock",
+                "$projectDir/2.3.20/native-daemon.sock",
+                "$projectDir/2.4.0/daemon.sock",
+            ),
+            subdirs = mapOf(projectDir to listOf("2.3.20", "2.4.0")),
+        )
+
+        val stopped = stopProjectDaemons(
+            projectDir = projectDir,
+            fileExists = fs::exists,
+            listSubdirectories = fs::list,
+            sendJvmShutdown = { true },
+            sendNativeShutdown = { true },
+        )
+
+        assertEquals(3, stopped, "three sockets across two version dirs")
+    }
+
+    @Test
+    fun legacyDaemonSockIsJvmOnly() {
+        // Pre-#138 layout: a single `<projectHash>/daemon.sock`, no version
+        // subdirectory. Native daemon was introduced in #170 and never
+        // lived under the legacy layout, so only the JVM shutdown helper
+        // is tried at this path.
+        val projectDir = "/home/u/.kolt/daemon/hash"
+        val fs = FakeFs(
+            existing = setOf("$projectDir", "$projectDir/daemon.sock"),
+            subdirs = mapOf(projectDir to emptyList()),
+        )
+        val jvmSockets = mutableListOf<String>()
+        var nativeCalls = 0
+
+        val stopped = stopProjectDaemons(
+            projectDir = projectDir,
+            fileExists = fs::exists,
+            listSubdirectories = fs::list,
+            sendJvmShutdown = { jvmSockets += it; true },
+            sendNativeShutdown = { nativeCalls++; true },
+        )
+
+        assertEquals(1, stopped)
+        assertEquals(listOf("$projectDir/daemon.sock"), jvmSockets)
+        assertEquals(0, nativeCalls, "native shutdown must not probe the legacy layout")
+    }
+
+    @Test
+    fun failingSendDoesNotCount() {
+        val projectDir = "/home/u/.kolt/daemon/hash"
+        val fs = FakeFs(
+            existing = setOf(
+                "$projectDir",
+                "$projectDir/2.3.20/daemon.sock",
+                "$projectDir/2.3.20/native-daemon.sock",
+            ),
+            subdirs = mapOf(projectDir to listOf("2.3.20")),
+        )
+
+        val stopped = stopProjectDaemons(
+            projectDir = projectDir,
+            fileExists = fs::exists,
+            listSubdirectories = fs::list,
+            sendJvmShutdown = { false },
+            sendNativeShutdown = { true },
+        )
+
+        assertEquals(1, stopped, "only successful sends should count")
+    }
+
+    @Test
+    fun jvmSuccessDoesNotCoverForNativeFailureInSameVersionDir() {
+        // Each arm reports independently — a half-dead daemon pair should
+        // count as 1, not 2. Mirrors `failingSendDoesNotCount` but with
+        // the opposite failure half so the pair together pin "count only
+        // the arm that actually sent" on both legs.
+        val projectDir = "/home/u/.kolt/daemon/hash"
+        val fs = FakeFs(
+            existing = setOf(
+                "$projectDir",
+                "$projectDir/2.3.20/daemon.sock",
+                "$projectDir/2.3.20/native-daemon.sock",
+            ),
+            subdirs = mapOf(projectDir to listOf("2.3.20")),
+        )
+        val jvmSockets = mutableListOf<String>()
+        val nativeSockets = mutableListOf<String>()
+
+        val stopped = stopProjectDaemons(
+            projectDir = projectDir,
+            fileExists = fs::exists,
+            listSubdirectories = fs::list,
+            sendJvmShutdown = { jvmSockets += it; true },
+            sendNativeShutdown = { nativeSockets += it; false },
+        )
+
+        assertEquals(1, stopped)
+        assertEquals(listOf("$projectDir/2.3.20/daemon.sock"), jvmSockets)
+        assertEquals(listOf("$projectDir/2.3.20/native-daemon.sock"), nativeSockets)
+    }
+
+    @Test
+    fun nonExistentProjectDirReturnsZero() {
+        val fs = FakeFs(existing = emptySet())
+
+        val stopped = stopProjectDaemons(
+            projectDir = "/nowhere",
+            fileExists = fs::exists,
+            listSubdirectories = fs::list,
+            sendJvmShutdown = { error("must not send") },
+            sendNativeShutdown = { error("must not send") },
+        )
+
+        assertEquals(0, stopped)
+    }
+}


### PR DESCRIPTION
PR 5 of the native compiler daemon series. Teaches `kolt daemon stop` about `native-daemon.sock` so both daemons shut down cleanly from the same command. PR 6 (end-to-end integration test against a real konanc jar) is the only remaining piece.

## Places to double-check

**Two wire protocols, two typed helpers.** `sendShutdown` sends `kolt.daemon.wire.Message.Shutdown`; `sendNativeShutdown` sends `kolt.nativedaemon.wire.Message.Shutdown`. Both marshal to `{\"type\":\"Shutdown\"}` today, so runtime behaviour is identical — but keeping the send path typed makes a future divergence a compile error instead of a wire-level regression. Worth pushing back if you'd rather share the send path.

**Legacy `<projectHash>/daemon.sock` probed only as JVM.** The pre-#138 layout predates ADR 0024; the native daemon was never bound to a legacy-layout path. Only `sendShutdown` (JVM helper) is tried there.

**Plugin-fingerprint blind spot is out of scope.** `applyPluginsFingerprintToFile` appends `-noplugins` or `-<8hex>` to the JVM daemon socket filename, but `stopProjectDaemons` probes the bare `daemon.sock` name — so a fingerprinted JVM daemon slips through today. Pre-existing limitation, unaffected by this PR, and tracked as #181. The native daemon has no fingerprint (ADR 0024 §6), so the new enumeration is correct for it.

**Injectable deps on `stopProjectDaemons`.** The function is `internal` with four defaulted lambdas (fileExists, listSubdirectories, sendJvmShutdown, sendNativeShutdown). This is what unlocks the stub-based test suite without needing a live socket fixture. If you'd prefer a data class grouping, say so — I stayed with lambdas for parity with the rest of the module.

## Review fixes applied

- `kolt daemon stop` usage line updated from "Stop the compiler daemon" (singular) to reflect the two-daemon reality.
- Added the mixed-outcome test (JVM send succeeds, native send fails in the same version dir) — pins "count only the arm that actually sent" on both legs.
- Trimmed the `sendNativeShutdown` rationale comment to match the project's "命令形1文" house style.

## Tests

8 cases in `DaemonStopEnumerationTest`: both sockets, jvm-only, native-only, multi-version dirs, legacy-jvm-only, failing-send-not-counted (jvm-leg), mixed-outcome (jvm succeeds + native fails), non-existent project dir (no network touch). `./gradlew build` green end-to-end.