### PR TITLE
Harden build cache against stale state + skip native resolve on cache hit

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/BuildCache.kt
+++ b/src/nativeMain/kotlin/kolt/build/BuildCache.kt
@@ -20,12 +20,21 @@ data class BuildState(
 
 fun isBuildUpToDate(current: BuildState, cached: BuildState?): Boolean {
     if (cached == null) return false
-    return current.configMtime == cached.configMtime &&
+    val stateMatches = current.configMtime == cached.configMtime &&
         current.sourcesNewestMtime == cached.sourcesNewestMtime &&
         current.classesDirMtime == cached.classesDirMtime &&
         current.lockfileMtime == cached.lockfileMtime &&
         current.resourcesNewestMtime == cached.resourcesNewestMtime &&
         current.defNewestMtime == cached.defNewestMtime
+    if (!stateMatches) return false
+    // Input mtimes must not exceed artifact mtime, even when state
+    // matches. Guards against a stale artifact paired with equally
+    // stale state (#50).
+    val artifact = current.classesDirMtime ?: return false
+    if (current.sourcesNewestMtime > artifact) return false
+    if ((current.resourcesNewestMtime ?: 0L) > artifact) return false
+    if ((current.defNewestMtime ?: 0L) > artifact) return false
+    return true
 }
 
 private val json = Json { prettyPrint = true }

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -138,6 +138,9 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
         // cached builds don't hard-exit on a failed fetch.
         return Ok(BuildResult(config, cachedState!!.classpath, managedJavaBin))
     }
+    // Out of date → rebuild. Drop the state file first so any failure
+    // below leaves cached=null for the next run (#50).
+    if (fileExists(BUILD_STATE_FILE)) deleteFile(BUILD_STATE_FILE)
     val managedKotlincBin = ensureKotlincBin(config.kotlin.effectiveCompiler, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
     val classpath = resolveDependencies(config).getOrElse { return Err(it) }
     val pluginJarPathsByAlias = resolveEnabledPluginJarPaths(config, paths, EXIT_BUILD_ERROR).getOrElse { eprintln("error: ${it.message}"); return Err(it.exitCode) }
@@ -228,8 +231,6 @@ private fun doNativeBuild(config: KoltConfig, useDaemon: Boolean): Result<BuildR
     val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_BUILD_ERROR) }
     val managedKonancBin = ensureKonancBin(config.kotlin.effectiveCompiler, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
 
-    val depKlibs = resolveNativeDependencies(config, paths).getOrElse { return Err(it) }
-
     val kexePath = outputKexePath(config)
     val defNewestMtime = newestDefMtime(config)
     val currentState = BuildState(
@@ -248,6 +249,13 @@ private fun doNativeBuild(config: KoltConfig, useDaemon: Boolean): Result<BuildR
         println("${config.name} is up to date (${formatDuration(elapsed)})")
         return Ok(BuildResult(config, classpath = null, javaPath = null))
     }
+    // Out of date → rebuild. Drop the state file first so any failure
+    // below leaves cached=null for the next run (#50).
+    if (fileExists(BUILD_STATE_FILE)) deleteFile(BUILD_STATE_FILE)
+
+    // Resolve after the up-to-date check (#57) so cache hits don't walk
+    // the dependency graph and re-hash every cached klib.
+    val depKlibs = resolveNativeDependencies(config, paths).getOrElse { return Err(it) }
 
     val nativePluginArgs = resolvePluginArgs(config, paths, EXIT_BUILD_ERROR).getOrElse { eprintln("error: ${it.message}"); return Err(it.exitCode) }
 

--- a/src/nativeTest/kotlin/kolt/build/BuildCacheTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuildCacheTest.kt
@@ -179,9 +179,9 @@ class BuildCacheTest {
         val state = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            classesDirMtime = 3000L,
+            classesDirMtime = 4000L,
             lockfileMtime = null,
-            resourcesNewestMtime = 4000L
+            resourcesNewestMtime = 3000L
         )
         assertTrue(isBuildUpToDate(current = state, cached = state))
     }
