### PR TITLE
Acquire LOCK before other workingDir writes (#199)

### DIFF
--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
@@ -112,12 +112,12 @@ class BtaIncrementalCompiler private constructor(
         Files.createDirectories(request.workingDir)
 
         // #199: LOCK acquisition must be the first action on workingDir
-        // after `createDirectories` creates the parent. The IcReaper
-        // (documented in IcReaper.kt) treats LOCK as the invariant that
-        // proves a dir is alive — any write before LOCK leaves a window
-        // where a concurrent-daemon-boot reaper can wipe the dir. Order
-        // below: create workingDir → take LOCK → create BTA subdir →
-        // write breadcrumb.
+        // after `createDirectories(workingDir)` creates the dir itself.
+        // The IcReaper (documented in IcReaper.kt) treats LOCK as the
+        // invariant that proves a dir is alive — any write before LOCK
+        // leaves a window where a concurrent-daemon-boot reaper can
+        // wipe the dir. Order below: create workingDir → take LOCK →
+        // create BTA subdir → write breadcrumb.
         runCatching { ensureLock(request.workingDir) }
             .onFailure { metrics.record(METRIC_REAPER_LOCK_FAILED) }
 

--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
@@ -110,6 +110,17 @@ class BtaIncrementalCompiler private constructor(
         // arrives. `createDirectories` is a no-op if the tree already
         // exists, which is the common case for every non-initial request.
         Files.createDirectories(request.workingDir)
+
+        // #199: LOCK acquisition must be the first action on workingDir
+        // after `createDirectories` creates the parent. The IcReaper
+        // (documented in IcReaper.kt) treats LOCK as the invariant that
+        // proves a dir is alive — any write before LOCK leaves a window
+        // where a concurrent-daemon-boot reaper can wipe the dir. Order
+        // below: create workingDir → take LOCK → create BTA subdir →
+        // write breadcrumb.
+        runCatching { ensureLock(request.workingDir) }
+            .onFailure { metrics.record(METRIC_REAPER_LOCK_FAILED) }
+
         val btaWorkingDir = request.workingDir.resolve(BTA_SUBDIR)
         val wasEmptyBeforeCompile = isEmptyDir(btaWorkingDir)
         Files.createDirectories(btaWorkingDir)
@@ -118,14 +129,11 @@ class BtaIncrementalCompiler private constructor(
         // breadcrumb next to BTA state so the reaper can decide whether
         // this projectId's source tree still exists. Idempotent on every
         // compile — overwrite is cheap and resilient to a truncation by
-        // the self-heal path. Failure to write is logged as a reaper
-        // concern and does not fail the compile.
-        // ADR 0019 §Negative follow-up (IC reaper): drop a `project.path`
-        // breadcrumb next to the BTA subdir so the reaper can decide
-        // whether this projectId's source tree still exists. Kept
-        // above `btaWorkingDir` because BTA clears its workingDirectory
-        // on cold-path startup; a breadcrumb sitting inside BTA state
-        // would be swept away on every first compile.
+        // the self-heal path. Kept above `btaWorkingDir` because BTA
+        // clears its workingDirectory on cold-path startup; a breadcrumb
+        // sitting inside BTA state would be swept away on every first
+        // compile. Failure to write is logged as a reaper concern and
+        // does not fail the compile.
         runCatching {
             Files.writeString(
                 request.workingDir.resolve(PROJECT_PATH_BREADCRUMB),
@@ -135,9 +143,6 @@ class BtaIncrementalCompiler private constructor(
                 StandardOpenOption.TRUNCATE_EXISTING,
             )
         }.onFailure { metrics.record(METRIC_REAPER_BREADCRUMB_FAILED) }
-
-        runCatching { ensureLock(request.workingDir) }
-            .onFailure { metrics.record(METRIC_REAPER_LOCK_FAILED) }
 
         val builder = toolchain.jvm.jvmCompilationOperationBuilder(request.sources, request.outputDir)
 

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
@@ -80,12 +80,20 @@ class BtaIncrementalCompilerColdPathTest {
         assertTrue(breadcrumb.exists(), "expected project.path breadcrumb at $breadcrumb")
         assertEquals(workRoot.toString(), breadcrumb.readText().trim())
 
-        // #199: LOCK must exist under workingDir after compile. The
-        // ordering (LOCK before breadcrumb write) is the invariant
-        // IcReaper relies on; this assertion is a regression fence —
-        // the ordering itself lives in BtaIncrementalCompiler.compile.
+        // #199: LOCK must exist under workingDir after compile and its
+        // mtime must be no later than the breadcrumb's — a literal
+        // swap of the write order back to breadcrumb-first would flip
+        // this. Strict `<` would be flaky on WSL2 9p (1s mtime
+        // granularity); `<=` catches the swap without false positives
+        // on fast filesystems.
         val lock = workingDir.resolve("LOCK")
         assertTrue(lock.exists(), "expected LOCK at $lock")
+        val lockMtime = Files.getLastModifiedTime(lock)
+        val breadcrumbMtime = Files.getLastModifiedTime(breadcrumb)
+        assertTrue(
+            lockMtime <= breadcrumbMtime,
+            "expected LOCK mtime ($lockMtime) <= breadcrumb mtime ($breadcrumbMtime) — ordering regressed",
+        )
     }
 
     // A user type error is the only BTA outcome that maps to CompilationFailed.

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
@@ -79,6 +79,13 @@ class BtaIncrementalCompilerColdPathTest {
         val breadcrumb = workingDir.resolve("project.path")
         assertTrue(breadcrumb.exists(), "expected project.path breadcrumb at $breadcrumb")
         assertEquals(workRoot.toString(), breadcrumb.readText().trim())
+
+        // #199: LOCK must exist under workingDir after compile. The
+        // ordering (LOCK before breadcrumb write) is the invariant
+        // IcReaper relies on; this assertion is a regression fence —
+        // the ordering itself lives in BtaIncrementalCompiler.compile.
+        val lock = workingDir.resolve("LOCK")
+        assertTrue(lock.exists(), "expected LOCK at $lock")
     }
 
     // A user type error is the only BTA outcome that maps to CompilationFailed.

--- a/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/reaper/IcReaper.kt
+++ b/kolt-compiler-daemon/src/main/kotlin/kolt/daemon/reaper/IcReaper.kt
@@ -32,16 +32,11 @@ import java.nio.file.StandardOpenOption
 // Exclusion: an advisory `tryLock` probe on `<projectIdDir>/LOCK`.
 // `BtaIncrementalCompiler` holds this lock for the daemon's lifetime,
 // so a dir whose LOCK is held cannot be the current daemon's active
-// working directory — even across hash collisions. Rules A+B are
-// already safe by construction (A never touches the current version;
-// B only removes dangling projectRoots that a live daemon cannot have
-// spawned from), so the lock probe is belt-and-suspenders insurance.
-//
-// Known gap (#199): `BtaIncrementalCompiler.compile` creates the
-// working dir and writes the breadcrumb before calling `ensureLock`,
-// so a concurrent-daemon-boot reaper can unlink a live dir mid-setup.
-// Symptom is a cold recompile, not corruption. Fix lives on the writer
-// side (reorder to lock-first), tracked separately.
+// working directory — even across hash collisions. The probe is
+// load-bearing for concurrent-daemon-boot: `BtaIncrementalCompiler.compile`
+// acquires LOCK immediately after `createDirectories(workingDir)` and
+// before any other write (breadcrumb, BTA subdir), so a reaper firing
+// mid-setup either sees the LOCK or the dir not yet created.
 object IcReaper {
 
     data class Report(


### PR DESCRIPTION
Closes #199.

The LOCK-first ordering is the fix — three lines of `executeCompile` moved up. IcReaper.kt's doc comment now reads honestly: the lock probe is load-bearing, not belt-and-suspenders. The dogfood effect is invisible (the race was rare), but the invariant alignment is the point.

**Testing.** ordering itself isn't observable from post-compile state (LOCK and breadcrumb both exist after compile either way), and a race-reproduction test would be flaky + implementation-invasive. Added a LOCK-existence assertion to the cold-path test as a regression fence, and let the explicit code ordering + IcReaper.kt invariant doc carry the rest. If you see a cheap way to observe the mid-compile state without poking holes in the adapter, flag it.

**Drive-by.** The breadcrumb write had two duplicated doc blocks (merge residue). Folded into one while I was on those lines.