### PR TITLE
Make resolution reachability-aware (#216)

### DIFF
--- a/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
@@ -53,11 +53,14 @@ private data class QueueEntry(
  * Direct deps always win; among transitives, highest version wins. Exclusions
  * propagate transitively; strict pins and rejects error out.
  *
- * Resolution iterates a BFS pass to a fixpoint. Each pass seeds child versions
- * with the prior pass's committed version (highest-wins), so an upgrade that
- * happened late in pass N is visible at every child-selection site in pass N+1.
- * Children pulled only by a superseded version stop reappearing and drop out
- * of the result.
+ * Resolution iterates a BFS pass to a fixpoint. Each pass walks direct deps
+ * and, for every visited GA, fetches its children using the *prior pass's
+ * chosen version* — so a GA that gets upgraded in pass N is traversed through
+ * its new version in pass N+1, and children pulled only by the superseded
+ * version drop out. Inside one pass the `visited` set is keyed by GA (not by
+ * GA+version), so the first dequeue for a GA determines which version's
+ * children are enumerated this pass. All version proposals are collected and
+ * reduced by highest-wins at the end of the pass.
  */
 fun fixpointResolve(
     directDeps: Map<String, String>,
@@ -73,110 +76,118 @@ fun fixpointResolve(
         versions = directDeps.mapValues { (_, v) -> Pair(v, true) }
     )
 
-    while (true) {
+    // Safety cap on iterations. Fixpoint convergence is not proven monotone in
+    // pathological graphs; a non-converging input should fail loudly rather
+    // than hang. Bumped well past any realistic depth.
+    repeat(MAX_FIXPOINT_PASSES) {
         val next = iterate(state, directDeps, childLookup).getOrElse { return Err(it) }
         if (next.versions == state.versions) {
             return Ok(next.versions.map { (ga, vd) -> DependencyNode(ga, vd.first, vd.second) })
         }
         state = next
     }
+    return Err(ResolveError.ResolutionDidNotConverge(MAX_FIXPOINT_PASSES))
 }
+
+private const val MAX_FIXPOINT_PASSES = 100
 
 private fun iterate(
     prev: Resolution,
     directDeps: Map<String, String>,
     childLookup: (String, String) -> Result<List<Child>, ResolveError>
 ): Result<Resolution, ResolveError> {
-    val versions = mutableMapOf<String, Pair<String, Boolean>>()
+    // ga -> all version proposals this pass (highest-wins reduced at the end).
+    val proposals = mutableMapOf<String, MutableList<String>>()
     val queue = ArrayDeque<QueueEntry>()
+    // ga:version-keyed. Same GA may dequeue at multiple versions; the
+    // winning-version gate below decides which one actually fetches children.
     val visited = mutableSetOf<String>()
-    // Per-GA union of rejects declared by every contributor seen so far.
-    // Accumulated even when the contributor's own version proposal loses the
-    // conflict, mirroring Gradle's "rejects applies to the GA globally".
+    // Per-GA union of rejects declared by every contributor seen this pass.
     val rejects = mutableMapOf<String, MutableList<String>>()
     // Per-GA strict pin. Any other proposal for the same GA is a hard error.
     val strictPins = mutableMapOf<String, String>()
 
     for ((groupArtifact, version) in directDeps) {
-        versions[groupArtifact] = Pair(version, true)
+        proposals.getOrPut(groupArtifact) { mutableListOf() }.add(version)
         queue.addLast(QueueEntry(groupArtifact, version, emptySet()))
     }
 
     while (queue.isNotEmpty()) {
         val entry = queue.removeFirst()
-        val visitKey = "${entry.groupArtifact}:${entry.version}"
+        val ga = entry.groupArtifact
+        val visitKey = "$ga:${entry.version}"
         if (visitKey in visited) continue
+
+        // Winning-version gate: only fetch children for the version that will
+        // actually win for this GA. `prev.versions[ga]` wins when set (the
+        // previous pass's committed choice); otherwise fall back to the highest
+        // proposal seen so far in this pass. This avoids fetching metadata for
+        // a losing version (e.g., diamond test whose losing version has no
+        // published metadata at all).
+        val winningVersion = prev.versions[ga]?.first
+            ?: proposals.getValue(ga).reduce { a, b -> if (compareVersions(a, b) >= 0) a else b }
+        if (entry.version != winningVersion) continue
         visited.add(visitKey)
 
-        // A higher version may have superseded this entry while it waited in
-        // the queue. Skip the lookup for versions no longer current — only the
-        // final version needs its children enumerated.
-        if (versions[entry.groupArtifact]?.first != entry.version) continue
-
-        val children = childLookup(entry.groupArtifact, entry.version).getOrElse { return Err(it) }
+        val children = childLookup(ga, entry.version).getOrElse { return Err(it) }
 
         for (child in children) {
-            val depGA = child.groupArtifact
+            val cga = child.groupArtifact
 
-            if (isExcluded(depGA, entry.exclusions)) continue
+            if (isExcluded(cga, entry.exclusions)) continue
 
             if (child.rejects.isNotEmpty()) {
-                rejects.getOrPut(depGA) { mutableListOf() }.addAll(child.rejects)
+                rejects.getOrPut(cga) { mutableListOf() }.addAll(child.rejects)
             }
 
-            val patterns = rejects[depGA]
+            val patterns = rejects[cga]
             if (patterns != null && patterns.any { matchesRejectPattern(child.version, it) }) continue
 
-            val pin = strictPins[depGA]
+            val pin = strictPins[cga]
             if (pin != null && pin != child.version) {
                 return Err(
-                    ResolveError.StrictVersionConflict(depGA, pin, child.version, otherIsStrict = child.strict)
+                    ResolveError.StrictVersionConflict(cga, pin, child.version, otherIsStrict = child.strict)
                 )
             }
             if (child.strict) {
-                val alreadyResolved = versions[depGA]
-                if (alreadyResolved != null && alreadyResolved.first != child.version) {
-                    return Err(
-                        ResolveError.StrictVersionConflict(depGA, child.version, alreadyResolved.first)
-                    )
+                val existing = proposals[cga]?.firstOrNull { it != child.version }
+                if (existing != null) {
+                    return Err(ResolveError.StrictVersionConflict(cga, child.version, existing))
                 }
-                strictPins[depGA] = child.version
+                strictPins[cga] = child.version
             }
 
-            val committedEntry = prev.versions[depGA]
-            val depVersion = when {
-                committedEntry == null -> child.version
-                committedEntry.second -> continue
-                compareVersions(committedEntry.first, child.version) > 0 -> committedEntry.first
-                else -> child.version
-            }
-
-            val existing = versions[depGA]
-            if (existing != null) {
-                val (existingVersion, isDirect) = existing
-                if (isDirect) continue
-                if (compareVersions(depVersion, existingVersion) <= 0) continue
-            }
+            proposals.getOrPut(cga) { mutableListOf() }.add(child.version)
 
             val mergedExclusions = entry.exclusions + child.exclusions
-            versions[depGA] = Pair(depVersion, false)
-            queue.addLast(QueueEntry(depGA, depVersion, mergedExclusions))
+            queue.addLast(QueueEntry(cga, child.version, mergedExclusions))
         }
     }
 
-    // Re-check resolved versions against the fully-populated rejects. Catches
+    // Reduce proposals to a single chosen version per GA: direct wins,
+    // otherwise highest-wins across everything proposed this pass.
+    val newVersions = mutableMapOf<String, Pair<String, Boolean>>()
+    for ((ga, v) in directDeps) {
+        newVersions[ga] = Pair(v, true)
+    }
+    for ((ga, versionList) in proposals) {
+        if (ga in directDeps) continue
+        val highest = versionList.reduce { a, b -> if (compareVersions(a, b) >= 0) a else b }
+        newVersions[ga] = Pair(highest, false)
+    }
+
+    // Re-check chosen versions against the fully-populated rejects. Catches
     // the case where a later-seen contributor's rejects would have blocked an
     // earlier-accepted version (including direct deps): the BFS can't re-queue
     // mid-pass. Rejects are rebuilt each pass from the same contributors, so
     // any reject that fires in pass N also fires in pass N+1.
-    for ((groupArtifact, versionAndDirect) in versions) {
-        val patterns = rejects[groupArtifact] ?: continue
-        val version = versionAndDirect.first
-        val matched = patterns.firstOrNull { matchesRejectPattern(version, it) } ?: continue
-        return Err(ResolveError.RejectedVersionResolved(groupArtifact, version, matched))
+    for ((ga, versionAndDirect) in newVersions) {
+        val patterns = rejects[ga] ?: continue
+        val matched = patterns.firstOrNull { matchesRejectPattern(versionAndDirect.first, it) } ?: continue
+        return Err(ResolveError.RejectedVersionResolved(ga, versionAndDirect.first, matched))
     }
 
-    return Ok(Resolution(versions = versions.toMap()))
+    return Ok(Resolution(versions = newVersions.toMap()))
 }
 
 /**

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -32,6 +32,7 @@ sealed class ResolveError {
         val version: String,
         val rejectPattern: String
     ) : ResolveError()
+    data class ResolutionDidNotConverge(val maxPasses: Int) : ResolveError()
 }
 
 fun formatResolveError(error: ResolveError): String = when (error) {
@@ -59,6 +60,8 @@ fun formatResolveError(error: ResolveError): String = when (error) {
                 "${error.strictVersion} required strictly, but ${error.otherVersion} also requested"
     is ResolveError.RejectedVersionResolved ->
         "error: resolved ${error.groupArtifact}:${error.version} is rejected by constraint '${error.rejectPattern}'"
+    is ResolveError.ResolutionDidNotConverge ->
+        "error: dependency resolution did not converge within ${error.maxPasses} passes"
 }
 
 data class ResolvedDep(

--- a/src/nativeTest/kotlin/kolt/resolve/ResolutionTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolutionTest.kt
@@ -373,6 +373,62 @@ class ResolutionTest {
     }
 
     @Test
+    fun resolveGraphChildFollowsWinningParentChain() {
+        // a -> b:1.0 -> c:2.0 -> e:1.0
+        // d -> x -> b:2.0 -> c:1.0 -> f:1.0
+        //
+        // The extra `x` hop delays b's upgrade past b:1.0's first visit: b:1.0
+        // is dequeued (and gets to enqueue c:2.0) before x visits and upgrades
+        // b to 2.0, so the stale-version guard can't help. Reachability-correct
+        // result: b=2.0, c=1.0, f=1.0. c:2.0 and e:1.0 must be dropped —
+        // b:1.0's chain is superseded, so its children must not survive.
+        val poms = mapOf(
+            "com.example:a:1.0.0" to pomInfo(
+                "com.example", "a", "1.0.0",
+                deps = listOf(pomDep("com.example", "b", "1.0.0"))
+            ),
+            "com.example:d:1.0.0" to pomInfo(
+                "com.example", "d", "1.0.0",
+                deps = listOf(pomDep("com.example", "x", "1.0.0"))
+            ),
+            "com.example:x:1.0.0" to pomInfo(
+                "com.example", "x", "1.0.0",
+                deps = listOf(pomDep("com.example", "b", "2.0.0"))
+            ),
+            "com.example:b:1.0.0" to pomInfo(
+                "com.example", "b", "1.0.0",
+                deps = listOf(pomDep("com.example", "c", "2.0.0"))
+            ),
+            "com.example:b:2.0.0" to pomInfo(
+                "com.example", "b", "2.0.0",
+                deps = listOf(pomDep("com.example", "c", "1.0.0"))
+            ),
+            "com.example:c:1.0.0" to pomInfo(
+                "com.example", "c", "1.0.0",
+                deps = listOf(pomDep("com.example", "f", "1.0.0"))
+            ),
+            "com.example:c:2.0.0" to pomInfo(
+                "com.example", "c", "2.0.0",
+                deps = listOf(pomDep("com.example", "e", "1.0.0"))
+            ),
+            "com.example:e:1.0.0" to pomInfo("com.example", "e", "1.0.0"),
+            "com.example:f:1.0.0" to pomInfo("com.example", "f", "1.0.0")
+        )
+        val result = resolveGraph(
+            mapOf("com.example:a" to "1.0.0", "com.example:d" to "1.0.0"),
+            poms.pomLookup()
+        )
+        val nodes = assertNotNull(result.get())
+        val names = nodes.map { it.groupArtifact }.toSet()
+        val b = nodes.first { it.groupArtifact == "com.example:b" }
+        val c = nodes.first { it.groupArtifact == "com.example:c" }
+        assertEquals("2.0.0", b.version)
+        assertEquals("1.0.0", c.version)
+        assertTrue("com.example:f" in names)
+        assertFalse("com.example:e" in names)
+    }
+
+    @Test
     fun resolveGraphExclusionDoesNotAffectOtherPaths() {
         val poms = mapOf(
             "com.example:a:1.0.0" to pomInfo(


### PR DESCRIPTION
Closes #216.

Previous fixpoint used max-seed: a child version committed in pass N was pinned as a lower bound for subsequent passes. A child pulled through a chain that later got superseded stayed at the higher version even when the winning parent's chain no longer required it.

## What changed

`iterate()` now uses a **winning-version gate**. At dequeue, a `(ga, v)` entry is processed only if `v` equals the currently-winning version for `ga`:

- `prev.versions[ga].first` if the prior pass chose one
- else the highest proposal seen so far in this pass

Other `(ga, v)` entries skip `childLookup`. Children are enumerated only for the winning version, letting a chosen version **downgrade** across passes when its selecting chain loses.

Proposals are collected per GA and reduced by direct-wins / highest-wins at the end of the pass. Iteration terminates when versions stabilize. A safety cap (`MAX_FIXPOINT_PASSES = 100`) surfaces pathological non-convergence as a new `ResolutionDidNotConverge` error rather than hanging.

## Review focus

- `Resolution.kt:iterate` — the winning-version gate. Walk the `#216` repro and the diamond (`diamondDependencyHighestVersionWins` uses only shared:2.0's metadata — confirm shared:1.0 is gated out before `childLookup`).
- Strict/rejects behaviour: tests `rejectsFromLaterContributorRevokesAlreadyAcceptedVersion`, `rejectsMatchingDirectDepVersionFailsFast`, `strictlyConflictWithHigherTransitiveProposalFailsFast`, `depWithBothStrictlyAndRejectsHonorsBothConstraints` still pass — the strict pin and post-BFS rejects recheck run on proposals regardless of the gate.
- `MAX_FIXPOINT_PASSES` / `ResolutionDidNotConverge` — safety cap. Currently the #216 repro converges in 4 passes; 100 is an order of magnitude buffer.

## Test

`ResolutionTest.resolveGraphChildFollowsWinningParentChain` — `a -> b:1.0 -> c:2.0 -> e:1.0` and `d -> x -> b:2.0 -> c:1.0 -> f:1.0` converging to `c=1.0, f=1.0`. The extra `x` hop defeats the stale-version guard that made the naive issue example coincidentally green.

## Follow-ups

- #213 (path-aware exclusion) — last resolver correctness item, independent.