### PR TITLE
Evaluate exclusions per BFS path (#213)

### DIFF
--- a/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
@@ -158,6 +158,9 @@ private fun iterate(
             val existing = versions[depGA]
             if (existing != null) {
                 val (existingVersion, isDirect) = existing
+                // Direct-dep wins even over a transitive path with a different
+                // exclusion context: the user-declared direct dep decides the
+                // children, not a transitive's exclusion list. Matches Gradle.
                 if (isDirect) continue
                 // Keep enqueueing same-version entries with different exclusion
                 // sets so the per-path exclusion check runs against each one.

--- a/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
@@ -34,8 +34,7 @@ data class Child(
  * the fixpoint loop iterates until [versions] stops changing. Internal per-pass
  * scratch buffers (rejects, strict pins, visited, queue) stay mutable for
  * readability and are rebuilt each pass from the same contributors, so they
- * don't need to be threaded across passes today. Future reachability-aware
- * resolution (#216) may need to extend this record.
+ * don't need to be threaded across passes today.
  */
 data class Resolution(
     val versions: Map<String, Pair<String, Boolean>>
@@ -104,7 +103,12 @@ private fun iterate(
 
     while (queue.isNotEmpty()) {
         val entry = queue.removeFirst()
-        val visitKey = "${entry.groupArtifact}:${entry.version}"
+        // Path-aware exclusion: a (ga, version) reached through two different
+        // parent paths with different exclusion sets must enumerate children
+        // under each set independently. Keying visited by exclusions lets both
+        // visits proceed so that a child excluded on one path can still reach
+        // the resolved set via the other.
+        val visitKey = "${entry.groupArtifact}:${entry.version}:${exclusionsKey(entry.exclusions)}"
         if (visitKey in visited) continue
         visited.add(visitKey)
 
@@ -155,11 +159,17 @@ private fun iterate(
             if (existing != null) {
                 val (existingVersion, isDirect) = existing
                 if (isDirect) continue
-                if (compareVersions(depVersion, existingVersion) <= 0) continue
+                // Keep enqueueing same-version entries with different exclusion
+                // sets so the per-path exclusion check runs against each one.
+                // Strictly-lower versions stay skipped (they'd lose the
+                // highest-wins anyway).
+                if (compareVersions(depVersion, existingVersion) < 0) continue
             }
 
             val mergedExclusions = entry.exclusions + child.exclusions
-            versions[depGA] = Pair(depVersion, false)
+            if (existing == null || compareVersions(depVersion, existing.first) > 0) {
+                versions[depGA] = Pair(depVersion, false)
+            }
             queue.addLast(QueueEntry(depGA, depVersion, mergedExclusions))
         }
     }
@@ -211,6 +221,13 @@ private fun pomChildLookup(
         }
         Ok(children)
     }
+}
+
+private fun exclusionsKey(exclusions: Set<PomExclusion>): String {
+    if (exclusions.isEmpty()) return ""
+    return exclusions
+        .sortedWith(compareBy({ it.groupId }, { it.artifactId }))
+        .joinToString("|") { "${it.groupId}:${it.artifactId}" }
 }
 
 private fun isExcluded(groupArtifact: String, exclusions: Set<PomExclusion>): Boolean {

--- a/src/nativeTest/kotlin/kolt/resolve/ResolutionTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolutionTest.kt
@@ -373,6 +373,43 @@ class ResolutionTest {
     }
 
     @Test
+    fun resolveGraphExclusionIsEvaluatedPerPath() {
+        // direct: a, b
+        // a -> lib (exclude c)
+        // b -> lib (no exclusion)
+        // lib -> c
+        //
+        // Path-aware evaluation (Maven spec): c is excluded only if ALL paths
+        // to lib exclude it. b's path doesn't, so c reaches the resolved set.
+        val poms = mapOf(
+            "com.example:a:1.0.0" to pomInfo(
+                "com.example", "a", "1.0.0",
+                deps = listOf(
+                    pomDep("com.example", "lib", "1.0.0",
+                        exclusions = listOf(PomExclusion("com.example", "c")))
+                )
+            ),
+            "com.example:b:1.0.0" to pomInfo(
+                "com.example", "b", "1.0.0",
+                deps = listOf(pomDep("com.example", "lib", "1.0.0"))
+            ),
+            "com.example:lib:1.0.0" to pomInfo(
+                "com.example", "lib", "1.0.0",
+                deps = listOf(pomDep("com.example", "c", "1.0.0"))
+            ),
+            "com.example:c:1.0.0" to pomInfo("com.example", "c", "1.0.0")
+        )
+        val result = resolveGraph(
+            mapOf("com.example:a" to "1.0.0", "com.example:b" to "1.0.0"),
+            poms.pomLookup()
+        )
+        val nodes = assertNotNull(result.get())
+        val names = nodes.map { it.groupArtifact }.toSet()
+        assertTrue("com.example:lib" in names)
+        assertTrue("com.example:c" in names)
+    }
+
+    @Test
     fun resolveGraphExclusionDoesNotAffectOtherPaths() {
         val poms = mapOf(
             "com.example:a:1.0.0" to pomInfo(


### PR DESCRIPTION
Closes #213.

The kernel used to key `visited` by `ga:version`, so only the first parent path to reach a `(ga, version)` decided which children were excluded. Subsequent paths with a different (or empty) exclusion set were skipped and their children never surfaced — contrary to Maven's per-dep-declaration exclusion semantics.

## What changed

- `visited` key now includes a stable serialization of the path's exclusion set. A `(ga, version)` reached via two paths with different exclusions visits twice, once per context.
- The same-version short-circuit in child selection was relaxed: strictly-lower versions still bail, but equal-version siblings arriving from a different exclusion path get enqueued so the per-path check can run. `versions` still updates only on strict upgrades.
- Removed a stale `#216` reference from the `Resolution` doc (wontfix'd).

## Review focus

- `Resolution.kt:exclusionsKey` + the new `visitKey` line — the serialization sorts deterministically so identical sets map to the same key.
- The relaxed short-circuit (`compareVersions(...) < 0` instead of `<= 0`). Walk the existing exclusion tests (`resolveGraphExcludesSpecificTransitiveDep`, `resolveGraphWildcardExclusionExcludesAllTransitives`, `resolveGraphExclusionsPropagateTransitively`, `resolveGraphExclusionDoesNotAffectOtherPaths`) — they all still pass.
- No dep-management change: `collectDepMgmt` was already path-aware (it reads the specific parent pom's mgmt), so no fix needed on that axis.

## Test

`resolveGraphExclusionIsEvaluatedPerPath` — direct `a, b`; `a -> lib (exclude c)`; `b -> lib`; `lib -> c`. Expected: `c` is in the resolved set because `b`'s path doesn't exclude it.

## Scope note

This is the last resolver-kernel follow-up. With #56 / #211 / #212 / #213 merged and #216 settled as wontfix, kolt's dependency resolution matches standard Maven/Gradle semantics for its feature set.