### PR TITLE
Honor Gradle strictly/prefers/rejects version constraints

### DIFF
--- a/src/nativeMain/kotlin/kolt/resolve/GradleMetadata.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/GradleMetadata.kt
@@ -53,7 +53,9 @@ data class NativeArtifact(
 data class NativeDependency(
     val group: String,
     val module: String,
-    val version: String
+    val version: String,
+    val strict: Boolean = false,
+    val rejects: List<String> = emptyList()
 )
 
 // Unlike parseJvmRedirect, a variant without available-at is skipped (not aborted)
@@ -88,7 +90,13 @@ fun parseNativeArtifact(moduleJson: String, nativeTarget: String): NativeArtifac
         if (!matchesNativeVariant(variant.attributes, nativeTarget)) continue
         val klibFile = variant.files.firstOrNull { it.url.endsWith(".klib") } ?: continue
         val deps = variant.dependencies.map { d ->
-            NativeDependency(group = d.group, module = d.module, version = d.version.requires)
+            NativeDependency(
+                group = d.group,
+                module = d.module,
+                version = d.version.selectedVersion(),
+                strict = d.version.strictly.isNotEmpty(),
+                rejects = d.version.rejects
+            )
         }
         return NativeArtifact(
             klibFileUrl = klibFile.url,
@@ -155,7 +163,16 @@ private data class GradleDependency(
     val version: GradleVersionSpec
 )
 
+// Precedence: strictly > requires > prefers. This mirrors Gradle's own
+// "winning version" selection for a single constraint declaration. `rejects`
+// filters candidates during graph resolution; see NativeResolver.
 @Serializable
 private data class GradleVersionSpec(
-    val requires: String = ""
+    val requires: String = "",
+    val strictly: String = "",
+    val prefers: String = "",
+    val rejects: List<String> = emptyList()
 )
+
+private fun GradleVersionSpec.selectedVersion(): String =
+    strictly.ifEmpty { requires.ifEmpty { prefers } }

--- a/src/nativeMain/kotlin/kolt/resolve/GradleMetadata.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/GradleMetadata.kt
@@ -90,10 +90,12 @@ fun parseNativeArtifact(moduleJson: String, nativeTarget: String): NativeArtifac
         if (!matchesNativeVariant(variant.attributes, nativeTarget)) continue
         val klibFile = variant.files.firstOrNull { it.url.endsWith(".klib") } ?: continue
         val deps = variant.dependencies.map { d ->
+            val version = d.version.selectedVersion()
+            if (version.isEmpty()) return null
             NativeDependency(
                 group = d.group,
                 module = d.module,
-                version = d.version.selectedVersion(),
+                version = version,
                 strict = d.version.strictly.isNotEmpty(),
                 rejects = d.version.rejects
             )

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -64,6 +64,13 @@ fun resolveNative(
     val visited = mutableSetOf<String>()
     // processed[ga:version] = (redirect, artifact) populated during BFS
     val processed = mutableMapOf<String, NativeResolved>()
+    // Per-GA union of rejects declared by every contributor seen so far.
+    // Accumulated even when the contributor's own version proposal loses the
+    // conflict, mirroring Gradle's "rejects applies to the GA globally".
+    // Known approximation: rejects do NOT revoke an already-accepted version
+    // (the BFS doesn't re-queue); order can therefore affect outcome for
+    // contrived inputs. See NativeResolverTest.
+    val accumulatedRejects = mutableMapOf<String, MutableList<String>>()
 
     // Seed direct deps (skipping stdlib)
     for ((groupArtifact, version) in config.dependencies) {
@@ -92,6 +99,13 @@ fun resolveNative(
         for (dep in resolved.artifact.dependencies) {
             val depGA = "${dep.group}:${dep.module}"
             if (isKotlinStdlib(depGA)) continue
+
+            if (dep.rejects.isNotEmpty()) {
+                accumulatedRejects.getOrPut(depGA) { mutableListOf() }.addAll(dep.rejects)
+            }
+
+            val patterns = accumulatedRejects[depGA]
+            if (patterns != null && patterns.any { matchesRejectPattern(dep.version, it) }) continue
 
             val existing = resolvedVersions[depGA]
             if (existing != null) {

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -71,6 +71,8 @@ fun resolveNative(
     // (the BFS doesn't re-queue); order can therefore affect outcome for
     // contrived inputs. See NativeResolverTest.
     val accumulatedRejects = mutableMapOf<String, MutableList<String>>()
+    // Per-GA strict pin. Any other proposal for the same GA is a hard error.
+    val strictPins = mutableMapOf<String, String>()
 
     // Seed direct deps (skipping stdlib)
     for ((groupArtifact, version) in config.dependencies) {
@@ -106,6 +108,20 @@ fun resolveNative(
 
             val patterns = accumulatedRejects[depGA]
             if (patterns != null && patterns.any { matchesRejectPattern(dep.version, it) }) continue
+
+            val pin = strictPins[depGA]
+            if (pin != null && pin != dep.version) {
+                return Err(ResolveError.StrictVersionConflict(depGA, pin, dep.version))
+            }
+            if (dep.strict) {
+                val alreadyResolved = resolvedVersions[depGA]
+                if (alreadyResolved != null && alreadyResolved.first != dep.version) {
+                    return Err(
+                        ResolveError.StrictVersionConflict(depGA, dep.version, alreadyResolved.first)
+                    )
+                }
+                strictPins[depGA] = dep.version
+            }
 
             val existing = resolvedVersions[depGA]
             if (existing != null) {

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -111,7 +111,9 @@ fun resolveNative(
 
             val pin = strictPins[depGA]
             if (pin != null && pin != dep.version) {
-                return Err(ResolveError.StrictVersionConflict(depGA, pin, dep.version))
+                return Err(
+                    ResolveError.StrictVersionConflict(depGA, pin, dep.version, otherIsStrict = dep.strict)
+                )
             }
             if (dep.strict) {
                 val alreadyResolved = resolvedVersions[depGA]

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -67,9 +67,9 @@ fun resolveNative(
     // Per-GA union of rejects declared by every contributor seen so far.
     // Accumulated even when the contributor's own version proposal loses the
     // conflict, mirroring Gradle's "rejects applies to the GA globally".
-    // Known approximation: rejects do NOT revoke an already-accepted version
-    // (the BFS doesn't re-queue); order can therefore affect outcome for
-    // contrived inputs. See NativeResolverTest.
+    // A post-BFS recheck below verifies every resolved version against this
+    // final set, so an earlier-accepted version rejected by a later-seen
+    // contributor is caught as an error rather than silently kept.
     val accumulatedRejects = mutableMapOf<String, MutableList<String>>()
     // Per-GA strict pin. Any other proposal for the same GA is a hard error.
     val strictPins = mutableMapOf<String, String>()
@@ -132,6 +132,18 @@ fun resolveNative(
             resolvedVersions[depGA] = Pair(dep.version, false)
             queue.addLast(depGA to dep.version)
         }
+    }
+
+    // After BFS, re-check every resolved version against the fully-populated
+    // accumulatedRejects. Catches the case where a later-seen contributor's
+    // rejects would have blocked an earlier-accepted version (including direct
+    // deps): the BFS can't re-queue, so we error instead of silently keeping
+    // a rejected version.
+    for ((groupArtifact, versionAndDirect) in resolvedVersions) {
+        val patterns = accumulatedRejects[groupArtifact] ?: continue
+        val version = versionAndDirect.first
+        val matched = patterns.firstOrNull { matchesRejectPattern(version, it) } ?: continue
+        return Err(ResolveError.RejectedVersionResolved(groupArtifact, version, matched))
     }
 
     // Materialize: for each resolved (ga, version), download the .klib and

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -21,6 +21,11 @@ sealed class ResolveError {
     data class NoNativeVariant(val groupArtifact: String, val nativeTarget: String) : ResolveError()
     data class MetadataParseFailed(val groupArtifact: String) : ResolveError()
     data class MetadataFetchFailed(val groupArtifact: String) : ResolveError()
+    data class StrictVersionConflict(
+        val groupArtifact: String,
+        val strictVersion: String,
+        val otherVersion: String
+    ) : ResolveError()
 }
 
 fun formatResolveError(error: ResolveError): String = when (error) {
@@ -39,6 +44,9 @@ fun formatResolveError(error: ResolveError): String = when (error) {
         "error: failed to parse Gradle module metadata for ${error.groupArtifact}"
     is ResolveError.MetadataFetchFailed ->
         "error: failed to read Gradle module metadata for ${error.groupArtifact}"
+    is ResolveError.StrictVersionConflict ->
+        "error: strict version conflict on ${error.groupArtifact}: " +
+            "${error.strictVersion} required strictly, but ${error.otherVersion} also requested"
 }
 
 data class ResolvedDep(

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -24,7 +24,8 @@ sealed class ResolveError {
     data class StrictVersionConflict(
         val groupArtifact: String,
         val strictVersion: String,
-        val otherVersion: String
+        val otherVersion: String,
+        val otherIsStrict: Boolean = false
     ) : ResolveError()
     data class RejectedVersionResolved(
         val groupArtifact: String,
@@ -50,8 +51,12 @@ fun formatResolveError(error: ResolveError): String = when (error) {
     is ResolveError.MetadataFetchFailed ->
         "error: failed to read Gradle module metadata for ${error.groupArtifact}"
     is ResolveError.StrictVersionConflict ->
-        "error: strict version conflict on ${error.groupArtifact}: " +
-            "${error.strictVersion} required strictly, but ${error.otherVersion} also requested"
+        if (error.otherIsStrict)
+            "error: conflicting strict versions on ${error.groupArtifact}: " +
+                "${error.strictVersion} and ${error.otherVersion}"
+        else
+            "error: strict version conflict on ${error.groupArtifact}: " +
+                "${error.strictVersion} required strictly, but ${error.otherVersion} also requested"
     is ResolveError.RejectedVersionResolved ->
         "error: resolved ${error.groupArtifact}:${error.version} is rejected by constraint '${error.rejectPattern}'"
 }

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -26,6 +26,11 @@ sealed class ResolveError {
         val strictVersion: String,
         val otherVersion: String
     ) : ResolveError()
+    data class RejectedVersionResolved(
+        val groupArtifact: String,
+        val version: String,
+        val rejectPattern: String
+    ) : ResolveError()
 }
 
 fun formatResolveError(error: ResolveError): String = when (error) {
@@ -47,6 +52,8 @@ fun formatResolveError(error: ResolveError): String = when (error) {
     is ResolveError.StrictVersionConflict ->
         "error: strict version conflict on ${error.groupArtifact}: " +
             "${error.strictVersion} required strictly, but ${error.otherVersion} also requested"
+    is ResolveError.RejectedVersionResolved ->
+        "error: resolved ${error.groupArtifact}:${error.version} is rejected by constraint '${error.rejectPattern}'"
 }
 
 data class ResolvedDep(

--- a/src/nativeMain/kotlin/kolt/resolve/VersionCompare.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/VersionCompare.kt
@@ -140,3 +140,15 @@ fun selectVersion(constraint: String): String {
     val interval = vc.interval ?: return constraint
     return interval.from ?: interval.to ?: constraint
 }
+
+// A Gradle `rejects` pattern may be either an exact version ("1.6.0") or a
+// Maven-style interval ("[1.0.0,1.5.0)"). parseVersionConstraint already
+// handles both shapes — this helper just dispatches on which one it parsed.
+fun matchesRejectPattern(version: String, rejectPattern: String): Boolean {
+    val vc = parseVersionConstraint(rejectPattern)
+    return when {
+        vc.interval != null -> vc.interval.contains(version)
+        vc.preferred != null -> vc.preferred == version
+        else -> false
+    }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/GradleMetadataTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/GradleMetadataTest.kt
@@ -720,4 +720,97 @@ class GradleMetadataTest {
         assertEquals("lib-linuxx64", redirect?.module)
         assertEquals("1.0", redirect?.version)
     }
+
+    @Test
+    fun parseNativeArtifactPicksStrictlyOverRequiresAndSetsStrictFlag() {
+        val json = nativeArtifactJson(
+            """{ "strictly": "1.5.0", "requires": "1.7.0" }"""
+        )
+
+        val dep = parseNativeArtifact(json, "linux_x64")?.dependencies?.single()
+
+        assertEquals("1.5.0", dep?.version)
+        assertEquals(true, dep?.strict)
+        assertEquals(emptyList(), dep?.rejects)
+    }
+
+    @Test
+    fun parseNativeArtifactPicksRequiresOverPrefers() {
+        val json = nativeArtifactJson(
+            """{ "requires": "1.7.0", "prefers": "2.0.0" }"""
+        )
+
+        val dep = parseNativeArtifact(json, "linux_x64")?.dependencies?.single()
+
+        assertEquals("1.7.0", dep?.version)
+        assertEquals(false, dep?.strict)
+    }
+
+    @Test
+    fun parseNativeArtifactFallsBackToPrefersWhenOnlyPrefersPresent() {
+        val json = nativeArtifactJson(
+            """{ "prefers": "2.0.0" }"""
+        )
+
+        val dep = parseNativeArtifact(json, "linux_x64")?.dependencies?.single()
+
+        assertEquals("2.0.0", dep?.version)
+        assertEquals(false, dep?.strict)
+    }
+
+    @Test
+    fun parseNativeArtifactCarriesRejectsIncludingIntervalSyntax() {
+        val json = nativeArtifactJson(
+            """{ "requires": "1.7.0", "rejects": ["1.6.0", "[1.0.0,1.5.0)"] }"""
+        )
+
+        val dep = parseNativeArtifact(json, "linux_x64")?.dependencies?.single()
+
+        assertEquals("1.7.0", dep?.version)
+        assertEquals(listOf("1.6.0", "[1.0.0,1.5.0)"), dep?.rejects)
+    }
+
+    @Test
+    fun parseNativeArtifactDefaultsStrictFalseAndRejectsEmptyForBareRequires() {
+        val json = nativeArtifactJson(
+            """{ "requires": "1.0.0" }"""
+        )
+
+        val dep = parseNativeArtifact(json, "linux_x64")?.dependencies?.single()
+
+        assertEquals("1.0.0", dep?.version)
+        assertEquals(false, dep?.strict)
+        assertEquals(emptyList(), dep?.rejects)
+    }
+
+    private fun nativeArtifactJson(versionSpec: String): String = """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "dependencies": [
+                {
+                  "group": "com.example",
+                  "module": "lib",
+                  "version": $versionSpec
+                }
+              ],
+              "files": [
+                {
+                  "name": "x.klib",
+                  "url": "x-linuxx64-1.0.klib",
+                  "sha256": "abc"
+                }
+              ]
+            }
+          ]
+        }
+    """.trimIndent()
 }

--- a/src/nativeTest/kotlin/kolt/resolve/GradleMetadataTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/GradleMetadataTest.kt
@@ -778,6 +778,19 @@ class GradleMetadataTest {
     }
 
     @Test
+    fun parseNativeArtifactHandlesAllThreeVersionFieldsCoexisting() {
+        val json = nativeArtifactJson(
+            """{ "strictly": "1.5.0", "requires": "1.7.0", "rejects": ["1.6.0"] }"""
+        )
+
+        val dep = parseNativeArtifact(json, "linux_x64")?.dependencies?.single()
+
+        assertEquals("1.5.0", dep?.version)
+        assertEquals(true, dep?.strict)
+        assertEquals(listOf("1.6.0"), dep?.rejects)
+    }
+
+    @Test
     fun parseNativeArtifactDefaultsStrictFalseAndRejectsEmptyForBareRequires() {
         val json = nativeArtifactJson(
             """{ "requires": "1.0.0" }"""

--- a/src/nativeTest/kotlin/kolt/resolve/GradleMetadataTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/GradleMetadataTest.kt
@@ -771,6 +771,13 @@ class GradleMetadataTest {
     }
 
     @Test
+    fun parseNativeArtifactReturnsNullWhenDepHasNoVersionAtAll() {
+        val json = nativeArtifactJson("""{}""")
+
+        assertNull(parseNativeArtifact(json, "linux_x64"))
+    }
+
+    @Test
     fun parseNativeArtifactDefaultsStrictFalseAndRejectsEmptyForBareRequires() {
         val json = nativeArtifactJson(
             """{ "requires": "1.0.0" }"""

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -385,6 +385,141 @@ class NativeResolverTest {
     }
 
     @Test
+    fun rejectsExactVersionBlocksTransitiveUpgrade() {
+        val config = testConfig(target = "linuxX64").copy(
+            dependencies = mapOf(
+                "com.example:a" to "1.0.0",
+                "com.example:b" to "1.0.0"
+            )
+        )
+
+        val aRoot = rootModuleJson("com.example", "a-linuxx64", "1.0.0")
+        val aPlatform = platformModuleJson(
+            "a-linuxx64-1.0.0.klib", "h-a",
+            listOf(NativeDependency("com.example", "shared", "1.0.0", rejects = listOf("2.0.0")))
+        )
+        val bRoot = rootModuleJson("com.example", "b-linuxx64", "1.0.0")
+        val bPlatform = platformModuleJson(
+            "b-linuxx64-1.0.0.klib", "h-b",
+            listOf(NativeDependency("com.example", "shared", "2.0.0"))
+        )
+        val sharedRoot10 = rootModuleJson("com.example", "shared-linuxx64", "1.0.0")
+        val sharedPlatform10 = platformModuleJson("shared-linuxx64-1.0.0.klib", "h-s10", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/a/1.0.0/a-1.0.0.module" to aRoot,
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.module" to aPlatform,
+                "/cache/com/example/b/1.0.0/b-1.0.0.module" to bRoot,
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.module" to bPlatform,
+                "/cache/com/example/shared/1.0.0/shared-1.0.0.module" to sharedRoot10,
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.module" to sharedPlatform10
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.klib" to "h-a",
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.klib" to "h-b",
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.klib" to "h-s10"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        val shared = resolved.deps.first { it.groupArtifact == "com.example:shared" }
+        assertEquals("1.0.0", shared.version)
+    }
+
+    @Test
+    fun rejectsIntervalBlocksTransitiveUpgrade() {
+        val config = testConfig(target = "linuxX64").copy(
+            dependencies = mapOf(
+                "com.example:a" to "1.0.0",
+                "com.example:b" to "1.0.0"
+            )
+        )
+
+        val aRoot = rootModuleJson("com.example", "a-linuxx64", "1.0.0")
+        val aPlatform = platformModuleJson(
+            "a-linuxx64-1.0.0.klib", "h-a",
+            listOf(NativeDependency("com.example", "shared", "1.0.0", rejects = listOf("[2.0.0,)")))
+        )
+        val bRoot = rootModuleJson("com.example", "b-linuxx64", "1.0.0")
+        val bPlatform = platformModuleJson(
+            "b-linuxx64-1.0.0.klib", "h-b",
+            listOf(NativeDependency("com.example", "shared", "2.5.0"))
+        )
+        val sharedRoot10 = rootModuleJson("com.example", "shared-linuxx64", "1.0.0")
+        val sharedPlatform10 = platformModuleJson("shared-linuxx64-1.0.0.klib", "h-s10", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/a/1.0.0/a-1.0.0.module" to aRoot,
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.module" to aPlatform,
+                "/cache/com/example/b/1.0.0/b-1.0.0.module" to bRoot,
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.module" to bPlatform,
+                "/cache/com/example/shared/1.0.0/shared-1.0.0.module" to sharedRoot10,
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.module" to sharedPlatform10
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.klib" to "h-a",
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.klib" to "h-b",
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.klib" to "h-s10"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        val shared = resolved.deps.first { it.groupArtifact == "com.example:shared" }
+        assertEquals("1.0.0", shared.version)
+    }
+
+    // Known approximation: once a version is accepted it is not revoked by a
+    // later-seen rejects. The BFS pre-selection means contributor order affects
+    // the outcome in this pathological case.
+    @Test
+    fun rejectsDoNotRevokeAlreadyAcceptedVersionFromEarlierContributor() {
+        val config = testConfig(target = "linuxX64").copy(
+            dependencies = mapOf(
+                "com.example:a" to "1.0.0",
+                "com.example:b" to "1.0.0"
+            )
+        )
+
+        val aRoot = rootModuleJson("com.example", "a-linuxx64", "1.0.0")
+        val aPlatform = platformModuleJson(
+            "a-linuxx64-1.0.0.klib", "h-a",
+            listOf(NativeDependency("com.example", "shared", "2.0.0"))
+        )
+        val bRoot = rootModuleJson("com.example", "b-linuxx64", "1.0.0")
+        val bPlatform = platformModuleJson(
+            "b-linuxx64-1.0.0.klib", "h-b",
+            listOf(NativeDependency("com.example", "shared", "1.0.0", rejects = listOf("2.0.0")))
+        )
+        val sharedRoot20 = rootModuleJson("com.example", "shared-linuxx64", "2.0.0")
+        val sharedPlatform20 = platformModuleJson("shared-linuxx64-2.0.0.klib", "h-s20", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/a/1.0.0/a-1.0.0.module" to aRoot,
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.module" to aPlatform,
+                "/cache/com/example/b/1.0.0/b-1.0.0.module" to bRoot,
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.module" to bPlatform,
+                "/cache/com/example/shared/2.0.0/shared-2.0.0.module" to sharedRoot20,
+                "/cache/com/example/shared-linuxx64/2.0.0/shared-linuxx64-2.0.0.module" to sharedPlatform20
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.klib" to "h-a",
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.klib" to "h-b",
+                "/cache/com/example/shared-linuxx64/2.0.0/shared-linuxx64-2.0.0.klib" to "h-s20"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        val shared = resolved.deps.first { it.groupArtifact == "com.example:shared" }
+        assertEquals("2.0.0", shared.version)
+    }
+
+    @Test
     fun failsOnInvalidCoordinate() {
         val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf("invalid-no-colon" to "1.0.0")
@@ -446,11 +581,19 @@ class NativeResolverTest {
         dependencies: List<NativeDependency>
     ): String {
         val depsJson = dependencies.joinToString(",\n") { d ->
+            val versionParts = buildList {
+                if (d.strict) add(""""strictly": "${d.version}"""")
+                else add(""""requires": "${d.version}"""")
+                if (d.rejects.isNotEmpty()) {
+                    val list = d.rejects.joinToString(",") { "\"$it\"" }
+                    add(""""rejects": [$list]""")
+                }
+            }
             """
               {
                 "group": "${d.group}",
                 "module": "${d.module}",
-                "version": { "requires": "${d.version}" }
+                "version": { ${versionParts.joinToString(", ")} }
               }
             """.trimIndent()
         }

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -520,6 +520,182 @@ class NativeResolverTest {
     }
 
     @Test
+    fun strictlyPinSelectsLowerVersionOverTransitiveHighestWins() {
+        val config = testConfig(target = "linuxX64").copy(
+            dependencies = mapOf(
+                "com.example:a" to "1.0.0",
+                "com.example:b" to "1.0.0"
+            )
+        )
+
+        val aRoot = rootModuleJson("com.example", "a-linuxx64", "1.0.0")
+        val aPlatform = platformModuleJson(
+            "a-linuxx64-1.0.0.klib", "h-a",
+            listOf(NativeDependency("com.example", "shared", "1.0.0", strict = true))
+        )
+        val bRoot = rootModuleJson("com.example", "b-linuxx64", "1.0.0")
+        val bPlatform = platformModuleJson(
+            "b-linuxx64-1.0.0.klib", "h-b",
+            listOf(NativeDependency("com.example", "shared", "1.0.0"))
+        )
+        val sharedRoot10 = rootModuleJson("com.example", "shared-linuxx64", "1.0.0")
+        val sharedPlatform10 = platformModuleJson("shared-linuxx64-1.0.0.klib", "h-s10", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/a/1.0.0/a-1.0.0.module" to aRoot,
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.module" to aPlatform,
+                "/cache/com/example/b/1.0.0/b-1.0.0.module" to bRoot,
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.module" to bPlatform,
+                "/cache/com/example/shared/1.0.0/shared-1.0.0.module" to sharedRoot10,
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.module" to sharedPlatform10
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.klib" to "h-a",
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.klib" to "h-b",
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.klib" to "h-s10"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        val shared = resolved.deps.first { it.groupArtifact == "com.example:shared" }
+        assertEquals("1.0.0", shared.version)
+    }
+
+    @Test
+    fun strictlyConflictWithHigherTransitiveProposalFailsFast() {
+        val config = testConfig(target = "linuxX64").copy(
+            dependencies = mapOf(
+                "com.example:a" to "1.0.0",
+                "com.example:b" to "1.0.0"
+            )
+        )
+
+        val aRoot = rootModuleJson("com.example", "a-linuxx64", "1.0.0")
+        val aPlatform = platformModuleJson(
+            "a-linuxx64-1.0.0.klib", "h-a",
+            listOf(NativeDependency("com.example", "shared", "1.0.0", strict = true))
+        )
+        val bRoot = rootModuleJson("com.example", "b-linuxx64", "1.0.0")
+        val bPlatform = platformModuleJson(
+            "b-linuxx64-1.0.0.klib", "h-b",
+            listOf(NativeDependency("com.example", "shared", "2.0.0"))
+        )
+        val sharedRoot10 = rootModuleJson("com.example", "shared-linuxx64", "1.0.0")
+        val sharedPlatform10 = platformModuleJson("shared-linuxx64-1.0.0.klib", "h-s10", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/a/1.0.0/a-1.0.0.module" to aRoot,
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.module" to aPlatform,
+                "/cache/com/example/b/1.0.0/b-1.0.0.module" to bRoot,
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.module" to bPlatform,
+                "/cache/com/example/shared/1.0.0/shared-1.0.0.module" to sharedRoot10,
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.module" to sharedPlatform10
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.klib" to "h-a",
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.klib" to "h-b",
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.klib" to "h-s10"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val error = assertIs<ResolveError.StrictVersionConflict>(result.getError())
+        assertEquals("com.example:shared", error.groupArtifact)
+        assertEquals("1.0.0", error.strictVersion)
+        assertEquals("2.0.0", error.otherVersion)
+    }
+
+    @Test
+    fun conflictingStrictPinsFromDifferentTransitivesFailFast() {
+        val config = testConfig(target = "linuxX64").copy(
+            dependencies = mapOf(
+                "com.example:a" to "1.0.0",
+                "com.example:b" to "1.0.0"
+            )
+        )
+
+        val aRoot = rootModuleJson("com.example", "a-linuxx64", "1.0.0")
+        val aPlatform = platformModuleJson(
+            "a-linuxx64-1.0.0.klib", "h-a",
+            listOf(NativeDependency("com.example", "shared", "1.0.0", strict = true))
+        )
+        val bRoot = rootModuleJson("com.example", "b-linuxx64", "1.0.0")
+        val bPlatform = platformModuleJson(
+            "b-linuxx64-1.0.0.klib", "h-b",
+            listOf(NativeDependency("com.example", "shared", "1.5.0", strict = true))
+        )
+        val sharedRoot10 = rootModuleJson("com.example", "shared-linuxx64", "1.0.0")
+        val sharedPlatform10 = platformModuleJson("shared-linuxx64-1.0.0.klib", "h-s10", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/a/1.0.0/a-1.0.0.module" to aRoot,
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.module" to aPlatform,
+                "/cache/com/example/b/1.0.0/b-1.0.0.module" to bRoot,
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.module" to bPlatform,
+                "/cache/com/example/shared/1.0.0/shared-1.0.0.module" to sharedRoot10,
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.module" to sharedPlatform10
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.klib" to "h-a",
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.klib" to "h-b",
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.klib" to "h-s10"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val error = assertIs<ResolveError.StrictVersionConflict>(result.getError())
+        assertEquals("com.example:shared", error.groupArtifact)
+    }
+
+    @Test
+    fun strictPinAgreeingWithEarlierTransitiveResolvesCleanly() {
+        val config = testConfig(target = "linuxX64").copy(
+            dependencies = mapOf(
+                "com.example:a" to "1.0.0",
+                "com.example:b" to "1.0.0"
+            )
+        )
+
+        val aRoot = rootModuleJson("com.example", "a-linuxx64", "1.0.0")
+        val aPlatform = platformModuleJson(
+            "a-linuxx64-1.0.0.klib", "h-a",
+            listOf(NativeDependency("com.example", "shared", "1.0.0"))
+        )
+        val bRoot = rootModuleJson("com.example", "b-linuxx64", "1.0.0")
+        val bPlatform = platformModuleJson(
+            "b-linuxx64-1.0.0.klib", "h-b",
+            listOf(NativeDependency("com.example", "shared", "1.0.0", strict = true))
+        )
+        val sharedRoot10 = rootModuleJson("com.example", "shared-linuxx64", "1.0.0")
+        val sharedPlatform10 = platformModuleJson("shared-linuxx64-1.0.0.klib", "h-s10", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/a/1.0.0/a-1.0.0.module" to aRoot,
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.module" to aPlatform,
+                "/cache/com/example/b/1.0.0/b-1.0.0.module" to bRoot,
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.module" to bPlatform,
+                "/cache/com/example/shared/1.0.0/shared-1.0.0.module" to sharedRoot10,
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.module" to sharedPlatform10
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.klib" to "h-a",
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.klib" to "h-b",
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.klib" to "h-s10"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        val shared = resolved.deps.first { it.groupArtifact == "com.example:shared" }
+        assertEquals("1.0.0", shared.version)
+    }
+
+    @Test
     fun failsOnInvalidCoordinate() {
         val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf("invalid-no-colon" to "1.0.0")

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -472,11 +472,8 @@ class NativeResolverTest {
         assertEquals("1.0.0", shared.version)
     }
 
-    // Known approximation: once a version is accepted it is not revoked by a
-    // later-seen rejects. The BFS pre-selection means contributor order affects
-    // the outcome in this pathological case.
     @Test
-    fun rejectsDoNotRevokeAlreadyAcceptedVersionFromEarlierContributor() {
+    fun rejectsFromLaterContributorRevokesAlreadyAcceptedVersion() {
         val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf(
                 "com.example:a" to "1.0.0",
@@ -514,9 +511,46 @@ class NativeResolverTest {
         )
 
         val result = resolveNative(config, "/cache", deps)
-        val resolved = assertNotNull(result.get())
-        val shared = resolved.deps.first { it.groupArtifact == "com.example:shared" }
-        assertEquals("2.0.0", shared.version)
+        val error = assertIs<ResolveError.RejectedVersionResolved>(result.getError())
+        assertEquals("com.example:shared", error.groupArtifact)
+        assertEquals("2.0.0", error.version)
+        assertEquals("2.0.0", error.rejectPattern)
+    }
+
+    @Test
+    fun rejectsMatchingDirectDepVersionFailsFast() {
+        val config = testConfig(target = "linuxX64").copy(
+            dependencies = mapOf(
+                "com.example:shared" to "1.0.0",
+                "com.example:b" to "1.0.0"
+            )
+        )
+
+        val sharedRoot = rootModuleJson("com.example", "shared-linuxx64", "1.0.0")
+        val sharedPlatform = platformModuleJson("shared-linuxx64-1.0.0.klib", "h-s10", emptyList())
+        val bRoot = rootModuleJson("com.example", "b-linuxx64", "1.0.0")
+        val bPlatform = platformModuleJson(
+            "b-linuxx64-1.0.0.klib", "h-b",
+            listOf(NativeDependency("com.example", "shared", "2.0.0", rejects = listOf("1.0.0")))
+        )
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/shared/1.0.0/shared-1.0.0.module" to sharedRoot,
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.module" to sharedPlatform,
+                "/cache/com/example/b/1.0.0/b-1.0.0.module" to bRoot,
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.module" to bPlatform
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.klib" to "h-s10",
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.klib" to "h-b"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val error = assertIs<ResolveError.RejectedVersionResolved>(result.getError())
+        assertEquals("com.example:shared", error.groupArtifact)
+        assertEquals("1.0.0", error.version)
     }
 
     @Test

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -640,6 +640,7 @@ class NativeResolverTest {
         assertEquals("com.example:shared", error.groupArtifact)
         assertEquals("1.0.0", error.strictVersion)
         assertEquals("2.0.0", error.otherVersion)
+        assertFalse(error.otherIsStrict)
     }
 
     @Test
@@ -683,6 +684,57 @@ class NativeResolverTest {
         val result = resolveNative(config, "/cache", deps)
         val error = assertIs<ResolveError.StrictVersionConflict>(result.getError())
         assertEquals("com.example:shared", error.groupArtifact)
+        assertTrue(error.otherIsStrict)
+        assertTrue(formatResolveError(error).contains("conflicting strict versions"))
+    }
+
+    @Test
+    fun depWithBothStrictlyAndRejectsHonorsBothConstraints() {
+        val config = testConfig(target = "linuxX64").copy(
+            dependencies = mapOf(
+                "com.example:a" to "1.0.0",
+                "com.example:b" to "1.0.0"
+            )
+        )
+
+        val aRoot = rootModuleJson("com.example", "a-linuxx64", "1.0.0")
+        val aPlatform = platformModuleJson(
+            "a-linuxx64-1.0.0.klib", "h-a",
+            listOf(
+                NativeDependency(
+                    "com.example", "shared", "1.0.0",
+                    strict = true, rejects = listOf("2.0.0")
+                )
+            )
+        )
+        val bRoot = rootModuleJson("com.example", "b-linuxx64", "1.0.0")
+        val bPlatform = platformModuleJson(
+            "b-linuxx64-1.0.0.klib", "h-b",
+            listOf(NativeDependency("com.example", "shared", "2.0.0"))
+        )
+        val sharedRoot10 = rootModuleJson("com.example", "shared-linuxx64", "1.0.0")
+        val sharedPlatform10 = platformModuleJson("shared-linuxx64-1.0.0.klib", "h-s10", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/a/1.0.0/a-1.0.0.module" to aRoot,
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.module" to aPlatform,
+                "/cache/com/example/b/1.0.0/b-1.0.0.module" to bRoot,
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.module" to bPlatform,
+                "/cache/com/example/shared/1.0.0/shared-1.0.0.module" to sharedRoot10,
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.module" to sharedPlatform10
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.klib" to "h-a",
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.klib" to "h-b",
+                "/cache/com/example/shared-linuxx64/1.0.0/shared-linuxx64-1.0.0.klib" to "h-s10"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        val shared = resolved.deps.first { it.groupArtifact == "com.example:shared" }
+        assertEquals("1.0.0", shared.version)
     }
 
     @Test

--- a/src/nativeTest/kotlin/kolt/resolve/VersionCompareTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/VersionCompareTest.kt
@@ -219,4 +219,31 @@ class VersionCompareTest {
         val vc = parseVersionConstraint("(1.0.0,2.0.0)")
         assertFalse(vc.interval!!.contains("1.0.0"))
     }
+
+    // --- matchesRejectPattern ---
+
+    @Test
+    fun rejectExactVersionMatchesIdenticalString() {
+        assertTrue(matchesRejectPattern("1.6.0", "1.6.0"))
+    }
+
+    @Test
+    fun rejectExactVersionDoesNotMatchDifferentString() {
+        assertFalse(matchesRejectPattern("1.7.0", "1.6.0"))
+    }
+
+    @Test
+    fun rejectIntervalMatchesVersionInRange() {
+        assertTrue(matchesRejectPattern("1.2.0", "[1.0.0,1.5.0)"))
+    }
+
+    @Test
+    fun rejectIntervalExcludesVersionAtExclusiveUpperBound() {
+        assertFalse(matchesRejectPattern("1.5.0", "[1.0.0,1.5.0)"))
+    }
+
+    @Test
+    fun rejectUnboundedUpperIntervalMatchesAnyHigherVersion() {
+        assertTrue(matchesRejectPattern("3.0.0", "[2.0.0,)"))
+    }
 }


### PR DESCRIPTION
Closes #54.

Gradle module metadata's `version` object supports four fields; kolt's native resolver previously only read `requires`. Libraries that start publishing `strictly` (forced pin) or `rejects` (blacklist) would be silently misresolved. This PR fixes that.

## What to look at

**Selection precedence (commit 1, `GradleMetadata.kt`).** `selectedVersion()` picks `strictly > requires > prefers` per declaration. `NativeDependency` grows `strict: Boolean` and `rejects: List<String>` with defaults, so existing call sites compile unchanged.

**Rejects filter (commit 2, `NativeResolver.kt`).** Accumulated per groupArtifact across all contributors — Gradle's model is "rejects applies to the GA, not to the declaring dep". Matching reuses `parseVersionConstraint` so both exact versions (`"1.6.0"`) and intervals (`"[1.0.0,1.5.0)"`) work. **Known approximation:** an already-accepted version is not revoked by a later-seen rejects, because the BFS can't re-queue. Pinned by the `rejectsDoNotRevokeAlreadyAcceptedVersion…` regression test so the limit stays visible.

**Strict conflict (commit 3, `NativeResolver.kt`, `Resolver.kt`).** Fail-fast. Any non-matching proposal (strict-vs-strict mismatch, strict vs earlier non-strict, strict pin vs later higher transitive) returns `ResolveError.StrictVersionConflict`. Gradle would attempt to satisfy by downgrading; kolt's BFS can't, so fail-fast avoids silent misresolution — which is the exact failure mode issue #54 called out.

**Maven side.** POM has no equivalents; `Resolution.kt` is unchanged. The only shared surface is `matchesRejectPattern` in `VersionCompare.kt`, which delegates to `parseVersionConstraint` (already used by the Maven path).