### PR TITLE
Document kolt init behavior and generated files

### DIFF
--- a/.claude/skills/kolt-usage/SKILL.md
+++ b/.claude/skills/kolt-usage/SKILL.md
@@ -18,6 +18,14 @@ kolt build
 kolt run
 ```
 
+`kolt init [name]` writes into the current directory — it does **not** create a subdirectory, so `mkdir + cd` first. Without `[name]`, the project name is inferred from the directory. Generated files:
+
+- `kolt.toml` — defaults to `target = "jvm"`, `jvm_target = "17"`, `main = "main"`, `sources = ["src"]`, `[kotlin] version = "2.3.20"`
+- `src/Main.kt` — `fun main()` hello-world stub
+- `test/MainTest.kt` — `kotlin.test` example
+
+JVM is the default target; change `[build] target` in `kolt.toml` for native (`linuxX64`, etc.).
+
 ## Commands
 
 ```


### PR DESCRIPTION
Surface-level skill tuning of \`kolt-usage\`. Empirical-prompt-tuning (baseline subagent + iter 1 re-eval) surfaced one real gap: a fresh reader could not tell from the skill whether \`kolt init <name>\` creates a subdirectory or writes into cwd, what files it generates, or whether JVM is the default target.

Add a short paragraph after Quick Start covering:
- init writes into cwd (\`mkdir + cd\` first)
- default \`kolt.toml\` fields (target/jvm_target/main/sources/kotlin version)
- generated files (\`kolt.toml\`, \`src/Main.kt\`, \`test/MainTest.kt\`)
- JVM is the default

Verified against source (\`config/Init.kt\`, \`cli/DependencyCommands.kt\`).

## Tuning result

| Scenario | Baseline | Iter 1 |
|---|---|---|
| JVM app setup | 90% (item 5 部分的) | **100%** |
| CI exit codes | 100% | 100% |

\`kolt-dev\` was also evaluated (two scenarios: \`kolt daemon status\` implementation plan, \`PomParser\` parent-inheritance change). Both baseline 100% with no skill-level unclear points, so no tuning commit there — the per-package refresh in PR #190 already lands at the right granularity.

## Review focus

- **Paragraph placement** after Quick Start vs. a dedicated \"kolt init\" subsection. I chose inline so the Quick Start → Commands → Configuration flow stays linear; flag if you'd prefer a dedicated heading.
- **Scope** — this PR only touches \`kolt-usage\`. Not branched off \`186/kolt-dev-skill-refresh\` because that PR is about the dev skill's architecture table; this is a separate tuning outcome.