@@ -264,9 +264,9 @@ class BuildCacheTest {
         val state = BuildState(
             configMtime = 1000L,
             sourcesNewestMtime = 2000L,
-            classesDirMtime = 3000L,
+            classesDirMtime = 5000L,
             lockfileMtime = null,
-            defNewestMtime = 5000L
+            defNewestMtime = 3000L
         )
         assertTrue(isBuildUpToDate(current = state, cached = state))
     }
@@ -355,5 +355,67 @@ class BuildCacheTest {
         val parsed = parseBuildState(oldJson)
         assertNotNull(parsed)
         assertNull(parsed.defNewestMtime)
+    }
+
+    // #50: defence against stale state file + stale artifact combo.
+    // If any input mtime exceeds the artifact mtime, the artifact cannot
+    // reflect current inputs regardless of state equality.
+    @Test
+    fun notUpToDateWhenSourcesNewerThanClassesDir() {
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 5000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null
+        )
+        assertFalse(isBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun notUpToDateWhenResourcesNewerThanClassesDir() {
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            resourcesNewestMtime = 4000L
+        )
+        assertFalse(isBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun notUpToDateWhenDefNewerThanClassesDir() {
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            defNewestMtime = 4000L
+        )
+        assertFalse(isBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun notUpToDateWhenClassesDirMtimeNullEvenIfStateMatches() {
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = null,
+            lockfileMtime = null
+        )
+        assertFalse(isBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun upToDateWhenInputsNotNewerThanArtifact() {
+        val state = BuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            classesDirMtime = 3000L,
+            lockfileMtime = null,
+            resourcesNewestMtime = 2500L,
+            defNewestMtime = 2700L
+        )
+        assertTrue(isBuildUpToDate(current = state, cached = state))
     }
 }


### PR DESCRIPTION
Closes #50. Closes #57.

## Changes

**`BuildCache.isBuildUpToDate` — cross-check inputs against the artifact (#50).**
Even when every cached field matches, require that `sourcesNewestMtime`, `resourcesNewestMtime`, and `defNewestMtime` are not greater than `classesDirMtime`. This guards the specific stale-state scenario called out in #50: an earlier build succeeded, failed rebuilds never rewrote state, and inputs have since settled at timestamps that happen to line up with the stale entry. A null `classesDirMtime` now forces a rebuild unconditionally.

**`doBuild` / `doNativeBuild` — drop state file on entering rebuild (#50).**
After `isBuildUpToDate` returns false, delete `BUILD_STATE_FILE` before doing any work. Any downstream failure (resolver, compile, link, jar) therefore leaves `cached=null` for the next run. Combined with the cross-check this is belt-and-suspenders — if the delete itself silently fails, the cross-check still catches the inputs-advanced case.

**`doNativeBuild` — move `resolveNativeDependencies` after the up-to-date check (#57).**
Cache hits no longer walk the dependency graph and re-hash every cached klib. JVM `doBuild` already called its resolver in this order, so no change there. Safe because `resolveNativeDependencies` (in `DependencyResolution.kt`) is side-effect-free, unlike the JVM resolver which writes `kolt.lock` / `workspace.json`.

## Review focus

- **Cross-check edge cases.** In particular, the JVM `classesDirMtime = newestMtimeAll(CLASSES_DIR)` includes copied resources, so `resourcesNewestMtime > classesDirMtime` should never happen on a healthy build; worth sanity-checking. Future-dated source mtimes (tarball extract, clock skew) will now force a rebuild every time — known limitation, not fixed here.
- **The two test mtime edits** in `BuildCacheTest` (`upToDateWhenResourcesMtimesMatch`, `upToDateWhenDefMtimesMatch`) swap the mtimes so they satisfy the new invariant. Original intent was field serialization / state-equality, not the mtime ordering.
- **`doNativeTest` still resolves unconditionally.** Intentional — native test flow doesn't go through `doNativeBuild`, and test invocation is always a rebuild anyway.