### PR TITLE
Pin native daemon heap ceiling as SSoT constant (#178)

### DIFF
--- a/docs/adr/0024-native-compiler-daemon.md
+++ b/docs/adr/0024-native-compiler-daemon.md
@@ -50,7 +50,7 @@ Lifecycle config (initial values, tunable later):
 | Idle timeout | 10 min | Shorter than JVM daemon (30 min) — native builds are less frequent |
 | Max compiles | 500 | Conservative; stress test showed no drift at 100 |
 | Heap watermark | 2 GB | Stage 2 linking uses significant LLVM backend memory |
-| `-Xmx` | 4 GB | Stress test ran cleanly at this limit |
+| `-Xmx` | 4 GB | Stress test ran cleanly at this limit; pinned as `NativeDaemonBackend.HEAP_CEILING_XMX` (native client) — tune the constant and this row together |
 
 The daemon is spawned on demand by the native client (same pattern as JVM daemon) and exits cleanly when any threshold is reached.
 

--- a/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
@@ -132,12 +132,12 @@ class NativeDaemonBackend internal constructor(
         )
     }
 
-    // ADR 0024 §3: `-Xmx4G` is load-bearing — the spike validated reflective
-    // K2Native.exec() at this ceiling. Drop it and stage 2 linking will OOM
-    // on medium-sized fixtures. ADR 0024 §8 pins the three daemon CLI flags.
+    // ADR 0024 §8 pins the three daemon CLI flags; the heap ceiling lives in
+    // `HEAP_CEILING_XMX` so tuning is a one-edit change paired with the ADR
+    // 0024 §3 table.
     private fun spawnArgv(): List<String> = buildList {
         add(javaBin)
-        add("-Xmx4G")
+        add(HEAP_CEILING_XMX)
         add("-jar")
         add(daemonJarPath)
         add("--socket")
@@ -152,6 +152,17 @@ class NativeDaemonBackend internal constructor(
         internal const val INITIAL_BACKOFF_MS = 10
         internal const val MAX_BACKOFF_MS = 200
         internal const val CONNECT_TOTAL_BUDGET_MS: Long = 3000L
+
+        // SSoT for the native daemon's JVM heap ceiling. ADR 0024 §3 is the
+        // prose rationale (spike validated reflective K2Native.exec() at 4G;
+        // stage 2 LLVM linking OOMs below it on medium fixtures); keep the
+        // constant and the §3 table row in lockstep.
+        //
+        // Asymmetry: `kolt.build.daemon.DaemonCompilerBackend.spawnArgv`
+        // deliberately omits `-Xmx`. BTA's steady-state heap is modest and
+        // leaves `-Xmx` to the JVM default, while K2Native's LLVM backend
+        // allocates enough during linking that an explicit ceiling is needed.
+        internal const val HEAP_CEILING_XMX = "-Xmx4G"
     }
 }
 

--- a/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
@@ -132,9 +132,7 @@ class NativeDaemonBackend internal constructor(
         )
     }
 
-    // ADR 0024 §8 pins the three daemon CLI flags; the heap ceiling lives in
-    // `HEAP_CEILING_XMX` so tuning is a one-edit change paired with the ADR
-    // 0024 §3 table.
+    // ADR 0024 §8: the three daemon CLI flags.
     private fun spawnArgv(): List<String> = buildList {
         add(javaBin)
         add(HEAP_CEILING_XMX)
@@ -153,15 +151,9 @@ class NativeDaemonBackend internal constructor(
         internal const val MAX_BACKOFF_MS = 200
         internal const val CONNECT_TOTAL_BUDGET_MS: Long = 3000L
 
-        // SSoT for the native daemon's JVM heap ceiling. ADR 0024 §3 is the
-        // prose rationale (spike validated reflective K2Native.exec() at 4G;
-        // stage 2 LLVM linking OOMs below it on medium fixtures); keep the
-        // constant and the §3 table row in lockstep.
-        //
-        // Asymmetry: `kolt.build.daemon.DaemonCompilerBackend.spawnArgv`
-        // deliberately omits `-Xmx`. BTA's steady-state heap is modest and
-        // leaves `-Xmx` to the JVM default, while K2Native's LLVM backend
-        // allocates enough during linking that an explicit ceiling is needed.
+        // Heap ceiling SSoT — lockstep with ADR 0024 §3.
+        // JVM daemon's spawnArgv omits `-Xmx` by design: BTA's steady-state
+        // heap is modest; K2Native's LLVM backend needs an explicit ceiling.
         internal const val HEAP_CEILING_XMX = "-Xmx4G"
     }
 }

--- a/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
@@ -354,8 +354,10 @@ class NativeDaemonBackendConnectAndSpawnTest {
         backend.compile(sampleArgs)
 
         val argv = assertNotNull(capturedArgv)
-        // ADR 0024 §3: -Xmx4G is load-bearing for stage 2 linking.
-        assertTrue("-Xmx4G" in argv, "missing -Xmx4G: $argv")
+        // ADR 0024 §3 pins the heap ceiling; the constant is the SSoT so the
+        // assertion names it rather than the literal.
+        assertEquals("-Xmx4G", NativeDaemonBackend.HEAP_CEILING_XMX)
+        assertTrue(NativeDaemonBackend.HEAP_CEILING_XMX in argv, "missing heap ceiling: $argv")
         // ADR 0024 §8: the three daemon-side CLI flags are non-negotiable.
         assertTrue("--socket" in argv)
         assertTrue("--konanc-jar" in argv)

--- a/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
@@ -354,8 +354,7 @@ class NativeDaemonBackendConnectAndSpawnTest {
         backend.compile(sampleArgs)
 
         val argv = assertNotNull(capturedArgv)
-        // ADR 0024 §3 pins the heap ceiling; the constant is the SSoT so the
-        // assertion names it rather than the literal.
+        // Pin the literal so a typo in the constant is caught here.
         assertEquals("-Xmx4G", NativeDaemonBackend.HEAP_CEILING_XMX)
         assertTrue(NativeDaemonBackend.HEAP_CEILING_XMX in argv, "missing heap ceiling: $argv")
         // ADR 0024 §8: the three daemon-side CLI flags are non-negotiable.


### PR DESCRIPTION
Closes #178.

`NativeDaemonBackend.spawnArgv` used to inline `-Xmx4G` with only the ADR 0024 §3 table as a written anchor. A tune required editing both places in lockstep with nothing enforcing it. Extracting the literal as `NativeDaemonBackend.HEAP_CEILING_XMX` makes the coupling concrete: the ADR 0024 §3 row now names the constant, the comment on the spawn argv points back at §3, and the regression test references the constant so a future rename is a one-edit change.

## Review focus

- **Asymmetry comment** on the constant: `DaemonCompilerBackend.spawnArgv` really does omit `-Xmx` (verified at `src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt:132`). Worth confirming the rationale I wrote — BTA's steady-state heap profile differing from K2Native's LLVM backend — is the framing you want recorded in code rather than as a separate ADR follow-up.
- **ADR 0024 §3 row wording** — kept the "Stress test ran cleanly at this limit" prose and appended the SSoT pointer. Alternative would be to drop the stress-test prose and keep only the pointer; I chose retention to preserve the rationale trail.
- **Test anchor** — assertion now pins `HEAP_CEILING_XMX == "-Xmx4G"` plus membership. The equality check is tautological given `const val`, but it makes the test the place where a literal-vs-constant drift is caught at review time if someone rewrites the assertion later.