### PR TITLE
Extract shared resolution kernel for JVM and native (#211)

### DIFF
--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -21,32 +21,17 @@ private fun isKotlinStdlib(groupArtifact: String): Boolean =
 
 private data class NativeResolved(val redirect: NativeRedirect, val artifact: NativeArtifact)
 
-private data class NativePass(
-    val resolvedVersions: Map<String, Pair<String, Boolean>>,
-    val processed: Map<String, NativeResolved>
-)
-
 /**
- * Resolves Kotlin/Native dependencies by walking Gradle Module Metadata.
+ * Resolves Kotlin/Native dependencies via the shared resolution kernel
+ * ([fixpointResolve]).
  *
- * Resolution iterates a BFS pass to a fixpoint. Each pass:
- * 1. Fetches the root `.module` file and finds the available-at redirect for
- *    the current native target (linux_x64 in Phase B).
- * 2. Fetches the redirect target's `.module` file and extracts the `.klib`
- *    file reference (url + sha256) and the variant's `dependencies[]`.
- * 3. Seeds each child version with the prior pass's committed version so an
- *    upgrade that happened late in the previous pass is visible at every
- *    child-selection site in this pass. Children pulled only by a superseded
- *    version stop being enqueued and drop out of the result.
- * 4. Skips stdlib artifacts covered by [isKotlinStdlib] (konanc bundles them).
+ * Native-specific responsibilities live here:
+ *  - Konan target selection and module redirect handling (via `fetchNativeMetadata`)
+ *  - klib download and sha256 verification
+ *  - Skipping stdlib artifacts konanc bundles (both as direct deps and children)
  *
- * After the fixpoint is reached, each resolved `(groupArtifact, version)` has
- * its `.klib` downloaded and hashed; the sha256 is verified against the
- * metadata.
- *
- * Version conflict resolution mirrors the JVM resolver:
- * - Direct deps always win over transitive.
- * - Among transitive deps, the highest version wins.
+ * Fixpoint loop, highest-wins, direct-wins, strict/rejects, and
+ * superseded-child rollback all live in the kernel.
  *
  * The lockfile is not consulted or written for native targets in Phase B;
  * `lockChanged` is always false. Lockfile support for native comes later.
@@ -67,24 +52,17 @@ fun resolveNative(
     }
 
     val directDeps = config.dependencies.filterKeys { !isKotlinStdlib(it) }
-    var committed: Map<String, Pair<String, Boolean>> =
-        directDeps.mapValues { (_, v) -> Pair(v, true) }
-    var finalProcessed: Map<String, NativeResolved> = emptyMap()
 
-    while (true) {
-        val pass = resolveNativeOnce(
-            directDeps, committed, nativeTarget, cacheBase, repos, deps
-        ).getOrElse { return Err(it) }
-        finalProcessed = pass.processed
-        if (pass.resolvedVersions == committed) break
-        committed = pass.resolvedVersions
-    }
+    // Populated by childLookup during resolution and reused for materialization.
+    val processed = mutableMapOf<String, NativeResolved>()
+    val childLookup = makeNativeChildLookup(processed, nativeTarget, cacheBase, repos, deps)
+
+    val nodes = fixpointResolve(directDeps, childLookup).getOrElse { return Err(it) }
 
     val resolvedDeps = mutableListOf<ResolvedDep>()
-    for ((groupArtifact, versionAndDirect) in committed) {
-        val (version, isDirect) = versionAndDirect
-        val resolved = finalProcessed["$groupArtifact:$version"]
-            ?: return Err(ResolveError.MetadataParseFailed(groupArtifact))
+    for (node in nodes) {
+        val resolved = processed["${node.groupArtifact}:${node.version}"]
+            ?: return Err(ResolveError.MetadataParseFailed(node.groupArtifact))
 
         val targetCoord = Coordinate(
             resolved.redirect.group,
@@ -103,23 +81,25 @@ fun resolveNative(
                 klibCachePath,
                 { buildKlibDownloadUrl(targetCoord, it) },
                 deps::downloadFile
-            ).getOrElse { return Err(ResolveError.DownloadFailed(groupArtifact, it)) }
+            ).getOrElse { return Err(ResolveError.DownloadFailed(node.groupArtifact, it)) }
         }
 
         val actualHash = deps.computeSha256(klibCachePath).getOrElse {
-            return Err(ResolveError.HashComputeFailed(groupArtifact, it))
+            return Err(ResolveError.HashComputeFailed(node.groupArtifact, it))
         }
         if (actualHash != resolved.artifact.klibSha256) {
-            return Err(ResolveError.Sha256Mismatch(groupArtifact, resolved.artifact.klibSha256, actualHash))
+            return Err(
+                ResolveError.Sha256Mismatch(node.groupArtifact, resolved.artifact.klibSha256, actualHash)
+            )
         }
 
         resolvedDeps.add(
             ResolvedDep(
-                groupArtifact = groupArtifact,
-                version = version,
+                groupArtifact = node.groupArtifact,
+                version = node.version,
                 sha256 = actualHash,
                 cachePath = klibCachePath,
-                transitive = !isDirect
+                transitive = !node.direct
             )
         )
     }
@@ -127,109 +107,34 @@ fun resolveNative(
     return Ok(ResolveResult(deps = resolvedDeps, lockChanged = false))
 }
 
-private fun resolveNativeOnce(
-    directDeps: Map<String, String>,
-    committed: Map<String, Pair<String, Boolean>>,
+private fun makeNativeChildLookup(
+    processed: MutableMap<String, NativeResolved>,
     nativeTarget: String,
     cacheBase: String,
     repos: List<String>,
     deps: ResolverDeps
-): Result<NativePass, ResolveError> {
-    val resolvedVersions = mutableMapOf<String, Pair<String, Boolean>>()
-    val queue = ArrayDeque<Pair<String, String>>()
-    val visited = mutableSetOf<String>()
-    val processed = mutableMapOf<String, NativeResolved>()
-    // Per-GA union of rejects declared by every contributor seen so far.
-    // Accumulated even when the contributor's own version proposal loses the
-    // conflict, mirroring Gradle's "rejects applies to the GA globally".
-    // A post-BFS recheck below verifies every resolved version against this
-    // final set, so an earlier-accepted version rejected by a later-seen
-    // contributor is caught as an error rather than silently kept.
-    val accumulatedRejects = mutableMapOf<String, MutableList<String>>()
-    // Per-GA strict pin. Any other proposal for the same GA is a hard error.
-    val strictPins = mutableMapOf<String, String>()
-
-    for ((groupArtifact, version) in directDeps) {
-        resolvedVersions[groupArtifact] = Pair(version, true)
-        queue.addLast(groupArtifact to version)
+): (String, String) -> Result<List<Child>, ResolveError> = lookup@{ ga, v ->
+    val cacheKey = "$ga:$v"
+    val cached = processed[cacheKey]
+    val native = if (cached != null) {
+        cached
+    } else {
+        val fetched = fetchNativeMetadata(ga, v, nativeTarget, cacheBase, repos, deps)
+            .getOrElse { return@lookup Err(it) }
+        processed[cacheKey] = fetched
+        fetched
     }
-
-    while (queue.isNotEmpty()) {
-        val (groupArtifact, version) = queue.removeFirst()
-        val visitKey = "$groupArtifact:$version"
-        if (visitKey in visited) continue
-        visited.add(visitKey)
-
-        // A higher version may have superseded this entry while it waited in
-        // the queue. Skip fetching metadata for versions that no longer match
-        // the current resolution — we only need to materialize the final one.
-        if (resolvedVersions[groupArtifact]?.first != version) continue
-
-        val resolved = fetchNativeMetadata(
-            groupArtifact, version, nativeTarget, cacheBase, repos, deps
-        ).getOrElse { return Err(it) }
-        processed[visitKey] = resolved
-
-        for (dep in resolved.artifact.dependencies) {
-            val depGA = "${dep.group}:${dep.module}"
-            if (isKotlinStdlib(depGA)) continue
-
-            if (dep.rejects.isNotEmpty()) {
-                accumulatedRejects.getOrPut(depGA) { mutableListOf() }.addAll(dep.rejects)
-            }
-
-            val patterns = accumulatedRejects[depGA]
-            if (patterns != null && patterns.any { matchesRejectPattern(dep.version, it) }) continue
-
-            val pin = strictPins[depGA]
-            if (pin != null && pin != dep.version) {
-                return Err(
-                    ResolveError.StrictVersionConflict(depGA, pin, dep.version, otherIsStrict = dep.strict)
-                )
-            }
-            if (dep.strict) {
-                val alreadyResolved = resolvedVersions[depGA]
-                if (alreadyResolved != null && alreadyResolved.first != dep.version) {
-                    return Err(
-                        ResolveError.StrictVersionConflict(depGA, dep.version, alreadyResolved.first)
-                    )
-                }
-                strictPins[depGA] = dep.version
-            }
-
-            val committedEntry = committed[depGA]
-            val depVersion = when {
-                committedEntry == null -> dep.version
-                committedEntry.second -> continue
-                compareVersions(committedEntry.first, dep.version) > 0 -> committedEntry.first
-                else -> dep.version
-            }
-
-            val existing = resolvedVersions[depGA]
-            if (existing != null) {
-                val (existingVersion, isDirect) = existing
-                if (isDirect) continue
-                if (compareVersions(depVersion, existingVersion) <= 0) continue
-            }
-            resolvedVersions[depGA] = Pair(depVersion, false)
-            queue.addLast(depGA to depVersion)
-        }
+    val children = native.artifact.dependencies.mapNotNull { d ->
+        val depGA = "${d.group}:${d.module}"
+        if (isKotlinStdlib(depGA)) return@mapNotNull null
+        Child(
+            groupArtifact = depGA,
+            version = d.version,
+            strict = d.strict,
+            rejects = d.rejects
+        )
     }
-
-    // After BFS within this pass, re-check every resolved version against the
-    // accumulated rejects. Catches the case where a later-seen contributor's
-    // rejects would have blocked an earlier-accepted version (including direct
-    // deps): the BFS can't re-queue mid-pass. Rejects are per-pass, but the
-    // fixpoint driver rebuilds accumulatedRejects every pass from the same
-    // contributors, so any reject that fires in pass N also fires in pass N+1.
-    for ((groupArtifact, versionAndDirect) in resolvedVersions) {
-        val patterns = accumulatedRejects[groupArtifact] ?: continue
-        val version = versionAndDirect.first
-        val matched = patterns.firstOrNull { matchesRejectPattern(version, it) } ?: continue
-        return Err(ResolveError.RejectedVersionResolved(groupArtifact, version, matched))
-    }
-
-    return Ok(NativePass(resolvedVersions, processed))
+    Ok(children)
 }
 
 /**

--- a/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
@@ -11,23 +11,43 @@ data class DependencyNode(
     val direct: Boolean
 )
 
+/**
+ * A child as seen by the resolution kernel. Populated by resolver-specific
+ * lookup adapters (pom-based for JVM, gradle-metadata-based for native).
+ *
+ * Fields other than [groupArtifact] and [version] default to empty so a
+ * resolver that doesn't use a feature (e.g. JVM has no strict/rejects today)
+ * doesn't have to populate it.
+ */
+data class Child(
+    val groupArtifact: String,
+    val version: String,
+    val strict: Boolean = false,
+    val rejects: List<String> = emptyList(),
+    val exclusions: Set<PomExclusion> = emptySet()
+)
+
 private data class QueueEntry(
     val groupArtifact: String,
     val version: String,
     val exclusions: Set<PomExclusion>
 )
 
-// Direct deps always win; among transitives, highest version wins.
-// Exclusions propagate transitively.
-//
-// Resolution iterates a BFS pass to a fixpoint. Each pass seeds child versions
-// with the prior pass's committed version (highest-wins), so an upgrade that
-// happened late in pass N is visible at every child-selection site in pass N+1.
-// Children pulled only by a superseded version stop reappearing and drop out
-// of the result.
-fun resolveGraph(
+/**
+ * Shared resolution kernel.
+ *
+ * Direct deps always win; among transitives, highest version wins. Exclusions
+ * propagate transitively; strict pins and rejects error out.
+ *
+ * Resolution iterates a BFS pass to a fixpoint. Each pass seeds child versions
+ * with the prior pass's committed version (highest-wins), so an upgrade that
+ * happened late in pass N is visible at every child-selection site in pass N+1.
+ * Children pulled only by a superseded version stop reappearing and drop out
+ * of the result.
+ */
+fun fixpointResolve(
     directDeps: Map<String, String>,
-    pomLookup: (groupArtifact: String, version: String) -> PomInfo?
+    childLookup: (groupArtifact: String, version: String) -> Result<List<Child>, ResolveError>
 ): Result<List<DependencyNode>, ResolveError> {
     for ((groupArtifact, version) in directDeps) {
         parseCoordinate(groupArtifact, version).getOrElse {
@@ -39,25 +59,28 @@ fun resolveGraph(
         directDeps.mapValues { (_, v) -> Pair(v, true) }
 
     while (true) {
-        val next = resolveGraphOnce(directDeps, committed, pomLookup)
+        val next = resolveOnce(directDeps, committed, childLookup).getOrElse { return Err(it) }
         if (next == committed) break
         committed = next
     }
 
-    val nodes = committed.map { (groupArtifact, versionAndDirect) ->
-        DependencyNode(groupArtifact, versionAndDirect.first, versionAndDirect.second)
-    }
-    return Ok(nodes)
+    return Ok(committed.map { (ga, vd) -> DependencyNode(ga, vd.first, vd.second) })
 }
 
-private fun resolveGraphOnce(
+private fun resolveOnce(
     directDeps: Map<String, String>,
     committed: Map<String, Pair<String, Boolean>>,
-    pomLookup: (String, String) -> PomInfo?
-): Map<String, Pair<String, Boolean>> {
+    childLookup: (String, String) -> Result<List<Child>, ResolveError>
+): Result<Map<String, Pair<String, Boolean>>, ResolveError> {
     val resolvedVersions = mutableMapOf<String, Pair<String, Boolean>>()
     val queue = ArrayDeque<QueueEntry>()
     val visited = mutableSetOf<String>()
+    // Per-GA union of rejects declared by every contributor seen so far.
+    // Accumulated even when the contributor's own version proposal loses the
+    // conflict, mirroring Gradle's "rejects applies to the GA globally".
+    val accumulatedRejects = mutableMapOf<String, MutableList<String>>()
+    // Per-GA strict pin. Any other proposal for the same GA is a hard error.
+    val strictPins = mutableMapOf<String, String>()
 
     for ((groupArtifact, version) in directDeps) {
         resolvedVersions[groupArtifact] = Pair(version, true)
@@ -70,49 +93,117 @@ private fun resolveGraphOnce(
         if (visitKey in visited) continue
         visited.add(visitKey)
 
-        val pomInfo = pomLookup(entry.groupArtifact, entry.version) ?: continue
+        // A higher version may have superseded this entry while it waited in
+        // the queue. Skip the lookup for versions no longer current — only the
+        // final version needs its children enumerated.
+        if (resolvedVersions[entry.groupArtifact]?.first != entry.version) continue
 
-        val depMgmt = collectDepMgmt(pomInfo, pomLookup)
+        val children = childLookup(entry.groupArtifact, entry.version).getOrElse { return Err(it) }
 
-        for (pomDep in pomInfo.dependencies) {
-            if (!isIncludedScope(pomDep.scope)) continue
-            if (pomDep.optional) continue
+        for (child in children) {
+            val depGA = child.groupArtifact
 
-            val depGroupArtifact = "${pomDep.groupId}:${pomDep.artifactId}"
+            if (isExcluded(depGA, entry.exclusions)) continue
 
-            if (isExcluded(pomDep.groupId, pomDep.artifactId, entry.exclusions)) continue
-
-            val rawVersion = pomDep.version
-                ?: depMgmt[depGroupArtifact]
-                ?: continue
-            val proposedVersion = selectVersion(rawVersion)
-
-            val committedEntry = committed[depGroupArtifact]
-            val depVersion = when {
-                committedEntry == null -> proposedVersion
-                committedEntry.second -> continue
-                compareVersions(committedEntry.first, proposedVersion) > 0 -> committedEntry.first
-                else -> proposedVersion
+            if (child.rejects.isNotEmpty()) {
+                accumulatedRejects.getOrPut(depGA) { mutableListOf() }.addAll(child.rejects)
             }
 
-            val existing = resolvedVersions[depGroupArtifact]
+            val patterns = accumulatedRejects[depGA]
+            if (patterns != null && patterns.any { matchesRejectPattern(child.version, it) }) continue
+
+            val pin = strictPins[depGA]
+            if (pin != null && pin != child.version) {
+                return Err(
+                    ResolveError.StrictVersionConflict(depGA, pin, child.version, otherIsStrict = child.strict)
+                )
+            }
+            if (child.strict) {
+                val alreadyResolved = resolvedVersions[depGA]
+                if (alreadyResolved != null && alreadyResolved.first != child.version) {
+                    return Err(
+                        ResolveError.StrictVersionConflict(depGA, child.version, alreadyResolved.first)
+                    )
+                }
+                strictPins[depGA] = child.version
+            }
+
+            val committedEntry = committed[depGA]
+            val depVersion = when {
+                committedEntry == null -> child.version
+                committedEntry.second -> continue
+                compareVersions(committedEntry.first, child.version) > 0 -> committedEntry.first
+                else -> child.version
+            }
+
+            val existing = resolvedVersions[depGA]
             if (existing != null) {
                 val (existingVersion, isDirect) = existing
                 if (isDirect) continue
                 if (compareVersions(depVersion, existingVersion) <= 0) continue
             }
 
-            val mergedExclusions = entry.exclusions + pomDep.exclusions.toSet()
-
-            resolvedVersions[depGroupArtifact] = Pair(depVersion, false)
-            queue.addLast(QueueEntry(depGroupArtifact, depVersion, mergedExclusions))
+            val mergedExclusions = entry.exclusions + child.exclusions
+            resolvedVersions[depGA] = Pair(depVersion, false)
+            queue.addLast(QueueEntry(depGA, depVersion, mergedExclusions))
         }
     }
 
-    return resolvedVersions
+    // Re-check resolved versions against the fully-populated accumulatedRejects.
+    // Catches the case where a later-seen contributor's rejects would have
+    // blocked an earlier-accepted version (including direct deps): the BFS
+    // can't re-queue mid-pass. Rejects are per-pass, but the fixpoint driver
+    // rebuilds accumulatedRejects every pass from the same contributors, so
+    // any reject that fires in pass N also fires in pass N+1.
+    for ((groupArtifact, versionAndDirect) in resolvedVersions) {
+        val patterns = accumulatedRejects[groupArtifact] ?: continue
+        val version = versionAndDirect.first
+        val matched = patterns.firstOrNull { matchesRejectPattern(version, it) } ?: continue
+        return Err(ResolveError.RejectedVersionResolved(groupArtifact, version, matched))
+    }
+
+    return Ok(resolvedVersions)
 }
 
-private fun isExcluded(groupId: String, artifactId: String, exclusions: Set<PomExclusion>): Boolean {
+/**
+ * JVM / pom-based adapter. Kept as a thin wrapper so existing callers and
+ * tests can keep passing `pomLookup` directly; the kernel itself is
+ * [fixpointResolve].
+ */
+fun resolveGraph(
+    directDeps: Map<String, String>,
+    pomLookup: (groupArtifact: String, version: String) -> PomInfo?
+): Result<List<DependencyNode>, ResolveError> =
+    fixpointResolve(directDeps, pomChildLookup(pomLookup))
+
+private fun pomChildLookup(
+    pomLookup: (String, String) -> PomInfo?
+): (String, String) -> Result<List<Child>, ResolveError> = { groupArtifact, version ->
+    val pomInfo = pomLookup(groupArtifact, version)
+    if (pomInfo == null) {
+        Ok(emptyList())
+    } else {
+        val depMgmt = collectDepMgmt(pomInfo, pomLookup)
+        val children = pomInfo.dependencies.mapNotNull { pomDep ->
+            if (!isIncludedScope(pomDep.scope)) return@mapNotNull null
+            if (pomDep.optional) return@mapNotNull null
+            val depGA = "${pomDep.groupId}:${pomDep.artifactId}"
+            val rawVersion = pomDep.version ?: depMgmt[depGA] ?: return@mapNotNull null
+            Child(
+                groupArtifact = depGA,
+                version = selectVersion(rawVersion),
+                exclusions = pomDep.exclusions.toSet()
+            )
+        }
+        Ok(children)
+    }
+}
+
+private fun isExcluded(groupArtifact: String, exclusions: Set<PomExclusion>): Boolean {
+    if (exclusions.isEmpty()) return false
+    val parts = groupArtifact.split(":", limit = 2)
+    if (parts.size != 2) return false
+    val (groupId, artifactId) = parts
     return exclusions.any { ex ->
         (ex.groupId == "*" || ex.groupId == groupId) &&
             (ex.artifactId == "*" || ex.artifactId == artifactId)


### PR DESCRIPTION
Closes #211.

Move the fixpoint BFS, highest-wins, direct-wins, strict/rejects, exclusion propagation, and superseded-child rollback into a single `fixpointResolve` kernel. The kernel takes `childLookup: (ga, v) -> Result<List<Child>, ResolveError>` and a `Child` record that carries per-edge constraint metadata (strict, rejects, exclusions).

## Review focus

- `Resolution.kt` — `Child` record, `fixpointResolve` kernel, `resolveOnce` with the existing per-pass accumulated-rejects / strict-pin logic. `resolveGraph` is now a thin pom-based adapter; existing `ResolutionTest` cases go through the same code path.
- `NativeResolver.kt` — `makeNativeChildLookup` wraps `fetchNativeMetadata` and also memoizes `NativeResolved` for the materialization pass. `isKotlinStdlib` is still the only native-specific filter on children.
- `isExcluded` moved into the kernel and now splits `groupArtifact` into `(groupId, artifactId)`. Equivalent behavior; check the wildcard test cases still pass (they do).
- The stale-version guard (`resolvedVersions[ga].first != entry.version`) was absent on the JVM path pre-refactor; it's now unconditional in the kernel. Safe: skips redundant `childLookup` calls for superseded entries, no behavior change.

Pure refactor on top of #56. No new tests; existing JVM and native test suites pass unchanged.

## Follow-ups

- #212 (immutable Resolution state) sits naturally on top of this.
- #213 (path-aware exclusion) and #216 (reachability-aware downgrade) remain independent.