### PR TITLE
Pin native daemon stderr prefix contract with regression tests (#177)

### DIFF
--- a/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/server/DaemonServer.kt
+++ b/kolt-native-daemon/src/main/kotlin/kolt/nativedaemon/server/DaemonServer.kt
@@ -198,20 +198,14 @@ class DaemonServer(
     private fun outcomeToReply(outcome: NativeCompileOutcome): Message.NativeCompileResult =
         Message.NativeCompileResult(exitCode = outcome.exitCode, stderr = outcome.stderr)
 
-    // ADR 0024 §7 (interpreted): genuine reflective failures (the
-    // URLClassLoader cracked, K2Native.exec threw an uncaught exception) are
-    // surfaced to the client as exitCode=2 with a descriptive stderr. §7
-    // names "connect refused, spawn failure, unexpected disconnect" as the
-    // explicit fallback triggers; a reflective crack is the same class of
-    // "daemon is not healthy for this request" signal and routes the same
-    // way. This keeps the wire contract uniform — every request gets a
-    // NativeCompileResult — while letting the client escape to the subprocess
-    // path when the daemon's execution vehicle is broken. The `native
-    // compiler invocation failed: ` stderr prefix is the load-bearing
-    // contract: the native client's `NativeDaemonBackend.isDaemonSideFailure`
-    // pattern-matches on it, and renaming on either side without updating
-    // the other turns daemon failures into silently-routed konanc errors
-    // and loses fallback.
+    // ADR 0024 §7: reflective failures ride the same fallback path as
+    // connect/spawn/disconnect errors. Wire contract stays uniform (every
+    // request → NativeCompileResult); the client escapes via
+    // `NativeDaemonBackend.isDaemonSideFailure`, which pattern-matches on
+    // the `native compiler invocation failed: ` stderr prefix below.
+    // Prefix drift is pinned by DaemonServerTest `InvocationFailed...` and
+    // `rejects server-only messages...`; change them together or fallback
+    // silently routes daemon failures through as konanc errors.
     private fun errorToReply(error: NativeCompileError): Message.NativeCompileResult = when (error) {
         is NativeCompileError.InvocationFailed -> Message.NativeCompileResult(
             exitCode = 2,

--- a/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonServerTest.kt
+++ b/kolt-native-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonServerTest.kt
@@ -122,6 +122,15 @@ class DaemonServerTest {
             FrameCodec.writeFrame(output, Message.NativeCompile(args = listOf("-target", "linux_x64")))
             val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
             assertEquals(2, response.exitCode)
+            // LOAD-BEARING prefix — mirrored in the native client's
+            // `NativeDaemonBackend.isDaemonSideFailure` (and its mock-reply
+            // test in src/nativeTest/.../NativeDaemonBackendTest.kt). Rename
+            // without updating the client side turns reflective-invocation
+            // failures into silently-routed konanc errors and loses fallback.
+            assertTrue(
+                response.stderr.startsWith(INVOCATION_FAILED_PREFIX),
+                "expected stderr to start with '$INVOCATION_FAILED_PREFIX', got: ${response.stderr}",
+            )
             assertTrue(response.stderr.contains("K2Native.exec threw"))
         }
     }
@@ -159,11 +168,23 @@ class DaemonServerTest {
             FrameCodec.writeFrame(output, Message.Pong)
             val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
             assertEquals(2, response.exitCode)
+            // LOAD-BEARING prefix — paired with the client side same as the
+            // InvocationFailed test above. See the comment there.
             assertTrue(
-                response.stderr.contains("protocol error"),
-                "expected protocol error in stderr, got: ${response.stderr}",
+                response.stderr.startsWith(PROTOCOL_ERROR_PREFIX),
+                "expected stderr to start with '$PROTOCOL_ERROR_PREFIX', got: ${response.stderr}",
             )
         }
+    }
+
+    companion object {
+        // These must match the prefixes the client matches on in
+        // `kolt.build.nativedaemon.NativeDaemonBackend.isDaemonSideFailure`.
+        // Hardcoding the literals on both sides is the contract; the two
+        // sibling tests (here + client-side NativeDaemonBackendTest mock
+        // replies) catch a drift on whichever side renames first.
+        private const val PROTOCOL_ERROR_PREFIX = "protocol error: "
+        private const val INVOCATION_FAILED_PREFIX = "native compiler invocation failed: "
     }
 
     private class FakeCompiler(

--- a/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
@@ -238,15 +238,13 @@ internal fun mapReplyToOutcome(reply: Message): Result<NativeCompileOutcome, Nat
     )
 }
 
-// DaemonServer emits these prefixes for server-side failures (writeProtocolError
-// and NativeCompileError.InvocationFailed → exitCode=2 replies). Any other
-// exitCode=2 reply is assumed to come from konanc itself (ExitCode.INTERNAL_ERROR
-// has code=2) and rides the CompilationFailed path. Collision risk: a konanc
-// error whose stderr happens to start with one of these prefixes would be
-// mis-routed as a daemon failure. The prefixes are long and specific enough
-// that this is not a realistic concern today, but the assumption is
-// load-bearing — renaming a prefix on either side without updating the other
-// silently breaks fallback routing.
+// Server emits these prefixes for `writeProtocolError` + `InvocationFailed`
+// replies (both exitCode=2). Other exitCode=2 replies come from konanc
+// itself (ExitCode.INTERNAL_ERROR=2) and ride the CompilationFailed path.
+// Prefix drift is pinned by two paired tests:
+//   - server: DaemonServerTest `InvocationFailed...` / `rejects server-only...`
+//   - client: NativeDaemonBackendTest `exitCode2With{Protocol,InvocationFailed}Prefix...`
+// Rename on either side without updating the other and one of the two fails.
 private const val DAEMON_PROTOCOL_ERROR_PREFIX = "protocol error: "
 private const val DAEMON_INVOCATION_FAILED_PREFIX = "native compiler invocation failed: "
 


### PR DESCRIPTION
Closes #177.

Two stderr prefixes — \`protocol error: \` and \`native compiler invocation failed: \` — route daemon-side failures to the subprocess fallback via \`NativeDaemonBackend.isDaemonSideFailure\`. Until now the prefixes were independently-maintained string literals on both sides; drift on either side would have silently turned daemon failures into mis-routed konanc errors.

Picked the regression-test path from #177's two options (test vs cross-build constant extraction). Tightened the two \`DaemonServerTest\` cases that actually produce each failure (the \`rejects server-only messages\` case was previously a \`contains(\"protocol error\")\` substring check, and the \`InvocationFailed\` case didn't assert the prefix at all). They now \`startsWith\` exact literals anchored on companion constants. Paired with the existing client-side mock-reply tests (\`NativeDaemonBackendTest.exitCode2With{Protocol,InvocationFailed}Prefix...\`), a rename fails one side: client-side if the server renames (stale mock literal), server-side if the client renames (stale \`startsWith\`).

Also shrunk the two long-form \"load-bearing\" comments on \`DaemonServer.errorToReply\` and \`NativeDaemonBackend\`'s prefix constants — they were doing the enforcement work in prose, which tests now do; comments collapse to ADR pointers plus cross-side test names.

## Review focus

- **Test pairing claim** — the four tests (two server + two client) are the enforcement mechanism. Worth a quick read of the two client-side tests (\`src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt\` L122–159) to confirm they actually anchor on the exact literal you expect, not a substring.
- **Red-verified** the server-side tests by temporarily breaking \`errorToReply\`'s prefix to \`\"native compiler BROKEN: \"\` — \`InvocationFailed...\` fails with the expected \`startsWith\` message before revert.
- **Deferred** cross-build constant extraction (issue's other option). The tiny published-jar route felt like overkill for two strings; happy to revisit if the pair grows.