### PR TITLE
Distinguish kolt.toml parse errors from missing file in kolt info (#210)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.build.daemon.KOTLIN_VERSION_FLOOR
+import kolt.config.ConfigError
 import kolt.config.KOLT_VERSION
 import kolt.config.KoltConfig
 import kolt.config.KoltPaths
@@ -79,7 +80,14 @@ internal data class InfoSnapshot(
     val host: String,
     val project: ProjectInfo?,
     val koltHomeBreakdown: HomeBreakdown? = null,
+    val parseError: String? = null,
 )
+
+internal sealed class ProjectLoad {
+    data object NotAProject : ProjectLoad()
+    data class Loaded(val config: KoltConfig) : ProjectLoad()
+    data class ParseFailed(val message: String) : ProjectLoad()
+}
 
 private const val UNKNOWN_DISPLAY = "(unknown)"
 
@@ -124,9 +132,16 @@ private fun formatInfoDefault(snap: InfoSnapshot): String = buildString {
         append(labeled("target", snap.project.target))
     } else {
         appendLine()
-        append("(not in a kolt project -- no kolt.toml in current directory)")
+        append(projectPlaceholder(snap.parseError))
     }
 }.trimEnd('\n')
+
+private fun projectPlaceholder(parseError: String?): String =
+    if (parseError != null) {
+        "(kolt.toml failed to parse -- see error above)"
+    } else {
+        "(not in a kolt project -- no kolt.toml in current directory)"
+    }
 
 private fun formatInfoVerbose(snap: InfoSnapshot): String = buildString {
     appendLine(labeled("kolt", "v${snap.koltVersion} (${snap.koltPath ?: UNKNOWN_DISPLAY})", VERBOSE_LABEL_WIDTH))
@@ -182,7 +197,7 @@ private fun formatInfoVerbose(snap: InfoSnapshot): String = buildString {
             ?.let { appendLine(subLabeled("plugins", it.joinToString(", "))) }
     } else {
         appendLine()
-        append("(not in a kolt project -- no kolt.toml in current directory)")
+        append(projectPlaceholder(snap.parseError))
     }
 }.trimEnd('\n')
 
@@ -220,12 +235,13 @@ internal fun doInfo(args: List<String>): Result<Unit, Int> {
     // `--verbose --format=json` is equivalent to `--format=json` — json always
     // carries the full field set.
     val snap = gatherInfo(verbose = opts.verbose || opts.json)
+    snap.parseError?.let { eprintln("error: $it") }
     if (opts.json) {
         println(formatInfoJson(snap))
     } else {
         println(formatInfo(snap, verbose = opts.verbose))
     }
-    return Ok(Unit)
+    return if (snap.parseError != null) Err(EXIT_CONFIG_ERROR) else Ok(Unit)
 }
 
 @OptIn(ExperimentalForeignApi::class)
@@ -240,7 +256,9 @@ private fun gatherInfo(verbose: Boolean): InfoSnapshot {
     val breakdown = if (verbose && paths != null) walkHomeBreakdown(paths, home) else null
     val koltHomeBytes = breakdown?.totalBytes
 
-    val project = loadProjectForInfo()
+    val load = loadProjectForInfo()
+    val project = (load as? ProjectLoad.Loaded)?.config
+    val parseError = (load as? ProjectLoad.ParseFailed)?.message
 
     val kotlinInfo = project?.let { config ->
         val version = config.kotlin.effectiveCompiler
@@ -307,6 +325,7 @@ private fun gatherInfo(verbose: Boolean): InfoSnapshot {
         host = hostString(),
         project = projectInfo,
         koltHomeBreakdown = breakdown,
+        parseError = parseError,
     )
 }
 
@@ -327,10 +346,16 @@ private fun absoluteManifestPath(): String {
     return absolutise(KOLT_TOML, cwd)
 }
 
-private fun loadProjectForInfo(): KoltConfig? {
-    if (!fileExists(KOLT_TOML)) return null
-    val toml = readFileAsString(KOLT_TOML).getOrElse { return null }
-    return parseConfig(toml).getOrElse { null }
+internal fun loadProjectForInfo(): ProjectLoad {
+    if (!fileExists(KOLT_TOML)) return ProjectLoad.NotAProject
+    val toml = readFileAsString(KOLT_TOML).getOrElse { err ->
+        return ProjectLoad.ParseFailed("could not read ${err.path}")
+    }
+    val config = parseConfig(toml).getOrElse { err ->
+        val message = when (err) { is ConfigError.ParseFailed -> err.message }
+        return ProjectLoad.ParseFailed(message)
+    }
+    return ProjectLoad.Loaded(config)
 }
 
 @OptIn(ExperimentalForeignApi::class)
@@ -354,6 +379,7 @@ private data class InfoJson(
     val kotlin: InfoKotlinJson? = null,
     val jdk: InfoJdkJson? = null,
     val project: InfoProjectJson? = null,
+    val parseError: String? = null,
 )
 
 @Serializable
@@ -449,6 +475,7 @@ internal fun formatInfoJson(snap: InfoSnapshot): String {
         kotlin = kotlin,
         jdk = jdk,
         project = project,
+        parseError = snap.parseError,
     )
     return infoJson.encodeToString(InfoJson.serializer(), dto)
 }

--- a/src/nativeTest/kotlin/kolt/cli/InfoCommandTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/InfoCommandTest.kt
@@ -350,4 +350,58 @@ class InfoCommandTest {
         }
         fail("expected Err, got Ok")
     }
