### PR TITLE
Add --verbose and --format=json to kolt info (#207)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
@@ -7,8 +7,12 @@ import com.github.michaelbull.result.getOrElse
 import kolt.build.daemon.KOTLIN_VERSION_FLOOR
 import kolt.config.KOLT_VERSION
 import kolt.config.KoltConfig
+import kolt.config.KoltPaths
 import kolt.config.parseConfig
 import kolt.config.resolveKoltPaths
+import kolt.infra.absolutise
+import kolt.infra.currentWorkingDirectory
+import kolt.infra.directorySize
 import kolt.infra.eprintln
 import kolt.infra.fileExists
 import kolt.infra.formatBytes
@@ -21,36 +25,87 @@ import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.toKString
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import platform.posix.uname
 import platform.posix.utsname
 
-internal data class KotlinInfo(val version: String, val mode: String, val path: String)
-internal data class JdkInfo(val version: String, val path: String)
-internal data class ProjectInfo(val name: String, val version: String, val kind: String, val target: String)
+internal data class HomeBreakdown(
+    val cacheBytes: Long,
+    val toolchainsBytes: Long,
+    val daemonBytes: Long,
+    val toolsBytes: Long,
+    val cachePath: String,
+    val toolchainsPath: String,
+    val daemonPath: String,
+    val toolsPath: String,
+) {
+    val totalBytes: Long get() = cacheBytes + toolchainsBytes + daemonBytes + toolsBytes
+}
+
+internal data class KotlinInfo(
+    val version: String,
+    val mode: String,
+    val path: String,
+    val requestedVersion: String? = null,
+    val daemonBaseline: String? = null,
+    val subprocessFallbackReason: String? = null,
+)
+
+internal data class JdkInfo(
+    val version: String?,
+    val path: String,
+    val source: String? = null,
+)
+
+internal data class ProjectInfo(
+    val name: String,
+    val version: String,
+    val kind: String,
+    val target: String,
+    val manifestPath: String? = null,
+    val dependencyCount: Int? = null,
+    val testDependencyCount: Int? = null,
+    val enabledPlugins: List<String>? = null,
+)
 
 internal data class InfoSnapshot(
     val koltVersion: String,
-    val koltPath: String,
-    val koltHomeDisplay: String,
+    val koltPath: String?,
+    val koltHomeDisplay: String?,
     val koltHomeBytes: Long?,
     val kotlin: KotlinInfo?,
     val jdk: JdkInfo?,
     val host: String,
-    val project: ProjectInfo?
+    val project: ProjectInfo?,
+    val koltHomeBreakdown: HomeBreakdown? = null,
 )
 
+private const val UNKNOWN_DISPLAY = "(unknown)"
+
+internal data class InfoOptions(val verbose: Boolean, val json: Boolean)
+
 private const val LABEL_WIDTH = 12
+private const val VERBOSE_LABEL_WIDTH = 14
+private const val SUB_INDENT = "  "
 
-private fun labeled(label: String, value: String): String =
-    label.padEnd(LABEL_WIDTH) + value
+private fun labeled(label: String, value: String, width: Int = LABEL_WIDTH): String =
+    label.padEnd(width) + value
 
-internal fun formatInfo(snap: InfoSnapshot): String = buildString {
-    appendLine(labeled("kolt", "v${snap.koltVersion} (${snap.koltPath})"))
+private fun subLabeled(label: String, value: String): String =
+    SUB_INDENT + label.padEnd(VERBOSE_LABEL_WIDTH) + value
 
+internal fun formatInfo(snap: InfoSnapshot, verbose: Boolean = false): String =
+    if (verbose) formatInfoVerbose(snap) else formatInfoDefault(snap)
+
+private fun formatInfoDefault(snap: InfoSnapshot): String = buildString {
+    appendLine(labeled("kolt", "v${snap.koltVersion} (${snap.koltPath ?: UNKNOWN_DISPLAY})"))
+
+    val home = snap.koltHomeDisplay ?: UNKNOWN_DISPLAY
     val homeValue = if (snap.koltHomeBytes != null) {
-        "${snap.koltHomeDisplay} (${formatBytes(snap.koltHomeBytes)})"
+        "$home (${formatBytes(snap.koltHomeBytes)})"
     } else {
-        snap.koltHomeDisplay
+        home
     }
     appendLine(labeled("kolt home", homeValue))
 
@@ -73,6 +128,64 @@ internal fun formatInfo(snap: InfoSnapshot): String = buildString {
     }
 }.trimEnd('\n')
 
+private fun formatInfoVerbose(snap: InfoSnapshot): String = buildString {
+    appendLine(labeled("kolt", "v${snap.koltVersion} (${snap.koltPath ?: UNKNOWN_DISPLAY})", VERBOSE_LABEL_WIDTH))
+    appendLine()
+
+    val home = snap.koltHomeDisplay ?: UNKNOWN_DISPLAY
+    val homeValue = if (snap.koltHomeBytes != null) {
+        "$home (${formatBytes(snap.koltHomeBytes)})"
+    } else {
+        home
+    }
+    appendLine(labeled("kolt home", homeValue, VERBOSE_LABEL_WIDTH))
+    snap.koltHomeBreakdown?.let { b ->
+        appendLine(subLabeled("cache", "${b.cachePath} (${formatBytes(b.cacheBytes)})"))
+        appendLine(subLabeled("toolchains", "${b.toolchainsPath} (${formatBytes(b.toolchainsBytes)})"))
+        appendLine(subLabeled("daemon", "${b.daemonPath} (${formatBytes(b.daemonBytes)})"))
+        appendLine(subLabeled("tools", "${b.toolsPath} (${formatBytes(b.toolsBytes)})"))
+    }
+
+    snap.kotlin?.let { k ->
+        appendLine()
+        appendLine(labeled("kotlin", "${k.version} (${k.mode})", VERBOSE_LABEL_WIDTH))
+        k.requestedVersion?.let { appendLine(subLabeled("requested", it)) }
+        appendLine(subLabeled("resolved", k.version))
+        appendLine(subLabeled("compiler", k.path))
+        k.daemonBaseline?.let { appendLine(subLabeled("daemon base", it)) }
+        k.subprocessFallbackReason?.let { appendLine(subLabeled("fallback", it)) }
+    }
+
+    snap.jdk?.let { j ->
+        appendLine()
+        val versionPart = j.version.orEmpty()
+        val sourcePart = j.source?.let { "($it)" } ?: ""
+        val headerValue = listOf(versionPart, sourcePart).filter { it.isNotEmpty() }.joinToString(" ")
+        appendLine(labeled("jdk", headerValue, VERBOSE_LABEL_WIDTH))
+        appendLine(subLabeled("path", j.path))
+        j.source?.let { appendLine(subLabeled("source", it)) }
+    }
+
+    appendLine()
+    appendLine(labeled("host", snap.host, VERBOSE_LABEL_WIDTH))
+
+    if (snap.project != null) {
+        appendLine()
+        appendLine(labeled("project", "${snap.project.name} v${snap.project.version}", VERBOSE_LABEL_WIDTH))
+        snap.project.manifestPath?.let { appendLine(subLabeled("manifest", it)) }
+        appendLine(subLabeled("kind", snap.project.kind))
+        appendLine(subLabeled("target", snap.project.target))
+        snap.project.dependencyCount?.let { appendLine(subLabeled("dependencies", it.toString())) }
+        snap.project.testDependencyCount?.let { appendLine(subLabeled("test deps", it.toString())) }
+        snap.project.enabledPlugins
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { appendLine(subLabeled("plugins", it.joinToString(", "))) }
+    } else {
+        appendLine()
+        append("(not in a kolt project -- no kolt.toml in current directory)")
+    }
+}.trimEnd('\n')
+
 internal fun abbreviateHomePath(path: String, home: String): String {
     // Without this guard, an empty `home` turns `prefix` into "/", which
     // matches every absolute path and mangles them into bogus "~/..." forms.
@@ -82,58 +195,136 @@ internal fun abbreviateHomePath(path: String, home: String): String {
     return if (path.startsWith(prefix)) "~/" + path.substring(prefix.length) else path
 }
 
+internal fun parseInfoArgs(args: List<String>): Result<InfoOptions, String> {
+    var verbose = false
+    var json = false
+    val usage = "usage: kolt info [--verbose] [--format=json]"
+    for (arg in args) {
+        when {
+            arg == "--verbose" -> verbose = true
+            arg == "--format=json" -> json = true
+            arg.startsWith("--format=") -> return Err(
+                "error: unsupported --format value '${arg.removePrefix("--format=")}' (only 'json' is supported)\n$usage"
+            )
+            else -> return Err("error: unknown flag '$arg'\n$usage")
+        }
+    }
+    return Ok(InfoOptions(verbose = verbose, json = json))
+}
+
 internal fun doInfo(args: List<String>): Result<Unit, Int> {
-    if (args.isNotEmpty()) {
-        eprintln("usage: kolt info")
+    val opts = parseInfoArgs(args).getOrElse { msg ->
+        eprintln(msg)
         return Err(EXIT_CONFIG_ERROR)
     }
-    println(formatInfo(gatherInfo()))
+    // `--verbose --format=json` is equivalent to `--format=json` — json always
+    // carries the full field set.
+    val snap = gatherInfo(verbose = opts.verbose || opts.json)
+    if (opts.json) {
+        println(formatInfoJson(snap))
+    } else {
+        println(formatInfo(snap, verbose = opts.verbose))
+    }
     return Ok(Unit)
 }
 
 @OptIn(ExperimentalForeignApi::class)
-private fun gatherInfo(): InfoSnapshot {
-    val koltPath = readSelfExe().getOrElse { "(unknown)" }
+private fun gatherInfo(verbose: Boolean): InfoSnapshot {
+    val koltPath = readSelfExe().getOrElse { null }
     val home = homeDirectory().getOrElse { null }.orEmpty()
     val paths = resolveKoltPaths().getOrElse { null }
 
     val koltHomeAbs = paths?.let { "${it.home}/.kolt" }
-    val koltHomeDisplay = koltHomeAbs?.let { abbreviateHomePath(it, home) } ?: "(unknown)"
+    val koltHomeDisplay = koltHomeAbs?.let { abbreviateHomePath(it, home) }
+
+    val breakdown = if (verbose && paths != null) walkHomeBreakdown(paths, home) else null
+    val koltHomeBytes = breakdown?.totalBytes
 
     val project = loadProjectForInfo()
 
     val kotlinInfo = project?.let { config ->
         val version = config.kotlin.effectiveCompiler
-        val mode = if (compareVersions(version, KOTLIN_VERSION_FLOOR) >= 0) {
-            "daemon"
-        } else {
-            "subprocess [<$KOTLIN_VERSION_FLOOR]"
-        }
+        val onDaemon = compareVersions(version, KOTLIN_VERSION_FLOOR) >= 0
+        val mode = if (onDaemon) "daemon" else "subprocess [<$KOTLIN_VERSION_FLOOR]"
         val rawPath = paths?.kotlincBin(version) ?: ""
-        KotlinInfo(version, mode, abbreviateHomePath(rawPath, home))
+        KotlinInfo(
+            version = version,
+            mode = mode,
+            path = abbreviateHomePath(rawPath, home),
+            requestedVersion = if (verbose) config.kotlin.version else null,
+            daemonBaseline = if (verbose) KOTLIN_VERSION_FLOOR else null,
+            subprocessFallbackReason = if (verbose && !onDaemon) {
+                "compiler $version is below daemon baseline $KOTLIN_VERSION_FLOOR"
+            } else null,
+        )
     }
 
-    val jdkInfo = project?.build?.jdk?.let { version ->
-        val rawPath = paths?.javaBin(version) ?: ""
-        JdkInfo(version, abbreviateHomePath(rawPath, home))
+    // JDK only surfaces for JVM builds. Native targets don't invoke `java`,
+    // so reporting a "system" JDK there would mislead users — the field has
+    // no bearing on the build.
+    val jdkInfo = project?.takeIf { it.build.target == "jvm" }?.let { config ->
+        val managedVersion = config.build.jdk
+        if (managedVersion != null) {
+            val rawPath = paths?.javaBin(managedVersion) ?: ""
+            JdkInfo(
+                version = managedVersion,
+                path = abbreviateHomePath(rawPath, home),
+                source = if (verbose) "managed" else null,
+            )
+        } else if (verbose) {
+            // The build uses `java` from PATH (Runner.kt:18); kolt does not
+            // consult $JAVA_HOME. Report "system" so the disclosure matches
+            // behavior rather than speculating about an env var kolt ignores.
+            JdkInfo(version = null, path = "java", source = "system")
+        } else null
     }
 
     val projectInfo = project?.let {
-        ProjectInfo(it.name, it.version, it.kind, it.build.target)
+        ProjectInfo(
+            name = it.name,
+            version = it.version,
+            kind = it.kind,
+            target = it.build.target,
+            manifestPath = if (verbose) absoluteManifestPath() else null,
+            dependencyCount = if (verbose) it.dependencies.size else null,
+            testDependencyCount = if (verbose) it.testDependencies.size else null,
+            enabledPlugins = if (verbose) {
+                it.kotlin.plugins.filterValues { enabled -> enabled }.keys.sorted()
+            } else null,
+        )
     }
 
     return InfoSnapshot(
         koltVersion = KOLT_VERSION,
         koltPath = koltPath,
         koltHomeDisplay = koltHomeDisplay,
-        // Total size is deferred to `kolt info --verbose` (issue #207):
-        // walking multi-GB caches makes the default path sluggish.
-        koltHomeBytes = null,
+        // Default mode skips the walk because multi-GB caches make the path
+        // sluggish. Verbose opts in via `walkHomeBreakdown` and shares the
+        // subdir totals with the home-level total (no double walk).
+        koltHomeBytes = koltHomeBytes,
         kotlin = kotlinInfo,
         jdk = jdkInfo,
         host = hostString(),
-        project = projectInfo
+        project = projectInfo,
+        koltHomeBreakdown = breakdown,
     )
+}
+
+private fun walkHomeBreakdown(paths: KoltPaths, home: String): HomeBreakdown =
+    HomeBreakdown(
+        cacheBytes = directorySize(paths.cacheBase),
+        toolchainsBytes = directorySize(paths.toolchainsDir),
+        daemonBytes = directorySize(paths.daemonBaseDir),
+        toolsBytes = directorySize(paths.toolsDir),
+        cachePath = abbreviateHomePath(paths.cacheBase, home),
+        toolchainsPath = abbreviateHomePath(paths.toolchainsDir, home),
+        daemonPath = abbreviateHomePath(paths.daemonBaseDir, home),
+        toolsPath = abbreviateHomePath(paths.toolsDir, home),
+    )
+
+private fun absoluteManifestPath(): String {
+    val cwd = currentWorkingDirectory() ?: return KOLT_TOML
+    return absolutise(KOLT_TOML, cwd)
 }
 
 private fun loadProjectForInfo(): KoltConfig? {
@@ -149,4 +340,115 @@ private fun hostString(): String = memScoped {
     val sysname = buf.sysname.toKString().lowercase()
     val machine = buf.machine.toKString()
     "$sysname-$machine"
+}
+
+// `kolt info --format=json` schema. Consumed by editors / IDEs / CI, so the
+// field set is additive-only: rename = breaking change, removal = breaking
+// change. `explicitNulls = false` keeps unavailable fields out of the
+// payload; new fields must default to null/empty to stay backward-compatible
+// with older consumers.
+@Serializable
+private data class InfoJson(
+    val kolt: InfoKoltJson,
+    val host: String,
+    val kotlin: InfoKotlinJson? = null,
+    val jdk: InfoJdkJson? = null,
+    val project: InfoProjectJson? = null,
+)
+
+@Serializable
+private data class InfoKoltJson(
+    val version: String,
+    val path: String? = null,
+    val home: String? = null,
+    val homeBytes: Long? = null,
+    val cacheBytes: Long? = null,
+    val toolchainsBytes: Long? = null,
+    val daemonBytes: Long? = null,
+    val toolsBytes: Long? = null,
+)
+
+@Serializable
+private data class InfoKotlinJson(
+    val requestedVersion: String,
+    val resolvedVersion: String,
+    val mode: String,
+    val compilerPath: String,
+    val daemonBaseline: String,
+    val subprocessFallbackReason: String? = null,
+)
+
+@Serializable
+private data class InfoJdkJson(
+    val version: String? = null,
+    val path: String,
+    val source: String,
+)
+
+@Serializable
+private data class InfoProjectJson(
+    val name: String,
+    val version: String,
+    val kind: String,
+    val target: String,
+    val manifestPath: String,
+    val dependencyCount: Int,
+    val testDependencyCount: Int,
+    val enabledPlugins: List<String>,
+)
+
+private val infoJson = Json {
+    prettyPrint = true
+    prettyPrintIndent = "  "
+    encodeDefaults = false
+    explicitNulls = false
+}
+
+internal fun formatInfoJson(snap: InfoSnapshot): String {
+    val kotlin = snap.kotlin?.let { k ->
+        InfoKotlinJson(
+            requestedVersion = k.requestedVersion ?: k.version,
+            resolvedVersion = k.version,
+            mode = k.mode,
+            compilerPath = k.path,
+            daemonBaseline = k.daemonBaseline ?: KOTLIN_VERSION_FLOOR,
+            subprocessFallbackReason = k.subprocessFallbackReason,
+        )
+    }
+    val jdk = snap.jdk?.let { j ->
+        InfoJdkJson(
+            version = j.version,
+            path = j.path,
+            source = j.source ?: "managed",
+        )
+    }
+    val project = snap.project?.let { p ->
+        InfoProjectJson(
+            name = p.name,
+            version = p.version,
+            kind = p.kind,
+            target = p.target,
+            manifestPath = p.manifestPath ?: KOLT_TOML,
+            dependencyCount = p.dependencyCount ?: 0,
+            testDependencyCount = p.testDependencyCount ?: 0,
+            enabledPlugins = p.enabledPlugins.orEmpty(),
+        )
+    }
+    val dto = InfoJson(
+        kolt = InfoKoltJson(
+            version = snap.koltVersion,
+            path = snap.koltPath,
+            home = snap.koltHomeDisplay,
+            homeBytes = snap.koltHomeBytes,
+            cacheBytes = snap.koltHomeBreakdown?.cacheBytes,
+            toolchainsBytes = snap.koltHomeBreakdown?.toolchainsBytes,
+            daemonBytes = snap.koltHomeBreakdown?.daemonBytes,
+            toolsBytes = snap.koltHomeBreakdown?.toolsBytes,
+        ),
+        host = snap.host,
+        kotlin = kotlin,
+        jdk = jdk,
+        project = project,
+    )
+    return infoJson.encodeToString(InfoJson.serializer(), dto)
 }

--- a/src/nativeTest/kotlin/kolt/cli/InfoCommandTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/InfoCommandTest.kt
@@ -1,10 +1,17 @@
 package kolt.cli
 
+import com.github.michaelbull.result.getOrElse
 import kolt.build.daemon.KOTLIN_VERSION_FLOOR
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
 class InfoCommandTest {
     private val withProject = InfoSnapshot(
@@ -16,6 +23,43 @@ class InfoCommandTest {
         jdk = JdkInfo("21", "~/.kolt/toolchains/jdk/21/bin/java"),
         host = "linux-x86_64",
         project = ProjectInfo("my-app", "0.1.0", "app", "jvm")
+    )
+
+    private val verboseProject = withProject.copy(
+        koltHomeBytes = (100L + 30L + 10L + 2L) * 1024 * 1024,
+        koltHomeBreakdown = HomeBreakdown(
+            cacheBytes = 100L * 1024 * 1024,
+            toolchainsBytes = 30L * 1024 * 1024,
+            daemonBytes = 10L * 1024 * 1024,
+            toolsBytes = 2L * 1024 * 1024,
+            cachePath = "~/.kolt/cache",
+            toolchainsPath = "~/.kolt/toolchains",
+            daemonPath = "~/.kolt/daemon",
+            toolsPath = "~/.kolt/tools"
+        ),
+        kotlin = KotlinInfo(
+            version = "2.3.20",
+            mode = "daemon",
+            path = "~/.kolt/toolchains/kotlinc/2.3.20/bin/kotlinc",
+            requestedVersion = "2.3.0",
+            daemonBaseline = "2.3.0",
+            subprocessFallbackReason = null
+        ),
+        jdk = JdkInfo(
+            version = "21",
+            path = "~/.kolt/toolchains/jdk/21/bin/java",
+            source = "managed"
+        ),
+        project = ProjectInfo(
+            name = "my-app",
+            version = "0.1.0",
+            kind = "app",
+            target = "jvm",
+            manifestPath = "/abs/path/kolt.toml",
+            dependencyCount = 3,
+            testDependencyCount = 1,
+            enabledPlugins = listOf("serialization")
+        )
     )
 
     @Test
@@ -82,5 +126,228 @@ class InfoCommandTest {
         // and mangle every absolute path into "~/..." form.
         assertEquals("/usr/local/bin/kolt", abbreviateHomePath("/usr/local/bin/kolt", ""))
         assertEquals("/home/alice/.kolt", abbreviateHomePath("/home/alice/.kolt", ""))
+    }
+
+    @Test
+    fun verboseExpandsKoltHomeIntoBreakdown() {
+        val lines = formatInfo(verboseProject, verbose = true).lines()
+
+        val homeLineIdx = lines.indexOfFirst { it.startsWith("kolt home") }
+        assertTrue(homeLineIdx >= 0)
+        assertEquals("  cache         ~/.kolt/cache (100.0 MB)", lines[homeLineIdx + 1])
+        assertEquals("  toolchains    ~/.kolt/toolchains (30.0 MB)", lines[homeLineIdx + 2])
+        assertEquals("  daemon        ~/.kolt/daemon (10.0 MB)", lines[homeLineIdx + 3])
+        assertEquals("  tools         ~/.kolt/tools (2.0 MB)", lines[homeLineIdx + 4])
+    }
+
+    @Test
+    fun verboseExpandsKotlinSection() {
+        val lines = formatInfo(verboseProject, verbose = true).lines()
+        val kotlinIdx = lines.indexOfFirst { it.startsWith("kotlin") }
+
+        assertTrue(kotlinIdx >= 0)
+        assertEquals("  requested     2.3.0", lines[kotlinIdx + 1])
+        assertEquals("  resolved      2.3.20", lines[kotlinIdx + 2])
+        assertEquals("  compiler      ~/.kolt/toolchains/kotlinc/2.3.20/bin/kotlinc", lines[kotlinIdx + 3])
+        assertEquals("  daemon base   2.3.0", lines[kotlinIdx + 4])
+    }
+
+    @Test
+    fun verboseExpandsKotlinSubprocessFallback() {
+        val snap = verboseProject.copy(
+            kotlin = verboseProject.kotlin!!.copy(
+                version = "2.2.0",
+                mode = "subprocess [<$KOTLIN_VERSION_FLOOR]",
+                path = "~/.kolt/toolchains/kotlinc/2.2.0/bin/kotlinc",
+                requestedVersion = "2.2.0",
+                subprocessFallbackReason = "compiler 2.2.0 is below daemon baseline $KOTLIN_VERSION_FLOOR"
+            )
+        )
+        val lines = formatInfo(snap, verbose = true).lines()
+
+        assertTrue(lines.any { it.trim().startsWith("fallback") && it.contains(KOTLIN_VERSION_FLOOR) })
+    }
+
+    @Test
+    fun verboseExpandsJdkSection() {
+        val lines = formatInfo(verboseProject, verbose = true).lines()
+        val jdkIdx = lines.indexOfFirst { it.startsWith("jdk") }
+
+        assertTrue(jdkIdx >= 0)
+        assertEquals("  path          ~/.kolt/toolchains/jdk/21/bin/java", lines[jdkIdx + 1])
+        assertEquals("  source        managed", lines[jdkIdx + 2])
+    }
+
+    @Test
+    fun verboseExpandsProjectSection() {
+        val lines = formatInfo(verboseProject, verbose = true).lines()
+        val projectIdx = lines.indexOfFirst { it.startsWith("project") }
+
+        assertTrue(projectIdx >= 0)
+        assertEquals("  manifest      /abs/path/kolt.toml", lines[projectIdx + 1])
+        assertEquals("  kind          app", lines[projectIdx + 2])
+        assertEquals("  target        jvm", lines[projectIdx + 3])
+        assertEquals("  dependencies  3", lines[projectIdx + 4])
+        assertEquals("  test deps     1", lines[projectIdx + 5])
+        assertEquals("  plugins       serialization", lines[projectIdx + 6])
+    }
+
+    @Test
+    fun verboseOmitsPluginsLineWhenNoneEnabled() {
+        val snap = verboseProject.copy(
+            project = verboseProject.project!!.copy(enabledPlugins = emptyList())
+        )
+        val lines = formatInfo(snap, verbose = true).lines()
+
+        assertFalse(lines.any { it.trim().startsWith("plugins") })
+    }
+
+    @Test
+    fun verboseOutsideProjectStillShowsHomeBreakdown() {
+        val snap = verboseProject.copy(kotlin = null, jdk = null, project = null)
+        val lines = formatInfo(snap, verbose = true).lines()
+
+        assertTrue(lines.any { it.trim().startsWith("cache") })
+        assertFalse(lines.any { it.startsWith("kotlin") })
+        assertFalse(lines.any { it.startsWith("project") })
+        assertTrue(lines.any { it.contains("not in a kolt project") })
+    }
+
+    @Test
+    fun verboseFallsBackToSingleLineHomeWhenBreakdownMissing() {
+        val snap = verboseProject.copy(koltHomeBreakdown = null)
+        val lines = formatInfo(snap, verbose = true).lines()
+
+        val homeLine = lines.first { it.startsWith("kolt home") }
+        assertEquals("kolt home     ~/.kolt (142.0 MB)", homeLine)
+        val nextLine = lines[lines.indexOf(homeLine) + 1]
+        assertFalse(nextLine.trim().startsWith("cache"))
+    }
+
+    @Test
+    fun jsonFormatEmitsAllFields() {
+        val json = formatInfoJson(verboseProject)
+
+        assertTrue(json.contains("\"version\": \"0.12.0\""))
+        assertTrue(json.contains("\"homeBytes\""))
+        assertTrue(json.contains("\"cacheBytes\": 104857600"))
+        assertTrue(json.contains("\"requestedVersion\": \"2.3.0\""))
+        assertTrue(json.contains("\"resolvedVersion\": \"2.3.20\""))
+        assertTrue(json.contains("\"daemonBaseline\": \"2.3.0\""))
+        assertTrue(json.contains("\"source\": \"managed\""))
+        assertTrue(json.contains("\"manifestPath\": \"/abs/path/kolt.toml\""))
+        assertTrue(json.contains("\"dependencyCount\": 3"))
+        assertTrue(json.contains("\"enabledPlugins\""))
+        assertTrue(json.contains("\"host\": \"linux-x86_64\""))
+    }
+
+    @Test
+    fun jsonFormatOmitsUnavailableFields() {
+        val snap = verboseProject.copy(kotlin = null, jdk = null, project = null)
+        val json = formatInfoJson(snap)
+
+        assertFalse(json.contains("\"kotlin\""))
+        assertFalse(json.contains("\"jdk\""))
+        assertFalse(json.contains("\"project\""))
+        assertFalse(json.contains("null"))
+    }
+
+    @Test
+    fun jsonFormatOmitsSubprocessFallbackReasonWhenAbsent() {
+        val json = formatInfoJson(verboseProject)
+        assertFalse(json.contains("subprocessFallbackReason"))
+    }
+
+    @Test
+    fun parseInfoArgsAcceptsEmpty() {
+        val opts = parseInfoArgs(emptyList()).getOrElse { fail("expected Ok, got $it") }
+        assertFalse(opts.verbose)
+        assertFalse(opts.json)
+    }
+
+    @Test
+    fun parseInfoArgsAcceptsVerbose() {
+        val opts = parseInfoArgs(listOf("--verbose")).getOrElse { fail("expected Ok, got $it") }
+        assertTrue(opts.verbose)
+        assertFalse(opts.json)
+    }
+
+    @Test
+    fun parseInfoArgsAcceptsFormatJson() {
+        val opts = parseInfoArgs(listOf("--format=json")).getOrElse { fail("expected Ok, got $it") }
+        assertFalse(opts.verbose)
+        assertTrue(opts.json)
+    }
+
+    @Test
+    fun parseInfoArgsAcceptsBoth() {
+        val opts = parseInfoArgs(listOf("--verbose", "--format=json")).getOrElse { fail("expected Ok, got $it") }
+        assertTrue(opts.verbose)
+        assertTrue(opts.json)
+    }
+
+    @Test
+    fun parseInfoArgsRejectsUnknownFlag() {
+        val result = parseInfoArgs(listOf("--bogus"))
+        result.getOrElse {
+            assertTrue(it.contains("usage:"))
+            return
+        }
+        fail("expected Err, got Ok")
+    }
+
+    @Test
+    fun jsonFormatIsParseable() {
+        val parsed = Json.parseToJsonElement(formatInfoJson(verboseProject)).jsonObject
+
+        val kolt = parsed["kolt"]?.jsonObject ?: fail("missing kolt object")
+        assertEquals("0.12.0", kolt["version"]?.jsonPrimitive?.content)
+        val kotlin = parsed["kotlin"]?.jsonObject ?: fail("missing kotlin object")
+        assertEquals("2.3.20", kotlin["resolvedVersion"]?.jsonPrimitive?.content)
+        val project = parsed["project"]?.jsonObject ?: fail("missing project object")
+        assertEquals("my-app", project["name"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun jsonFormatOmitsKoltPathWhenUnknown() {
+        val snap = verboseProject.copy(koltPath = null)
+        val parsed = Json.parseToJsonElement(formatInfoJson(snap)).jsonObject
+        val kolt = parsed["kolt"] as? JsonObject ?: fail("missing kolt object")
+        assertFalse(kolt.containsKey("path"))
+    }
+
+    @Test
+    fun verboseOmitsJdkSectionForNativeTarget() {
+        val snap = verboseProject.copy(
+            jdk = null,
+            project = verboseProject.project!!.copy(target = "linuxX64")
+        )
+        val lines = formatInfo(snap, verbose = true).lines()
+
+        assertFalse(lines.any { it.startsWith("jdk") })
+        assertFalse(lines.any { it.trim().startsWith("source") })
+        assertNotNull(lines.firstOrNull { it.startsWith("kotlin") })
+    }
+
+    @Test
+    fun jsonOmitsJdkSectionForNativeTarget() {
+        val snap = verboseProject.copy(
+            jdk = null,
+            project = verboseProject.project!!.copy(target = "linuxX64")
+        )
+        val parsed = Json.parseToJsonElement(formatInfoJson(snap)).jsonObject
+
+        assertFalse(parsed.containsKey("jdk"))
+        assertTrue(parsed.containsKey("project"))
+    }
+
+    @Test
+    fun parseInfoArgsRejectsUnsupportedFormat() {
+        val result = parseInfoArgs(listOf("--format=yaml"))
+        result.getOrElse {
+            assertTrue(it.contains("--format"))
+            return
+        }
+        fail("expected Err, got Ok")
     }
 }


### PR DESCRIPTION
Closes #207.

`kolt info --verbose` expands each section into an indented subsection; `--format=json` emits the same field set as stable JSON. `--verbose --format=json` collapses to `--format=json`.

Judgment calls worth a second look:

- **JSON is nested, not flat.** The issue text says "flat", but nested objects (`kolt` / `kotlin` / `jdk` / `project`) read better for editor/IDE consumers and scope the additive-only schema contract per section. A comment on `InfoJson` spells out the stability rules (renames and removals are breaking, new fields default to null/empty via `explicitNulls = false`).
- **JDK section only emits for `target = "jvm"`.** Native targets don't invoke `java`; surfacing a "system" JDK there would be noise with no bearing on the build.
- **No `JAVA_HOME` source label.** `Runner.kt:18` uses `java` from PATH and never consults `$JAVA_HOME`, so disclosing `source: JAVA_HOME` would mislead users into thinking the env var matters. Source is `managed` or `system`.
- **Unknown fields are omitted from JSON, not serialised as `"(unknown)"`.** Snapshot carries `koltPath` / `koltHomeDisplay` / `JdkInfo.version` as nullable; the text renderer fills `(unknown)` where needed, JSON drops them via `explicitNulls = false`.
- **Default `kolt info` still skips the home-dir walk.** The DoD note about "shared size computation" is satisfied trivially — default walks nothing; verbose walks each subdir once and sums for the total.

Pre-existing: when `kolt.toml` exists but fails to parse, `kolt info` falls through to "not in a kolt project". Inherited from #208; will be a separate follow-up.