### PR TITLE
Add kolt cache clean (#25)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/CacheCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/CacheCommands.kt
@@ -4,7 +4,9 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
+import kolt.config.KoltPaths
 import kolt.config.resolveKoltPaths
+import kolt.infra.RemoveFailed
 import kolt.infra.directorySize
 import kolt.infra.eprintln
 import kolt.infra.fileExists
@@ -12,6 +14,7 @@ import kolt.infra.formatBytes
 import kolt.infra.removeDirectoryRecursive
 
 internal data class CacheCleanArgs(val includeTools: Boolean)
+internal data class CacheCleanSummary(val removedPaths: List<String>, val freedBytes: Long)
 
 internal fun parseCacheCleanArgs(args: List<String>): Result<CacheCleanArgs, String> {
     var includeTools = false
@@ -38,6 +41,21 @@ internal fun doCache(args: List<String>): Result<Unit, Int> {
     }
 }
 
+internal fun cleanCacheDirs(paths: KoltPaths, includeTools: Boolean): Result<CacheCleanSummary, RemoveFailed> {
+    val targets = mutableListOf(paths.cacheBase)
+    if (includeTools) targets.add(paths.toolsDir)
+
+    val removed = mutableListOf<String>()
+    var freed = 0L
+    for (target in targets) {
+        if (!fileExists(target)) continue
+        freed += directorySize(target)
+        removeDirectoryRecursive(target).getOrElse { return Err(it) }
+        removed.add(target)
+    }
+    return Ok(CacheCleanSummary(removed, freed))
+}
+
 private fun doCacheClean(args: List<String>): Result<Unit, Int> {
     val parsed = parseCacheCleanArgs(args).getOrElse { error ->
         eprintln(error)
@@ -47,24 +65,16 @@ private fun doCacheClean(args: List<String>): Result<Unit, Int> {
 
     val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_CONFIG_ERROR) }
 
-    val targets = mutableListOf(paths.cacheBase)
-    if (parsed.includeTools) targets.add(paths.toolsDir)
-
-    var freed = 0L
-    for (target in targets) {
-        if (!fileExists(target)) continue
-        freed += directorySize(target)
-        removeDirectoryRecursive(target).getOrElse { err ->
-            eprintln("error: could not remove ${err.path}")
-            return Err(EXIT_BUILD_ERROR)
-        }
-        println("removed $target")
+    val summary = cleanCacheDirs(paths, parsed.includeTools).getOrElse { err ->
+        eprintln("error: could not remove ${err.path}")
+        return Err(EXIT_BUILD_ERROR)
     }
 
-    if (freed == 0L) {
+    for (path in summary.removedPaths) println("removed $path")
+    if (summary.freedBytes == 0L) {
         println("nothing to clean")
     } else {
-        println("freed ${formatBytes(freed)}")
+        println("freed ${formatBytes(summary.freedBytes)}")
     }
     return Ok(Unit)
 }

--- a/src/nativeMain/kotlin/kolt/cli/CacheCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/CacheCommands.kt
@@ -3,6 +3,7 @@ package kolt.cli
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltPaths
 import kolt.config.resolveKoltPaths
@@ -14,7 +15,16 @@ import kolt.infra.formatBytes
 import kolt.infra.removeDirectoryRecursive
 
 internal data class CacheCleanArgs(val includeTools: Boolean)
-internal data class CacheCleanSummary(val removedPaths: List<String>, val freedBytes: Long)
+
+// `error` is non-null when removal of one of the targets fails; the
+// `removedPaths` and `freedBytes` fields still report whatever was
+// successfully cleared up to that point so the caller can tell the
+// user how much was reclaimed before the failure.
+internal data class CacheCleanResult(
+    val removedPaths: List<String>,
+    val freedBytes: Long,
+    val error: RemoveFailed? = null,
+)
 
 internal fun parseCacheCleanArgs(args: List<String>): Result<CacheCleanArgs, String> {
     var includeTools = false
@@ -41,7 +51,7 @@ internal fun doCache(args: List<String>): Result<Unit, Int> {
     }
 }
 
-internal fun cleanCacheDirs(paths: KoltPaths, includeTools: Boolean): Result<CacheCleanSummary, RemoveFailed> {
+internal fun cleanCacheDirs(paths: KoltPaths, includeTools: Boolean): CacheCleanResult {
     val targets = mutableListOf(paths.cacheBase)
     if (includeTools) targets.add(paths.toolsDir)
 
@@ -49,11 +59,18 @@ internal fun cleanCacheDirs(paths: KoltPaths, includeTools: Boolean): Result<Cac
     var freed = 0L
     for (target in targets) {
         if (!fileExists(target)) continue
-        freed += directorySize(target)
-        removeDirectoryRecursive(target).getOrElse { return Err(it) }
+        // Size is computed before removal but only credited *after* a
+        // successful remove, so a partial failure doesn't claim freed
+        // bytes for a target that's still on disk.
+        val targetSize = directorySize(target)
+        val err = removeDirectoryRecursive(target).getError()
+        if (err != null) {
+            return CacheCleanResult(removed, freed, err)
+        }
+        freed += targetSize
         removed.add(target)
     }
-    return Ok(CacheCleanSummary(removed, freed))
+    return CacheCleanResult(removed, freed)
 }
 
 private fun doCacheClean(args: List<String>): Result<Unit, Int> {
@@ -65,16 +82,21 @@ private fun doCacheClean(args: List<String>): Result<Unit, Int> {
 
     val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_CONFIG_ERROR) }
 
-    val summary = cleanCacheDirs(paths, parsed.includeTools).getOrElse { err ->
-        eprintln("error: could not remove ${err.path}")
+    val result = cleanCacheDirs(paths, parsed.includeTools)
+    for (path in result.removedPaths) println("removed $path")
+
+    if (result.error != null) {
+        eprintln("error: could not remove ${result.error.path}")
+        if (result.freedBytes > 0) {
+            println("partially freed ${formatBytes(result.freedBytes)} before failure")
+        }
         return Err(EXIT_BUILD_ERROR)
     }
 
-    for (path in summary.removedPaths) println("removed $path")
-    if (summary.freedBytes == 0L) {
+    if (result.freedBytes == 0L) {
         println("nothing to clean")
     } else {
-        println("freed ${formatBytes(summary.freedBytes)}")
+        println("freed ${formatBytes(result.freedBytes)}")
     }
     return Ok(Unit)
 }

--- a/src/nativeMain/kotlin/kolt/cli/CacheCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/CacheCommands.kt
@@ -1,0 +1,80 @@
+package kolt.cli
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.config.resolveKoltPaths
+import kolt.infra.directorySize
+import kolt.infra.eprintln
+import kolt.infra.fileExists
+import kolt.infra.formatBytes
+import kolt.infra.removeDirectoryRecursive
+
+internal data class CacheCleanArgs(val includeTools: Boolean)
+
+internal fun parseCacheCleanArgs(args: List<String>): Result<CacheCleanArgs, String> {
+    var includeTools = false
+    for (arg in args) {
+        when (arg) {
+            "--tools" -> includeTools = true
+            else -> return Err("error: unknown flag '$arg'")
+        }
+    }
+    return Ok(CacheCleanArgs(includeTools))
+}
+
+internal fun doCache(args: List<String>): Result<Unit, Int> {
+    if (args.isEmpty()) {
+        printCacheUsage()
+        return Err(EXIT_CONFIG_ERROR)
+    }
+    return when (args[0]) {
+        "clean" -> doCacheClean(args.drop(1))
+        else -> {
+            printCacheUsage()
+            Err(EXIT_CONFIG_ERROR)
+        }
+    }
+}
+
+private fun doCacheClean(args: List<String>): Result<Unit, Int> {
+    val parsed = parseCacheCleanArgs(args).getOrElse { error ->
+        eprintln(error)
+        printCacheUsage()
+        return Err(EXIT_CONFIG_ERROR)
+    }
+
+    val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_CONFIG_ERROR) }
+
+    val targets = mutableListOf(paths.cacheBase)
+    if (parsed.includeTools) targets.add(paths.toolsDir)
+
+    var freed = 0L
+    for (target in targets) {
+        if (!fileExists(target)) continue
+        freed += directorySize(target)
+        removeDirectoryRecursive(target).getOrElse { err ->
+            eprintln("error: could not remove ${err.path}")
+            return Err(EXIT_BUILD_ERROR)
+        }
+        println("removed $target")
+    }
+
+    if (freed == 0L) {
+        println("nothing to clean")
+    } else {
+        println("freed ${formatBytes(freed)}")
+    }
+    return Ok(Unit)
+}
+
+private fun printCacheUsage() {
+    eprintln("usage: kolt cache <subcommand>")
+    eprintln("")
+    eprintln("subcommands:")
+    eprintln("  clean         Remove the global dependency cache")
+    eprintln("")
+    eprintln("flags:")
+    eprintln("  --tools       Also remove cached tools (ktfmt, junit-console)")
+}

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -58,6 +58,7 @@ fun main(args: Array<String>) {
         "tree" -> doDeps(listOf("tree")).getOrElse { exitProcess(it) }
         "toolchain" -> doToolchain(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
         "daemon" -> doDaemon(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
+        "cache" -> doCache(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
         "--version", "version" -> println(versionString())
         else -> {
             eprintln("error: unknown command '${filteredArgs[0]}'")
@@ -86,6 +87,7 @@ private fun printUsage() {
     eprintln("             install, update, tree are also available as top-level aliases")
     eprintln("  toolchain  Manage toolchains (install, list, remove)")
     eprintln("  daemon     Manage compiler daemons (stop)")
+    eprintln("  cache      Manage the global dependency cache (clean)")
     eprintln("  version    Show version information")
     eprintln("")
     eprintln("flags:")

--- a/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
+++ b/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
@@ -142,6 +142,34 @@ fun fileMtime(path: String): Long? {
     }
 }
 
+@OptIn(ExperimentalForeignApi::class)
+fun directorySize(path: String): Long {
+    if (!fileExists(path)) return 0L
+    var total = 0L
+    val dir = opendir(path) ?: return 0L
+    try {
+        while (true) {
+            val entry = readdir(dir) ?: break
+            val name = entry.pointed.d_name.toKString()
+            if (name == "." || name == "..") continue
+            val child = "$path/$name"
+            if (isDirectory(child)) {
+                total += directorySize(child)
+            } else {
+                memScoped {
+                    val statBuf = alloc<stat>()
+                    if (lstat(child, statBuf.ptr) == 0) {
+                        total += statBuf.st_size
+                    }
+                }
+            }
+        }
+    } finally {
+        closedir(dir)
+    }
+    return total
+}
+
 fun newestMtime(directories: List<String>): Long {
     var newest = 0L
     for (dir in directories) {

--- a/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
+++ b/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
@@ -142,6 +142,10 @@ fun fileMtime(path: String): Long? {
     }
 }
 
+// `lstat` (not `stat`) so a symlink's own inode size is counted rather
+// than the size of whatever it points at — prevents double-counting
+// when a symlink inside the tree targets a file also enumerated here,
+// and prevents escaping the tree via symlinks to outside paths.
 @OptIn(ExperimentalForeignApi::class)
 fun directorySize(path: String): Long {
     if (!fileExists(path)) return 0L

--- a/src/nativeMain/kotlin/kolt/infra/Format.kt
+++ b/src/nativeMain/kotlin/kolt/infra/Format.kt
@@ -10,8 +10,8 @@ fun formatDuration(duration: Duration): String {
     return if (minutes > 0) "${minutes}m $secStr" else secStr
 }
 
-// Binary units (KB = 1024 B), one decimal, matching what `du -h` users expect
-// to see from a build-tool cache readout. Drops the decimal for raw bytes.
+// Binary units (KB = 1024 B), one decimal, rounded to match `du -h`.
+// Drops the decimal for raw bytes.
 fun formatBytes(n: Long): String {
     if (n < 1024) return "$n B"
     val units = listOf("KB", "MB", "GB", "TB")
@@ -21,6 +21,6 @@ fun formatBytes(n: Long): String {
         value /= 1024.0
         unitIndex++
     }
-    val tenths = (value * 10).toLong()
+    val tenths = kotlin.math.round(value * 10).toLong()
     return "${tenths / 10}.${tenths % 10} ${units[unitIndex]}"
 }

--- a/src/nativeMain/kotlin/kolt/infra/Format.kt
+++ b/src/nativeMain/kotlin/kolt/infra/Format.kt
@@ -9,3 +9,18 @@ fun formatDuration(duration: Duration): String {
     val secStr = "${secondsTenths / 10}.${secondsTenths % 10}s"
     return if (minutes > 0) "${minutes}m $secStr" else secStr
 }
+
+// Binary units (KB = 1024 B), one decimal, matching what `du -h` users expect
+// to see from a build-tool cache readout. Drops the decimal for raw bytes.
+fun formatBytes(n: Long): String {
+    if (n < 1024) return "$n B"
+    val units = listOf("KB", "MB", "GB", "TB")
+    var value = n.toDouble() / 1024.0
+    var unitIndex = 0
+    while (value >= 1024.0 && unitIndex < units.lastIndex) {
+        value /= 1024.0
+        unitIndex++
+    }
+    val tenths = (value * 10).toLong()
+    return "${tenths / 10}.${tenths % 10} ${units[unitIndex]}"
+}

--- a/src/nativeTest/kotlin/kolt/cli/CacheCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/CacheCommandsTest.kt
@@ -2,6 +2,7 @@ package kolt.cli
 
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
+import kolt.config.KoltPaths
 import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.directorySize
 import kolt.infra.fileExists
@@ -16,7 +17,9 @@ import platform.posix.mkdtemp
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalForeignApi::class)
 class CacheCommandsTest {
@@ -57,6 +60,14 @@ class CacheCommandsTest {
     }
 
     @Test
+    fun formatBytesRoundsHalfUp() {
+        // 1599 B / 1024 = 1.5615... → rounds to 1.6 KB, not truncates to 1.5
+        assertEquals("1.6 KB", formatBytes(1599))
+        // 1075 B / 1024 = 1.0498... → rounds to 1.0 KB
+        assertEquals("1.0 KB", formatBytes(1075))
+    }
+
+    @Test
     fun directorySizeSumsRecursively() {
         tmpDir = createTempDir("kolt-cache-size-")
         ensureDirectoryRecursive("$tmpDir/nested").getOrElse { error("mkdir failed") }
@@ -69,6 +80,61 @@ class CacheCommandsTest {
     @Test
     fun directorySizeReturnsZeroForMissingPath() {
         assertEquals(0L, directorySize("/tmp/nonexistent-kolt-dir-xyz"))
+    }
+
+    @Test
+    fun cleanCacheDirsRemovesCacheAndReportsFreedBytes() {
+        tmpDir = createTempDir("kolt-clean-cache-")
+        val paths = KoltPaths(home = tmpDir)
+        ensureDirectoryRecursive(paths.cacheBase).getOrElse { error("mkdir cache failed") }
+        writeFileAsString("${paths.cacheBase}/a.jar", "0123456789").getOrElse { error("seed a.jar failed") }
+
+        val summary = cleanCacheDirs(paths, includeTools = false).getOrElse { error("clean failed: $it") }
+
+        assertEquals(10L, summary.freedBytes)
+        assertEquals(listOf(paths.cacheBase), summary.removedPaths)
+        assertFalse(fileExists(paths.cacheBase))
+    }
+
+    @Test
+    fun cleanCacheDirsReportsNothingWhenCacheMissing() {
+        tmpDir = createTempDir("kolt-clean-nothing-")
+        val paths = KoltPaths(home = tmpDir)
+
+        val summary = cleanCacheDirs(paths, includeTools = false).getOrElse { error("clean failed: $it") }
+
+        assertEquals(0L, summary.freedBytes)
+        assertTrue(summary.removedPaths.isEmpty())
+    }
+
+    @Test
+    fun cleanCacheDirsIncludesToolsWhenFlagSet() {
+        tmpDir = createTempDir("kolt-clean-tools-")
+        val paths = KoltPaths(home = tmpDir)
+        ensureDirectoryRecursive(paths.cacheBase).getOrElse { error("mkdir cache failed") }
+        ensureDirectoryRecursive(paths.toolsDir).getOrElse { error("mkdir tools failed") }
+        writeFileAsString("${paths.cacheBase}/a.jar", "12345").getOrElse { error("seed a.jar failed") }
+        writeFileAsString("${paths.toolsDir}/ktfmt.jar", "67890").getOrElse { error("seed ktfmt failed") }
+
+        val summary = cleanCacheDirs(paths, includeTools = true).getOrElse { error("clean failed: $it") }
+
+        assertEquals(10L, summary.freedBytes)
+        assertEquals(2, summary.removedPaths.size)
+        assertFalse(fileExists(paths.cacheBase))
+        assertFalse(fileExists(paths.toolsDir))
+    }
+
+    @Test
+    fun cleanCacheDirsLeavesToolsWhenFlagOff() {
+        tmpDir = createTempDir("kolt-clean-leave-tools-")
+        val paths = KoltPaths(home = tmpDir)
+        ensureDirectoryRecursive(paths.cacheBase).getOrElse { error("mkdir cache failed") }
+        ensureDirectoryRecursive(paths.toolsDir).getOrElse { error("mkdir tools failed") }
+        writeFileAsString("${paths.toolsDir}/ktfmt.jar", "67890").getOrElse { error("seed ktfmt failed") }
+
+        cleanCacheDirs(paths, includeTools = false).getOrElse { error("clean failed: $it") }
+
+        assertTrue(fileExists(paths.toolsDir), "tools dir must survive when --tools is not set")
     }
 
     private fun createTempDir(prefix: String): String {

--- a/src/nativeTest/kotlin/kolt/cli/CacheCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/CacheCommandsTest.kt
@@ -9,6 +9,7 @@ import kolt.infra.fileExists
 import kolt.infra.formatBytes
 import kolt.infra.removeDirectoryRecursive
 import kolt.infra.writeFileAsString
+import kotlin.test.assertNull
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.toKString
@@ -89,10 +90,11 @@ class CacheCommandsTest {
         ensureDirectoryRecursive(paths.cacheBase).getOrElse { error("mkdir cache failed") }
         writeFileAsString("${paths.cacheBase}/a.jar", "0123456789").getOrElse { error("seed a.jar failed") }
 
-        val summary = cleanCacheDirs(paths, includeTools = false).getOrElse { error("clean failed: $it") }
+        val result = cleanCacheDirs(paths, includeTools = false)
 
-        assertEquals(10L, summary.freedBytes)
-        assertEquals(listOf(paths.cacheBase), summary.removedPaths)
+        assertNull(result.error)
+        assertEquals(10L, result.freedBytes)
+        assertEquals(listOf(paths.cacheBase), result.removedPaths)
         assertFalse(fileExists(paths.cacheBase))
     }
 
@@ -101,10 +103,11 @@ class CacheCommandsTest {
         tmpDir = createTempDir("kolt-clean-nothing-")
         val paths = KoltPaths(home = tmpDir)
 
-        val summary = cleanCacheDirs(paths, includeTools = false).getOrElse { error("clean failed: $it") }
+        val result = cleanCacheDirs(paths, includeTools = false)
 
-        assertEquals(0L, summary.freedBytes)
-        assertTrue(summary.removedPaths.isEmpty())
+        assertNull(result.error)
+        assertEquals(0L, result.freedBytes)
+        assertTrue(result.removedPaths.isEmpty())
     }
 
     @Test
@@ -116,10 +119,11 @@ class CacheCommandsTest {
         writeFileAsString("${paths.cacheBase}/a.jar", "12345").getOrElse { error("seed a.jar failed") }
         writeFileAsString("${paths.toolsDir}/ktfmt.jar", "67890").getOrElse { error("seed ktfmt failed") }
 
-        val summary = cleanCacheDirs(paths, includeTools = true).getOrElse { error("clean failed: $it") }
+        val result = cleanCacheDirs(paths, includeTools = true)
 
-        assertEquals(10L, summary.freedBytes)
-        assertEquals(2, summary.removedPaths.size)
+        assertNull(result.error)
+        assertEquals(10L, result.freedBytes)
+        assertEquals(2, result.removedPaths.size)
         assertFalse(fileExists(paths.cacheBase))
         assertFalse(fileExists(paths.toolsDir))
     }
@@ -132,9 +136,32 @@ class CacheCommandsTest {
         ensureDirectoryRecursive(paths.toolsDir).getOrElse { error("mkdir tools failed") }
         writeFileAsString("${paths.toolsDir}/ktfmt.jar", "67890").getOrElse { error("seed ktfmt failed") }
 
-        cleanCacheDirs(paths, includeTools = false).getOrElse { error("clean failed: $it") }
+        cleanCacheDirs(paths, includeTools = false)
 
         assertTrue(fileExists(paths.toolsDir), "tools dir must survive when --tools is not set")
+    }
+
+    @Test
+    fun cleanCacheDirsReportsPartialOnRemoveFailure() {
+        // Seed cacheBase as a directory we can clean, and toolsDir as a
+        // *regular file* so removeDirectoryRecursive's opendir() bails.
+        // After the failure, the cacheBase removal should still be reported.
+        tmpDir = createTempDir("kolt-clean-partial-")
+        val paths = KoltPaths(home = tmpDir)
+        ensureDirectoryRecursive(paths.cacheBase).getOrElse { error("mkdir cache failed") }
+        writeFileAsString("${paths.cacheBase}/a.jar", "12345").getOrElse { error("seed a.jar failed") }
+        ensureDirectoryRecursive(paths.toolsDir.substringBeforeLast('/'))
+            .getOrElse { error("mkdir parent failed") }
+        writeFileAsString(paths.toolsDir, "not a directory").getOrElse { error("seed file failed") }
+
+        val result = cleanCacheDirs(paths, includeTools = true)
+
+        assertNotNull(result.error)
+        assertEquals(paths.toolsDir, result.error.path)
+        assertEquals(listOf(paths.cacheBase), result.removedPaths)
+        assertEquals(5L, result.freedBytes)
+        assertFalse(fileExists(paths.cacheBase))
+        assertTrue(fileExists(paths.toolsDir), "tools 'dir' (actually a file) survives")
     }
 
     private fun createTempDir(prefix: String): String {

--- a/src/nativeTest/kotlin/kolt/cli/CacheCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/CacheCommandsTest.kt
@@ -1,0 +1,82 @@
+package kolt.cli
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.directorySize
+import kolt.infra.fileExists
+import kolt.infra.formatBytes
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.mkdtemp
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@OptIn(ExperimentalForeignApi::class)
+class CacheCommandsTest {
+    private var tmpDir: String = ""
+
+    @AfterTest
+    fun tearDown() {
+        if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
+            removeDirectoryRecursive(tmpDir)
+        }
+    }
+
+    @Test
+    fun parseArgsWithoutFlagsIsCacheOnly() {
+        val parsed = parseCacheCleanArgs(emptyList()).getOrElse { error("unexpected: $it") }
+        assertEquals(false, parsed.includeTools)
+    }
+
+    @Test
+    fun parseArgsWithToolsFlagIncludesTools() {
+        val parsed = parseCacheCleanArgs(listOf("--tools")).getOrElse { error("unexpected: $it") }
+        assertEquals(true, parsed.includeTools)
+    }
+
+    @Test
+    fun parseArgsRejectsUnknownFlag() {
+        assertNotNull(parseCacheCleanArgs(listOf("--unknown")).getError())
+    }
+
+    @Test
+    fun formatBytesFormatsUnits() {
+        assertEquals("0 B", formatBytes(0))
+        assertEquals("512 B", formatBytes(512))
+        assertEquals("1.0 KB", formatBytes(1024))
+        assertEquals("1.5 KB", formatBytes(1536))
+        assertEquals("1.0 MB", formatBytes(1024L * 1024))
+        assertEquals("1.0 GB", formatBytes(1024L * 1024 * 1024))
+    }
+
+    @Test
+    fun directorySizeSumsRecursively() {
+        tmpDir = createTempDir("kolt-cache-size-")
+        ensureDirectoryRecursive("$tmpDir/nested").getOrElse { error("mkdir failed") }
+        writeFileAsString("$tmpDir/a.txt", "0123456789").getOrElse { error("write failed") }
+        writeFileAsString("$tmpDir/nested/b.txt", "abcde").getOrElse { error("write failed") }
+
+        assertEquals(15L, directorySize(tmpDir))
+    }
+
+    @Test
+    fun directorySizeReturnsZeroForMissingPath() {
+        assertEquals(0L, directorySize("/tmp/nonexistent-kolt-dir-xyz"))
+    }
+
+    private fun createTempDir(prefix: String): String {
+        val template = "/tmp/${prefix}XXXXXX"
+        val buf = template.encodeToByteArray().copyOf(template.length + 1)
+        buf.usePinned { pinned ->
+            val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+            return result.toKString()
+        }
+    }
+}


### PR DESCRIPTION
Closes #25.

`kolt cache clean` removes `~/.kolt/cache/`. `--tools` extends it to
`~/.kolt/tools/` (ktfmt, junit-console). Size freed is reported in
binary units with one decimal (e.g. \`freed 142.0 MB\`).

Review points:

- The `directorySize` walk runs before removal — on a multi-GB cache
  that doubles the I/O. Acceptable since it's a one-shot diagnostic,
  but flagging it in case we'd rather drop the byte total to skip the
  extra traversal.
- Unknown flags (anything besides \`--tools\`) are rejected. Cargo's
  \`--dry-run\` isn't in scope here; can be a follow-up if useful.