+
+    @Test
+    fun parseErrorBannerReplacesNotInProjectBanner() {
+        val snap = withProject.copy(
+            kotlin = null,
+            jdk = null,
+            project = null,
+            parseError = "kolt.toml:3: expected '='"
+        )
+        val text = formatInfo(snap)
+        assertFalse(
+            text.contains("not in a kolt project"),
+            "parse-error must not masquerade as missing kolt.toml"
+        )
+        assertTrue(
+            text.contains("kolt.toml failed to parse"),
+            "must tell the user the project section is absent because the file is broken"
+        )
+    }
+
+    @Test
+    fun verboseParseErrorBannerReplacesNotInProjectBanner() {
+        val snap = verboseProject.copy(
+            kotlin = null,
+            jdk = null,
+            project = null,
+            parseError = "kolt.toml:3: expected '='"
+        )
+        val text = formatInfo(snap, verbose = true)
+        assertFalse(text.contains("not in a kolt project"))
+        assertTrue(text.contains("kolt.toml failed to parse"))
+    }
+
+    @Test
+    fun jsonEmitsParseErrorFieldWhenPresent() {
+        val snap = verboseProject.copy(
+            kotlin = null,
+            jdk = null,
+            project = null,
+            parseError = "kolt.toml:3: expected '='"
+        )
+        val parsed = Json.parseToJsonElement(formatInfoJson(snap)).jsonObject
+        assertEquals(
+            "kolt.toml:3: expected '='",
+            parsed["parseError"]?.jsonPrimitive?.content
+        )
+        assertFalse(parsed.containsKey("project"))
+    }
+
+    @Test
+    fun jsonOmitsParseErrorFieldWhenAbsent() {
+        val parsed = Json.parseToJsonElement(formatInfoJson(verboseProject)).jsonObject
+        assertFalse(parsed.containsKey("parseError"))
+    }
 }

