### PR TITLE
Enumerate fingerprinted JVM daemon sockets in stop + reap (#181)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
@@ -106,9 +106,13 @@ internal fun stopProjectDaemons(
 
 // JVM daemon socket = `daemon.sock` (unfingerprinted, possible on old disks)
 // or `daemon-<fingerprint>.sock` (#138). `native-daemon.sock` starts with
-// `native-` and is explicitly excluded.
+// `native-` and is explicitly excluded. The fingerprint segment must be
+// non-empty — `daemon-.sock` is not something `applyPluginsFingerprintToFile`
+// can emit today, but the length check keeps the predicate strict against
+// a future refactor.
 internal fun isJvmDaemonSocket(name: String): Boolean =
-    name == "daemon.sock" || (name.startsWith("daemon-") && name.endsWith(".sock"))
+    name == "daemon.sock" ||
+        (name.startsWith("daemon-") && name.endsWith(".sock") && name.length > "daemon-.sock".length)
 
 internal fun isNativeDaemonSocket(name: String): Boolean =
     name == "native-daemon.sock"

--- a/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
@@ -10,6 +10,7 @@ import kolt.infra.ListFilesFailed
 import kolt.infra.currentWorkingDirectory
 import kolt.infra.eprintln
 import kolt.infra.fileExists as infraFileExists
+import kolt.infra.listFiles as infraListFiles
 import kolt.infra.listSubdirectories as infraListSubdirectories
 import kolt.infra.net.UnixSocket
 import kolt.daemon.wire.FrameCodec as JvmFrameCodec
@@ -65,6 +66,7 @@ internal fun stopProjectDaemons(
     projectDir: String,
     fileExists: (String) -> Boolean = ::infraFileExists,
     listSubdirectories: (String) -> Result<List<String>, ListFilesFailed> = ::infraListSubdirectories,
+    listFiles: (String) -> Result<List<String>, ListFilesFailed> = ::infraListFiles,
     sendJvmShutdown: (String) -> Boolean = ::sendShutdown,
     sendNativeShutdown: (String) -> Boolean = ::sendNativeShutdown,
 ): Int {
@@ -73,6 +75,8 @@ internal fun stopProjectDaemons(
     // Pre-#138 layout: JVM daemon socket sat directly under <projectHash>/.
     // The native daemon (ADR 0024, #170) post-dates the versioned layout,
     // so it has no legacy variant — only the JVM shutdown is attempted here.
+    // Enumeration uses `fileExists` because the legacy filename is fixed and
+    // no sibling fingerprints ever lived at this layer.
     val legacySocket = "$projectDir/daemon.sock"
     if (fileExists(legacySocket) && sendJvmShutdown(legacySocket)) {
         stopped++
@@ -80,20 +84,34 @@ internal fun stopProjectDaemons(
     val versionDirs = listSubdirectories(projectDir).getOrElse { return stopped }
     for (versionDir in versionDirs) {
         // ADR 0024 §3: both daemons share <projectHash>/<version>/, keyed
-        // by filename. Probe each and send the protocol-appropriate
-        // Shutdown — the two wire formats are structurally similar but
-        // bound to separate Message types per ADR 0024 §1.
-        val jvmSocket = "$projectDir/$versionDir/daemon.sock"
-        if (fileExists(jvmSocket) && sendJvmShutdown(jvmSocket)) {
-            stopped++
-        }
-        val nativeSocket = "$projectDir/$versionDir/native-daemon.sock"
-        if (fileExists(nativeSocket) && sendNativeShutdown(nativeSocket)) {
-            stopped++
+        // by filename. #138 appended a plugin fingerprint to the JVM socket
+        // (`daemon-noplugins.sock` or `daemon-<8hex>.sock`), so enumeration
+        // — not a fixed-name probe — is required to hit every JVM daemon.
+        val versionFullDir = "$projectDir/$versionDir"
+        val entries = listFiles(versionFullDir).getOrElse { emptyList() }
+        for (name in entries) {
+            val socketPath = "$versionFullDir/$name"
+            when {
+                isJvmDaemonSocket(name) -> {
+                    if (sendJvmShutdown(socketPath)) stopped++
+                }
+                isNativeDaemonSocket(name) -> {
+                    if (sendNativeShutdown(socketPath)) stopped++
+                }
+            }
         }
     }
     return stopped
 }
+
+// JVM daemon socket = `daemon.sock` (unfingerprinted, possible on old disks)
+// or `daemon-<fingerprint>.sock` (#138). `native-daemon.sock` starts with
+// `native-` and is explicitly excluded.
+internal fun isJvmDaemonSocket(name: String): Boolean =
+    name == "daemon.sock" || (name.startsWith("daemon-") && name.endsWith(".sock"))
+
+internal fun isNativeDaemonSocket(name: String): Boolean =
+    name == "native-daemon.sock"
 
 private fun stopAllDaemons(daemonBaseDir: String) {
     if (!infraFileExists(daemonBaseDir)) {

--- a/src/nativeMain/kotlin/kolt/cli/DaemonReaper.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonReaper.kt
@@ -3,6 +3,7 @@ package kolt.cli
 import com.github.michaelbull.result.getOrElse
 import kolt.infra.deleteFile
 import kolt.infra.fileExists
+import kolt.infra.listFiles
 import kolt.infra.listSubdirectories
 import kolt.infra.net.UnixSocket
 import kolt.infra.removeDirectoryRecursive
@@ -57,15 +58,20 @@ internal fun reapStaleDaemons(daemonBaseDir: String): ReapResult {
         var versionsRemaining = 0
         for (versionDir in versionDirs) {
             val versionFullDir = "$projectFullDir/$versionDir"
-            val socketPath = "$versionFullDir/daemon.sock"
-            if (fileExists(socketPath)) {
-                val socket = UnixSocket.connect(socketPath)
-                if (socket.isOk) {
-                    socket.getOrElse { null }?.close()
-                    alive++
-                    versionsRemaining++
-                    continue
-                }
+            // #181: enumerate all JVM daemon sockets in the version dir
+            // (`daemon.sock`, `daemon-noplugins.sock`, `daemon-<8hex>.sock`),
+            // not just the bare `daemon.sock`. If any fingerprint is alive,
+            // the whole version dir stays — reaping would unlink the live
+            // socket file. Stale siblings ride along until they're the only
+            // ones left.
+            val jvmSockets = listFiles(versionFullDir).getOrElse { emptyList() }
+                .filter { isJvmDaemonSocket(it) }
+                .map { "$versionFullDir/$it" }
+            val aliveHere = jvmSockets.count { probeAlive(it) }
+            if (aliveHere > 0) {
+                alive += aliveHere
+                versionsRemaining++
+                continue
             }
             if (removeDirectoryRecursive(versionFullDir).isOk) {
                 reaped++
@@ -79,4 +85,11 @@ internal fun reapStaleDaemons(daemonBaseDir: String): ReapResult {
         }
     }
     return ReapResult(reaped, alive, failed)
+}
+
+private fun probeAlive(socketPath: String): Boolean {
+    val socket = UnixSocket.connect(socketPath)
+    if (socket.isErr) return false
+    socket.getOrElse { null }?.close()
+    return true
 }

--- a/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
+++ b/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
@@ -213,6 +213,29 @@ fun listJarFiles(path: String): Result<List<String>, ListFilesFailed> {
     return Ok(entries)
 }
 
+// Counterpart to `listSubdirectories` that returns entries which are NOT
+// directories — regular files, sockets, symlinks. Unix daemon sockets land
+// here (S_IFSOCK is not S_IFDIR).
+@OptIn(ExperimentalForeignApi::class)
+fun listFiles(path: String): Result<List<String>, ListFilesFailed> {
+    val dir = opendir(path) ?: return Err(ListFilesFailed(path))
+    val entries = mutableListOf<String>()
+    try {
+        while (true) {
+            val entry = readdir(dir) ?: break
+            val name = entry.pointed.d_name.toKString()
+            if (name == "." || name == "..") continue
+            if (!isDirectory("$path/$name")) {
+                entries.add(name)
+            }
+        }
+    } finally {
+        closedir(dir)
+    }
+    entries.sort()
+    return Ok(entries)
+}
+
 @OptIn(ExperimentalForeignApi::class)
 fun listSubdirectories(path: String): Result<List<String>, ListFilesFailed> {
     val dir = opendir(path) ?: return Err(ListFilesFailed(path))

--- a/src/nativeTest/kotlin/kolt/cli/DaemonReaperTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DaemonReaperTest.kt
@@ -199,6 +199,74 @@ class DaemonReaperTest {
         }
     }
 
+    // #181: `createDaemonBackend` fingerprints the socket filename
+    // (`daemon-noplugins.sock` or `daemon-<8hex>.sock`). The reaper probed
+    // only the bare `daemon.sock`, so fingerprinted orphans never got
+    // swept. Post-fix, enumeration matches any `daemon*.sock` under a
+    // version dir.
+    @Test
+    fun fingerprintedOrphanedSocketIsReaped() {
+        val base = createTempDir("reaper-fp-orphan-")
+        val projectDir = "$base/fp111"
+        val versionDir = "$projectDir/2.3.20"
+        ensureDirectoryRecursive(versionDir).getOrElse { error("mkdir failed") }
+        writeFileAsString("$versionDir/daemon-noplugins.sock", "").getOrElse { error("write failed") }
+
+        val result = reapStaleDaemons(base)
+
+        assertEquals(1, result.reaped)
+        assertFalse(fileExists(versionDir))
+        assertFalse(fileExists(projectDir))
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun fingerprintedLiveDaemonIsPreserved() {
+        val base = createTempDir("reaper-fp-alive-")
+        val projectDir = "$base/fp222"
+        val versionDir = "$projectDir/2.3.20"
+        ensureDirectoryRecursive(versionDir).getOrElse { error("mkdir failed") }
+
+        val socketPath = "$versionDir/daemon-abcd1234.sock"
+        val listenFd = bindAndListen(socketPath)
+        try {
+            val result = reapStaleDaemons(base)
+            assertEquals(0, result.reaped)
+            assertEquals(1, result.alive)
+            assertTrue(fileExists(versionDir), "live fingerprinted daemon dir must not be deleted")
+        } finally {
+            close(listenFd)
+            unlink(socketPath)
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun versionDirWithOneLiveFingerprintSurvivesEvenIfSiblingIsStale() {
+        // Mixed state: one fingerprint's daemon is alive, a sibling
+        // fingerprint's socket is stale. The version dir must stay because
+        // reaping would unlink the live socket; the stale sibling rides
+        // along and gets swept the next time it's the only one left.
+        val base = createTempDir("reaper-fp-mixed-")
+        val projectDir = "$base/fp333"
+        val versionDir = "$projectDir/2.3.20"
+        ensureDirectoryRecursive(versionDir).getOrElse { error("mkdir failed") }
+
+        writeFileAsString("$versionDir/daemon-noplugins.sock", "").getOrElse { error("write failed") }
+        val liveSocket = "$versionDir/daemon-abcd1234.sock"
+        val listenFd = bindAndListen(liveSocket)
+        try {
+            val result = reapStaleDaemons(base)
+            assertEquals(0, result.reaped, "version dir must not be wiped while a fingerprint is alive")
+            assertEquals(1, result.alive)
+            assertTrue(fileExists(liveSocket), "live socket must not be unlinked")
+            assertTrue(fileExists(versionDir))
+        } finally {
+            close(listenFd)
+            unlink(liveSocket)
+        }
+    }
+
     @Test
     fun icSiblingIsNotReaped() {
         val base = createTempDir("reaper-ic-")

--- a/src/nativeTest/kotlin/kolt/cli/DaemonStopEnumerationTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DaemonStopEnumerationTest.kt
@@ -283,6 +283,23 @@ class DaemonStopEnumerationTest {
     }
 
     @Test
+    fun isJvmDaemonSocketPredicateShape() {
+        // `applyPluginsFingerprintToFile` never emits an empty fingerprint
+        // (`pluginsFingerprint` returns "noplugins" or 8 hex chars), so
+        // `daemon-.sock` is not a real on-disk name — but the predicate
+        // stays strict to survive a future refactor of the fingerprint
+        // source.
+        assertEquals(true, isJvmDaemonSocket("daemon.sock"))
+        assertEquals(true, isJvmDaemonSocket("daemon-noplugins.sock"))
+        assertEquals(true, isJvmDaemonSocket("daemon-abcd1234.sock"))
+        assertEquals(false, isJvmDaemonSocket("daemon-.sock"))
+        assertEquals(false, isJvmDaemonSocket("daemon.log"))
+        assertEquals(false, isJvmDaemonSocket("daemon-noplugins.log"))
+        assertEquals(false, isJvmDaemonSocket("native-daemon.sock"))
+        assertEquals(false, isJvmDaemonSocket("Daemon.sock"))
+    }
+
+    @Test
     fun nonExistentProjectDirReturnsZero() {
         val fs = FakeFs(existing = emptySet())
 

--- a/src/nativeTest/kotlin/kolt/cli/DaemonStopEnumerationTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DaemonStopEnumerationTest.kt
@@ -9,32 +9,33 @@ import kotlin.test.assertEquals
 
 // Pins the `stopProjectDaemons` enumeration shape. Each version directory
 // under `<daemonBaseDir>/<projectHash>/` can contain both a JVM daemon
-// socket (`daemon.sock`, ADR 0016) AND a native daemon socket
-// (`native-daemon.sock`, ADR 0024 §3). `daemon stop` must signal both.
-// The legacy pre-#138 socket (`<projectHash>/daemon.sock`, no version
-// segment) only ever held a JVM daemon — the native daemon did not exist
-// before #170 — so only the JVM shutdown helper probes it.
+// socket (`daemon.sock` / `daemon-<fp>.sock`, ADR 0016 + #138 plugin
+// fingerprint) AND a native daemon socket (`native-daemon.sock`,
+// ADR 0024 §3). `daemon stop` must signal all of them. The legacy pre-#138
+// socket (`<projectHash>/daemon.sock`, no version segment) only ever held a
+// JVM daemon — the native daemon did not exist before #170 — so only the
+// JVM shutdown helper probes it.
 class DaemonStopEnumerationTest {
 
     private class FakeFs(
         private val existing: Set<String> = emptySet(),
         private val subdirs: Map<String, List<String>> = emptyMap(),
+        private val files: Map<String, List<String>> = emptyMap(),
     ) {
         fun exists(path: String): Boolean = path in existing
         fun list(path: String): Result<List<String>, ListFilesFailed> =
             subdirs[path]?.let(::Ok) ?: Err(ListFilesFailed(path))
+        fun listFiles(path: String): Result<List<String>, ListFilesFailed> =
+            files[path]?.let(::Ok) ?: Err(ListFilesFailed(path))
     }
 
     @Test
     fun enumeratesBothJvmAndNativeSocketsUnderEachVersionDir() {
         val projectDir = "/home/u/.kolt/daemon/abc123"
         val fs = FakeFs(
-            existing = setOf(
-                "$projectDir",
-                "$projectDir/2.3.20/daemon.sock",
-                "$projectDir/2.3.20/native-daemon.sock",
-            ),
+            existing = setOf(projectDir),
             subdirs = mapOf(projectDir to listOf("2.3.20")),
+            files = mapOf("$projectDir/2.3.20" to listOf("daemon.sock", "native-daemon.sock")),
         )
         val jvmSockets = mutableListOf<String>()
         val nativeSockets = mutableListOf<String>()
@@ -43,6 +44,7 @@ class DaemonStopEnumerationTest {
             projectDir = projectDir,
             fileExists = fs::exists,
             listSubdirectories = fs::list,
+            listFiles = fs::listFiles,
             sendJvmShutdown = { jvmSockets += it; true },
             sendNativeShutdown = { nativeSockets += it; true },
         )
@@ -53,64 +55,153 @@ class DaemonStopEnumerationTest {
     }
 
     @Test
-    fun versionDirWithOnlyJvmSocketCountsOnlyJvm() {
+    fun enumeratesFingerprintedJvmSocket() {
+        // #138 plugin fingerprint: `applyPluginsFingerprintToFile` rewrites
+        // `daemon.sock` → `daemon-noplugins.sock` (no plugins) or
+        // `daemon-<8hex>.sock`. Before #181 these were invisible to `stop`.
         val projectDir = "/home/u/.kolt/daemon/hash"
         val fs = FakeFs(
-            existing = setOf("$projectDir", "$projectDir/2.3.20/daemon.sock"),
+            existing = setOf(projectDir),
             subdirs = mapOf(projectDir to listOf("2.3.20")),
+            files = mapOf("$projectDir/2.3.20" to listOf("daemon-noplugins.sock")),
         )
-        var nativeCalls = 0
+        val jvmSockets = mutableListOf<String>()
 
         val stopped = stopProjectDaemons(
             projectDir = projectDir,
             fileExists = fs::exists,
             listSubdirectories = fs::list,
-            sendJvmShutdown = { true },
-            sendNativeShutdown = { nativeCalls++; true },
+            listFiles = fs::listFiles,
+            sendJvmShutdown = { jvmSockets += it; true },
+            sendNativeShutdown = { error("must not send") },
         )
 
         assertEquals(1, stopped)
-        assertEquals(0, nativeCalls, "native send must not fire when the socket is absent")
+        assertEquals(listOf("$projectDir/2.3.20/daemon-noplugins.sock"), jvmSockets)
+    }
+
+    @Test
+    fun enumeratesMultipleFingerprintedJvmSocketsInOneVersionDir() {
+        // A project can have several plugin configurations coexisting
+        // (e.g. test compile vs main compile) → multiple fingerprinted
+        // daemons under the same version dir. Stop must hit all of them.
+        val projectDir = "/home/u/.kolt/daemon/hash"
+        val fs = FakeFs(
+            existing = setOf(projectDir),
+            subdirs = mapOf(projectDir to listOf("2.3.20")),
+            files = mapOf(
+                "$projectDir/2.3.20" to listOf(
+                    "daemon-abcd1234.sock",
+                    "daemon-noplugins.sock",
+                ),
+            ),
+        )
+        val jvmSockets = mutableListOf<String>()
+
+        val stopped = stopProjectDaemons(
+            projectDir = projectDir,
+            fileExists = fs::exists,
+            listSubdirectories = fs::list,
+            listFiles = fs::listFiles,
+            sendJvmShutdown = { jvmSockets += it; true },
+            sendNativeShutdown = { error("must not send") },
+        )
+
+        assertEquals(2, stopped)
+        assertEquals(
+            listOf(
+                "$projectDir/2.3.20/daemon-abcd1234.sock",
+                "$projectDir/2.3.20/daemon-noplugins.sock",
+            ),
+            jvmSockets,
+        )
+    }
+
+    @Test
+    fun nativeDaemonSockIsNotMatchedByJvmEnumeration() {
+        // `native-daemon.sock` starts with `native-`, not `daemon-`, so the
+        // JVM fingerprint pattern must not pick it up. A native-only
+        // version dir counts as one native shutdown, zero JVM.
+        val projectDir = "/home/u/.kolt/daemon/hash"
+        val fs = FakeFs(
+            existing = setOf(projectDir),
+            subdirs = mapOf(projectDir to listOf("2.3.20")),
+            files = mapOf("$projectDir/2.3.20" to listOf("native-daemon.sock")),
+        )
+        val nativeSockets = mutableListOf<String>()
+
+        val stopped = stopProjectDaemons(
+            projectDir = projectDir,
+            fileExists = fs::exists,
+            listSubdirectories = fs::list,
+            listFiles = fs::listFiles,
+            sendJvmShutdown = { error("must not send — `native-daemon.sock` is not a JVM daemon") },
+            sendNativeShutdown = { nativeSockets += it; true },
+        )
+
+        assertEquals(1, stopped)
+        assertEquals(listOf("$projectDir/2.3.20/native-daemon.sock"), nativeSockets)
+    }
+
+    @Test
+    fun versionDirWithOnlyJvmSocketCountsOnlyJvm() {
+        val projectDir = "/home/u/.kolt/daemon/hash"
+        val fs = FakeFs(
+            existing = setOf(projectDir),
+            subdirs = mapOf(projectDir to listOf("2.3.20")),
+            files = mapOf("$projectDir/2.3.20" to listOf("daemon.sock")),
+        )
+
+        val stopped = stopProjectDaemons(
+            projectDir = projectDir,
+            fileExists = fs::exists,
+            listSubdirectories = fs::list,
+            listFiles = fs::listFiles,
+            sendJvmShutdown = { true },
+            sendNativeShutdown = { error("must not send") },
+        )
+
+        assertEquals(1, stopped)
     }
 
     @Test
     fun versionDirWithOnlyNativeSocketCountsOnlyNative() {
         val projectDir = "/home/u/.kolt/daemon/hash"
         val fs = FakeFs(
-            existing = setOf("$projectDir", "$projectDir/2.3.20/native-daemon.sock"),
+            existing = setOf(projectDir),
             subdirs = mapOf(projectDir to listOf("2.3.20")),
+            files = mapOf("$projectDir/2.3.20" to listOf("native-daemon.sock")),
         )
-        var jvmCalls = 0
 
         val stopped = stopProjectDaemons(
             projectDir = projectDir,
             fileExists = fs::exists,
             listSubdirectories = fs::list,
-            sendJvmShutdown = { jvmCalls++; true },
+            listFiles = fs::listFiles,
+            sendJvmShutdown = { error("must not send") },
             sendNativeShutdown = { true },
         )
 
         assertEquals(1, stopped)
-        assertEquals(0, jvmCalls, "jvm send must not fire when the socket is absent")
     }
 
     @Test
     fun multipleVersionDirsEnumerateAllSockets() {
         val projectDir = "/home/u/.kolt/daemon/hash"
         val fs = FakeFs(
-            existing = setOf(
-                "$projectDir",
-                "$projectDir/2.3.20/daemon.sock",
-                "$projectDir/2.3.20/native-daemon.sock",
-                "$projectDir/2.4.0/daemon.sock",
-            ),
+            existing = setOf(projectDir),
             subdirs = mapOf(projectDir to listOf("2.3.20", "2.4.0")),
+            files = mapOf(
+                "$projectDir/2.3.20" to listOf("daemon.sock", "native-daemon.sock"),
+                "$projectDir/2.4.0" to listOf("daemon-noplugins.sock"),
+            ),
         )
 
         val stopped = stopProjectDaemons(
             projectDir = projectDir,
             fileExists = fs::exists,
             listSubdirectories = fs::list,
+            listFiles = fs::listFiles,
             sendJvmShutdown = { true },
             sendNativeShutdown = { true },
         )
@@ -123,44 +214,42 @@ class DaemonStopEnumerationTest {
         // Pre-#138 layout: a single `<projectHash>/daemon.sock`, no version
         // subdirectory. Native daemon was introduced in #170 and never
         // lived under the legacy layout, so only the JVM shutdown helper
-        // is tried at this path.
+        // is tried at this path. Enumeration uses `fileExists` here because
+        // the legacy filename is fixed and no sibling fingerprints exist.
         val projectDir = "/home/u/.kolt/daemon/hash"
         val fs = FakeFs(
-            existing = setOf("$projectDir", "$projectDir/daemon.sock"),
+            existing = setOf(projectDir, "$projectDir/daemon.sock"),
             subdirs = mapOf(projectDir to emptyList()),
         )
         val jvmSockets = mutableListOf<String>()
-        var nativeCalls = 0
 
         val stopped = stopProjectDaemons(
             projectDir = projectDir,
             fileExists = fs::exists,
             listSubdirectories = fs::list,
+            listFiles = fs::listFiles,
             sendJvmShutdown = { jvmSockets += it; true },
-            sendNativeShutdown = { nativeCalls++; true },
+            sendNativeShutdown = { error("must not send") },
         )
 
         assertEquals(1, stopped)
         assertEquals(listOf("$projectDir/daemon.sock"), jvmSockets)
-        assertEquals(0, nativeCalls, "native shutdown must not probe the legacy layout")
     }
 
     @Test
     fun failingSendDoesNotCount() {
         val projectDir = "/home/u/.kolt/daemon/hash"
         val fs = FakeFs(
-            existing = setOf(
-                "$projectDir",
-                "$projectDir/2.3.20/daemon.sock",
-                "$projectDir/2.3.20/native-daemon.sock",
-            ),
+            existing = setOf(projectDir),
             subdirs = mapOf(projectDir to listOf("2.3.20")),
+            files = mapOf("$projectDir/2.3.20" to listOf("daemon.sock", "native-daemon.sock")),
         )
 
         val stopped = stopProjectDaemons(
             projectDir = projectDir,
             fileExists = fs::exists,
             listSubdirectories = fs::list,
+            listFiles = fs::listFiles,
             sendJvmShutdown = { false },
             sendNativeShutdown = { true },
         )
@@ -170,18 +259,11 @@ class DaemonStopEnumerationTest {
 
     @Test
     fun jvmSuccessDoesNotCoverForNativeFailureInSameVersionDir() {
-        // Each arm reports independently — a half-dead daemon pair should
-        // count as 1, not 2. Mirrors `failingSendDoesNotCount` but with
-        // the opposite failure half so the pair together pin "count only
-        // the arm that actually sent" on both legs.
         val projectDir = "/home/u/.kolt/daemon/hash"
         val fs = FakeFs(
-            existing = setOf(
-                "$projectDir",
-                "$projectDir/2.3.20/daemon.sock",
-                "$projectDir/2.3.20/native-daemon.sock",
-            ),
+            existing = setOf(projectDir),
             subdirs = mapOf(projectDir to listOf("2.3.20")),
+            files = mapOf("$projectDir/2.3.20" to listOf("daemon.sock", "native-daemon.sock")),
         )
         val jvmSockets = mutableListOf<String>()
         val nativeSockets = mutableListOf<String>()
@@ -190,6 +272,7 @@ class DaemonStopEnumerationTest {
             projectDir = projectDir,
             fileExists = fs::exists,
             listSubdirectories = fs::list,
+            listFiles = fs::listFiles,
             sendJvmShutdown = { jvmSockets += it; true },
             sendNativeShutdown = { nativeSockets += it; false },
         )
@@ -207,6 +290,7 @@ class DaemonStopEnumerationTest {
             projectDir = "/nowhere",
             fileExists = fs::exists,
             listSubdirectories = fs::list,
+            listFiles = fs::listFiles,
             sendJvmShutdown = { error("must not send") },
             sendNativeShutdown = { error("must not send") },
         )

--- a/src/nativeTest/kotlin/kolt/infra/FileSystemTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/FileSystemTest.kt
@@ -504,6 +504,50 @@ class FileSystemTest {
     }
 
     @Test
+    fun listFilesReturnsSortedNames() {
+        val base = "/tmp/kolt_list_files_sorted"
+        platform.posix.mkdir(base, 0b111111101u)
+        writeTestFile("$base/beta.sock", "")
+        writeTestFile("$base/alpha.sock", "")
+        writeTestFile("$base/gamma.sock", "")
+        try {
+            val result = listFiles(base)
+
+            assertEquals(listOf("alpha.sock", "beta.sock", "gamma.sock"), result.get())
+        } finally {
+            remove("$base/alpha.sock")
+            remove("$base/beta.sock")
+            remove("$base/gamma.sock")
+            platform.posix.rmdir(base)
+        }
+    }
+
+    @Test
+    fun listFilesExcludesSubdirectories() {
+        val base = "/tmp/kolt_list_files_mixed"
+        platform.posix.mkdir(base, 0b111111101u)
+        platform.posix.mkdir("$base/subdir", 0b111111101u)
+        writeTestFile("$base/a.sock", "")
+        try {
+            val result = listFiles(base)
+
+            assertEquals(listOf("a.sock"), result.get())
+        } finally {
+            remove("$base/a.sock")
+            platform.posix.rmdir("$base/subdir")
+            platform.posix.rmdir(base)
+        }
+    }
+
+    @Test
+    fun listFilesReturnsErrForNonExistentDir() {
+        val result = listFiles("/tmp/kolt_list_files_nonexistent")
+
+        assertNull(result.get())
+        assertIs<ListFilesFailed>(result.getError())
+    }
+
+    @Test
     fun listSubdirectoriesExcludesFiles() {
         val base = "/tmp/kolt_list_subdirs_mixed"
         platform.posix.mkdir(base, 0b111111101u)


### PR DESCRIPTION
Closes #181.

`BuildCommands.createDaemonBackend` fingerprints the JVM daemon socket filename via \`applyPluginsFingerprintToFile\` → \`daemon-noplugins.sock\` (no plugins) or \`daemon-<8hex>.sock\`. \`stopProjectDaemons\` and \`DaemonReaper\` both probed only the bare \`daemon.sock\`, so fingerprinted daemons slipped past \`kolt daemon stop\` and the reaper's orphan cleanup — pre-existing since the fingerprint landed in #138.

Switch version-dir enumeration from fixed-name probes to a \`daemon*.sock\` scan. Added \`listFiles\` to \`kolt.infra\` (counterpart to \`listSubdirectories\` returning non-directory entries; Unix sockets land there via \`S_IFSOCK\`), and two predicates \`isJvmDaemonSocket\` / \`isNativeDaemonSocket\`. Legacy pre-#138 \`<projectHash>/daemon.sock\` still uses \`fileExists\` since no sibling fingerprints ever lived at that layer. Native daemon is untouched — \`native-daemon.sock\` has no fingerprint and its enumeration is unchanged.

## Review focus

- **Mixed-state reaper semantics.** When one fingerprint is alive and a sibling's socket is stale, the current PR keeps the whole version dir — reaping would unlink the live socket. The stale sibling rides along until it's the only one left. The alternative (target-delete individual dead sockets) is cleaner in theory but adds complexity for no user benefit I can see. Flag if you'd rather see per-socket cleanup.
- **Predicate edge cases.** \`isJvmDaemonSocket\` matches \`daemon.sock\` OR (\`daemon-*.sock\`). \`daemon-.sock\` would match but is harmless; \`daemon.log\` does not (wrong suffix); \`native-daemon.sock\` does not (no \`daemon-\` prefix). Let me know if the definition should be tighter (e.g. require the fingerprint segment to match \`[a-z0-9]+\`).
- **Pre-existing reaper blindness to native daemon** (version dir with only \`native-daemon.sock\` would be wiped by the reaper today) is explicitly **out of scope** per #181's *Out:* clause. Worth a separate issue if you want it tracked; flag here if so.
- **Red-verified.** \`fingerprintedLiveDaemonIsPreserved\` and \`versionDirWithOneLiveFingerprintSurvivesEvenIfSiblingIsStale\` both failed on main and pass on this branch. The stop-side tests failed compilation pre-implementation (missing \`listFiles\` seam).