### PR TITLE
Drop superseded transitive deps via fixpoint resolution (#56)

### DIFF
--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -216,6 +216,12 @@ private fun resolveNativeOnce(
         }
     }
 
+    // After BFS within this pass, re-check every resolved version against the
+    // accumulated rejects. Catches the case where a later-seen contributor's
+    // rejects would have blocked an earlier-accepted version (including direct
+    // deps): the BFS can't re-queue mid-pass. Rejects are per-pass, but the
+    // fixpoint driver rebuilds accumulatedRejects every pass from the same
+    // contributors, so any reject that fires in pass N also fires in pass N+1.
     for ((groupArtifact, versionAndDirect) in resolvedVersions) {
         val patterns = accumulatedRejects[groupArtifact] ?: continue
         val version = versionAndDirect.first

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -21,19 +21,28 @@ private fun isKotlinStdlib(groupArtifact: String): Boolean =
 
 private data class NativeResolved(val redirect: NativeRedirect, val artifact: NativeArtifact)
 
+private data class NativePass(
+    val resolvedVersions: Map<String, Pair<String, Boolean>>,
+    val processed: Map<String, NativeResolved>
+)
+
 /**
  * Resolves Kotlin/Native dependencies by walking Gradle Module Metadata.
  *
- * For each dependency in the BFS queue:
- * 1. Fetch the root `.module` file and find the available-at redirect for
+ * Resolution iterates a BFS pass to a fixpoint. Each pass:
+ * 1. Fetches the root `.module` file and finds the available-at redirect for
  *    the current native target (linux_x64 in Phase B).
- * 2. Fetch the redirect target's `.module` file and extract the `.klib`
+ * 2. Fetches the redirect target's `.module` file and extracts the `.klib`
  *    file reference (url + sha256) and the variant's `dependencies[]`.
- * 3. Enqueue each transitive dependency (except the stdlib artifacts
- *    covered by [isKotlinStdlib], which konanc bundles).
+ * 3. Seeds each child version with the prior pass's committed version so an
+ *    upgrade that happened late in the previous pass is visible at every
+ *    child-selection site in this pass. Children pulled only by a superseded
+ *    version stop being enqueued and drop out of the result.
+ * 4. Skips stdlib artifacts covered by [isKotlinStdlib] (konanc bundles them).
  *
- * After BFS, each resolved `(groupArtifact, version)` has its `.klib`
- * downloaded and hashed; the sha256 is verified against the metadata.
+ * After the fixpoint is reached, each resolved `(groupArtifact, version)` has
+ * its `.klib` downloaded and hashed; the sha256 is verified against the
+ * metadata.
  *
  * Version conflict resolution mirrors the JVM resolver:
  * - Direct deps always win over transitive.
@@ -50,7 +59,6 @@ fun resolveNative(
     val nativeTarget = konanTargetGradleName(config.build.target)
     val repos = config.repositories.values.toList()
 
-    // Validate direct coords up front (mirrors jvm resolver)
     for ((groupArtifact, _) in config.dependencies) {
         if (isKotlinStdlib(groupArtifact)) continue
         parseCoordinate(groupArtifact, "0").getOrElse {
@@ -58,103 +66,24 @@ fun resolveNative(
         }
     }
 
-    // resolvedVersions: groupArtifact -> (version, isDirect)
-    val resolvedVersions = mutableMapOf<String, Pair<String, Boolean>>()
-    val queue = ArrayDeque<Pair<String, String>>()
-    val visited = mutableSetOf<String>()
-    // processed[ga:version] = (redirect, artifact) populated during BFS
-    val processed = mutableMapOf<String, NativeResolved>()
-    // Per-GA union of rejects declared by every contributor seen so far.
-    // Accumulated even when the contributor's own version proposal loses the
-    // conflict, mirroring Gradle's "rejects applies to the GA globally".
-    // A post-BFS recheck below verifies every resolved version against this
-    // final set, so an earlier-accepted version rejected by a later-seen
-    // contributor is caught as an error rather than silently kept.
-    val accumulatedRejects = mutableMapOf<String, MutableList<String>>()
-    // Per-GA strict pin. Any other proposal for the same GA is a hard error.
-    val strictPins = mutableMapOf<String, String>()
+    val directDeps = config.dependencies.filterKeys { !isKotlinStdlib(it) }
+    var committed: Map<String, Pair<String, Boolean>> =
+        directDeps.mapValues { (_, v) -> Pair(v, true) }
+    var finalProcessed: Map<String, NativeResolved> = emptyMap()
 
-    // Seed direct deps (skipping stdlib)
-    for ((groupArtifact, version) in config.dependencies) {
-        if (isKotlinStdlib(groupArtifact)) continue
-        resolvedVersions[groupArtifact] = Pair(version, true)
-        queue.addLast(groupArtifact to version)
-    }
-
-    while (queue.isNotEmpty()) {
-        val (groupArtifact, version) = queue.removeFirst()
-        val visitKey = "$groupArtifact:$version"
-        if (visitKey in visited) continue
-        visited.add(visitKey)
-
-        // A higher version may have superseded this entry while it waited in
-        // the queue. Skip fetching metadata for versions that no longer match
-        // the current resolution — we only need to materialize the final one.
-        if (resolvedVersions[groupArtifact]?.first != version) continue
-
-        val resolved = fetchNativeMetadata(
-            groupArtifact, version, nativeTarget, cacheBase, repos, deps
+    while (true) {
+        val pass = resolveNativeOnce(
+            directDeps, committed, nativeTarget, cacheBase, repos, deps
         ).getOrElse { return Err(it) }
-        processed[visitKey] = resolved
-
-        // Enqueue transitive deps
-        for (dep in resolved.artifact.dependencies) {
-            val depGA = "${dep.group}:${dep.module}"
-            if (isKotlinStdlib(depGA)) continue
-
-            if (dep.rejects.isNotEmpty()) {
-                accumulatedRejects.getOrPut(depGA) { mutableListOf() }.addAll(dep.rejects)
-            }
-
-            val patterns = accumulatedRejects[depGA]
-            if (patterns != null && patterns.any { matchesRejectPattern(dep.version, it) }) continue
-
-            val pin = strictPins[depGA]
-            if (pin != null && pin != dep.version) {
-                return Err(
-                    ResolveError.StrictVersionConflict(depGA, pin, dep.version, otherIsStrict = dep.strict)
-                )
-            }
-            if (dep.strict) {
-                val alreadyResolved = resolvedVersions[depGA]
-                if (alreadyResolved != null && alreadyResolved.first != dep.version) {
-                    return Err(
-                        ResolveError.StrictVersionConflict(depGA, dep.version, alreadyResolved.first)
-                    )
-                }
-                strictPins[depGA] = dep.version
-            }
-
-            val existing = resolvedVersions[depGA]
-            if (existing != null) {
-                val (existingVersion, isDirect) = existing
-                if (isDirect) continue
-                if (compareVersions(dep.version, existingVersion) <= 0) continue
-            }
-            resolvedVersions[depGA] = Pair(dep.version, false)
-            queue.addLast(depGA to dep.version)
-        }
+        finalProcessed = pass.processed
+        if (pass.resolvedVersions == committed) break
+        committed = pass.resolvedVersions
     }
 
-    // After BFS, re-check every resolved version against the fully-populated
-    // accumulatedRejects. Catches the case where a later-seen contributor's
-    // rejects would have blocked an earlier-accepted version (including direct
-    // deps): the BFS can't re-queue, so we error instead of silently keeping
-    // a rejected version.
-    for ((groupArtifact, versionAndDirect) in resolvedVersions) {
-        val patterns = accumulatedRejects[groupArtifact] ?: continue
-        val version = versionAndDirect.first
-        val matched = patterns.firstOrNull { matchesRejectPattern(version, it) } ?: continue
-        return Err(ResolveError.RejectedVersionResolved(groupArtifact, version, matched))
-    }
-
-    // Materialize: for each resolved (ga, version), download the .klib and
-    // verify its sha256. processed[ga:version] is guaranteed to exist because
-    // BFS visits every version that ends up in resolvedVersions.
     val resolvedDeps = mutableListOf<ResolvedDep>()
-    for ((groupArtifact, versionAndDirect) in resolvedVersions) {
+    for ((groupArtifact, versionAndDirect) in committed) {
         val (version, isDirect) = versionAndDirect
-        val resolved = processed["$groupArtifact:$version"]
+        val resolved = finalProcessed["$groupArtifact:$version"]
             ?: return Err(ResolveError.MetadataParseFailed(groupArtifact))
 
         val targetCoord = Coordinate(
@@ -196,6 +125,105 @@ fun resolveNative(
     }
 
     return Ok(ResolveResult(deps = resolvedDeps, lockChanged = false))
+}
+
+private fun resolveNativeOnce(
+    directDeps: Map<String, String>,
+    committed: Map<String, Pair<String, Boolean>>,
+    nativeTarget: String,
+    cacheBase: String,
+    repos: List<String>,
+    deps: ResolverDeps
+): Result<NativePass, ResolveError> {
+    val resolvedVersions = mutableMapOf<String, Pair<String, Boolean>>()
+    val queue = ArrayDeque<Pair<String, String>>()
+    val visited = mutableSetOf<String>()
+    val processed = mutableMapOf<String, NativeResolved>()
+    // Per-GA union of rejects declared by every contributor seen so far.
+    // Accumulated even when the contributor's own version proposal loses the
+    // conflict, mirroring Gradle's "rejects applies to the GA globally".
+    // A post-BFS recheck below verifies every resolved version against this
+    // final set, so an earlier-accepted version rejected by a later-seen
+    // contributor is caught as an error rather than silently kept.
+    val accumulatedRejects = mutableMapOf<String, MutableList<String>>()
+    // Per-GA strict pin. Any other proposal for the same GA is a hard error.
+    val strictPins = mutableMapOf<String, String>()
+
+    for ((groupArtifact, version) in directDeps) {
+        resolvedVersions[groupArtifact] = Pair(version, true)
+        queue.addLast(groupArtifact to version)
+    }
+
+    while (queue.isNotEmpty()) {
+        val (groupArtifact, version) = queue.removeFirst()
+        val visitKey = "$groupArtifact:$version"
+        if (visitKey in visited) continue
+        visited.add(visitKey)
+
+        // A higher version may have superseded this entry while it waited in
+        // the queue. Skip fetching metadata for versions that no longer match
+        // the current resolution — we only need to materialize the final one.
+        if (resolvedVersions[groupArtifact]?.first != version) continue
+
+        val resolved = fetchNativeMetadata(
+            groupArtifact, version, nativeTarget, cacheBase, repos, deps
+        ).getOrElse { return Err(it) }
+        processed[visitKey] = resolved
+
+        for (dep in resolved.artifact.dependencies) {
+            val depGA = "${dep.group}:${dep.module}"
+            if (isKotlinStdlib(depGA)) continue
+
+            if (dep.rejects.isNotEmpty()) {
+                accumulatedRejects.getOrPut(depGA) { mutableListOf() }.addAll(dep.rejects)
+            }
+
+            val patterns = accumulatedRejects[depGA]
+            if (patterns != null && patterns.any { matchesRejectPattern(dep.version, it) }) continue
+
+            val pin = strictPins[depGA]
+            if (pin != null && pin != dep.version) {
+                return Err(
+                    ResolveError.StrictVersionConflict(depGA, pin, dep.version, otherIsStrict = dep.strict)
+                )
+            }
+            if (dep.strict) {
+                val alreadyResolved = resolvedVersions[depGA]
+                if (alreadyResolved != null && alreadyResolved.first != dep.version) {
+                    return Err(
+                        ResolveError.StrictVersionConflict(depGA, dep.version, alreadyResolved.first)
+                    )
+                }
+                strictPins[depGA] = dep.version
+            }
+
+            val committedEntry = committed[depGA]
+            val depVersion = when {
+                committedEntry == null -> dep.version
+                committedEntry.second -> continue
+                compareVersions(committedEntry.first, dep.version) > 0 -> committedEntry.first
+                else -> dep.version
+            }
+
+            val existing = resolvedVersions[depGA]
+            if (existing != null) {
+                val (existingVersion, isDirect) = existing
+                if (isDirect) continue
+                if (compareVersions(depVersion, existingVersion) <= 0) continue
+            }
+            resolvedVersions[depGA] = Pair(depVersion, false)
+            queue.addLast(depGA to depVersion)
+        }
+    }
+
+    for ((groupArtifact, versionAndDirect) in resolvedVersions) {
+        val patterns = accumulatedRejects[groupArtifact] ?: continue
+        val version = versionAndDirect.first
+        val matched = patterns.firstOrNull { matchesRejectPattern(version, it) } ?: continue
+        return Err(ResolveError.RejectedVersionResolved(groupArtifact, version, matched))
+    }
+
+    return Ok(NativePass(resolvedVersions, processed))
 }
 
 /**

--- a/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
@@ -19,18 +19,47 @@ private data class QueueEntry(
 
 // Direct deps always win; among transitives, highest version wins.
 // Exclusions propagate transitively.
+//
+// Resolution iterates a BFS pass to a fixpoint. Each pass seeds child versions
+// with the prior pass's committed version (highest-wins), so an upgrade that
+// happened late in pass N is visible at every child-selection site in pass N+1.
+// Children pulled only by a superseded version stop reappearing and drop out
+// of the result.
 fun resolveGraph(
     directDeps: Map<String, String>,
     pomLookup: (groupArtifact: String, version: String) -> PomInfo?
 ): Result<List<DependencyNode>, ResolveError> {
+    for ((groupArtifact, version) in directDeps) {
+        parseCoordinate(groupArtifact, version).getOrElse {
+            return Err(ResolveError.InvalidDependency(groupArtifact))
+        }
+    }
+
+    var committed: Map<String, Pair<String, Boolean>> =
+        directDeps.mapValues { (_, v) -> Pair(v, true) }
+
+    while (true) {
+        val next = resolveGraphOnce(directDeps, committed, pomLookup)
+        if (next == committed) break
+        committed = next
+    }
+
+    val nodes = committed.map { (groupArtifact, versionAndDirect) ->
+        DependencyNode(groupArtifact, versionAndDirect.first, versionAndDirect.second)
+    }
+    return Ok(nodes)
+}
+
+private fun resolveGraphOnce(
+    directDeps: Map<String, String>,
+    committed: Map<String, Pair<String, Boolean>>,
+    pomLookup: (String, String) -> PomInfo?
+): Map<String, Pair<String, Boolean>> {
     val resolvedVersions = mutableMapOf<String, Pair<String, Boolean>>()
     val queue = ArrayDeque<QueueEntry>()
     val visited = mutableSetOf<String>()
 
     for ((groupArtifact, version) in directDeps) {
-        parseCoordinate(groupArtifact, version).getOrElse {
-            return Err(ResolveError.InvalidDependency(groupArtifact))
-        }
         resolvedVersions[groupArtifact] = Pair(version, true)
         queue.addLast(QueueEntry(groupArtifact, version, emptySet()))
     }
@@ -56,7 +85,15 @@ fun resolveGraph(
             val rawVersion = pomDep.version
                 ?: depMgmt[depGroupArtifact]
                 ?: continue
-            val depVersion = selectVersion(rawVersion)
+            val proposedVersion = selectVersion(rawVersion)
+
+            val committedEntry = committed[depGroupArtifact]
+            val depVersion = when {
+                committedEntry == null -> proposedVersion
+                committedEntry.second -> continue
+                compareVersions(committedEntry.first, proposedVersion) > 0 -> committedEntry.first
+                else -> proposedVersion
+            }
 
             val existing = resolvedVersions[depGroupArtifact]
             if (existing != null) {
@@ -72,10 +109,7 @@ fun resolveGraph(
         }
     }
 
-    val nodes = resolvedVersions.map { (groupArtifact, versionAndDirect) ->
-        DependencyNode(groupArtifact, versionAndDirect.first, versionAndDirect.second)
-    }
-    return Ok(nodes)
+    return resolvedVersions
 }
 
 private fun isExcluded(groupId: String, artifactId: String, exclusions: Set<PomExclusion>): Boolean {

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -352,6 +352,13 @@ class NativeResolverTest {
         // a -> lib:1.0 -> old-helper:1.0
         // b -> c -> lib:2.0 -> new-helper:1.0
         // After lib is upgraded to 2.0, old-helper (pulled only by lib:1.0) must be dropped.
+        //
+        // BFS order matters: {a, b} dequeues lib:1.0 before lib:2.0 (via c), so
+        // old-helper is enqueued before the stale-version guard can kick in.
+        // The reverse direct-dep order would let the guard skip lib:1.0 and
+        // mask the bug. If this test ever stops failing on main after an
+        // unrelated refactor, check whether queue ordering still exercises
+        // the dequeue-before-upgrade path.
         val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf(
                 "com.example:a" to "1.0.0",

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -348,6 +348,85 @@ class NativeResolverTest {
     }
 
     @Test
+    fun dropsSupersededTransitiveChildren() {
+        // a -> lib:1.0 -> old-helper:1.0
+        // b -> c -> lib:2.0 -> new-helper:1.0
+        // After lib is upgraded to 2.0, old-helper (pulled only by lib:1.0) must be dropped.
+        val config = testConfig(target = "linuxX64").copy(
+            dependencies = mapOf(
+                "com.example:a" to "1.0.0",
+                "com.example:b" to "1.0.0"
+            )
+        )
+
+        val aRoot = rootModuleJson("com.example", "a-linuxx64", "1.0.0")
+        val aPlatform = platformModuleJson(
+            "a-linuxx64-1.0.0.klib", "h-a",
+            listOf(NativeDependency("com.example", "lib", "1.0.0"))
+        )
+        val bRoot = rootModuleJson("com.example", "b-linuxx64", "1.0.0")
+        val bPlatform = platformModuleJson(
+            "b-linuxx64-1.0.0.klib", "h-b",
+            listOf(NativeDependency("com.example", "c", "1.0.0"))
+        )
+        val cRoot = rootModuleJson("com.example", "c-linuxx64", "1.0.0")
+        val cPlatform = platformModuleJson(
+            "c-linuxx64-1.0.0.klib", "h-c",
+            listOf(NativeDependency("com.example", "lib", "2.0.0"))
+        )
+        val lib10Root = rootModuleJson("com.example", "lib-linuxx64", "1.0.0")
+        val lib10Platform = platformModuleJson(
+            "lib-linuxx64-1.0.0.klib", "h-lib10",
+            listOf(NativeDependency("com.example", "old-helper", "1.0.0"))
+        )
+        val lib20Root = rootModuleJson("com.example", "lib-linuxx64", "2.0.0")
+        val lib20Platform = platformModuleJson(
+            "lib-linuxx64-2.0.0.klib", "h-lib20",
+            listOf(NativeDependency("com.example", "new-helper", "1.0.0"))
+        )
+        val oldHelperRoot = rootModuleJson("com.example", "old-helper-linuxx64", "1.0.0")
+        val oldHelperPlatform = platformModuleJson("old-helper-linuxx64-1.0.0.klib", "h-old", emptyList())
+        val newHelperRoot = rootModuleJson("com.example", "new-helper-linuxx64", "1.0.0")
+        val newHelperPlatform = platformModuleJson("new-helper-linuxx64-1.0.0.klib", "h-new", emptyList())
+
+        val deps = fakeDeps(
+            contents = mapOf(
+                "/cache/com/example/a/1.0.0/a-1.0.0.module" to aRoot,
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.module" to aPlatform,
+                "/cache/com/example/b/1.0.0/b-1.0.0.module" to bRoot,
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.module" to bPlatform,
+                "/cache/com/example/c/1.0.0/c-1.0.0.module" to cRoot,
+                "/cache/com/example/c-linuxx64/1.0.0/c-linuxx64-1.0.0.module" to cPlatform,
+                "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to lib10Root,
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to lib10Platform,
+                "/cache/com/example/lib/2.0.0/lib-2.0.0.module" to lib20Root,
+                "/cache/com/example/lib-linuxx64/2.0.0/lib-linuxx64-2.0.0.module" to lib20Platform,
+                "/cache/com/example/old-helper/1.0.0/old-helper-1.0.0.module" to oldHelperRoot,
+                "/cache/com/example/old-helper-linuxx64/1.0.0/old-helper-linuxx64-1.0.0.module" to oldHelperPlatform,
+                "/cache/com/example/new-helper/1.0.0/new-helper-1.0.0.module" to newHelperRoot,
+                "/cache/com/example/new-helper-linuxx64/1.0.0/new-helper-linuxx64-1.0.0.module" to newHelperPlatform
+            ),
+            sha256 = mapOf(
+                "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.klib" to "h-a",
+                "/cache/com/example/b-linuxx64/1.0.0/b-linuxx64-1.0.0.klib" to "h-b",
+                "/cache/com/example/c-linuxx64/1.0.0/c-linuxx64-1.0.0.klib" to "h-c",
+                "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "h-lib10",
+                "/cache/com/example/lib-linuxx64/2.0.0/lib-linuxx64-2.0.0.klib" to "h-lib20",
+                "/cache/com/example/old-helper-linuxx64/1.0.0/old-helper-linuxx64-1.0.0.klib" to "h-old",
+                "/cache/com/example/new-helper-linuxx64/1.0.0/new-helper-linuxx64-1.0.0.klib" to "h-new"
+            )
+        )
+
+        val result = resolveNative(config, "/cache", deps)
+        val resolved = assertNotNull(result.get())
+        val names = resolved.deps.map { it.groupArtifact }.toSet()
+        val lib = resolved.deps.first { it.groupArtifact == "com.example:lib" }
+        assertEquals("2.0.0", lib.version)
+        assertTrue("com.example:new-helper" in names)
+        assertFalse("com.example:old-helper" in names)
+    }
+
+    @Test
     fun directDepVersionWinsOverTransitive() {
         val config = testConfig(target = "linuxX64").copy(
             dependencies = mapOf(

--- a/src/nativeTest/kotlin/kolt/resolve/ResolutionTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolutionTest.kt
@@ -332,6 +332,47 @@ class ResolutionTest {
     }
 
     @Test
+    fun resolveGraphDropsSupersededTransitiveChildren() {
+        // a -> lib:1.0 -> old-helper:1.0
+        // b -> c -> lib:2.0 -> new-helper:1.0
+        // After lib is upgraded to 2.0, old-helper (pulled only by lib:1.0) must be dropped.
+        val poms = mapOf(
+            "com.example:a:1.0.0" to pomInfo(
+                "com.example", "a", "1.0.0",
+                deps = listOf(pomDep("com.example", "lib", "1.0.0"))
+            ),
+            "com.example:b:1.0.0" to pomInfo(
+                "com.example", "b", "1.0.0",
+                deps = listOf(pomDep("com.example", "c", "1.0.0"))
+            ),
+            "com.example:c:1.0.0" to pomInfo(
+                "com.example", "c", "1.0.0",
+                deps = listOf(pomDep("com.example", "lib", "2.0.0"))
+            ),
+            "com.example:lib:1.0.0" to pomInfo(
+                "com.example", "lib", "1.0.0",
+                deps = listOf(pomDep("com.example", "old-helper", "1.0.0"))
+            ),
+            "com.example:lib:2.0.0" to pomInfo(
+                "com.example", "lib", "2.0.0",
+                deps = listOf(pomDep("com.example", "new-helper", "1.0.0"))
+            ),
+            "com.example:old-helper:1.0.0" to pomInfo("com.example", "old-helper", "1.0.0"),
+            "com.example:new-helper:1.0.0" to pomInfo("com.example", "new-helper", "1.0.0")
+        )
+        val result = resolveGraph(
+            mapOf("com.example:a" to "1.0.0", "com.example:b" to "1.0.0"),
+            poms.pomLookup()
+        )
+        val nodes = assertNotNull(result.get())
+        val names = nodes.map { it.groupArtifact }.toSet()
+        val lib = nodes.first { it.groupArtifact == "com.example:lib" }
+        assertEquals("2.0.0", lib.version)
+        assertTrue("com.example:new-helper" in names)
+        assertFalse("com.example:old-helper" in names)
+    }
+
+    @Test
     fun resolveGraphExclusionDoesNotAffectOtherPaths() {
         val poms = mapOf(
             "com.example:a:1.0.0" to pomInfo(


### PR DESCRIPTION
Closes #56.

Both JVM (`Resolution.resolveGraph`) and native (`NativeResolver.resolveNative`) previously ran a single BFS pass. When a dependency was upgraded mid-BFS (e.g. `a -> lib:1.0 -> old-helper` vs `b -> c -> lib:2.0 -> new-helper`), children pulled only by the earlier version stayed in the resolved set.

Each resolver now iterates its BFS pass to a fixpoint. A pass seeds child version proposals with the prior pass's committed version (max of proposed and committed), so a late upgrade propagates across the whole tree on the next pass and children of the superseded version stop being enqueued.

## Review focus

- `Resolution.kt` — fixpoint loop + new `resolveGraphOnce` with the `committed` seed on child version selection.
- `NativeResolver.kt` — same pattern. `accumulatedRejects` / `strictPins` / post-BFS recheck reset per pass (safe: rejects/strict failures are deterministic and reappear every pass; see the restored why-not comment).
- `NativeResolverTest.dropsSupersededTransitiveChildren` / `ResolutionTest.resolveGraphDropsSupersededTransitiveChildren` — Red-phase repro that fails on `main`. The native test carries a comment on its BFS-order dependence.

## Known limitation (out of scope, tracked as #216)

The fixpoint is monotone (max-seed) but not reachability-aware: if the chain that originally chose a child version is superseded, the child version isn't downgraded. Example: `a -> b:1.0 -> c:2.0`, `d -> b:2.0 -> c:1.0` lands on `c:2.0` even though only `b:2.0`'s chain contributes reachably. This PR solves the "dropped children" half of the problem; #216 covers the reachability-downgrade half.

## Follow-ups

- #211 (share kernel between JVM / native)
- #212 (immutable Resolution state)
- #213 (path-aware exclusion)
- #216 (reachability-aware downgrade — noted above)