### PR TITLE
Cache native test builds to skip konanc on unchanged sources

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/TestBuildCache.kt
+++ b/src/nativeMain/kotlin/kolt/build/TestBuildCache.kt
@@ -1,0 +1,48 @@
+package kolt.build
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+// Separate from BUILD_STATE_FILE so a test-cache invalidation does not
+// wipe the build-cache entry and vice versa (#59).
+internal const val TEST_BUILD_STATE_FILE = "$BUILD_DIR/.kolt-test-state.json"
+
+@Serializable
+data class TestBuildState(
+    @SerialName("config_mtime") val configMtime: Long,
+    @SerialName("sources_newest_mtime") val sourcesNewestMtime: Long,
+    @SerialName("test_sources_newest_mtime") val testSourcesNewestMtime: Long,
+    @SerialName("test_kexe_mtime") val testKexeMtime: Long?,
+    @SerialName("def_newest_mtime") val defNewestMtime: Long? = null,
+)
+
+fun isTestBuildUpToDate(current: TestBuildState, cached: TestBuildState?): Boolean {
+    if (cached == null) return false
+    val stateMatches = current.configMtime == cached.configMtime &&
+        current.sourcesNewestMtime == cached.sourcesNewestMtime &&
+        current.testSourcesNewestMtime == cached.testSourcesNewestMtime &&
+        current.testKexeMtime == cached.testKexeMtime &&
+        current.defNewestMtime == cached.defNewestMtime
+    if (!stateMatches) return false
+    // Mirror of BuildCache cross-check (#50): no input mtime may exceed
+    // the test kexe mtime, even when cached state matches.
+    val artifact = current.testKexeMtime ?: return false
+    if (current.sourcesNewestMtime > artifact) return false
+    if (current.testSourcesNewestMtime > artifact) return false
+    if ((current.defNewestMtime ?: 0L) > artifact) return false
+    return true
+}
+
+private val json = Json { prettyPrint = true }
+
+fun serializeTestBuildState(state: TestBuildState): String =
+    json.encodeToString(state)
+
+fun parseTestBuildState(input: String): TestBuildState? =
+    try {
+        json.decodeFromString<TestBuildState>(input)
+    } catch (_: Exception) {
+        null
+    }

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -497,39 +497,61 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>): Result<Uni
     }
 
     val testStartMark = TimeSource.Monotonic.markNow()
-
-    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_TEST_ERROR) }
-    val managedKonancBin = ensureKonancBin(config.kotlin.effectiveCompiler, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_TEST_ERROR) }
-    val nativePluginArgs = resolvePluginArgs(config, paths, EXIT_TEST_ERROR).getOrElse { eprintln("error: ${it.message}"); return Err(it.exitCode) }
-
-    val depKlibs = resolveNativeDependencies(config, paths).getOrElse { return Err(it) }
-
-    ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
-        eprintln("error: could not create directory ${error.path}")
-        return Err(EXIT_BUILD_ERROR)
-    }
-
-    val cinteropKlibs = runCinterop(config, paths).getOrElse { return Err(it) }
-    val klibs = depKlibs + cinteropKlibs
-
     val testConfig = config.copy(build = config.build.copy(testSources = existingTestSources))
-    val libraryCmd = nativeTestLibraryCommand(testConfig, pluginArgs = nativePluginArgs, konancPath = managedKonancBin, klibs = klibs)
-    println("compiling tests (native)...")
-    executeCommand(libraryCmd.args).getOrElse { error ->
-        eprintln("error: " + formatProcessError(error, "test compilation"))
-        return Err(EXIT_BUILD_ERROR)
-    }
+    val testKexePath = outputNativeTestKexePath(testConfig)
 
-    val linkCmd = nativeTestLinkCommand(testConfig, konancPath = managedKonancBin, klibs = klibs)
-    println("linking tests (native)...")
-    executeCommand(linkCmd.args).getOrElse { error ->
-        eprintln("error: " + formatProcessError(error, "test linking"))
-        return Err(EXIT_BUILD_ERROR)
-    }
+    val currentState = TestBuildState(
+        configMtime = fileMtime(KOLT_TOML) ?: 0L,
+        sourcesNewestMtime = newestMtime(config.build.sources),
+        testSourcesNewestMtime = newestMtime(existingTestSources),
+        testKexeMtime = if (fileExists(testKexePath)) fileMtime(testKexePath) else null,
+        defNewestMtime = newestDefMtime(config),
+    )
+    val cachedState = readFileAsString(TEST_BUILD_STATE_FILE).getOrElse { null }
+        ?.let { parseTestBuildState(it) }
 
