### PR TITLE
Add kolt info command (#26)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
@@ -9,8 +9,6 @@ import kolt.config.KOLT_VERSION
 import kolt.config.KoltConfig
 import kolt.config.parseConfig
 import kolt.config.resolveKoltPaths
-import kolt.infra.currentWorkingDirectory
-import kolt.infra.directorySize
 import kolt.infra.eprintln
 import kolt.infra.fileExists
 import kolt.infra.formatBytes
@@ -64,15 +62,21 @@ internal fun formatInfo(snap: InfoSnapshot): String = buildString {
     }
     appendLine(labeled("host", snap.host))
 
-    snap.project?.let {
+    if (snap.project != null) {
         appendLine()
-        appendLine(labeled("project", "${it.name} v${it.version}"))
-        appendLine(labeled("kind", it.kind))
-        append(labeled("target", it.target))
+        appendLine(labeled("project", "${snap.project.name} v${snap.project.version}"))
+        appendLine(labeled("kind", snap.project.kind))
+        append(labeled("target", snap.project.target))
+    } else {
+        appendLine()
+        append("(not in a kolt project — no kolt.toml in current directory)")
     }
 }.trimEnd('\n')
 
 internal fun abbreviateHomePath(path: String, home: String): String {
+    // Without this guard, an empty `home` turns `prefix` into "/", which
+    // matches every absolute path and mangles them into bogus "~/..." forms.
+    if (home.isEmpty()) return path
     if (path == home) return "~"
     val prefix = "$home/"
     return if (path.startsWith(prefix)) "~/" + path.substring(prefix.length) else path
@@ -90,25 +94,28 @@ internal fun doInfo(args: List<String>): Result<Unit, Int> {
 @OptIn(ExperimentalForeignApi::class)
 private fun gatherInfo(): InfoSnapshot {
     val koltPath = readSelfExe().getOrElse { "(unknown)" }
-    val home = homeDirectory().getOrElse { null }
+    val home = homeDirectory().getOrElse { null }.orEmpty()
     val paths = resolveKoltPaths().getOrElse { null }
 
     val koltHomeAbs = paths?.let { "${it.home}/.kolt" }
-    val koltHomeDisplay = koltHomeAbs?.let { abbreviateHomePath(it, home ?: "") } ?: "(unknown)"
-    val koltHomeBytes = koltHomeAbs?.takeIf { fileExists(it) }?.let { directorySize(it) }
+    val koltHomeDisplay = koltHomeAbs?.let { abbreviateHomePath(it, home) } ?: "(unknown)"
 
     val project = loadProjectForInfo()
 
     val kotlinInfo = project?.let { config ->
         val version = config.kotlin.effectiveCompiler
-        val mode = if (compareVersions(version, KOTLIN_VERSION_FLOOR) >= 0) "daemon" else "subprocess"
+        val mode = if (compareVersions(version, KOTLIN_VERSION_FLOOR) >= 0) {
+            "daemon"
+        } else {
+            "subprocess [<$KOTLIN_VERSION_FLOOR]"
+        }
         val rawPath = paths?.kotlincBin(version) ?: ""
-        KotlinInfo(version, mode, abbreviateHomePath(rawPath, home ?: ""))
+        KotlinInfo(version, mode, abbreviateHomePath(rawPath, home))
     }
 
     val jdkInfo = project?.build?.jdk?.let { version ->
         val rawPath = paths?.javaBin(version) ?: ""
-        JdkInfo(version, abbreviateHomePath(rawPath, home ?: ""))
+        JdkInfo(version, abbreviateHomePath(rawPath, home))
     }
 
     val projectInfo = project?.let {
@@ -119,7 +126,9 @@ private fun gatherInfo(): InfoSnapshot {
         koltVersion = KOLT_VERSION,
         koltPath = koltPath,
         koltHomeDisplay = koltHomeDisplay,
-        koltHomeBytes = koltHomeBytes,
+        // Total size is deferred to `kolt info --verbose` (issue #207):
+        // walking multi-GB caches makes the default path sluggish.
+        koltHomeBytes = null,
         kotlin = kotlinInfo,
         jdk = jdkInfo,
         host = hostString(),

--- a/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
@@ -69,7 +69,7 @@ internal fun formatInfo(snap: InfoSnapshot): String = buildString {
         append(labeled("target", snap.project.target))
     } else {
         appendLine()
-        append("(not in a kolt project — no kolt.toml in current directory)")
+        append("(not in a kolt project -- no kolt.toml in current directory)")
     }
 }.trimEnd('\n')
 

--- a/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
@@ -1,0 +1,143 @@
+package kolt.cli
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.build.daemon.KOTLIN_VERSION_FLOOR
+import kolt.config.KOLT_VERSION
+import kolt.config.KoltConfig
+import kolt.config.parseConfig
+import kolt.config.resolveKoltPaths
+import kolt.infra.currentWorkingDirectory
+import kolt.infra.directorySize
+import kolt.infra.eprintln
+import kolt.infra.fileExists
+import kolt.infra.formatBytes
+import kolt.infra.homeDirectory
+import kolt.infra.readFileAsString
+import kolt.infra.readSelfExe
+import kolt.resolve.compareVersions
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.toKString
+import platform.posix.uname
+import platform.posix.utsname
+
+internal data class KotlinInfo(val version: String, val mode: String, val path: String)
+internal data class JdkInfo(val version: String, val path: String)
+internal data class ProjectInfo(val name: String, val version: String, val kind: String, val target: String)
+
+internal data class InfoSnapshot(
+    val koltVersion: String,
+    val koltPath: String,
+    val koltHomeDisplay: String,
+    val koltHomeBytes: Long?,
+    val kotlin: KotlinInfo?,
+    val jdk: JdkInfo?,
+    val host: String,
+    val project: ProjectInfo?
+)
+
+private const val LABEL_WIDTH = 12
+
+private fun labeled(label: String, value: String): String =
+    label.padEnd(LABEL_WIDTH) + value
+
+internal fun formatInfo(snap: InfoSnapshot): String = buildString {
+    appendLine(labeled("kolt", "v${snap.koltVersion} (${snap.koltPath})"))
+
+    val homeValue = if (snap.koltHomeBytes != null) {
+        "${snap.koltHomeDisplay} (${formatBytes(snap.koltHomeBytes)})"
+    } else {
+        snap.koltHomeDisplay
+    }
+    appendLine(labeled("kolt home", homeValue))
+
+    snap.kotlin?.let {
+        appendLine(labeled("kotlin", "${it.version} (${it.mode}, ${it.path})"))
+    }
+    snap.jdk?.let {
+        appendLine(labeled("jdk", "${it.version} (${it.path})"))
+    }
+    appendLine(labeled("host", snap.host))
+
+    snap.project?.let {
+        appendLine()
+        appendLine(labeled("project", "${it.name} v${it.version}"))
+        appendLine(labeled("kind", it.kind))
+        append(labeled("target", it.target))
+    }
+}.trimEnd('\n')
+
+internal fun abbreviateHomePath(path: String, home: String): String {
+    if (path == home) return "~"
+    val prefix = "$home/"
+    return if (path.startsWith(prefix)) "~/" + path.substring(prefix.length) else path
+}
+
+internal fun doInfo(args: List<String>): Result<Unit, Int> {
+    if (args.isNotEmpty()) {
+        eprintln("usage: kolt info")
+        return Err(EXIT_CONFIG_ERROR)
+    }
+    println(formatInfo(gatherInfo()))
+    return Ok(Unit)
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun gatherInfo(): InfoSnapshot {
+    val koltPath = readSelfExe().getOrElse { "(unknown)" }
+    val home = homeDirectory().getOrElse { null }
+    val paths = resolveKoltPaths().getOrElse { null }
+
+    val koltHomeAbs = paths?.let { "${it.home}/.kolt" }
+    val koltHomeDisplay = koltHomeAbs?.let { abbreviateHomePath(it, home ?: "") } ?: "(unknown)"
+    val koltHomeBytes = koltHomeAbs?.takeIf { fileExists(it) }?.let { directorySize(it) }
+
+    val project = loadProjectForInfo()
+
+    val kotlinInfo = project?.let { config ->
+        val version = config.kotlin.effectiveCompiler
+        val mode = if (compareVersions(version, KOTLIN_VERSION_FLOOR) >= 0) "daemon" else "subprocess"
+        val rawPath = paths?.kotlincBin(version) ?: ""
+        KotlinInfo(version, mode, abbreviateHomePath(rawPath, home ?: ""))
+    }
+
+    val jdkInfo = project?.build?.jdk?.let { version ->
+        val rawPath = paths?.javaBin(version) ?: ""
+        JdkInfo(version, abbreviateHomePath(rawPath, home ?: ""))
+    }
+
+    val projectInfo = project?.let {
+        ProjectInfo(it.name, it.version, it.kind, it.build.target)
+    }
+
+    return InfoSnapshot(
+        koltVersion = KOLT_VERSION,
+        koltPath = koltPath,
+        koltHomeDisplay = koltHomeDisplay,
+        koltHomeBytes = koltHomeBytes,
+        kotlin = kotlinInfo,
+        jdk = jdkInfo,
+        host = hostString(),
+        project = projectInfo
+    )
+}
+
+private fun loadProjectForInfo(): KoltConfig? {
+    if (!fileExists(KOLT_TOML)) return null
+    val toml = readFileAsString(KOLT_TOML).getOrElse { return null }
+    return parseConfig(toml).getOrElse { null }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun hostString(): String = memScoped {
+    val buf = alloc<utsname>()
+    if (uname(buf.ptr) != 0) return@memScoped "unknown"
+    val sysname = buf.sysname.toKString().lowercase()
+    val machine = buf.machine.toKString()
+    "$sysname-$machine"
+}

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -59,6 +59,7 @@ fun main(args: Array<String>) {
         "toolchain" -> doToolchain(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
         "daemon" -> doDaemon(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
         "cache" -> doCache(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
+        "info" -> doInfo(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
         "--version", "version" -> println(versionString())
         else -> {
             eprintln("error: unknown command '${filteredArgs[0]}'")
@@ -88,6 +89,7 @@ private fun printUsage() {
     eprintln("  toolchain  Manage toolchains (install, list, remove)")
     eprintln("  daemon     Manage compiler daemons (stop)")
     eprintln("  cache      Manage the global dependency cache (clean)")
+    eprintln("  info       Display environment and project information")
     eprintln("  version    Show version information")
     eprintln("")
     eprintln("flags:")

--- a/src/nativeMain/kotlin/kolt/infra/SelfExe.kt
+++ b/src/nativeMain/kotlin/kolt/infra/SelfExe.kt
@@ -19,6 +19,8 @@ import platform.posix.strerror
 data class SelfExeError(val errno: Int, val message: String)
 
 // readlink does not NUL-terminate; we reserve one byte and add it.
+// Linux-only: `/proc/self/exe` is not present on macOS (use `_NSGetExecutablePath`)
+// or BSD/Windows. Revisit when adding non-linux targets.
 @OptIn(ExperimentalForeignApi::class)
 fun readSelfExe(): Result<String, SelfExeError> {
     return memScoped {

--- a/src/nativeTest/kotlin/kolt/cli/InfoCommandTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/InfoCommandTest.kt
@@ -33,15 +33,18 @@ class InfoCommandTest {
     }
 
     @Test
-    fun omitsProjectSectionWhenOutsideProject() {
+    fun showsOutsideProjectHintInsteadOfProjectSection() {
         val snap = withProject.copy(kotlin = null, jdk = null, project = null)
-        val output = formatInfo(snap)
+        val lines = formatInfo(snap).lines()
 
-        assertTrue(output.contains("kolt        v0.12.0"))
-        assertTrue(output.contains("host        linux-x86_64"))
-        assertFalse(output.contains("kotlin"))
-        assertFalse(output.contains("project"))
-        assertFalse(output.contains("target"))
+        assertTrue(lines[0].startsWith("kolt        v0.12.0"))
+        assertTrue(lines.any { it.startsWith("host") })
+        assertFalse(lines.any { it.startsWith("kotlin") })
+        assertFalse(lines.any { it.startsWith("project") })
+        assertTrue(
+            lines.any { it.contains("not in a kolt project") },
+            "must tell the user why the project section is absent"
+        )
     }
 
     @Test
@@ -52,9 +55,26 @@ class InfoCommandTest {
     }
 
     @Test
+    fun kotlinLineShowsFloorHintWhenSubprocess() {
+        val snap = withProject.copy(
+            kotlin = KotlinInfo("2.2.0", "subprocess [<2.3.0]", "~/.kolt/toolchains/kotlinc/2.2.0/bin/kotlinc")
+        )
+        val kotlinLine = formatInfo(snap).lines().first { it.startsWith("kotlin") }
+        assertTrue(kotlinLine.contains("<2.3.0"), "subprocess mode must disclose the daemon floor: $kotlinLine")
+    }
+
+    @Test
     fun abbreviateHomePathReplacesHomeWithTilde() {
         assertEquals("~/.kolt", abbreviateHomePath("/home/alice/.kolt", "/home/alice"))
         assertEquals("/etc/kolt", abbreviateHomePath("/etc/kolt", "/home/alice"))
         assertEquals("~", abbreviateHomePath("/home/alice", "/home/alice"))
+    }
+
+    @Test
+    fun abbreviateHomePathLeavesPathAloneWhenHomeIsEmpty() {
+        // Guards against a bug where empty home would turn prefix into "/"
+        // and mangle every absolute path into "~/..." form.
+        assertEquals("/usr/local/bin/kolt", abbreviateHomePath("/usr/local/bin/kolt", ""))
+        assertEquals("/home/alice/.kolt", abbreviateHomePath("/home/alice/.kolt", ""))
     }
 }

--- a/src/nativeTest/kotlin/kolt/cli/InfoCommandTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/InfoCommandTest.kt
@@ -1,0 +1,60 @@
+package kolt.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class InfoCommandTest {
+    private val withProject = InfoSnapshot(
+        koltVersion = "0.12.0",
+        koltPath = "/usr/local/bin/kolt",
+        koltHomeDisplay = "~/.kolt",
+        koltHomeBytes = 142L * 1024 * 1024,
+        kotlin = KotlinInfo("2.3.20", "daemon", "~/.kolt/toolchains/kotlinc/2.3.20/bin/kotlinc"),
+        jdk = JdkInfo("21", "~/.kolt/toolchains/jdk/21/bin/java"),
+        host = "linux-x86_64",
+        project = ProjectInfo("my-app", "0.1.0", "app", "jvm")
+    )
+
+    @Test
+    fun formatsAllFieldsWhenInsideProject() {
+        val lines = formatInfo(withProject).lines()
+
+        assertEquals("kolt        v0.12.0 (/usr/local/bin/kolt)", lines[0])
+        assertEquals("kolt home   ~/.kolt (142.0 MB)", lines[1])
+        assertEquals("kotlin      2.3.20 (daemon, ~/.kolt/toolchains/kotlinc/2.3.20/bin/kotlinc)", lines[2])
+        assertEquals("jdk         21 (~/.kolt/toolchains/jdk/21/bin/java)", lines[3])
+        assertEquals("host        linux-x86_64", lines[4])
+        assertEquals("", lines[5])
+        assertEquals("project     my-app v0.1.0", lines[6])
+        assertEquals("kind        app", lines[7])
+        assertEquals("target      jvm", lines[8])
+    }
+
+    @Test
+    fun omitsProjectSectionWhenOutsideProject() {
+        val snap = withProject.copy(kotlin = null, jdk = null, project = null)
+        val output = formatInfo(snap)
+
+        assertTrue(output.contains("kolt        v0.12.0"))
+        assertTrue(output.contains("host        linux-x86_64"))
+        assertFalse(output.contains("kotlin"))
+        assertFalse(output.contains("project"))
+        assertFalse(output.contains("target"))
+    }
+
+    @Test
+    fun hidesHomeSizeWhenKoltHomeMissing() {
+        val snap = withProject.copy(koltHomeBytes = null)
+        val line = formatInfo(snap).lines()[1]
+        assertEquals("kolt home   ~/.kolt", line)
+    }
+
+    @Test
+    fun abbreviateHomePathReplacesHomeWithTilde() {
+        assertEquals("~/.kolt", abbreviateHomePath("/home/alice/.kolt", "/home/alice"))
+        assertEquals("/etc/kolt", abbreviateHomePath("/etc/kolt", "/home/alice"))
+        assertEquals("~", abbreviateHomePath("/home/alice", "/home/alice"))
+    }
+}

--- a/src/nativeTest/kotlin/kolt/cli/InfoCommandTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/InfoCommandTest.kt
@@ -1,5 +1,6 @@
 package kolt.cli
 
+import kolt.build.daemon.KOTLIN_VERSION_FLOOR
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -56,11 +57,16 @@ class InfoCommandTest {
 
     @Test
     fun kotlinLineShowsFloorHintWhenSubprocess() {
+        // Anchor on the live KOTLIN_VERSION_FLOOR so this test follows the
+        // floor when the daemon family bumps, instead of going stale silently.
         val snap = withProject.copy(
-            kotlin = KotlinInfo("2.2.0", "subprocess [<2.3.0]", "~/.kolt/toolchains/kotlinc/2.2.0/bin/kotlinc")
+            kotlin = KotlinInfo("2.2.0", "subprocess [<$KOTLIN_VERSION_FLOOR]", "~/.kolt/toolchains/kotlinc/2.2.0/bin/kotlinc")
         )
         val kotlinLine = formatInfo(snap).lines().first { it.startsWith("kotlin") }
-        assertTrue(kotlinLine.contains("<2.3.0"), "subprocess mode must disclose the daemon floor: $kotlinLine")
+        assertTrue(
+            kotlinLine.contains("<$KOTLIN_VERSION_FLOOR"),
+            "subprocess mode must disclose the daemon floor: $kotlinLine"
+        )
     }
 
     @Test


### PR DESCRIPTION
Closes #26. Successor to #206 — that PR auto-closed when its base branch (25-cache-clean) was deleted on merge.

Output format:

\`\`\`
kolt        v0.12.0 (/usr/local/bin/kolt)
kolt home   ~/.kolt
kotlin      2.3.20 (daemon, ~/.kolt/toolchains/kotlinc/2.3.20/bin/kotlinc)
jdk         21 (~/.kolt/toolchains/jdk/21/bin/java)
host        linux-x86_64

project     my-app v0.1.0
kind        app
target      jvm
\`\`\`

\`kolt home\` size walk is deferred to \`kolt info --verbose\` (issue #207) so the default stays near-instant on multi-GB caches. Outside a project, the kotlin / jdk / project sections are replaced with \`(not in a kolt project -- no kolt.toml in current directory)\`. Subprocess mode discloses the daemon floor it missed: \`kotlin 2.2.0 (subprocess [<2.3.0], ~/...)\`.

Daemon vs subprocess detection compares \`config.kotlin.effectiveCompiler\` against \`KOTLIN_VERSION_FLOOR\` — dry check, doesn't probe BTA-impl availability. Acceptable for a diagnostic line.