### PR TITLE
Generate .gitignore and run git init on kolt init (#192, #193)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -108,9 +108,13 @@ internal fun doInit(args: List<String>): Result<Unit, Int> {
     return Ok(Unit)
 }
 
-// stderr is redirected so the "fatal: not a git repository" message from
-// git doesn't leak into kolt's output when we're *not* in a worktree —
-// that's the expected signal, not an error.
+// `executeAndCapture` only redirects stdout via popen("r"); git's
+// "fatal: not a git repository" still goes to the parent's stderr.
+// The 2>/dev/null is load-bearing: it suppresses that noise on the
+// expected non-zero-exit path (= cwd not in any worktree).
+// Any failure (popen error, missing git, weird permission denied) is
+// treated as "not in a worktree" — false negatives are safe (we'd
+// just create a fresh `.git/`); false positives would be worse.
 private fun isInsideExistingGitWorktree(): Boolean =
     executeAndCapture("git rev-parse --is-inside-work-tree 2>/dev/null").getError() == null
 

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -95,7 +95,7 @@ internal fun doInit(args: List<String>): Result<Unit, Int> {
         println("created $GITIGNORE")
     }
 
-    if (!fileExists(GIT_DIR)) {
+    if (!fileExists(GIT_DIR) && !isInsideExistingGitWorktree()) {
         val err = executeCommand(listOf("git", "init", "-q")).getError()
         if (err == null) {
             println("initialized git repository")
@@ -107,6 +107,12 @@ internal fun doInit(args: List<String>): Result<Unit, Int> {
     println("initialized project '$projectName'")
     return Ok(Unit)
 }
+
+// stderr is redirected so the "fatal: not a git repository" message from
+// git doesn't leak into kolt's output when we're *not* in a worktree —
+// that's the expected signal, not an error.
+private fun isInsideExistingGitWorktree(): Boolean =
+    executeAndCapture("git rev-parse --is-inside-work-tree 2>/dev/null").getError() == null
 
 internal fun doAdd(args: List<String>): Result<Unit, Int> {
     val addArgs = parseAddArgs(args).getOrElse { error ->

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -18,6 +18,8 @@ import platform.posix.PATH_MAX
 import platform.posix.getcwd
 
 private const val SRC_DIR = "src"
+private const val GITIGNORE = ".gitignore"
+private const val GIT_DIR = ".git"
 
 @OptIn(ExperimentalForeignApi::class)
 internal fun doInit(args: List<String>): Result<Unit, Int> {
@@ -83,6 +85,23 @@ internal fun doInit(args: List<String>): Result<Unit, Int> {
             return Err(EXIT_BUILD_ERROR)
         }
         println("created $testKtPath")
+    }
+
+    if (!fileExists(GITIGNORE)) {
+        writeFileAsString(GITIGNORE, generateGitignore()).getOrElse { error ->
+            eprintln("error: could not write ${error.path}")
+            return Err(EXIT_BUILD_ERROR)
+        }
+        println("created $GITIGNORE")
+    }
+
+    if (!fileExists(GIT_DIR)) {
+        val err = executeCommand(listOf("git", "init", "-q")).getError()
+        if (err == null) {
+            println("initialized git repository")
+        } else {
+            eprintln("warning: could not run git init (${formatProcessError(err, "git init")})")
+        }
     }
 
     println("initialized project '$projectName'")

--- a/src/nativeMain/kotlin/kolt/config/Init.kt
+++ b/src/nativeMain/kotlin/kolt/config/Init.kt
@@ -38,6 +38,8 @@ fun generateMainKt(): String = buildString {
     appendLine("}")
 }
 
+fun generateGitignore(): String = "build/\n"
+
 fun inferProjectName(dirPath: String): String {
     val name = dirPath.trimEnd('/').substringAfterLast('/')
     return name.ifEmpty { "project" }

--- a/src/nativeTest/kotlin/kolt/cli/DoInitTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DoInitTest.kt
@@ -2,7 +2,9 @@ package kolt.cli
 
 import com.github.michaelbull.result.getOrElse
 import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.executeCommand
 import kolt.infra.fileExists
+import kolt.infra.readFileAsString
 import kolt.infra.removeDirectoryRecursive
 import kolt.infra.writeFileAsString
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -16,10 +18,13 @@ import platform.posix.PATH_MAX
 import platform.posix.chdir
 import platform.posix.getcwd
 import platform.posix.mkdtemp
+import platform.posix.setenv
+import platform.posix.unsetenv
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalForeignApi::class)
@@ -35,10 +40,17 @@ class DoInitTest {
         }
         tmpDir = createTempDir("kolt-init-")
         check(chdir(tmpDir) == 0) { "chdir to $tmpDir failed" }
+        // Pins git's upward .git search to tmpDir's parent so the
+        // "outside any repo" tests see a clean state even when the tmp
+        // root happens to sit under a repo. Ceiling is the parent
+        // (not tmpDir itself) so the `skipsGitInitInsideExistingWorktree`
+        // test can still reach a `.git` we seed in tmpDir.
+        setenv("GIT_CEILING_DIRECTORIES", tmpDir.substringBeforeLast('/'), 1)
     }
 
     @AfterTest
     fun tearDown() {
+        unsetenv("GIT_CEILING_DIRECTORIES")
         chdir(originalCwd)
         if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
             removeDirectoryRecursive(tmpDir)
@@ -58,7 +70,7 @@ class DoInitTest {
 
         doInit(listOf("my-app")).getOrElse { error("doInit failed: exit=$it") }
 
-        val content = kolt.infra.readFileAsString(".gitignore").getOrElse { error("read failed") }
+        val content = readFileAsString(".gitignore").getOrElse { error("read failed") }
         assertEquals("custom\n", content)
     }
 
@@ -77,6 +89,35 @@ class DoInitTest {
         doInit(listOf("my-app")).getOrElse { error("doInit failed: exit=$it") }
 
         assertTrue(fileExists(".git/marker"), "existing .git/ must be left alone")
+        // Seed was a bare dir, not a real repo — `git init` would populate
+        // HEAD / objects / refs. Their absence proves init was skipped.
+        assertFalse(fileExists(".git/HEAD"), "git init must not run over existing .git/")
+    }
+
+    // Submodule / worktree gitlink — `.git` is a regular file pointing at a
+    // real gitdir elsewhere. `access(F_OK)` treats it as existing, so init
+    // is skipped. Pin the invariant.
+    @Test
+    fun leavesGitGitlinkFileUntouched() {
+        writeFileAsString(".git", "gitdir: ../other/.git/worktrees/w1\n")
+            .getOrElse { error("seed .git file failed") }
+
+        doInit(listOf("my-app")).getOrElse { error("doInit failed: exit=$it") }
+
+        val content = readFileAsString(".git").getOrElse { error("read failed") }
+        assertEquals("gitdir: ../other/.git/worktrees/w1\n", content)
+    }
+
+    @Test
+    fun skipsGitInitInsideExistingWorktree() {
+        // Make tmpDir a real repo, then run doInit from a subdirectory.
+        executeCommand(listOf("git", "init", "-q")).getOrElse { error("parent git init failed") }
+        ensureDirectoryRecursive("sub").getOrElse { error("mkdir sub failed") }
+        check(chdir("sub") == 0) { "chdir to sub failed" }
+
+        doInit(listOf("my-app")).getOrElse { error("doInit failed: exit=$it") }
+
+        assertFalse(fileExists(".git"), "nested .git must not be created inside an existing worktree")
     }
 
     private fun createTempDir(prefix: String): String {

--- a/src/nativeTest/kotlin/kolt/cli/DoInitTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DoInitTest.kt
@@ -1,0 +1,90 @@
+package kolt.cli
+
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.fileExists
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.chdir
+import platform.posix.getcwd
+import platform.posix.mkdtemp
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalForeignApi::class)
+class DoInitTest {
+    private var originalCwd: String = ""
+    private var tmpDir: String = ""
+
+    @BeforeTest
+    fun setUp() {
+        originalCwd = memScoped {
+            val buf = allocArray<ByteVar>(PATH_MAX)
+            getcwd(buf, PATH_MAX.toULong())?.toKString() ?: error("getcwd failed")
+        }
+        tmpDir = createTempDir("kolt-init-")
+        check(chdir(tmpDir) == 0) { "chdir to $tmpDir failed" }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        chdir(originalCwd)
+        if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
+            removeDirectoryRecursive(tmpDir)
+        }
+    }
+
+    @Test
+    fun writesGitignoreWhenAbsent() {
+        doInit(listOf("my-app")).getOrElse { error("doInit failed: exit=$it") }
+
+        assertTrue(fileExists(".gitignore"))
+    }
+
+    @Test
+    fun leavesExistingGitignoreUntouched() {
+        writeFileAsString(".gitignore", "custom\n").getOrElse { error("seed failed") }
+
+        doInit(listOf("my-app")).getOrElse { error("doInit failed: exit=$it") }
+
+        val content = kolt.infra.readFileAsString(".gitignore").getOrElse { error("read failed") }
+        assertEquals("custom\n", content)
+    }
+
+    @Test
+    fun runsGitInitWhenNoGitDir() {
+        doInit(listOf("my-app")).getOrElse { error("doInit failed: exit=$it") }
+
+        assertTrue(fileExists(".git"), ".git/ must exist after kolt init")
+    }
+
+    @Test
+    fun leavesExistingGitRepoUntouched() {
+        ensureDirectoryRecursive(".git").getOrElse { error("seed .git failed") }
+        writeFileAsString(".git/marker", "keep me").getOrElse { error("seed marker failed") }
+
+        doInit(listOf("my-app")).getOrElse { error("doInit failed: exit=$it") }
+
+        assertTrue(fileExists(".git/marker"), "existing .git/ must be left alone")
+    }
+
+    private fun createTempDir(prefix: String): String {
+        val template = "/tmp/${prefix}XXXXXX"
+        val buf = template.encodeToByteArray().copyOf(template.length + 1)
+        buf.usePinned { pinned ->
+            val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+            return result.toKString()
+        }
+    }
+}

--- a/src/nativeTest/kotlin/kolt/config/InitTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/InitTest.kt
@@ -75,6 +75,11 @@ class InitTest {
     }
 
     @Test
+    fun generateGitignoreContainsBuildDir() {
+        assertEquals("build/\n", generateGitignore())
+    }
+
+    @Test
     fun invalidProjectNames() {
         assertFalse(isValidProjectName(""))
         assertFalse(isValidProjectName("my\"app"))


### PR DESCRIPTION
Closes #192, #193.

`kolt init` now writes `.gitignore` (single-line `build/`) and runs `git init -q`
in fresh projects. Existing `.gitignore` / `.git/` are left alone, matching the
idempotency of `Main.kt` / `MainTest.kt` generation.

`git init` failure is downgraded to a warning. Users without git installed still
get a usable project skeleton — review point: is warning-and-continue the right
call, or should missing-git abort init?

Filesystem behavior is covered by the new `DoInitTest` (mkdtemp + chdir). The
pure `generateGitignore()` helper has a unit test in `InitTest`.