-    if (!fileExists(linkCmd.outputPath)) {
-        eprintln("error: ${linkCmd.outputPath} not produced by konanc")
-        return Err(EXIT_BUILD_ERROR)
+    if (!isTestBuildUpToDate(current = currentState, cached = cachedState)) {
+        // Out of date → rebuild. Drop the state file first so any failure
+        // below leaves cached=null for the next run (mirror of #50).
+        if (fileExists(TEST_BUILD_STATE_FILE)) deleteFile(TEST_BUILD_STATE_FILE)
+
+        val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_TEST_ERROR) }
+        val managedKonancBin = ensureKonancBin(config.kotlin.effectiveCompiler, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_TEST_ERROR) }
+        val nativePluginArgs = resolvePluginArgs(config, paths, EXIT_TEST_ERROR).getOrElse { eprintln("error: ${it.message}"); return Err(it.exitCode) }
+
+        val depKlibs = resolveNativeDependencies(config, paths).getOrElse { return Err(it) }
+
+        ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
+            eprintln("error: could not create directory ${error.path}")
+            return Err(EXIT_BUILD_ERROR)
+        }
+
+        val cinteropKlibs = runCinterop(config, paths).getOrElse { return Err(it) }
+        val klibs = depKlibs + cinteropKlibs
+
+        val libraryCmd = nativeTestLibraryCommand(testConfig, pluginArgs = nativePluginArgs, konancPath = managedKonancBin, klibs = klibs)
+        println("compiling tests (native)...")
+        executeCommand(libraryCmd.args).getOrElse { error ->
+            eprintln("error: " + formatProcessError(error, "test compilation"))
+            return Err(EXIT_BUILD_ERROR)
+        }
+
+        val linkCmd = nativeTestLinkCommand(testConfig, konancPath = managedKonancBin, klibs = klibs)
+        println("linking tests (native)...")
+        executeCommand(linkCmd.args).getOrElse { error ->
+            eprintln("error: " + formatProcessError(error, "test linking"))
+            return Err(EXIT_BUILD_ERROR)
+        }
+
+        if (!fileExists(linkCmd.outputPath)) {
+            eprintln("error: ${linkCmd.outputPath} not produced by konanc")
+            return Err(EXIT_BUILD_ERROR)
+        }
+
+        val newState = currentState.copy(testKexeMtime = fileMtime(linkCmd.outputPath))
+        writeFileAsString(TEST_BUILD_STATE_FILE, serializeTestBuildState(newState)).getOrElse {
+            eprintln("warning: could not write test state file")
+        }
     }
 
     val runCmd = nativeTestRunCommand(testConfig, testArgs)