--- a/src/nativeTest/kotlin/kolt/cli/LoadProjectForInfoTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/LoadProjectForInfoTest.kt
@@ -1,0 +1,135 @@
+package kolt.cli
+
+import com.github.michaelbull.result.fold
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.fileExists
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.chdir
+import platform.posix.getcwd
+import platform.posix.mkdtemp
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+@OptIn(ExperimentalForeignApi::class)
+class LoadProjectForInfoTest {
+    private var originalCwd: String = ""
+    private var tmpDir: String = ""
+
+    @BeforeTest
+    fun setUp() {
+        originalCwd = memScoped {
+            val buf = allocArray<ByteVar>(PATH_MAX)
+            getcwd(buf, PATH_MAX.toULong())?.toKString() ?: error("getcwd failed")
+        }
+        tmpDir = createTempDir("kolt-info-load-")
+        check(chdir(tmpDir) == 0) { "chdir to $tmpDir failed" }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        chdir(originalCwd)
+        if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
+            removeDirectoryRecursive(tmpDir)
+        }
+    }
+
+    @Test
+    fun returnsNotAProjectWhenKoltTomlMissing() {
+        val outcome = loadProjectForInfo()
+        assertEquals(ProjectLoad.NotAProject, outcome)
+    }
+
+    @Test
+    fun returnsLoadedWhenKoltTomlParses() {
+        writeFileAsString(KOLT_TOML, VALID_TOML).getOrElse { error("seed failed: $it") }
+
+        val outcome = loadProjectForInfo()
+
+        val loaded = assertIs<ProjectLoad.Loaded>(outcome)
+        assertEquals("my-app", loaded.config.name)
+    }
+
+    @Test
+    fun returnsParseFailedWhenKoltTomlBroken() {
+        writeFileAsString(KOLT_TOML, INVALID_TOML).getOrElse { error("seed failed: $it") }
+
+        val outcome = loadProjectForInfo()
+
+        val failed = assertIs<ProjectLoad.ParseFailed>(outcome)
+        assertTrue(
+            failed.message.isNotBlank(),
+            "must surface a non-empty error so the caller can print it",
+        )
+    }
+
+    @Test
+    fun doInfoExitsWithConfigErrorWhenKoltTomlBroken() {
+        writeFileAsString(KOLT_TOML, INVALID_TOML).getOrElse { error("seed failed: $it") }
+
+        val exit = doInfo(emptyList()).fold(success = { null }, failure = { it })
+
+        assertEquals(EXIT_CONFIG_ERROR, exit)
+    }
+
+    @Test
+    fun doInfoExitsWithConfigErrorWhenKoltTomlBrokenInJsonMode() {
+        writeFileAsString(KOLT_TOML, INVALID_TOML).getOrElse { error("seed failed: $it") }
+
+        val exit = doInfo(listOf("--format=json")).fold(success = { null }, failure = { it })
+
+        assertEquals(EXIT_CONFIG_ERROR, exit)
+    }
+
+    @Test
+    fun doInfoExitsOkWhenKoltTomlMissing() {
+        val outcome = doInfo(emptyList())
+
+        outcome.getOrElse { fail("expected Ok, got exit=$it") }
+    }
+
+    private fun createTempDir(prefix: String): String {
+        val template = "/tmp/${prefix}XXXXXX"
+        val buf = template.encodeToByteArray().copyOf(template.length + 1)
+        buf.usePinned { pinned ->
+            val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+            return result.toKString()
+        }
+    }
+
+    companion object {
+        private val VALID_TOML = """
+            name = "my-app"
+            version = "0.1.0"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            main = "com.example.main"
+            sources = ["src"]
+        """.trimIndent()
+
+        private val INVALID_TOML = """
+            name = "my-app"
+            version = "0.1.0"
+
+            [kotlin]
+            version = "2.1.0"
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
Closes #210.

`loadProjectForInfo` now returns a `ProjectLoad` sealed type (`NotAProject` / `Loaded` / `ParseFailed`) rather than `KoltConfig?`. `gatherInfo` carries the parse message through `InfoSnapshot.parseError` so the renderer can pick the right banner and `doInfo` can wire stderr + exit code.

Judgment calls worth a second look:

- **Both text and JSON exit `EXIT_CONFIG_ERROR` on parse failure.** The issue text allowed text mode to stay exit 0 with a banner, but kolt's other commands (`BuildCommands.loadProjectConfig`) already exit `EXIT_CONFIG_ERROR` on parse errors, so consistency wins over the softer option.
- **JSON `parseError` is a top-level field** next to `kolt` / `host`, not nested under a fake "project" object. Mutually exclusive with `project`. Defaults to `null` so `explicitNulls = false` keeps it out of the happy-path schema — additive-only contract intact.
- **Text placeholder says "see error above"** because the parser diagnostic goes to stderr before the snapshot is rendered. Chose stderr-then-stdout ordering so users reading a terminal see the error just above the banner.
- **`loadProjectForInfo` was promoted from `private` to `internal`** to enable the filesystem-level test in `LoadProjectForInfoTest` that nails the three-state behavior directly (previously only `formatInfo` / `formatInfoJson` were testable).