### PR TITLE
Fail compile fast when LOCK file cannot be created (#201)

### DIFF
--- a/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
+++ b/kolt-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
@@ -5,6 +5,7 @@ package kolt.daemon.ic
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
 import org.jetbrains.kotlin.buildtools.api.BuildOperation
 import org.jetbrains.kotlin.buildtools.api.CompilationResult
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
@@ -111,15 +112,11 @@ class BtaIncrementalCompiler private constructor(
         // exists, which is the common case for every non-initial request.
         Files.createDirectories(request.workingDir)
 
-        // #199: LOCK acquisition must be the first action on workingDir
-        // after `createDirectories(workingDir)` creates the dir itself.
-        // The IcReaper (documented in IcReaper.kt) treats LOCK as the
-        // invariant that proves a dir is alive — any write before LOCK
-        // leaves a window where a concurrent-daemon-boot reaper can
-        // wipe the dir. Order below: create workingDir → take LOCK →
-        // create BTA subdir → write breadcrumb.
-        runCatching { ensureLock(request.workingDir) }
-            .onFailure { metrics.record(METRIC_REAPER_LOCK_FAILED) }
+        // LOCK must be the first write on workingDir — IcReaper treats
+        // LOCK-existence as proof the dir is alive, so any earlier write
+        // opens a concurrent-boot wipe window. Contended LOCK continues:
+        // reaper keys off existence, not ownership.
+        ensureLock(request.workingDir).getOrElse { return Err(it) }
 
         val btaWorkingDir = request.workingDir.resolve(BTA_SUBDIR)
         val wasEmptyBeforeCompile = isEmptyDir(btaWorkingDir)
@@ -300,11 +297,14 @@ class BtaIncrementalCompiler private constructor(
         // already URL/FS-safe enough to serve as a kotlinc module name.
         "kolt-${request.projectId}"
 
-    private fun ensureLock(workingDir: Path) {
+    // Err = LOCK file could not be created; caller must abort before any
+    // non-LOCK write. Ok = either we hold it or another owner does
+    // (reaper's existence probe is load-bearing in both cases).
+    private fun ensureLock(workingDir: Path): Result<Unit, IcError.InternalError> {
         val lockPath = workingDir.resolve(LOCK_FILE)
         val cached = heldLocks[workingDir]
         if (cached != null && cached.lock.isValid && Files.isRegularFile(lockPath)) {
-            return
+            return Ok(Unit)
         }
         if (cached != null) {
             // Stale cache entry: either the lock was released or
@@ -314,12 +314,23 @@ class BtaIncrementalCompiler private constructor(
             runCatching { cached.channel.close() }
             heldLocks.remove(workingDir)
         }
-        val channel = FileChannel.open(
-            lockPath,
-            StandardOpenOption.CREATE,
-            StandardOpenOption.READ,
-            StandardOpenOption.WRITE,
-        )
+        val channel = try {
+            FileChannel.open(
+                lockPath,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE,
+            )
+        } catch (vme: VirtualMachineError) {
+            throw vme
+        } catch (t: Throwable) {
+            // Disk full, EACCES, FS error, or LOCK path collides with a
+            // non-file entry (EISDIR → `FileSystemException`). Self-heal's
+            // wipe+retry does not help — the same failure recurs — so
+            // surface InternalError and let the caller abort.
+            metrics.record(METRIC_REAPER_LOCK_FAILED)
+            return Err(IcError.InternalError(t))
+        }
         val lock: FileLock? = try {
             channel.tryLock()
         } catch (_: OverlappingFileLockException) {
@@ -328,9 +339,10 @@ class BtaIncrementalCompiler private constructor(
         if (lock == null) {
             channel.close()
             metrics.record(METRIC_REAPER_LOCK_CONFLICT)
-            return
+            return Ok(Unit)
         }
         heldLocks[workingDir] = HeldLock(channel, lock)
+        return Ok(Unit)
     }
 
     private fun isEmptyDir(workingDir: Path): Boolean {

--- a/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalLockFailureTest.kt
+++ b/kolt-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalLockFailureTest.kt
@@ -1,0 +1,144 @@
+@file:OptIn(kotlin.io.path.ExperimentalPathApi::class)
+
+package kolt.daemon.ic
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import java.io.File
+import java.nio.channels.FileChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class BtaIncrementalLockFailureTest {
+
+    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+
+    @Test
+    fun `LOCK file creation failure fails compile with InternalError and skips subsequent writes`() {
+        val workRoot = Files.createTempDirectory("bta-lock-fail-")
+        val sourceFile = workRoot.resolve("Main.kt").also {
+            it.writeText(
+                """
+                package fixture
+                object Main { fun greeting(): String = "hi" }
+                """.trimIndent(),
+            )
+        }
+        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+        val workingDir = workRoot.resolve("ic").apply { createDirectories() }
+        // Precreate LOCK as a directory so `FileChannel.open(lockPath,
+        // CREATE, READ, WRITE)` cannot open it — EISDIR on Linux surfaces
+        // as `FileSystemException` from the JDK.
+        workingDir.resolve("LOCK").createDirectories()
+
+        val metrics = RecordingMetricsSink()
+        val compiler = BtaIncrementalCompiler.create(
+            btaImplJars = btaImplJars,
+            metrics = metrics,
+        ).getOrElse { fail("failed to load BTA toolchain: $it") }
+
+        val err = compiler.compile(
+            IcRequest(
+                projectId = "lock-failure-smoke",
+                projectRoot = workRoot,
+                sources = listOf(sourceFile),
+                classpath = fixtureClasspath,
+                outputDir = outputDir,
+                workingDir = workingDir,
+            ),
+        ).getError() ?: fail("expected Err when LOCK file cannot be created")
+
+        assertTrue(err is IcError.InternalError, "expected InternalError, got $err")
+        val counterNames = metrics.events.map { it.first }.toSet()
+        assertTrue(
+            "reaper.lock_failed" in counterNames,
+            "expected reaper.lock_failed metric, got: $counterNames",
+        )
+        // If ensureLock failed but compile continued, breadcrumb would leak here.
+        assertTrue(
+            !Files.exists(workingDir.resolve("project.path")),
+            "breadcrumb must not be written when ensureLock failed",
+        )
+    }
+
+    @Test
+    fun `LOCK held by another owner lets compile proceed and records lock_conflict`() {
+        val workRoot = Files.createTempDirectory("bta-lock-conflict-")
+        val sourceFile = workRoot.resolve("Main.kt").also {
+            it.writeText(
+                """
+                package fixture
+                object Main { fun greeting(): String = "hi" }
+                """.trimIndent(),
+            )
+        }
+        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+        val workingDir = workRoot.resolve("ic").apply { createDirectories() }
+        val lockPath = workingDir.resolve("LOCK")
+
+        // Holding an exclusive FileLock from another channel in the same JVM
+        // makes the adapter's subsequent `tryLock` raise
+        // `OverlappingFileLockException` (a different process would instead
+        // get `null`). Both converge at `if (lock == null)`, so this one
+        // fixture covers both the same-JVM and cross-process paths.
+        FileChannel.open(
+            lockPath,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.READ,
+            StandardOpenOption.WRITE,
+        ).use { holder ->
+            holder.lock().use {
+                val metrics = RecordingMetricsSink()
+                val compiler = BtaIncrementalCompiler.create(
+                    btaImplJars = btaImplJars,
+                    metrics = metrics,
+                ).getOrElse { fail("failed to load BTA toolchain: $it") }
+
+                compiler.compile(
+                    IcRequest(
+                        projectId = "lock-conflict-smoke",
+                        projectRoot = workRoot,
+                        sources = listOf(sourceFile),
+                        classpath = fixtureClasspath,
+                        outputDir = outputDir,
+                        workingDir = workingDir,
+                    ),
+                ).getOrElse { fail("expected success despite lock conflict, got Err($it)") }
+
+                val counterNames = metrics.events.map { it.first }.toSet()
+                assertTrue(
+                    "reaper.lock_conflict" in counterNames,
+                    "expected reaper.lock_conflict metric, got: $counterNames",
+                )
+                assertEquals(
+                    false,
+                    "reaper.lock_failed" in counterNames,
+                    "must not record lock_failed when LOCK file already exists, got: $counterNames",
+                )
+            }
+        }
+    }
+
+    private class RecordingMetricsSink : IcMetricsSink {
+        val events: MutableList<Pair<String, Long>> = mutableListOf()
+        override fun record(name: String, value: Long) {
+            events += name to value
+        }
+    }
+
+    private fun systemClasspath(key: String): List<Path> {
+        val raw = System.getProperty(key)
+            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        return raw.split(File.pathSeparator)
+            .filter { it.isNotBlank() }
+            .map { Path.of(it) }
+    }
+}


### PR DESCRIPTION
Closes #201.

`ensureLock` used to swallow every failure: a `FileChannel.open` throw left workingDir without a LOCK file, and the compile still wrote breadcrumb + BTA state — reopening the #199 race at a smaller cross-section. The other two modes (`tryLock` returning null, `OverlappingFileLockException`) stayed silent too.

`ensureLock` now returns `Result<Unit, IcError.InternalError>`, and `executeCompile` aborts on `Err`. Only the file-creation failure path maps to `Err` — contended LOCK (file exists, another owner holds it) still continues with the conflict metric, matching today's multi-owner semantics. The invariant sharpens to "if compile got past ensureLock, LOCK exists on disk".

**Testing.** Cheap stand-in for disk full / EACCES / FS error: precreate `workingDir/LOCK` as a directory so `FileChannel.open(..., CREATE, READ, WRITE)` hits EISDIR. The test asserts `Err(IcError.InternalError)`, the `reaper.lock_failed` metric, and — regression fence for the #199 shape — that the breadcrumb was never written. Cross-process `null` and same-JVM `OverlappingFileLockException` converge at `if (lock == null)`, so one same-JVM fixture (pre-acquire LOCK from a second FileChannel) covers both observable paths.

Scope stays writer-side — `IcReaper` and `tryDelete` unchanged.