--- a/src/nativeTest/kotlin/kolt/build/TestBuildCacheTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/TestBuildCacheTest.kt
@@ -1,0 +1,237 @@
+package kolt.build
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TestBuildCacheTest {
+
+    @Test
+    fun upToDateWhenAllMtimesMatch() {
+        val state = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L
+        )
+        assertTrue(isTestBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun notUpToDateWhenCachedIsNull() {
+        val state = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L
+        )
+        assertFalse(isTestBuildUpToDate(current = state, cached = null))
+    }
+
+    @Test
+    fun notUpToDateWhenConfigMtimeChanged() {
+        val cached = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L
+        )
+        val current = cached.copy(configMtime = 1500L)
+        assertFalse(isTestBuildUpToDate(current = current, cached = cached))
+    }
+
+    @Test
+    fun notUpToDateWhenSourceMtimeChanged() {
+        val cached = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L
+        )
+        val current = cached.copy(sourcesNewestMtime = 2800L)
+        assertFalse(isTestBuildUpToDate(current = current, cached = cached))
+    }
+
+    @Test
+    fun notUpToDateWhenTestSourceMtimeChanged() {
+        val cached = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L
+        )
+        val current = cached.copy(testSourcesNewestMtime = 2900L)
+        assertFalse(isTestBuildUpToDate(current = current, cached = cached))
+    }
+
+    @Test
+    fun notUpToDateWhenTestKexeMtimeChanged() {
+        val cached = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L
+        )
+        val current = cached.copy(testKexeMtime = 3500L)
+        assertFalse(isTestBuildUpToDate(current = current, cached = cached))
+    }
+
+    @Test
+    fun notUpToDateWhenTestKexeMissing() {
+        val cached = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L
+        )
+        val current = cached.copy(testKexeMtime = null)
+        assertFalse(isTestBuildUpToDate(current = current, cached = cached))
+    }
+
+    @Test
+    fun notUpToDateWhenDefMtimeChanged() {
+        val cached = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L,
+            defNewestMtime = 2700L
+        )
+        val current = cached.copy(defNewestMtime = 2800L)
+        assertFalse(isTestBuildUpToDate(current = current, cached = cached))
+    }
+
+    // Cross-check: any input newer than the test kexe means the kexe is stale.
+    @Test
+    fun notUpToDateWhenSourcesNewerThanTestKexe() {
+        val state = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 5000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L
+        )
+        assertFalse(isTestBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun notUpToDateWhenTestSourcesNewerThanTestKexe() {
+        val state = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 5000L,
+            testKexeMtime = 3000L
+        )
+        assertFalse(isTestBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun notUpToDateWhenDefNewerThanTestKexe() {
+        val state = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L,
+            defNewestMtime = 4000L
+        )
+        assertFalse(isTestBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun notUpToDateWhenTestKexeMtimeNullEvenIfStateMatches() {
+        val state = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = null
+        )
+        assertFalse(isTestBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun upToDateWhenInputsNotNewerThanTestKexe() {
+        val state = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L,
+            defNewestMtime = 2700L
+        )
+        assertTrue(isTestBuildUpToDate(current = state, cached = state))
+    }
+
+    @Test
+    fun serializeAndDeserializeRoundTrip() {
+        val state = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L,
+            defNewestMtime = 2700L
+        )
+        val json = serializeTestBuildState(state)
+        val parsed = parseTestBuildState(json)
+        assertEquals(state, parsed)
+    }
+
+    @Test
+    fun serializeWithNullDefMtime() {
+        val state = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L,
+            defNewestMtime = null
+        )
+        val json = serializeTestBuildState(state)
+        val parsed = parseTestBuildState(json)
+        assertEquals(state, parsed)
+        assertNotNull(parsed)
+        assertNull(parsed.defNewestMtime)
+    }
+
+    @Test
+    fun serializationUsesSnakeCaseKeys() {
+        val state = TestBuildState(
+            configMtime = 1000L,
+            sourcesNewestMtime = 2000L,
+            testSourcesNewestMtime = 2500L,
+            testKexeMtime = 3000L,
+            defNewestMtime = 2700L
+        )
+        val json = serializeTestBuildState(state)
+        assertTrue(json.contains("test_sources_newest_mtime"), "Expected 'test_sources_newest_mtime' in: $json")
+        assertTrue(json.contains("test_kexe_mtime"), "Expected 'test_kexe_mtime' in: $json")
+        assertTrue(json.contains("def_newest_mtime"), "Expected 'def_newest_mtime' in: $json")
+    }
+
+    @Test
+    fun parseInvalidJsonReturnsNull() {
+        assertNull(parseTestBuildState("not json"))
+    }
+
+    @Test
+    fun parseEmptyStringReturnsNull() {
+        assertNull(parseTestBuildState(""))
+    }
+
+    @Test
+    fun testStateFilePathLivesUnderBuildDir() {
+        assertTrue(
+            TEST_BUILD_STATE_FILE.startsWith("$BUILD_DIR/"),
+            "TEST_BUILD_STATE_FILE=$TEST_BUILD_STATE_FILE must live under BUILD_DIR=$BUILD_DIR"
+        )
+    }
+
+    @Test
+    fun testStateFilePathDiffersFromBuildStateFile() {
+        // Separate from build state so test-cache invalidation does not
+        // wipe the build-cache entry and vice versa (#59).
+        assertFalse(
+            TEST_BUILD_STATE_FILE == BUILD_STATE_FILE,
+            "test state file must not collide with build state file"
+        )
+    }
+}


### PR DESCRIPTION
Closes #59.

## Changes

**New `TestBuildState` + predicate** (`TestBuildCache.kt`). Schema: `configMtime`, `sourcesNewestMtime`, `testSourcesNewestMtime`, `testKexeMtime`, `defNewestMtime`. Predicate matches the `BuildCache.isBuildUpToDate` pattern, including the #50 cross-check (no input may exceed the artifact mtime).

**`doNativeTest` integration** (`BuildCommands.kt`). On cache hit, skip `resolveKoltPaths` / `ensureKonancBin` / `resolvePluginArgs` / `resolveNativeDependencies` / `runCinterop` / library + link passes, and jump straight to `nativeTestRunCommand`. On cache miss, delete the state file first (same #50-style hardening), rebuild, and only write the new state after library + link succeed and the kexe is verified.

## Review focus

- **Cache-key gaps are intentional, not oversights.** `klibs` not tracked — dependency changes flow through `configMtime`; cinterop klib content is covered by `defNewestMtime`. `kotlin.compiler` version not tracked either, same limitation as `doNativeBuild`. All mirror the existing build-path cache.
- **State file is separate from `BUILD_STATE_FILE`** so a test-only invalidation doesn't nuke the main build cache and vice versa. `doClean` still wipes both transitively via `BUILD_DIR` removal.
- **Failure atomicity.** `TEST_BUILD_STATE_FILE` is deleted before compile/link, and the new state is written only after the kexe exists. Any early `return Err(...)` leaves no stale state.
- **`existingTestSources.isEmpty()` still short-circuits before any cache logic**, so an empty test dir never creates a state file.
- Not addressed: mtime `>` vs `>=` on WSL2 9p 1-second granularity. Same behaviour as `BuildCache`; handled at the bench layer via synthetic epochs.