### PR TITLE
Implement kind = "lib" build pipeline (#30)

### DIFF
--- a/.claude/skills/kiro-debug/SKILL.md
+++ b/.claude/skills/kiro-debug/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: kiro-debug
+description: Investigate implementation failures using root-cause-first debugging. Use when an implementer is blocked, verification fails, or repeated remediation does not converge.
+allowed-tools: Read, Bash, Grep, Glob, WebSearch, WebFetch
+argument-hint: <failure-summary>
+---
+
+# kiro-debug
+
+## Overview
+
+This skill is for fresh-context root cause investigation. It combines local evidence, runtime/config inspection, and external documentation or issue research when available. It is not a patch generator for guess-first debugging.
+
+## When to Use
+
+- Implementer reports `BLOCKED`
+- Reviewer rejection repeats after remediation
+- Validation fails unexpectedly
+- A task appears to conflict with runtime or platform reality
+- The same failure survives more than one attempted fix
+
+Do not use this skill to speculate about fixes before gathering evidence.
+
+## Inputs
+
+Provide:
+- Exact failure symptom or blocker statement
+- Error messages, stack trace, and failing command output
+- Current `git diff` or summary of uncommitted failed changes
+- Task brief: what was being built
+- Reviewer feedback, if the failure came from review rejection
+- Relevant spec file paths (`requirements.md`, `design.md`)
+- Relevant requirement/design section numbers
+- Relevant `## Implementation Notes`
+- Runtime or environment constraints already known
+
+## Outputs
+
+Return:
+- `ROOT_CAUSE`
+- `CATEGORY`
+- `FIX_PLAN`
+- `VERIFICATION`
+- `NEXT_ACTION: RETRY_TASK | BLOCK_TASK | STOP_FOR_HUMAN`
+- `CONFIDENCE: HIGH | MEDIUM | LOW`
+- `NOTES`
+
+Use the language specified in `spec.json`.
+
+## Method
+
+### 1. Read the Error Carefully
+Extract:
+- Exact error text
+- Stack trace or failure location
+- The command that produced the failure
+- Whether the failure is deterministic or intermittent
+
+### 2. Inspect Local Runtime and Repository State
+Inspect the repository for local evidence:
+- `package.json`, `pyproject.toml`, `go.mod`, `Makefile`, `README*`
+- Build config
+- `tsconfig` or equivalent language/runtime config
+- Runtime-specific config
+- Dependency versions and scripts
+- Relevant changed files from `git diff`
+
+### 3. Search the Web if Available
+If web access is available, search:
+- The exact error message
+- The technology + symptom combination
+- Official documentation
+- Version-specific issue trackers or migration notes
+
+Prefer:
+- Official docs
+- Official repos/issues
+- Version-specific references
+- Runtime-specific documentation
+
+### 4. Classify the Root Cause
+Use one category:
+- `MISSING_DEPENDENCY`
+- `RUNTIME_MISMATCH`
+- `MODULE_FORMAT`
+- `NATIVE_ABI`
+- `CONFIG_GAP`
+- `LOGIC_ERROR`
+- `TASK_ORDERING_PROBLEM`
+- `TASK_DECOMPOSITION_PROBLEM`
+- `SPEC_CONFLICT`
+- `EXTERNAL_DEPENDENCY`
+
+### 5. Determine the Smallest Safe Next Action
+Decide whether the issue can be fixed inside this repo by:
+- Editing files
+- Adjusting configuration
+- Adding or correcting dependencies
+- Restructuring code
+
+Use `NEXT_ACTION: RETRY_TASK` when the issue is repo-fixable inside the current approved task plan.
+
+### 6. Determine Whether the Task Plan Is Still Valid
+Decide whether the current approved task plan is still safe to execute as written.
+
+Prefer `NEXT_ACTION: STOP_FOR_HUMAN` when:
+- A missing prerequisite task should exist before this one
+- The current task is ordered incorrectly relative to unfinished work
+- The current task boundary is wrong and should be split or merged
+- The task is too large or ambiguous to fix safely inside the current implementation loop
+
+Use `NEXT_ACTION: BLOCK_TASK` only when the current task should stop but the rest of the queue can still proceed safely.
+
+Do not propose a brute-force code fix as a substitute for revising `tasks.md` or the approved plan.
+
+## Critical Rule
+
+Do not propose a multi-fix shotgun plan. Identify the root cause first, then produce the smallest plausible fix plan. If the true problem is a spec conflict or architecture problem, say so directly.
+
+## Stop / Escalate
+
+Use `NEXT_ACTION: STOP_FOR_HUMAN` when the blocker genuinely requires:
+- Human product/requirements decision
+- External credentials or inaccessible services
+- Hardware or unavailable external systems
+- Re-scoping due to spec/platform conflict
+
+If the issue is fixable by repo changes inside the current task plan, do not escalate prematurely.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| “This probably just needs a quick patch” | Patch-first debugging creates rework. |
+| “Let’s try a few fixes” | Multi-fix guessing hides root cause. |
+| “The spec is probably wrong, I’ll adapt it” | Spec conflicts must be surfaced explicitly. |
+| “The docs search is optional” | For runtime/dependency issues, docs and version issues often contain the shortest path to root cause. |
+
+## Output Format
+
+```md
+## Debug Report
+- ROOT_CAUSE: <1-2 sentence root cause>
+- CATEGORY: MISSING_DEPENDENCY | RUNTIME_MISMATCH | MODULE_FORMAT | NATIVE_ABI | CONFIG_GAP | LOGIC_ERROR | TASK_ORDERING_PROBLEM | TASK_DECOMPOSITION_PROBLEM | SPEC_CONFLICT | EXTERNAL_DEPENDENCY
+- FIX_PLAN:
+  1. <specific repo-fixable action>
+  2. <specific repo-fixable action>
+- VERIFICATION: <command(s) to confirm the fix>
+- NEXT_ACTION: RETRY_TASK | BLOCK_TASK | STOP_FOR_HUMAN
+- CONFIDENCE: HIGH | MEDIUM | LOW
+- NOTES: <context the next implementer should know>
+```

--- a/.claude/skills/kiro-discovery/SKILL.md
+++ b/.claude/skills/kiro-discovery/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: kiro-discovery
+description: Entry point for new work. Determines the best action path or work decomposition (update existing spec, create new spec, mixed decomposition, or no spec needed) and refines ideas through structured dialogue.
+disable-model-invocation: true
+allowed-tools: Read, Write, Glob, Grep, Agent, WebSearch, WebFetch, AskUserQuestion
+argument-hint: <idea-or-request>
+---
+
+# kiro-discovery Skill
+
+## Core Mission
+- **Success Criteria**:
+  - Correct action path or work decomposition identified based on existing project state
+  - User's intent clarified through questions, not assumptions
+  - Output is an actionable next step (not just a description)
+
+## Execution Steps
+
+### Step 1: Lightweight Scan
+
+Gather **only metadata** to determine the action path. Do NOT read full file contents yet.
+
+- **Specs inventory**: Glob `.kiro/specs/*/spec.json`, read each spec.json for `name`, `phase` fields and `approvals` status. Note feature names and their current status.
+- **Steering existence**: Check which files exist in `.kiro/steering/` (product.md, tech.md, structure.md, roadmap.md). Do NOT read their contents yet.
+- **Roadmap check**: If `.kiro/steering/roadmap.md` exists, read it. This contains project-level context (approach, scope, constraints, spec list) from a previous discovery session. Use it to restore project context.
+- **Top-level structure**: List the project root directory to note key directories and files. Do NOT recurse into subdirectories.
+
+This step should consume minimal context. If `specs/` is empty and no steering exists, note "greenfield project" and move to Step 2.
+
+### Step 2: Determine Action Path
+
+Based on the user's request and the metadata from Step 1, determine which path applies:
+
+**Path A: Existing spec covers this**
+- The request is an extension, enhancement, or fix within an existing spec's domain
+- Every meaningful part of the request fits that same spec boundary
+- Any remaining small follow-up work can be handled directly without creating a new spec
+- Skip remaining steps
+
+**Path B: No spec needed**
+- The request is a bug fix, config change, simple refactor, or trivial addition
+- No meaningful part of the request needs a new or updated spec boundary
+- The request does not need to update an existing spec either
+- Skip remaining steps
+
+**Path C: New single-scope feature**
+- The request is new, doesn't overlap with existing specs, and fits in one spec
+
+**Path D: Multi-scope decomposition needed**
+- The request spans multiple domains or would produce 20+ tasks in a single spec
+
+**Path E: Mixed decomposition**
+- The request contains a mix of: existing spec extensions, one or more new spec candidates, and optional direct-implementation work
+- Use this path only when at least one genuinely new spec boundary is needed
+
+For Path C/D/E, present the determined path (or mixed decomposition) to the user and confirm before proceeding.
+For Path A/B, recommend the next action and stop.
+
+### Step 3: Deep Context Loading
+
+**Only for Path C, D, and E.** Now load the context needed for discovery.
+
+**In main context** (essential for dialogue with user):
+- **Steering documents**: Read product.md and tech.md (if they exist) for project goals, constraints, and tech stack
+- **Relevant specs**: If the request is adjacent to an existing spec, read that spec's requirements.md to understand boundaries and avoid overlap
+
+**Delegate to subagent via Agent tool** (keeps exploration out of main context):
+- **Codebase exploration**: Dispatch a subagent to explore the codebase and return a structured summary. Example prompt: "Explore this project's codebase. Summarize: (1) tech stack and frameworks, (2) directory structure and key modules, (3) patterns and conventions used, (4) areas relevant to [user's request]. Return a summary under 200 lines."
+- The subagent uses Read/Glob/Grep to explore, then returns findings. Only the summary enters the main context.
+- For Path D/E, also ask the subagent to identify natural domain boundaries, existing module separation, and which areas look like existing-spec extensions vs new boundaries.
+- Skip subagent dispatch for small/obvious requests where the top-level directory listing from Step 1 is sufficient.
+
+**Context budget**: Keep total content loaded into main context under ~500 lines. The subagent handles the heavy exploration.
+
+### Step 4: Understand the Idea
+
+Ask clarifying questions **sequentially** (not all at once), prioritizing boundary discovery over feature detail:
+
+1. **Who and why**: Who has the problem? What pain does it cause?
+2. **Desired outcome**: What should be true when this is done?
+3. **Boundary candidates**: What are the natural responsibility seams in this work? Where could this be split so implementation can proceed independently?
+4. **Out of boundary**: What should this spec explicitly NOT own, even if related?
+5. **Existing vs new**: Which parts seem like extensions to existing specs, and which parts look like genuinely new boundaries?
+6. **Upstream / downstream**: What existing systems, specs, or components does this depend on? What future work is likely to depend on this?
+7. **Constraints**: Are there technology, timeline, or compatibility constraints?
+
+Ask only questions whose answers you cannot infer from the context already loaded. Skip questions that steering documents already answer. If the user already provided a clear description, skip to Step 5.
+The goal is NOT to assign final owners yet. The goal is to discover the cleanest responsibility boundaries that can later become specs, tasks, and review scopes.
+
+### Step 5: Propose Approaches
+
+Propose **2-3 concrete approaches** with trade-offs:
+
+For each approach:
+- **Approach name**: One-line summary
+- **How it works**: 2-3 sentences on the technical approach
+- **Pros**: What makes this approach good
+- **Cons**: What are the risks or downsides
+- **Scope estimate**: Rough complexity (small / medium / large)
+
+If technical research is needed (unfamiliar framework, library evaluation), dispatch a subagent via Agent tool. Example prompt: "Research [topic]: compare options, check latest versions, note known issues. Return a summary of findings with recommendation." The subagent uses WebSearch/WebFetch and returns a concise summary. Raw search results never enter the main context.
+
+Recommend one approach and explain why.
+
+**After the user selects an approach**, dispatch a subagent to verify viability before proceeding to Step 6. Example prompt: "Verify the viability of this technical approach: [chosen tech stack / key libraries]. Check: (1) Are these technologies still actively maintained? (2) Any license incompatibilities (e.g., GPL contamination)? (3) Do the components actually work together for [use case]? (4) Any known showstoppers (critical bugs, security vulnerabilities, platform limitations)? Return only issues found, or 'No issues found' if everything checks out."
+
+If the viability check reveals issues, present them to the user and revisit the approach selection. If no issues, proceed to Step 6.
+
+### Step 6: Refine and Confirm
+
+- Address user's questions or concerns about the approaches
+- Narrow scope if needed: favor smaller, deliverable increments and cleaner responsibility seams
+- For Path D/E: propose work decomposition with dependency ordering
+  - Each new boundary-worthy feature = one spec
+  - Existing spec extensions are explicitly listed with their target spec
+  - Truly small direct-implementation items are listed separately instead of being forced into a spec
+  - Dependencies between specs/workstreams are explicit
+  - Consider vertical slices (end-to-end value) vs horizontal layers (one layer at a time) based on the project needs
+- Confirm the final direction
+
+### Step 7: Write Files to Disk
+
+**CRITICAL: You MUST use the Write tool to create these files BEFORE suggesting any next command. Conversation text does not survive session boundaries. If you skip this step, all discovery analysis is lost when the session ends.**
+
+**For Path C (single spec)**:
+
+Use the Write tool to create `.kiro/specs/<feature-name>/brief.md` with this structure:
+
+```
+# Brief: <feature-name>
+
+## Problem
+[who has the problem, what pain it causes]
+
+## Current State
+[what exists today, what's the gap]
+
+## Desired Outcome
+[what should be true when done]
+
+## Approach
+[chosen approach and why]
+
+## Scope
+- **In**: [what this feature includes]
+- **Out**: [what's explicitly excluded]
+
+## Boundary Candidates
+- [responsibility seam 1]
+- [responsibility seam 2]
+
+## Out of Boundary
+- [explicit non-goals this spec does not own]
+
+## Upstream / Downstream
+- **Upstream**: [existing systems/specs this depends on]
+- **Downstream**: [likely consumers or follow-on specs]
+
+## Existing Spec Touchpoints
+- **Extends**: [existing spec(s) this work updates, if any]
+- **Adjacent**: [neighbor specs or modules to avoid overlapping]
+
+## Constraints
+[technology, compatibility, or other constraints]
+```
+
+**For Path D (multi-spec decomposition)**:
+
+Use the Write tool to create:
+- `.kiro/steering/roadmap.md`
+- `.kiro/specs/<feature>/brief.md` for every feature listed under `## Specs (dependency order)`
+
+Use this roadmap structure:
+
+```
+# Roadmap
+
+## Overview
+[Project goal and chosen approach -- 1-2 paragraphs]
+
+## Approach Decision
+- **Chosen**: [approach name and summary]
+- **Why**: [key reasoning]
+- **Rejected alternatives**: [what was considered and why it was rejected]
+
+## Scope
+- **In**: [what the overall project includes]
+- **Out**: [what is explicitly excluded]
+
+## Constraints
+[technology, compatibility, timeline, or other project-wide constraints]
+
+## Boundary Strategy
+- **Why this split**: [why these spec boundaries improve independence]
+- **Shared seams to watch**: [cross-spec boundaries needing careful review]
+
+## Specs (dependency order)
+- [ ] feature-a -- [one-line description]. Dependencies: none
+- [ ] feature-b -- [one-line description]. Dependencies: feature-a
+- [ ] feature-c -- [one-line description]. Dependencies: feature-a, feature-b
+```
+
+Then create `.kiro/specs/<feature>/brief.md` for **every** feature listed under `## Specs (dependency order)` using the Path C brief format. This enables parallel spec creation via `/kiro-spec-batch`.
+
+**For Path E (mixed decomposition)**:
+
+Use the same roadmap structure as Path D, plus these additional sections:
+
+```
+## Existing Spec Updates
+- [ ] existing-feature-a -- [one-line description of the extension]. Dependencies: none
+- [ ] existing-feature-b -- [one-line description of the extension]. Dependencies: feature-a
+
+## Direct Implementation Candidates
+- [ ] small-item-a -- [why this stays direct implementation]
+- [ ] small-item-b -- [why this stays direct implementation]
+
+## Specs (dependency order)
+- [ ] new-feature-a -- [one-line description]. Dependencies: none
+- [ ] new-feature-b -- [one-line description]. Dependencies: new-feature-a
+```
+
+Path E rules:
+- Keep `## Specs (dependency order)` reserved for **new specs only** so `/kiro-spec-batch` can still parse it unchanged
+- Record existing-spec extensions under `## Existing Spec Updates`
+- Record true no-spec work under `## Direct Implementation Candidates`
+- Create `brief.md` only for the **new specs** listed under `## Specs (dependency order)`
+
+**Re-entry (roadmap.md already exists)**:
+Use the Write tool to create the next new spec's brief.md. Update roadmap.md with Write tool if scope/ordering changed, preserving completed items and prior phases.
+
+After writing, verify the files exist by reading them back.
+
+### Step 8: Suggest Next Steps
+
+Suggest the next command and stop. Do NOT automatically run downstream spec generation from this skill.
+
+- Path A: `/kiro-spec-requirements {feature}` to update the existing spec
+- Path B: Recommend direct implementation without creating a spec
+- Path C: Default to `/kiro-spec-init <feature-name>`
+  - Optional fast path: `/kiro-spec-quick <feature-name>` when the user explicitly wants to continue immediately
+- Path D: Default to `/kiro-spec-batch` (creates all specs in parallel based on roadmap.md dependency order)
+  - Optional cautious path: `/kiro-spec-init <first-feature-name>` when the user wants to validate the first slice before batching the rest
+- Path E: Choose the next command based on the new-spec portion of the decomposition
+  - If there is exactly one new spec: `/kiro-spec-init <new-feature-name>`
+  - If there are multiple new specs: `/kiro-spec-batch`
+  - Also note which existing specs should be revisited with `/kiro-spec-requirements <feature>`
+- Re-entry: `/kiro-spec-init <next-feature-name>` or `/kiro-spec-batch` if multiple specs remain
+
+If the decomposition contains only existing-spec updates plus direct implementation candidates, do NOT use Path E. Prefer Path A when one existing spec is the clear home, or recommend the existing-spec update plus direct implementation work without creating roadmap entries.
+
+## Critical Constraints
+- **Files on disk are the source of continuity**: For Path C/D/E, create brief.md and roadmap.md as needed before suggesting the next command. Do NOT leave discovery results only in conversation text.
+
+## Safety & Fallback
+
+**Roadmap Already Exists (re-entry)**:
+- Read roadmap.md to restore project context before asking questions
+- Determine next spec based on completed specs' status
+- Write brief.md for the next spec only (just-in-time)
+- Update roadmap.md if scope/ordering changed based on implementation experience
+- Append new specs as a new phase if the request expands the project, don't overwrite existing content

--- a/.claude/skills/kiro-impl/SKILL.md
+++ b/.claude/skills/kiro-impl/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: kiro-impl
+description: Implement approved tasks using TDD with native subagent dispatch. Runs all pending tasks autonomously or selected tasks manually.
+disable-model-invocation: true
+allowed-tools: Read, Write, Edit, MultiEdit, Bash, Glob, Grep, Agent, WebSearch, WebFetch
+argument-hint: <feature-name> [task-numbers]
+---
+
+# kiro-impl Skill
+
+## Role
+You operate in two modes:
+- **Autonomous mode** (no task numbers): Dispatch a fresh subagent per task, with independent review after each
+- **Manual mode** (task numbers provided): Execute selected tasks directly in the main context
+
+## Core Mission
+- **Success Criteria**:
+  - All tests written before implementation code
+  - Code passes all tests with no regressions
+  - Tasks marked as completed in tasks.md
+  - Implementation aligns with design and requirements
+  - Independent reviewer approves each task before completion
+
+## Execution Steps
+
+### Step 1: Gather Context
+
+If steering/spec context is already available from conversation, skip redundant file reads.
+Otherwise, load all necessary context:
+- `.kiro/specs/{feature}/spec.json`, `requirements.md`, `design.md`, `tasks.md`
+- Core steering context: `product.md`, `tech.md`, `structure.md`
+- Additional steering files only when directly relevant to the selected task's boundary, runtime prerequisites, integrations, domain rules, security/performance constraints, or team conventions that affect implementation or validation
+- Relevant local agent skills or playbooks only when they clearly match the task's host environment or use case; read the specific artifact(s) you need, not entire directories
+
+#### Parallel Research
+
+The following research areas are independent and can be executed in parallel:
+1. **Spec context loading**: spec.json, requirements.md, design.md, tasks.md
+2. **Steering, playbooks, & patterns**: Core steering, task-relevant extra steering, matching local agent skills/playbooks, and existing code patterns
+
+After all parallel research completes, synthesize implementation brief before starting.
+
+#### Preflight
+
+**Validate approvals**:
+- Verify tasks are approved in spec.json (stop if not, see Safety & Fallback)
+
+**Discover validation commands**:
+- Inspect repository-local sources of truth in this order: project scripts/manifests (`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, app manifests), task runners (`Makefile`, `justfile`), CI/workflow files, existing e2e/integration configs, then `README*`
+- Derive a canonical validation set for this repo: `TEST_COMMANDS`, `BUILD_COMMANDS`, and `SMOKE_COMMANDS`
+- Prefer commands already used by repo automation over ad hoc shell pipelines
+- For `SMOKE_COMMANDS`, choose the lightest trustworthy runtime-liveness check for the app shape (for example: root URL load, Electron launch, CLI `--help`, service health endpoint, mobile simulator/e2e harness if one already exists)
+- Keep the full command set in the parent context, and pass only the task-relevant subset to implementer and reviewer subagents
+
+**Establish repo baseline**:
+- Run `git status --porcelain` and note any pre-existing uncommitted changes
+
+### Step 2: Select Tasks & Determine Mode
+
+**Parse arguments**:
+- Extract feature name from first argument
+- If task numbers provided (e.g., "1.1" or "1,2,3"): **manual mode**
+- If no task numbers: **autonomous mode** (all pending tasks)
+
+**Build task queue**:
+- Read tasks.md, identify actionable sub-tasks (X.Y numbering like 1.1, 2.3)
+- Major tasks (1., 2.) are grouping headers, not execution units
+- Skip tasks with `_Blocked:_` annotation
+- For each selected task, check `_Depends:_` annotations -- verify referenced tasks are `[x]`
+- If prerequisites incomplete, execute them first or warn the user
+- Use `_Boundary:_` annotations to understand the task's component scope
+
+### Step 3: Execute Implementation
+
+#### Autonomous Mode (subagent dispatch)
+
+**Iteration discipline**: Process exactly ONE sub-task (e.g., 1.1) per iteration. Do NOT batch multiple sub-tasks into a single subagent dispatch. Each iteration follows the full cycle: dispatch implementer → review → commit → re-read tasks.md → next.
+
+**Context management**: At the start of each iteration, re-read `tasks.md` to determine the next actionable sub-task. Do NOT rely on accumulated memory of previous iterations. After completing each iteration, retain only a one-line summary (e.g., "1.1: READY_FOR_REVIEW, 3 files changed") and discard the full status report and reviewer details.
+
+For each task (one at a time):
+
+**a) Dispatch implementer**:
+- Read `templates/implementer-prompt.md` from this skill's directory
+- Construct a prompt by combining the template with task-specific context:
+  - Task description and boundary scope
+  - Paths to spec files: requirements.md, design.md, tasks.md
+  - Exact requirement and design section numbers this task must satisfy (using source numbering, NOT invented `REQ-*` aliases)
+  - Task-relevant steering context and parent-discovered validation commands (tests/build/smoke as relevant)
+  - Whether the task is behavioral (Feature Flag Protocol) or non-behavioral
+  - **Previous learnings**: Include any `## Implementation Notes` entries from tasks.md that are relevant to this task's boundary or dependencies (e.g., "better-sqlite3 requires separate rebuild for Electron"). This prevents the same mistakes from recurring.
+- The implementer subagent will read the spec files and build its own Task Brief (acceptance criteria, completion definition, design constraints, verification method) before implementation
+- Dispatch via **Agent tool** as a fresh subagent
+
+**b) Handle implementer status**:
+- Parse implementer status only from the exact `## Status Report` block and `- STATUS:` field.
+- If `STATUS` is missing, ambiguous, or replaced with prose, re-dispatch the implementer once requesting the exact structured status block only. Do NOT proceed to review without a parseable `READY_FOR_REVIEW | BLOCKED | NEEDS_CONTEXT` value.
+- **READY_FOR_REVIEW** → proceed to review
+- **BLOCKED** → dispatch debug subagent (see section below); do NOT immediately skip
+- **NEEDS_CONTEXT** → re-dispatch once with the requested additional context; if still unresolved → dispatch debug subagent
+
+**c) Dispatch reviewer**:
+- Read `templates/reviewer-prompt.md` from this skill's directory
+- Construct a review prompt with:
+  - The task description and relevant spec section numbers
+  - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
+  - The implementer's status report (for reference only — reviewer must verify independently)
+- The reviewer must apply the `kiro-review` protocol to this task-local review.
+- Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
+- The reviewer subagent will run `git diff` itself to read the actual code changes and verify against the spec
+- Dispatch via **Agent tool** as a fresh subagent
+
+**d) Handle reviewer verdict**:
+- Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
+- If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
+- **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+- **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
+- **REJECTED (round 3)** → dispatch debug subagent (see section below)
+
+**e) Commit** (parent-only, selective staging):
+- Stage only the files actually changed for this task, plus tasks.md
+- **NEVER** use `git add -A` or `git add .`
+- Use `git add <file1> <file2> ...` with explicit file paths
+- Commit message format: `feat(<feature-name>): <task description>`
+
+**f) Record learnings**:
+- If this task revealed cross-cutting insights, append a one-line note to the `## Implementation Notes` section at the bottom of tasks.md
+
+**g) Debug subagent** (triggered by BLOCKED, NEEDS_CONTEXT unresolved, or REJECTED after 2 remediation rounds):
+
+The debug subagent runs in a **fresh context** — it receives only the error information, not the failed implementation history. This avoids the context pollution that causes infinite retry loops.
+
+- Read `templates/debugger-prompt.md` from this skill's directory
+- Construct a debug prompt with:
+  - The error description / blocker reason / reviewer rejection findings
+  - `git diff` of the current uncommitted changes
+  - The task description and relevant spec section numbers
+  - Paths to spec files so the debugger can read them
+- The debugger must apply the `kiro-debug` protocol to this failure investigation.
+- Preserve rich failure context: error output, reviewer findings, current `git diff`, task/spec refs, and any relevant Implementation Notes.
+- When available, the debugger should inspect runtime/config state and use web or official documentation research to validate root-cause hypotheses before proposing a fix plan.
+- Dispatch via **Agent tool** as a fresh subagent
+
+**Handle debug report**:
+- Parse `NEXT_ACTION` from the debug report's exact structured field.
+- If `NEXT_ACTION: STOP_FOR_HUMAN` → append `_Blocked: <ROOT_CAUSE>_` to tasks.md, stop the feature run, and report that human review is required before continuing
+- If `NEXT_ACTION: BLOCK_TASK` → append `_Blocked: <ROOT_CAUSE>_` to tasks.md, skip to next task
+- If `NEXT_ACTION: RETRY_TASK` → preserve the current worktree; do NOT reset or discard unrelated changes. Spawn a **new** implementer subagent with the debug report's `FIX_PLAN`, `NOTES`, and the current `git diff`, and require it to repair the task with explicit edits only
+  - If the new implementer succeeds (READY_FOR_REVIEW → reviewer APPROVED) → normal flow
+  - If the new implementer also fails → repeat debug cycle (max 2 debug rounds total). After 2 failed debug rounds → append `_Blocked: debug attempted twice, still failing — <ROOT_CAUSE>_` to tasks.md, skip
+- **Max 2 debug rounds per task**. Each round: fresh debug subagent → fresh implementer. If still failing after 2 rounds, the task is blocked.
+- Record debug findings in `## Implementation Notes` (this helps subsequent tasks avoid the same issue)
+
+**`(P)` markers**: Tasks marked `(P)` in tasks.md indicate they have no inter-dependencies and could theoretically run in parallel. However, kiro-impl processes them sequentially (one at a time) to avoid git conflicts and simplify review. The `(P)` marker is informational for task planning, not an execution directive.
+
+**Completion check**: If all remaining tasks are BLOCKED, stop and report blocked tasks with reasons to the user.
+
+#### Manual Mode (main context)
+
+For each selected task:
+
+**1. Build Task Brief**:
+Before writing any code, read the relevant sections of requirements.md and design.md for this task and clarify:
+- What observable behaviors must be true when done (acceptance criteria)
+- What files/functions/tests must exist (completion definition)
+- What technical decisions to follow from design.md (design constraints)
+- How to confirm the task works (verification method)
+
+**2. Execute TDD cycle** (Kent Beck's RED → GREEN → REFACTOR):
+- **RED**: Write test for the next small piece of functionality based on the acceptance criteria. Test should fail.
+- **GREEN**: Implement simplest solution to make test pass, following the design constraints.
+- **REFACTOR**: Improve code structure, remove duplication. All tests must still pass.
+- **VERIFY**: All tests pass (new and existing), no regressions. Confirm verification method passes.
+- **REVIEW**: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
+- **MARK COMPLETE**: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+
+### Step 4: Final Validation
+
+**Autonomous mode**:
+- After all tasks complete, run `/kiro-validate-impl {feature}` as a GO/NO-GO gate
+- If validation returns GO → before reporting feature success, apply `kiro-verify-completion` to the feature-level claim using the validation result and fresh supporting evidence
+- If validation returns NO-GO:
+  - Fix only concrete findings from the validation report
+  - Cap remediation at 3 rounds; if still NO-GO, stop and report remaining findings
+- If validation returns MANUAL_VERIFY_REQUIRED → stop and report the missing verification step
+
+**Manual mode**:
+- Suggest running `/kiro-validate-impl {feature}` but do not auto-execute
+
+## Feature Flag Protocol
+
+For tasks that add or change behavior, enforce RED → GREEN with a feature flag:
+
+1. **Add flag** (OFF by default): Introduce a toggle appropriate to the codebase (env var, config constant, boolean, conditional -- agent chooses the mechanism)
+2. **RED -- flag OFF**: Write tests for the new behavior. Run tests → must FAIL. If tests pass with flag OFF, the tests are not testing the right thing. Rewrite.
+3. **GREEN -- flag ON + implement**: Enable the flag, write implementation. Run tests → must PASS.
+4. **Remove flag**: Make the code unconditional. Run tests → must still PASS.
+
+**Skip this protocol for**: refactoring, configuration, documentation, or tasks with no behavioral change.
+
+## Critical Constraints
+- **Strict Handoff Parsing**: Never infer implementer `STATUS` or reviewer `VERDICT` from surrounding prose; only the exact structured fields count
+- **No Destructive Reset**: Never use `git checkout .`, `git reset --hard`, or similar destructive rollback inside the implementation loop
+- **Selective Staging**: NEVER use `git add -A` or `git add .`; always stage explicit file paths
+- **Bounded Review Rounds**: Max 2 implementer re-dispatch rounds per reviewer rejection, then debug
+- **Bounded Debug**: Max 2 debug rounds per task (debug + re-implementation per round); if still failing → BLOCKED
+- **Bounded Remediation**: Cap final-validation remediation at 3 rounds
+
+## Output Description
+
+**Autonomous mode**: For each task, report:
+1. Task ID, implementer status, reviewer verdict
+2. Files changed, commit hash
+3. After all tasks: final validation result (GO/NO-GO)
+
+**Manual mode**:
+1. Tasks executed: task numbers and test results
+2. Status: completed tasks marked in tasks.md, remaining tasks count
+
+**Format**: Concise, in the language specified in spec.json.
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Tasks Not Approved or Missing Spec Files**:
+- **Stop Execution**: All spec files must exist and tasks must be approved
+- **Suggested Action**: "Complete previous phases: `/kiro-spec-requirements`, `/kiro-spec-design`, `/kiro-spec-tasks`"
+
+**Test Failures**:
+- **Stop Implementation**: Fix failing tests before continuing
+- **Action**: Debug and fix, then re-run
+
+**All Tasks Blocked**:
+- Stop and report all blocked tasks with reasons
+- Human review needed to resolve blockers
+
+**Spec Conflicts with Reality**:
+- If a requirement or design conflicts with reality (API doesn't exist, platform limitation), block the task with `_Blocked: <reason>_` -- do not silently work around it
+
+**Upstream Ownership Detected**:
+- If review, debug, or validation shows that the root cause belongs to an upstream, foundation, shared-platform, or dependency spec, do not patch around it inside the downstream feature
+- Route the fix back to the owning upstream spec, keep the downstream task blocked until that contract is repaired, and re-run validation/smoke for dependent specs after the upstream fix lands
+
+**Task Plan Invalidated During Implementation**:
+- If debug returns `NEXT_ACTION: STOP_FOR_HUMAN` because of task ordering, boundary, or decomposition problems, stop and return for human review of `tasks.md` or the approved plan instead of forcing a code workaround

--- a/.claude/skills/kiro-impl/templates/debugger-prompt.md
+++ b/.claude/skills/kiro-impl/templates/debugger-prompt.md
@@ -1,0 +1,54 @@
+# Debug Investigator
+
+Apply the `kiro-debug` protocol for this fresh-context root-cause investigation.
+
+If the host can invoke skills directly inside subagents, use `kiro-debug` as the governing debug protocol. Otherwise, follow the full investigation procedure embedded in this prompt, including local runtime inspection and web or official docs research when available.
+
+You are a fresh debug investigator with NO prior context about implementation attempts. Your sole job is root cause analysis and producing a concrete fix plan.
+
+## You Will Receive
+- Error description and messages
+- `git diff` of the failed changes (or a summary)
+- Task brief (what was being built)
+- Reviewer feedback (if the failure came from review rejection)
+- Relevant spec file paths (requirements.md, design.md)
+
+## Method
+
+1. **Read the error carefully** — extract the exact error message, stack trace, and failure location
+2. **Search the web** if available — search the exact error message, the technology + symptom combination, and official documentation
+   - e.g., `site:electronjs.org "Cannot find module"`, `better-sqlite3 electron ABI mismatch`
+   - Check GitHub Issues for the specific package/framework version
+3. **Inspect the runtime environment** — check package.json (dependencies, scripts, main/module fields), build config, tsconfig, and any runtime-specific configuration
+4. **Classify the root cause**:
+   - **Missing dependency**: A required package is not installed or not configured
+   - **Runtime mismatch**: Code works in one runtime (e.g., Node.js) but not the target (e.g., Electron, browser, Lambda)
+   - **Module format conflict**: ESM vs CJS incompatibility
+   - **Native module ABI**: Binary compiled for wrong runtime/version
+   - **Configuration gap**: Missing entry point, build output format, or runtime flags
+   - **Logic error**: Actual bug in the implementation
+   - **Spec conflict**: Requirements or design contradicts what's technically possible
+   - **External dependency**: Requires human decision, external API access, or hardware
+5. **Determine if repo-fixable** — can this be resolved by editing files, adding dependencies, or changing configuration within this repository?
+
+## Critical Rule
+
+Do not collapse this investigation into guess-first patching; preserve category classification, repo-fixability judgment, and explicit verification commands.
+
+Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something outside the repository or the approved task plan is no longer safe to continue. If the fix is adding a dependency, changing a config file, or restructuring code inside the current task plan, prefer `NEXT_ACTION: RETRY_TASK`.
+
+## Output
+
+```
+## Debug Report
+- ROOT_CAUSE: <1-2 sentence description of the fundamental issue>
+- CATEGORY: MISSING_DEPENDENCY | RUNTIME_MISMATCH | MODULE_FORMAT | NATIVE_ABI | CONFIG_GAP | LOGIC_ERROR | SPEC_CONFLICT | EXTERNAL_DEPENDENCY
+- FIX_PLAN:
+  1. <specific action with file path>
+  2. <specific action with file path>
+  ...
+- VERIFICATION: <command(s) to run after fix to confirm resolution>
+- NEXT_ACTION: RETRY_TASK | BLOCK_TASK | STOP_FOR_HUMAN
+- CONFIDENCE: HIGH | MEDIUM | LOW
+- NOTES: <any additional context the next implementer should know>
+```

--- a/.claude/skills/kiro-impl/templates/implementer-prompt.md
+++ b/.claude/skills/kiro-impl/templates/implementer-prompt.md
@@ -1,0 +1,93 @@
+# TDD Task Implementer
+
+## Role
+You are a specialized implementation subagent for a single task. The parent controller owns setup, task sequencing, task-state updates, and commits. You own only the implementation and validation work for the assigned task.
+
+## You Will Receive
+- Feature name and task identifier/text
+- Paths to spec files: `requirements.md`, `design.md`, `tasks.md`
+- Exact numbered sections from `requirements.md` and `design.md` that this task must satisfy (source numbering, e.g., `1.2`, `3.1`, `A.2`)
+- `_Boundary:_` scope constraints and any `_Depends:_` information already checked by the parent
+- Project steering context and parent-discovered validation commands (tests/build/smoke when available)
+- Whether the task is behavioral (Feature Flag Protocol) or non-behavioral
+
+## Execution Protocol
+
+### Step 1: Load Task-Relevant Context
+- Read the referenced sections of `requirements.md` and `design.md` for this task
+- Preserve the original section numbering; do NOT invent `REQ-*` aliases
+- Expand any file globs or path patterns before reading files
+- Inspect existing code patterns only in the declared boundary
+- Read only the provided task-relevant steering; do not bulk-load unrelated skills or playbooks
+
+### Step 2: Build Task Brief
+Before writing any code, synthesize a concrete Task Brief from the spec sections you just read:
+
+- **Acceptance criteria**: What observable behaviors must be true when done? Extract from the requirement sections. Be specific (e.g., "POST /auth/login returns JWT on valid credentials, 401 on invalid"), not vague.
+- **Completion definition**: What files, functions, tests, or artifacts must exist? Derive from design.md component structure and task boundary.
+- **Design constraints**: What specific technical decisions from design.md must be followed? (e.g., "use bcrypt for hashing", "implement as Express middleware"). If design says "use X", you must use X.
+- **Verification method**: How to confirm the task works. Derive from the requirement's testability and the parent-provided validation commands.
+
+If any of these cannot be determined from the spec — the requirements are too vague, the design doesn't specify the approach, or the task description is ambiguous — report as **NEEDS_CONTEXT** immediately with what's missing. Do not guess or fill gaps with assumptions.
+
+### Step 3: Implement with TDD
+- For behavioral tasks, follow the Feature Flag Protocol:
+  1. Add a flag defaulting OFF
+  2. RED: write/adjust tests so they fail with the flag OFF. **Run tests and capture the failing output.** You will include this in the status report as evidence.
+  3. GREEN: enable the flag and implement until tests pass
+  4. Remove the flag and confirm tests still pass
+- For non-behavioral tasks, use a standard RED → GREEN → REFACTOR cycle. **Run tests after writing them (before implementation) and capture the failing output.**
+- Use the acceptance criteria from the Task Brief to drive test design
+- Follow the design constraints exactly
+- Keep changes tightly scoped to the assigned task
+
+### Step 4: Validate
+- Run the parent-provided validation commands needed to establish confidence for this task
+- Prefer the parent-discovered canonical commands over inventing new ones; only add a task-local verification command when the parent set does not cover the task, and explain why
+- Re-read the referenced requirement and design sections and compare them against the changed code and tests
+- Confirm the verification method from the Task Brief passes
+- If a validation command fails because of a pre-existing unrelated issue, report that precisely instead of masking it
+
+### Step 5: Self-Review
+- Review your own changes before reporting back
+- Verify each acceptance criterion from the Task Brief is satisfied by concrete behavior
+- Verify each design constraint is reflected in the implementation
+- Verify the implementation is NOT a mock, stub, placeholder, fake, or TODO-only path unless the task explicitly requires one
+- Verify there are no TBD, TODO, or FIXME markers left in changed files
+- Verify the tests prove the required behavior, not just scaffolding or a happy-path shell
+- Verify that any namespace or qualified-name access used at runtime (for example `React.X`, `module.Foo`, `pkg.Bar`) has a real value import or runtime binding, not only a type-only import or ambient type reference
+- Verify that any newly introduced runtime-sensitive dependency or packaging assumption (native modules, module-format boundaries, generated assets, required env vars, boot-time config) is reflected in validation or called out explicitly in `CONCERNS`
+- If any review check fails, fix the implementation, re-run validation, and repeat this step
+
+## Critical Constraints
+- Do NOT update `tasks.md`
+- Do NOT create commits
+- Do NOT expand scope beyond the assigned task and boundary
+- Do NOT silently work around requirement or design mismatches
+- Use the exact section numbers from `requirements.md` and `design.md` in all notes and reports; do NOT invent `REQ-*` aliases
+- Do NOT stop at a mock, stub, placeholder, fake, or TODO-only implementation unless the task explicitly requires it
+- Prefer the minimal implementation that satisfies the Task Brief and tests
+
+## Status Report
+
+End your response with this structured status block:
+
+The parent controller parses the exact `- STATUS:` line. Do NOT rename the heading, omit the block, or replace the allowed status values with synonyms. Return exactly one final status block. Put extra explanation inside the defined fields, not after the block.
+
+
+```
+## Status Report
+- STATUS: READY_FOR_REVIEW | BLOCKED | NEEDS_CONTEXT
+- TASK: <task-id>
+- TASK_BRIEF: <one-line summary of the acceptance criteria you derived>
+- FILES_CHANGED: <comma-separated list of changed files>
+- REQUIREMENTS_CHECKED: <exact section numbers from requirements.md>
+- DESIGN_CHECKED: <exact section numbers from design.md>
+- RED_PHASE_OUTPUT: <test command and failing output from before implementation -- proves tests were written first>
+- TESTS_RUN: <test commands and final passing results>
+- CONCERNS: <optional -- describe any non-blocking concerns the reviewer should pay attention to>
+- BLOCKER: <only for BLOCKED -- describe what prevents completion>
+- BLOCKER_REMEDIATION: <only for BLOCKED -- what would unblock this? e.g., "design.md section 3.2 specifies API X but it doesn't exist; update design or provide alternative">
+- MISSING: <only for NEEDS_CONTEXT -- describe exactly what additional context is needed and where it might be found>
+- EVIDENCE: <concrete code paths, functions, and tests that prove the behavior>
+```

--- a/.claude/skills/kiro-impl/templates/reviewer-prompt.md
+++ b/.claude/skills/kiro-impl/templates/reviewer-prompt.md
@@ -1,0 +1,111 @@
+# Task Implementation Reviewer
+
+Apply the `kiro-review` protocol for this task-local adversarial review.
+
+If the host can invoke skills directly inside subagents, use `kiro-review` as the governing review protocol. Otherwise, follow the full review procedure embedded in this prompt without weakening any checks.
+
+## Role
+You are an independent, adversarial reviewer. Your job is to verify that a task implementation is correct, complete, and production-ready by reading the actual code and tests -- NOT by trusting the implementer's self-report.
+
+## You Will Receive
+- The task description and relevant spec section numbers
+- Paths to spec files (requirements.md, design.md) — read the relevant sections yourself
+- The implementer's status report (for reference only — do NOT trust it as source of truth)
+- The task's `_Boundary:_` scope constraints
+- Validation commands discovered by the controller
+
+## First Action
+
+Run `git diff` to see the actual code changes. This is your primary input. If the diff is large, also read the full changed files for context.
+
+## Core Principle
+
+**Do Not Trust the Report.** Run `git diff` yourself and read the actual code changes line by line. Read the spec sections yourself. The implementer may report READY_FOR_REVIEW while the code is a stub, tests are trivial, or requirements are partially met.
+
+**Taste encoded as tooling.** Where a check can be verified mechanically (grep, test execution, linter), run the command and use the result. Do not rely on visual inspection alone for checks that have mechanical equivalents.
+
+This review must preserve all existing mechanical checks, boundary checks, RED-phase checks, and structured remediation output.
+
+## Review Checklist
+
+Evaluate each item. If ANY item fails, the verdict is REJECTED.
+
+### Mechanical Checks (run commands, use results)
+
+**1. Regression Safety**
+- Run the project's test suite (e.g., `npm test`, `pytest`). Use the exit code.
+- If tests fail → REJECTED. No judgment needed.
+
+**2. Completeness — No TBD/TODO/FIXME**
+- Run: `grep -rn "TBD\|TODO\|FIXME\|HACK\|XXX" <changed-files>`
+- If matches found in changed files → REJECTED (unless the marker existed before this task).
+
+**3. No Hardcoded Secrets**
+- Run: `grep -rn "password\s*=\|api_key\s*=\|secret\s*=\|token\s*=" <changed-files>` (case-insensitive)
+- If matches found that aren't environment variable references → REJECTED.
+
+**4. Boundary Respect**
+- Run: `git diff --name-only` and compare against the task's `_Boundary:_` scope.
+- If files outside boundary are changed → REJECTED.
+
+**5. RED Phase Evidence**
+- Check the implementer's status report for `RED_PHASE_OUTPUT`.
+- If the task is behavioral and RED_PHASE_OUTPUT is missing or empty → REJECTED (tests may not have been written before implementation).
+- The output should show test failures related to the task's acceptance criteria.
+
+### Judgment Checks (read code, compare to spec)
+
+**6. Reality Check**
+- Read the `git diff`. Implementation is real production code.
+- NOT a mock, stub, placeholder, fake, or TODO-only path (unless the task explicitly requires one).
+- No "will be implemented later" or similar deferred-work patterns.
+
+**7. Acceptance Criteria**
+- Read the task description from tasks.md. All aspects are addressed, not just the primary case.
+- The Task Brief's acceptance criteria (from implementer's status report) are met.
+
+**8. Spec Alignment (Requirements)**
+- Read the referenced sections of requirements.md yourself.
+- Each referenced requirement is satisfied by concrete, observable behavior.
+- Use source section numbers (e.g., 1.2, 3.1); do NOT accept invented `REQ-*` aliases.
+
+**9. Spec Alignment (Design)**
+- Read the referenced sections of design.md yourself.
+- If design says "use X", the code uses X — not a substitute.
+- Component structure, interfaces, and data flow match the design.
+- Dependency direction follows design.md's architecture (no upward imports).
+
+**10. Test Quality**
+- Tests prove the required behavior, not just scaffolding or happy-path shells.
+- Test assertions are meaningful (not `expect(true).toBe(true)` or similar).
+- Tests would fail if the implementation were removed or broken.
+
+**11. Error Handling**
+- Error paths are handled, not just the happy path.
+- Errors are not silently swallowed.
+
+## Review Verdict
+
+End your response with this structured verdict:
+
+The parent controller parses the exact `- VERDICT:` line. Do NOT rename the heading, omit the block, or replace `APPROVED | REJECTED` with synonyms. Return exactly one final verdict block. Put extra explanation inside the defined sections, not after the block.
+
+
+```
+## Review Verdict
+- VERDICT: APPROVED | REJECTED
+- TASK: <task-id>
+- MECHANICAL_RESULTS:
+  - Tests: PASS | FAIL (command and exit code)
+  - TBD/TODO grep: CLEAN | <count> matches
+  - Secrets grep: CLEAN | <count> matches
+  - Boundary: WITHIN | <files outside boundary>
+  - RED phase: VERIFIED | MISSING | N/A (non-behavioral task)
+- FINDINGS:
+  - <numbered list of specific findings, if any>
+  - <reference exact file paths, line ranges, and spec section numbers>
+- REMEDIATION: <if REJECTED: specific, actionable steps to fix each finding>
+- SUMMARY: <one-sentence summary of the review outcome>
+```
+
+If REJECTED, REMEDIATION is mandatory — identify the exact file, the exact problem, and what the implementer should do to fix it. Vague feedback like "improve tests" is not acceptable.

--- a/.claude/skills/kiro-review/SKILL.md
+++ b/.claude/skills/kiro-review/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: kiro-review
+description: Review a task implementation against approved specs, task boundaries, and verification evidence. Use after an implementer finishes a task, after remediation, or before accepting a task as complete.
+allowed-tools: Read, Bash, Grep, Glob
+argument-hint: <task-id>
+---
+
+# kiro-review
+
+## Overview
+
+This skill performs task-local adversarial review. It verifies that the implementation is real, complete, bounded, aligned with approved requirements and design, and supported by mechanical verification evidence.
+
+Boundary terminology continuity:
+- discovery identifies `Boundary Candidates`
+- design fixes `Boundary Commitments`
+- tasks constrain execution with `_Boundary:_`
+- review rejects concrete `Boundary Violations`
+
+## When to Use
+
+- After an implementer reports `READY_FOR_REVIEW`
+- After remediation for a rejected review
+- Before marking a task `[x]`
+- Before accepting a task into feature-level validation
+
+Do not use this skill to invent missing requirements or silently reinterpret the spec.
+
+## Inputs
+
+Provide:
+- Task ID and exact task text from `tasks.md`
+- Relevant requirement section numbers
+- Relevant design section numbers
+- Spec file paths (`requirements.md`, `design.md`, optionally `tasks.md`)
+- The implementer's status report
+- The task `_Boundary:_` scope constraints
+- Validation commands discovered by the controller
+- Relevant steering excerpts when applicable
+- Relevant `## Implementation Notes` entries when applicable
+
+## Outputs
+
+Return one of:
+- `APPROVED`
+- `REJECTED`
+
+Also return:
+- Mechanical results
+- Findings with severity
+- Required remediation
+- One-sentence summary
+
+Use the language specified in `spec.json`.
+
+## First Action
+
+Run `git diff` to inspect the actual code changes. If the diff is large or ambiguous, read the changed files directly. Do not trust the implementer report as source of truth.
+
+## Core Principle
+
+Read the spec yourself. Read the diff yourself. Verify mechanically where possible. Reject on concrete failures rather than interpretive optimism.
+The main review question is not just "does it work?" but "does it stay inside the approved responsibility boundary without hiding new coupling?"
+
+## Mechanical Checks
+
+Run these checks and use the result as primary signal.
+
+### 1. Regression Safety
+- Run the project's canonical test suite using the validation commands discovered by the controller.
+- If tests fail, reject.
+
+### 2. No Residual Placeholder Markers
+- Check changed files for `TBD`, `TODO`, `FIXME`, `HACK`, `XXX`.
+- Reject if new placeholder markers were introduced without explicit task justification.
+
+### 3. No Hardcoded Secrets
+- Check changed files for hardcoded secrets or credentials.
+- Reject if concrete secret patterns are introduced.
+
+### 4. Boundary Respect
+- Compare changed files against the task `_Boundary:_` scope.
+- Reject if the change spills outside the approved boundary without explicit justification.
+- Reject if the implementation introduces hidden cross-boundary coordination inside what should be a local task.
+
+### 5. RED Phase Evidence
+- For behavioral tasks, verify that the implementer status report includes `RED_PHASE_OUTPUT`.
+- Reject if RED evidence is missing, empty, or unrelated to the task's acceptance criteria.
+
+### 6. Runtime-Sensitive Static Checks
+- If the project already has lint or equivalent static analysis for the touched stack, run the relevant command for the task boundary.
+- Pay attention to patterns that can survive typecheck/build yet fail at runtime: type-only imports used as values, missing namespace value imports for qualified-name access, unresolved globals, and newly introduced runtime-sensitive dependencies without matching boot/runtime handling.
+- If no project lint command exists, perform a targeted diff-based spot check in the changed files for those patterns.
+- Reject on concrete findings that create a realistic boot-time or module-load failure.
+
+## Judgment Checks
+
+### 7. Reality Check
+- Confirm the implementation is real production code, not a placeholder, stub, fake path, or deferred-work shell.
+
+### 8. Acceptance Criteria Coverage
+- Read the task description and confirm all aspects are implemented, not only the primary happy path.
+
+### 9. Requirements Alignment
+- Read the referenced sections in `requirements.md`.
+- Confirm each requirement is satisfied by concrete observable behavior.
+- Use original section numbers only.
+
+### 10. Design Alignment
+- Read the referenced sections in `design.md`.
+- Confirm the implementation uses the prescribed structures, interfaces, and dependency direction.
+- Reject silent substitutions for design-mandated choices.
+
+### 10.5 Boundary Audit
+- Compare the implementation against the design's boundary commitments and out-of-boundary statements.
+- Reject if downstream-specific behavior is pushed into an upstream boundary for convenience.
+- Reject if the implementation creates new hidden dependencies, shared ownership, or undeclared coupling across adjacent boundaries.
+- Reject if a task that is not an explicit integration task now behaves like one.
+
+### 11. Test Quality
+- Confirm tests prove the required behavior rather than only scaffolding.
+- Confirm tests would fail if the implementation were removed or broken.
+
+### 12. Error Handling
+- Confirm relevant failure paths are handled and not silently swallowed.
+
+## Severity Model
+
+Use:
+- `Critical` for broken functionality, invalid verification, data loss, security risk, or major scope violation
+- `Important` for required fixes before acceptance
+- `Suggestion` for non-blocking improvements
+- `FYI` for informational notes
+
+## Stop / Escalate
+
+Escalate instead of papering over the issue when:
+- The approved spec is ambiguous in a correctness-critical way
+- The design conflicts with what is technically possible
+- Required evidence cannot be gathered
+- The implementation only works by silently deviating from approved scope
+- Boundary ownership cannot be determined cleanly from requirements, design, and task scope
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| “Tests pass, so approve” | Passing tests do not prove spec compliance or boundary respect. |
+| “The extra behavior is useful” | Extra behavior outside approved scope is still drift. |
+| “The implementer said RED was done” | RED must be evidenced, not asserted. |
+| “This gap is small enough to let through” | Real gaps must be rejected or escalated. |
+
+## Output Format
+
+```md
+## Review Verdict
+- VERDICT: APPROVED | REJECTED
+- TASK: <task-id>
+- MECHANICAL_RESULTS:
+  - Tests: PASS | FAIL (command and exit code)
+  - TBD/TODO grep: CLEAN | <count> matches
+  - Secrets grep: CLEAN | <count> matches
+  - Static checks: PASS | FAIL | SPOT_CHECKED
+  - Boundary: WITHIN | <files outside boundary>
+  - Boundary audit: CLEAN | <spillover / hidden dependency findings>
+  - RED phase: VERIFIED | MISSING | N/A
+- FINDINGS:
+  1. <specific finding with exact files/spec refs>
+- REMEDIATION: <mandatory if REJECTED>
+- SUMMARY: <one sentence>
+```

--- a/.claude/skills/kiro-spec-batch/SKILL.md
+++ b/.claude/skills/kiro-spec-batch/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: kiro-spec-batch
+description: Create complete specs (requirements, design, tasks) for all features in roadmap.md using parallel subagent dispatch by dependency wave.
+allowed-tools: Read, Glob, Grep, Agent
+---
+
+# kiro-spec-batch Skill
+
+## Core Mission
+- **Success Criteria**:
+  - All features have complete spec files (spec.json, requirements.md, design.md, tasks.md)
+  - Dependency ordering respected (upstream specs complete before downstream)
+  - Independent features processed in parallel via subagent dispatch
+  - Cross-spec consistency verified (data models, interfaces, naming)
+  - Mixed roadmap context understood without breaking `## Specs (dependency order)` parsing
+  - Controller context stays lightweight (subagents do the heavy work)
+
+## Execution Steps
+
+### Step 1: Read Roadmap and Validate
+
+1. Read `.kiro/steering/roadmap.md`
+2. Parse the `## Specs (dependency order)` section to extract:
+   - Feature names
+   - One-line descriptions
+   - Dependencies for each feature
+   - Completion status (`[x]` = done, `[ ]` = pending)
+3. If present, also read for context:
+   - `## Existing Spec Updates`
+   - `## Direct Implementation Candidates`
+   Do not include these in dependency-wave execution; they are awareness-only inputs for sequencing and consistency review.
+4. For each pending feature in `## Specs (dependency order)`, verify `.kiro/specs/<feature>/brief.md` exists
+5. If any brief.md is missing, stop and report: "Missing brief.md for: [list]. Run `/kiro-discovery` to generate briefs first."
+
+### Step 2: Build Dependency Waves
+
+Group pending features into waves based on dependencies:
+
+- **Wave 1**: Features with no dependencies (or all dependencies already completed `[x]`)
+- **Wave 2**: Features whose dependencies are all in Wave 1 or already completed
+- **Wave N**: Features whose dependencies are all in earlier waves or already completed
+
+Display the execution plan:
+```
+Spec Batch Plan:
+  Wave 1 (parallel): app-foundation
+  Wave 2 (parallel): block-editor, page-management
+  Wave 3 (parallel): sidebar-navigation, database-views
+  Wave 4 (parallel): cli-integration
+  Total: 6 specs across 4 waves
+```
+
+If roadmap contains `## Existing Spec Updates` or `## Direct Implementation Candidates`, mention them separately as non-batch items so the user can see the whole decomposition.
+
+### Step 3: Execute Waves
+
+For each wave, dispatch all features in the wave as **parallel subagents** via the Agent tool.
+
+**For each feature in the wave**, dispatch a subagent with this prompt:
+
+```
+Create a complete specification for feature "{feature-name}".
+
+1. Read the brief at .kiro/specs/{feature-name}/brief.md for feature context
+2. Read the roadmap at .kiro/steering/roadmap.md for project context
+3. Execute the full spec pipeline. For each phase, read the corresponding skill's SKILL.md for complete instructions (templates, rules, review gates):
+   a. Initialize: Read .claude/skills/kiro-spec-init/SKILL.md, then create spec.json and requirements.md
+   b. Generate requirements: Read .claude/skills/kiro-spec-requirements/SKILL.md, then follow its steps
+   c. Generate design: Read .claude/skills/kiro-spec-design/SKILL.md, then follow its steps
+   d. Generate tasks: Read .claude/skills/kiro-spec-tasks/SKILL.md, then follow its steps
+4. Set all approvals to true in spec.json (auto-approve mode, equivalent of -y flag)
+5. Report completion with file list and task count
+```
+
+**After all subagents in the wave complete**:
+1. Verify each feature has: spec.json, requirements.md, design.md, tasks.md
+2. If any feature failed, report the error and continue with features that succeeded
+3. Display wave completion: "Wave N complete: [features]. Files verified."
+4. Proceed to next wave
+
+### Step 4: Cross-Spec Review
+
+After all waves complete, dispatch a **single subagent** for cross-spec consistency review. This is the highest-value quality gate -- it catches issues that per-spec review gates cannot.
+
+**Subagent prompt**:
+
+```
+You are a cross-spec reviewer. Read ALL generated specs and check for consistency across the entire project.
+
+Read these files for every feature in the roadmap:
+- .kiro/specs/*/design.md (primary: contains interfaces, data models, architecture)
+- .kiro/specs/*/requirements.md (for scope and acceptance criteria)
+- .kiro/specs/*/tasks.md (for boundary annotations only -- read _Boundary:_ lines, skip task descriptions)
+- .kiro/steering/roadmap.md
+
+Reading priority: Focus on design.md files (they contain interfaces, data models, architecture). For requirements.md, focus on section headings and acceptance criteria. For tasks.md, focus on _Boundary:_ annotations.
+
+Check the following:
+
+1. **Data model consistency**: Do all specs that reference the same entities (tables, types, interfaces) define them consistently? Are field names, types, and relationships aligned?
+
+2. **Interface alignment**: Where spec A produces output that spec B consumes (APIs, events, shared state), do the contracts match exactly? Are request/response shapes, event payloads, and error codes consistent?
+
+3. **No duplicate functionality**: Is any capability specified in more than one spec? Flag overlaps.
+
+4. **Dependency completeness**: Does every spec's design.md reference the correct upstream specs? Are there implicit dependencies not declared in roadmap.md?
+
+5. **Naming conventions**: Are component names, file paths, API routes, and database table names consistent across all specs?
+
+6. **Shared infrastructure**: Are shared concerns (authentication, error handling, logging, configuration) handled in one spec and correctly referenced by others?
+
+7. **Task boundary alignment**: Do task _Boundary:_ annotations across specs partition the codebase cleanly? Are there files claimed by multiple specs?
+8. **Roadmap boundary continuity**: If roadmap includes `Existing Spec Updates` or `Direct Implementation Candidates`, do the generated new specs avoid absorbing that work by accident?
+9. **Architecture boundary integrity**: Do the specs preserve clean responsibility seams, avoid shared ownership, keep dependency direction coherent, and include enough revalidation triggers to catch downstream impact?
+10. **Change-friendly decomposition**: Has any spec absorbed multiple independent seams that should probably be split instead of kept together?
+
+Output format:
+- CONSISTENT: [list areas that are well-aligned]
+- ISSUES: [list each issue with: which specs, what's inconsistent, suggested fix]
+- If no issues found: "All specs are consistent. Ready for implementation."
+```
+
+**After the review subagent returns**:
+- **Critical/important issues found**: Dispatch fix subagents for each affected spec to apply the suggested fixes. If the issue is really a decomposition problem (for example boundary overlap or one spec carrying multiple independent seams), stop and return to roadmap/discovery instead of papering over it locally. Re-run cross-spec review after fixes (max 3 remediation rounds).
+- **Minor issues only**: Report them for user awareness, proceed to Step 5.
+- **No issues**: Proceed to Step 5.
+
+### Step 5: Finalize
+
+1. Glob `.kiro/specs/*/tasks.md` to verify all specs exist
+2. For each completed spec, read spec.json to confirm phase and approvals
+3. Update roadmap.md: mark completed specs as `[x]`
+4. If roadmap.md includes `Existing Spec Updates` or `Direct Implementation Candidates`, leave them untouched and mention them as remaining follow-up items unless already explicitly completed elsewhere
+
+Display final summary:
+```
+Spec Batch Complete:
+  ✓ app-foundation: X requirements, Y design components, Z tasks
+  ✓ block-editor: ...
+  ✓ page-management: ...
+  ...
+  Total: N specs created, M tasks generated
+  Cross-spec review: PASSED / N issues found (M fixed)
+  Existing spec updates pending: <count or none>
+  Direct implementation candidates pending: <count or none>
+
+Next: Review generated specs, then start implementation with /kiro-impl <feature>
+```
+
+## Critical Constraints
+- **Controller stays lightweight**: Only read roadmap.md and brief.md existence checks in main context. All spec generation happens in subagents.
+- **Wave ordering is strict**: Never start a wave until all features in previous waves are complete.
+- **Parallel within waves**: All features in the same wave MUST be dispatched in parallel via Agent tool, not sequentially.
+- **No partial waves**: If a feature in a wave fails, still complete the other features in that wave before reporting.
+- **Skip completed specs**: Features with `[x]` in roadmap.md or existing tasks.md are skipped.
+- **`## Specs (dependency order)` remains authoritative for batch execution**: Other roadmap sections are context, not wave inputs.
+
+## Safety & Fallback
+
+**Subagent failure**:
+- Log the error, skip the failed feature
+- Continue with remaining features in the wave
+- Report failed features in the summary
+- Suggest: "Run `/kiro-spec-quick <feature> --auto` manually for failed features."
+
+**Circular dependencies**:
+- If dependency graph has cycles, report the cycle and stop
+- Suggest: "Fix dependency ordering in roadmap.md"
+
+**Roadmap not found**:
+- Stop and report: "No roadmap.md found. Run `/kiro-discovery` first."

--- a/.claude/skills/kiro-spec-design/SKILL.md
+++ b/.claude/skills/kiro-spec-design/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: kiro-spec-design
+description: Generate comprehensive technical design translating requirements (WHAT) into architecture (HOW) with discovery process. Use when creating architecture from requirements.
+allowed-tools: Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent
+argument-hint: <feature-name> [-y]
+metadata:
+  shared-rules: "design-principles.md, design-discovery-full.md, design-discovery-light.md, design-synthesis.md, design-review-gate.md"
+---
+
+# kiro-spec-design Skill
+
+## Core Mission
+- **Success Criteria**:
+  - All requirements mapped to technical components with clear interfaces
+  - The design makes responsibility boundaries explicit enough to guide task generation and review
+  - Appropriate architecture discovery and research completed
+  - Design aligns with steering context and existing patterns
+  - Visual diagrams included for complex architectures
+
+## Execution Steps
+
+### Step 1: Gather Context
+
+If steering/spec context is already available from conversation, skip redundant file reads.
+Otherwise, load all necessary context:
+- `.kiro/specs/{feature}/spec.json`, `requirements.md`, `design.md` (if exists)
+- `.kiro/specs/{feature}/research.md` (if exists, contains gap analysis from `/kiro-validate-gap`)
+- Core steering context: `product.md`, `tech.md`, `structure.md`
+- Additional steering files only when directly relevant to requirement coverage, architecture boundaries, integrations, runtime prerequisites, security/performance constraints, or team conventions that affect implementation readiness
+- `.kiro/settings/templates/specs/design.md` for document structure
+- Read `rules/design-principles.md` from this skill's directory for design principles
+- `.kiro/settings/templates/specs/research.md` for discovery log structure
+
+**Validate requirements approval**:
+- If auto-approve flag is true: Auto-approve requirements in spec.json
+- Otherwise: Verify approval status (stop if unapproved, see Safety & Fallback)
+
+### Step 2: Discovery & Analysis
+
+**Critical: This phase ensures design is based on complete, accurate information.**
+
+1. **Classify Feature Type**:
+   - **New Feature** (greenfield) → Full discovery required
+   - **Extension** (existing system) → Integration-focused discovery
+   - **Simple Addition** (CRUD/UI) → Minimal or no discovery
+   - **Complex Integration** → Comprehensive analysis required
+
+2. **Execute Appropriate Discovery Process**:
+
+   **For Complex/New Features**:
+   - Read and execute `rules/design-discovery-full.md` from this skill's directory
+   - Conduct thorough research using WebSearch/WebFetch:
+     - Latest architectural patterns and best practices
+     - External dependency verification (APIs, libraries, versions, compatibility)
+     - Official documentation, migration guides, known issues
+     - Performance benchmarks and security considerations
+
+   **For Extensions**:
+   - Read and execute `rules/design-discovery-light.md` from this skill's directory
+   - Focus on integration points, existing patterns, compatibility
+   - Use Grep to analyze existing codebase patterns
+
+   **For Simple Additions**:
+   - Skip formal discovery, quick pattern check only
+
+#### Parallel Research (subagent dispatch)
+
+The following research areas are independent and can be dispatched as **subagents** via the Agent tool. The agent should decide the optimal decomposition based on feature complexity — split, merge, add, or skip subagents as needed. Each subagent returns a **findings summary** (not raw data) to keep the main context clean for synthesis.
+
+**Typical research areas** (adjust as appropriate):
+- **Codebase analysis**: Existing architecture patterns, integration points, code conventions (using Grep/Glob)
+- **External research**: Dependencies, APIs, latest best practices (using WebSearch/WebFetch)
+- **Context loading** (usually main context): Steering files, design principles, discovery rules, templates
+
+For simple additions, skip subagent dispatch entirely and do a quick pattern check in main context.
+
+After all findings return, synthesize in main context before proceeding.
+
+3. **Retain Discovery Findings for Step 3**:
+   - External API contracts and constraints
+   - Technology decisions with rationale
+   - Existing patterns to follow or extend
+   - Integration points and dependencies
+   - Identified risks and mitigation strategies
+   - Boundary candidates, out-of-boundary decisions, and likely revalidation triggers
+
+4. **Persist Findings to Research Log**:
+   - Create or update `.kiro/specs/{feature}/research.md` using the shared template
+   - Summarize discovery scope and key findings
+   - Record investigations with sources and implications
+   - Document architecture pattern evaluation, design decisions, and risks
+   - Use the language specified in spec.json when writing or updating `research.md`
+
+### Step 3: Synthesis
+
+**Apply design synthesis to discovery findings before writing.**
+
+- Read and apply `rules/design-synthesis.md` from this skill's directory
+- This step requires the full picture from discovery findings — execute in main context, not in a subagent
+- Record synthesis outcomes (generalizations found, build-vs-adopt decisions, simplifications) in `research.md`
+
+### Step 4: Generate Design Draft
+
+1. **Generate Design Draft**:
+   - **Follow specs/design.md template structure and generation instructions strictly**
+   - **Boundary-first requirement**: Before expanding supporting sections, make the boundary explicit. The draft must clearly define what this spec owns, what it does not own, which dependencies are allowed, and what changes would require downstream revalidation.
+   - **Integrate all discovery findings and synthesis outcomes**: Use researched information (APIs, patterns, technologies) and synthesis decisions (generalizations, build-vs-adopt, simplifications) throughout component definitions, architecture decisions, and integration points
+   - **File Structure Plan** (required): Populate the File Structure Plan section with concrete file paths and responsibilities. Analyze the codebase to determine which files need to be created vs. modified. Each file must have one clear responsibility. This section directly drives task `_Boundary:_` annotations and implementation Task Briefs — vague file structures produce vague implementations.
+   - **Testing Strategy**: Derive test items from requirements' acceptance criteria, not generic patterns. Each test item should reference specific components and behaviors from this design. E2E paths must map to the critical user flows identified in requirements. Avoid vague entries like "test login works" -- instead specify what is being verified and why it matters.
+   - If existing design.md found in Step 1, use it as reference context (merge mode)
+   - Apply design rules: Type Safety, Visual Communication, Formal Tone
+   - Use language specified in spec.json
+   - Keep this as a draft until the review gate passes; do not write `design.md` yet
+
+### Step 5: Review Design Draft
+
+- Read and apply `rules/design-review-gate.md` from this skill's directory
+- Verify requirements coverage, architecture readiness, and implementation executability before finalizing the design
+- If issues are local to the draft, repair the design and review again
+- Keep the review bounded to at most 2 repair passes
+- If the draft exposes a real requirements/design gap, stop and return to requirements clarification instead of papering over it in `design.md`
+
+### Step 6: Finalize Design Document
+
+1. **Write Final Design**:
+   - Write `.kiro/specs/{feature}/design.md` only after the design review gate passes
+   - Write research.md with discovery findings and synthesis outcomes (if not already written)
+
+2. **Update Metadata** in spec.json:
+
+   - Set `phase: "design-generated"`
+   - Set `approvals.design.generated: true, approved: false`
+   - Set `approvals.requirements.approved: true`
+   - Update `updated_at` timestamp
+
+## Critical Constraints
+ - **Type Safety**:
+   - Enforce strong typing aligned with the project's technology stack.
+   - For statically typed languages, define explicit types/interfaces and avoid unsafe casts.
+   - For TypeScript, never use `any`; prefer precise types and generics.
+   - For dynamically typed languages, provide type hints/annotations where available (e.g., Python type hints) and validate inputs at boundaries.
+   - Document public interfaces and contracts clearly to ensure cross-component type safety.
+- **Requirements Traceability IDs**: Use numeric requirement IDs only (e.g. "1.1", "1.2", "3.1", "3.3") exactly as defined in requirements.md. Do not invent new IDs or use alphabetic labels.
+
+## Output Description
+
+**Command execution output** (separate from design.md content):
+
+Provide brief summary in the language specified in spec.json:
+
+1. **Status**: Confirm design document generated at `.kiro/specs/{feature}/design.md`
+2. **Discovery Type**: Which discovery process was executed (full/light/minimal)
+3. **Key Findings**: 2-3 critical insights from discovery that shaped the design
+4. **Review Gate**: Confirm the design review gate passed
+5. **Next Action**: Approval workflow guidance (see Safety & Fallback)
+6. **Research Log**: Confirm `research.md` updated with latest decisions
+
+**Format**: Concise Markdown (under 200 words) - this is the command output, NOT the design document itself
+
+**Note**: The actual design document follows `.kiro/settings/templates/specs/design.md` structure.
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Requirements Not Approved**:
+- **Stop Execution**: Cannot proceed without approved requirements
+- **User Message**: "Requirements not yet approved. Approval required before design generation."
+- **Suggested Action**: "Run `/kiro-spec-design {feature} -y` to auto-approve requirements and proceed"
+
+**Missing Requirements**:
+- **Stop Execution**: Requirements document must exist
+- **User Message**: "No requirements.md found at `.kiro/specs/{feature}/requirements.md`"
+- **Suggested Action**: "Run `/kiro-spec-requirements {feature}` to generate requirements first"
+
+**Template Missing**:
+- **User Message**: "Template file missing at `.kiro/settings/templates/specs/design.md`"
+- **Suggested Action**: "Check repository setup or restore template file"
+- **Fallback**: Use inline basic structure with warning
+
+**Steering Context Missing**:
+- **Warning**: "Steering directory empty or missing - design may not align with project standards"
+- **Proceed**: Continue with generation but note limitation in output
+
+**Invalid Requirement IDs**:
+  - **Stop Execution**: If requirements.md is missing numeric IDs or uses non-numeric headings (for example, "Requirement A"), stop and instruct the user to fix requirements.md before continuing.
+
+**Spec Gap Found During Design Review**:
+- **Stop Execution**: Do not write a patched-over `design.md`
+- **User Message**: "Design review found a real spec gap or ambiguity that must be resolved before design can be finalized."
+- **Suggested Action**: Clarify or fix `requirements.md`, then re-run `/kiro-spec-design {feature}`
+
+### Next Phase: Task Generation
+
+**If Design Approved**:
+- **Optional**: Run `/kiro-validate-design {feature}` for interactive quality review
+- Run `/kiro-spec-tasks {feature}` to generate implementation tasks
+- Or `/kiro-spec-tasks {feature} -y` to auto-approve and proceed directly
+
+**If Modifications Needed**:
+- Provide feedback and re-run `/kiro-spec-design {feature}`
+- Existing design used as reference (merge mode)

--- a/.claude/skills/kiro-spec-design/rules/design-discovery-full.md
+++ b/.claude/skills/kiro-spec-design/rules/design-discovery-full.md
@@ -1,0 +1,93 @@
+# Full Discovery Process for Technical Design
+
+## Objective
+Conduct comprehensive research and analysis to ensure the technical design is based on complete, accurate, and up-to-date information.
+
+## Discovery Steps
+
+### 1. Requirements Analysis
+**Map Requirements to Technical Needs**
+- Extract all functional requirements from EARS format
+- Identify non-functional requirements (performance, security, scalability)
+- Determine technical constraints and dependencies
+- List core technical challenges
+
+### 2. Existing Implementation Analysis
+**Understand Current System** (if modifying/extending):
+- Analyze codebase structure and architecture patterns
+- Map reusable components, services, utilities
+- Identify domain boundaries and data flows
+- Document integration points and dependencies
+- Determine approach: extend vs refactor vs wrap
+
+### 3. Technology Research
+**Investigate Best Practices and Solutions**:
+- **Use WebSearch** to find:
+  - Latest architectural patterns for similar problems
+  - Industry best practices for the technology stack
+  - Recent updates or changes in relevant technologies
+  - Common pitfalls and solutions
+
+- **Use WebFetch** to analyze:
+  - Official documentation for frameworks/libraries
+  - API references and usage examples
+  - Migration guides and breaking changes
+  - Performance benchmarks and comparisons
+
+### 4. External Dependencies Investigation
+**For Each External Service/Library**:
+- Search for official documentation and GitHub repositories
+- Verify API signatures and authentication methods
+- Check version compatibility with existing stack
+- Investigate rate limits and usage constraints
+- Find community resources and known issues
+- Document security considerations
+- Note any gaps requiring implementation investigation
+
+### 5. Architecture Pattern & Boundary Analysis
+**Evaluate Architectural Options**:
+- Compare relevant patterns (MVC, Clean, Hexagonal, Event-driven)
+- Assess fit with existing architecture and steering principles
+- Identify domain boundaries and ownership seams required to avoid team conflicts
+- Consider scalability implications and operational concerns
+- Evaluate maintainability and team expertise
+- Document preferred pattern and rejected alternatives in `research.md`
+
+### 6. Risk Assessment
+**Identify Technical Risks**:
+- Performance bottlenecks and scaling limits
+- Security vulnerabilities and attack vectors
+- Integration complexity and coupling
+- Technical debt creation vs resolution
+- Knowledge gaps and training needs
+
+## Research Guidelines
+
+### When to Search
+**Always search for**:
+- External API documentation and updates
+- Security best practices for authentication/authorization
+- Performance optimization techniques for identified bottlenecks
+- Latest versions and migration paths for dependencies
+
+**Search if uncertain about**:
+- Architectural patterns for specific use cases
+- Industry standards for data formats/protocols
+- Compliance requirements (GDPR, HIPAA, etc.)
+- Scalability approaches for expected load
+
+### Search Strategy
+1. Start with official sources (documentation, GitHub)
+2. Check recent blog posts and articles (last 6 months)
+3. Review Stack Overflow for common issues
+4. Investigate similar open-source implementations
+
+## Output Requirements
+Capture all findings that impact design decisions in `research.md` using the shared template:
+- Key insights affecting architecture, technology alignment, and contracts
+- Constraints discovered during research
+- Recommended approaches and selected architecture pattern with rationale
+- Rejected alternatives and trade-offs (documented in the Design Decisions section)
+- Updated domain boundaries that inform Components & Interface Contracts
+- Risks and mitigation strategies
+- Gaps requiring further investigation during implementation

--- a/.claude/skills/kiro-spec-design/rules/design-discovery-light.md
+++ b/.claude/skills/kiro-spec-design/rules/design-discovery-light.md
@@ -1,0 +1,49 @@
+# Light Discovery Process for Extensions
+
+## Objective
+Quickly analyze existing system and integration requirements for feature extensions.
+
+## Focused Discovery Steps
+
+### 1. Extension Point Analysis
+**Identify Integration Approach**:
+- Locate existing extension points or interfaces
+- Determine modification scope (files, components)
+- Check for existing patterns to follow
+- Identify backward compatibility requirements
+
+### 2. Dependency Check
+**Verify Compatibility**:
+- Check version compatibility of new dependencies
+- Validate API contracts haven't changed
+- Ensure no breaking changes in pipeline
+
+### 3. Quick Technology Verification
+**For New Libraries Only**:
+- Use WebSearch for official documentation
+- Verify basic usage patterns
+- Check for known compatibility issues
+- Confirm licensing compatibility
+- Record key findings in `research.md` (technology alignment section)
+
+### 4. Integration Risk Assessment
+**Quick Risk Check**:
+- Impact on existing functionality
+- Performance implications
+- Security considerations
+- Testing requirements
+
+## When to Escalate to Full Discovery
+Switch to full discovery if you find:
+- Significant architectural changes needed
+- Complex external service integrations
+- Security-sensitive implementations
+- Performance-critical components
+- Unknown or poorly documented dependencies
+
+## Output Requirements
+- Clear integration approach (note boundary impacts in `research.md`)
+- List of files/components to modify
+- New dependencies with versions
+- Integration risks and mitigations
+- Testing focus areas

--- a/.claude/skills/kiro-spec-design/rules/design-principles.md
+++ b/.claude/skills/kiro-spec-design/rules/design-principles.md
@@ -1,0 +1,198 @@
+# Technical Design Rules and Principles
+
+## Core Design Principles
+
+### 0. Boundary First
+- **Boundary is mandatory; owner is optional**
+- A design is not ready when it explains components but leaves responsibility seams ambiguous
+- Define what the spec owns before elaborating how it works
+- Explicitly record what is out of boundary
+- Do not leak downstream-specific behavior or assumptions into upstream boundaries
+
+### 1. Type Safety is Mandatory
+- **NEVER** use `any` type in TypeScript interfaces
+- Define explicit types for all parameters and returns
+- Use discriminated unions for error handling
+- Specify generic constraints clearly
+
+### 2. Design vs Implementation
+- **Focus on WHAT, not HOW**
+- Define interfaces and contracts, not code
+- Specify behavior through pre/post conditions
+- Document architectural decisions, not algorithms
+
+### 3. Visual Communication
+- **Simple features**: Basic component diagram or none
+- **Medium complexity**: Architecture + data flow
+- **High complexity**: Multiple diagrams (architecture, sequence, state)
+- **Always pure Mermaid**: No styling, just structure
+
+### 4. Component Design Rules
+- **Single Responsibility**: One clear purpose per component
+- **Clear Boundaries**: Explicit domain ownership
+- **Boundary Commitments First**: Before detailing components, state the responsibility boundary this design commits to
+- **Dependency Direction**: Follow architectural layers
+- **Interface Segregation**: Minimal, focused interfaces
+- **Team-safe Interfaces**: Design boundaries that allow parallel implementation without merge conflicts
+- **No Hidden Shared Ownership**: If two areas appear to co-own the same behavior or data, the design is incomplete
+- **Research Traceability**: Record boundary decisions and rationale in `research.md`
+
+### 5. Data Modeling Standards
+- **Domain First**: Start with business concepts
+- **Consistency Boundaries**: Clear aggregate roots
+- **Normalization**: Balance between performance and integrity
+- **Evolution**: Plan for schema changes
+
+### 6. Error Handling Philosophy
+- **Fail Fast**: Validate early and clearly
+- **Graceful Degradation**: Partial functionality over complete failure
+- **User Context**: Actionable error messages
+- **Observability**: Comprehensive logging and monitoring
+
+### 7. Integration Patterns
+- **Loose Coupling**: Minimize dependencies
+- **Contract First**: Define interfaces before implementation
+- **Versioning**: Plan for API evolution
+- **Idempotency**: Design for retry safety
+- **Contract Visibility**: Surface API and event contracts in design.md while linking extended details from `research.md`
+
+### 8. Dependency Direction
+- **Define and enforce the dependency direction** in the architecture section of design.md (e.g., Types → Config → Repository → Service → Runtime → UI)
+- Each layer imports only from layers to its left — never upward
+- This constraint is not a suggestion; implementation and review should treat violations as errors
+- When the File Structure Plan maps files to components, the dependency direction determines which imports are allowed
+
+## Documentation Standards
+
+### Language and Tone
+- **Declarative**: "The system authenticates users" not "The system should authenticate"
+- **Precise**: Specific technical terms over vague descriptions
+- **Concise**: Essential information only
+- **Formal**: Professional technical writing
+
+### Structure Requirements
+- **Hierarchical**: Clear section organization
+- **Traceable**: Requirements to components mapping
+- **Complete**: All aspects covered for implementation
+- **Consistent**: Uniform terminology throughout
+- **Focused**: Keep design.md centered on architecture and contracts; move investigation logs and lengthy comparisons to `research.md`
+
+## Section Authoring Guidance
+
+### Global Ordering
+- Default flow: Overview → Goals/Non-Goals → Boundary Commitments → Architecture → File Structure Plan → Components & Interfaces → Optional sections.
+- Teams may swap Traceability earlier or place Data Models nearer Architecture when it improves clarity, but keep section headings intact.
+- Within each section, follow **Summary → Scope → Decisions → Impacts/Risks** so reviewers can scan consistently.
+
+### Requirement IDs
+- Reference requirements as `2.1, 2.3` without prefixes (no “Requirement 2.1”).
+- All requirements MUST have numeric IDs. If a requirement lacks a numeric ID, stop and fix `requirements.md` before continuing.
+- Use `N.M`-style numeric IDs where `N` is the top-level requirement number from requirements.md (for example, Requirement 1 → 1.1, 1.2; Requirement 2 → 2.1, 2.2).
+- Every component, task, and traceability row must reference the same canonical numeric ID.
+
+### Technology Stack
+- Include ONLY layers impacted by this feature (frontend, backend, data, messaging, infra).
+- For each layer specify tool/library + version + the role it plays; push extended rationale, comparisons, or benchmarks to `research.md`.
+- When extending an existing system, highlight deviations from the current stack and list new dependencies.
+
+### System Flows
+- Add diagrams only when they clarify behavior:  
+  - **Sequence** for multi-step interactions  
+  - **Process/State** for branching rules or lifecycle  
+  - **Data/Event** for pipelines or async patterns
+- Always use pure Mermaid. If no complex flow exists, omit the entire section.
+
+### Requirements Traceability
+- Use the standard table (`Requirement | Summary | Components | Interfaces | Flows`) to prove coverage.
+- Collapse to bullet form only when a single requirement maps 1:1 to a component.
+- Prefer the component summary table for simple mappings; reserve the full traceability table for complex or compliance-sensitive requirements.
+- Re-run this mapping whenever requirements or components change to avoid drift.
+
+### Components & Interfaces Authoring
+- Boundary Commitments should already make the ownership seam explicit before this section begins.
+- Group components by domain/layer and provide one block per component.
+- Begin with a summary table listing Component, Domain, Intent, Requirement coverage, key dependencies, and selected contracts.
+- Table fields: Intent (one line), Requirements (`2.1, 2.3`), Owner/Reviewers (optional).
+- Dependencies table must mark each entry as Inbound/Outbound/External and assign Criticality (`P0` blocking, `P1` high-risk, `P2` informational).
+- Summaries of external dependency research stay here; detailed investigation (API signatures, rate limits, migration notes) belongs in `research.md`.
+- design.md must remain a self-contained reviewer artifact. Reference `research.md` only for background, and restate any conclusions or decisions here.
+- Contracts: tick only the relevant types (Service/API/Event/Batch/State). Unchecked types should not appear later in the component section.
+- Service interfaces must declare method signatures, inputs/outputs, and error envelopes. API/Event/Batch contracts require schema tables or bullet lists covering trigger, payload, delivery, idempotency.
+- Use **Integration & Migration Notes**, **Validation Hooks**, and **Open Questions / Risks** to document rollout strategy, observability, and unresolved decisions.
+- Detail density rules:
+  - **Full block**: components introducing new boundaries (logic hooks, shared services, external integrations, data layers).
+  - **Summary-only**: presentational/UI components with no new boundaries (plus a short Implementation Note if needed).
+- Implementation Notes must combine Integration / Validation / Risks into a single bulleted subsection to reduce repetition.
+- Prefer lists or inline descriptors for short data (dependencies, contract selections). Use tables only when comparing multiple items.
+
+### Shared Interfaces & Props
+- Define a base interface (e.g., `BaseUIPanelProps`) for recurring UI components and extend it per component to capture only the deltas.
+- Hooks, utilities, and integration adapters that introduce new contracts should still include full TypeScript signatures.
+- When reusing a base contract, reference it explicitly (e.g., “Extends `BaseUIPanelProps` with `onSubmitAnswer` callback”) instead of duplicating the code block.
+
+### Data Models
+- Domain Model covers aggregates, entities, value objects, domain events, and invariants. Add Mermaid diagrams only when relationships are non-trivial.
+- Logical Data Model should articulate structure, indexing, sharding, and storage-specific considerations (event store, KV/wide-column) relevant to the change.
+- Data Contracts & Integration section documents API payloads, event schemas, and cross-service synchronization patterns when the feature crosses boundaries.
+- Lengthy type definitions or vendor-specific option objects should be placed in the Supporting References section within design.md, linked from the relevant section. Investigation notes stay in `research.md`.
+- Supporting References usage is optional; only create it when keeping the content in the main body would reduce readability. All decisions must still appear in the main sections so design.md stands alone.
+
+### Error/Testing/Security/Performance Sections
+- Record only feature-specific decisions or deviations. Link or reference organization-wide standards (steering) for baseline practices instead of restating them.
+
+### Diagram & Text Deduplication
+- Do not restate diagram content verbatim in prose. Use the text to highlight key decisions, trade-offs, or impacts that are not obvious from the visual.
+- When a decision is fully captured in the diagram annotations, a short “Key Decisions” bullet is sufficient.
+
+### General Deduplication
+- Avoid repeating the same information across Overview, Architecture, and Components. Reference earlier sections when context is identical.
+- If a requirement/component relationship is captured in the summary table, do not rewrite it elsewhere unless extra nuance is added.
+
+## Diagram Guidelines
+
+### When to include a diagram
+- **Architecture**: Use a structural diagram when 3+ components or external systems interact.
+- **Sequence**: Draw a sequence diagram when calls/handshakes span multiple steps.
+- **State / Flow**: Capture complex state machines or business flows in a dedicated diagram.
+- **ER**: Provide an entity-relationship diagram for non-trivial data models.
+- **Skip**: Minor one-component changes generally do not need diagrams.
+
+### Mermaid requirements
+```mermaid
+graph TB
+    Client --> ApiGateway
+    ApiGateway --> ServiceA
+    ApiGateway --> ServiceB
+    ServiceA --> Database
+```
+
+- **Plain Mermaid only** – avoid custom styling or unsupported syntax.
+- **Node IDs** – alphanumeric plus underscores only (e.g., `Client`, `ServiceA`). Do not use `@`, `/`, or leading `-`.
+- **Labels** – simple words. Do not embed parentheses `()`, square brackets `[]`, quotes `"`, or slashes `/`.
+  - ❌ `DnD[@dnd-kit/core]` → invalid ID (`@`).
+  - ❌ `UI[KanbanBoard(React)]` → invalid label (`()`).
+  - ✅ `DndKit[dnd-kit core]` → use plain text in labels, keep technology details in the accompanying description.
+  - ℹ️ Mermaid strict-mode will otherwise fail with errors like `Expecting 'SQE' ... got 'PS'`; remove punctuation from labels before rendering.
+- **Edges** – show data or control flow direction.
+- **Groups** – using Mermaid subgraphs to cluster related components is allowed; use it sparingly for clarity.
+
+## Quality Metrics
+### Design Completeness Checklist
+- All requirements addressed
+- No implementation details leaked
+- Clear component boundaries
+- Explicit error handling
+- Comprehensive test strategy
+- Security considered
+- Performance targets defined
+- Migration path clear (if applicable)
+
+### Common Anti-patterns to Avoid
+❌ Mixing design with implementation
+❌ Vague interface definitions
+❌ Missing error scenarios
+❌ Ignored non-functional requirements
+❌ Overcomplicated architectures
+❌ Tight coupling between components
+❌ Missing data consistency strategy
+❌ Incomplete dependency analysis

--- a/.claude/skills/kiro-spec-design/rules/design-review-gate.md
+++ b/.claude/skills/kiro-spec-design/rules/design-review-gate.md
@@ -1,0 +1,50 @@
+# Design Review Gate
+
+Before writing `design.md`, review the draft design and repair local issues until the design passes or a true spec gap is discovered.
+
+## Requirements Coverage Review
+
+- Every numeric requirement ID from `requirements.md` must appear in the design traceability mapping and be backed by one or more concrete components, contracts, flows, data models, or operational decisions.
+- Every requirement that introduces an external dependency, integration point, runtime prerequisite, migration concern, observability need, security constraint, or performance target must be reflected explicitly in `design.md`.
+- If coverage is missing because the design draft is incomplete, repair the draft and review again.
+- If coverage cannot be completed cleanly because requirements are ambiguous, contradictory, or underspecified, stop and return to the requirements phase instead of inventing design detail.
+
+## Architecture Readiness Review
+
+- Component boundaries must be explicit enough that implementation tasks can be assigned without guessing ownership.
+- Interfaces, contracts, state transitions, and integration boundaries must be concrete enough for implementation and validation.
+- Build-vs-adopt decisions that materially affect architecture must be captured in `design.md`, with deeper investigation left in `research.md` when present.
+- Runtime prerequisites, migrations, rollout constraints, validation hooks, and failure modes must be surfaced when they materially affect implementation order or risk.
+
+## Boundary Readiness Review
+
+- The design must explicitly state what this spec owns.
+- The design must explicitly state what is out of boundary.
+- Allowed dependencies must be concrete enough that reviewers can detect boundary violations later.
+- If data, behavior, or integration responsibility appears shared across multiple areas without a clear seam, stop and repair the design.
+- If downstream assumptions are embedded in upstream components "for convenience," stop and repair the design.
+- If the boundary cannot be explained in a few direct bullets, it is probably still too vague for task generation.
+- If the design reveals multiple independent responsibility seams that could move separately, stop and split the spec or return to roadmap discovery instead of forcing them into one spec.
+
+## Executability Review
+
+- The design must be implementable as a sequence of bounded tasks without hidden prerequisites.
+- Parallel-safe boundaries should be visible where the architecture intends concurrent implementation.
+- Avoid speculative abstraction: remove components, adapters, or interfaces that exist only for hypothetical future scope.
+- If a section is too vague for tasks to reference directly, rewrite it before finalizing the design.
+
+## Mechanical Checks
+
+Before applying judgment, verify these mechanically:
+- **Requirements traceability**: Extract all numeric requirement IDs from `requirements.md`. Scan the design draft for each ID. Report any IDs not found in the design.
+- **Boundary section populated**: `Boundary Commitments`, `Out of Boundary`, `Allowed Dependencies`, and `Revalidation Triggers` must not be empty or placeholder-only.
+- **File Structure Plan populated**: The File Structure Plan section must contain concrete file paths (not just "TBD" or empty). Scan for placeholder text in that section.
+- **Boundary ↔ file structure alignment**: The File Structure Plan must reflect the stated responsibility boundary. If files imply broader ownership than the boundary section claims, report a mismatch.
+- **No orphan components**: Every component mentioned in the design must appear in the File Structure Plan with a file path. Scan for component names that have no corresponding file entry.
+
+## Review Loop
+
+- Run mechanical checks first, then judgment-based review.
+- If issues are local to the draft, repair the draft and re-run the review gate.
+- Keep the loop bounded: no more than 2 review-and-repair passes before escalating a real spec gap.
+- Write `design.md` only after the review gate passes.

--- a/.claude/skills/kiro-spec-design/rules/design-synthesis.md
+++ b/.claude/skills/kiro-spec-design/rules/design-synthesis.md
@@ -1,0 +1,29 @@
+# Design Synthesis
+
+After discovery and before writing the design document, apply these three lenses to the collected findings. This step requires the full picture — do not parallelize.
+
+## 1. Generalization
+
+Look across all requirements as a group. Identify cases where multiple requirements are variations of the same underlying problem.
+
+- If feature A is a special case of a more general capability X, design X with an interface that naturally supports A (and potentially B, C later)
+- Keep the implementation scope to what the current requirements demand — generalize the interface, not the implementation
+- Record identified generalizations in `research.md` under Design Decisions
+
+## 2. Build vs. Adopt
+
+For each major component in the emerging design, ask: is this problem already solved?
+
+- Search for established standards (RFCs, protocols), battle-tested libraries, or platform-native capabilities that address the requirement
+- Prefer adopting existing solutions over building custom ones when they fit the requirements without significant adaptation
+- If adopting: verify the solution is actively maintained, compatible with the project's stack (check steering), and meets non-functional requirements
+- If building: document why existing solutions were rejected (capture in `research.md`)
+
+## 3. Simplification
+
+For each component and abstraction layer in the emerging design, ask: is this necessary?
+
+- Remove components that exist "just in case" or for hypothetical future requirements not in the current spec
+- Flatten unnecessary abstraction layers — if an interface has only one implementation with no foreseeable second, it may not need the indirection
+- Prefer fewer, cohesive components over many fine-grained ones
+- The right design is the smallest one that satisfies all requirements and remains extensible at the interface level

--- a/.claude/skills/kiro-spec-init/SKILL.md
+++ b/.claude/skills/kiro-spec-init/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: kiro-spec-init
+description: Initialize a new specification with detailed project description
+allowed-tools: Bash, Read, Write, Glob, AskUserQuestion
+argument-hint: <project-description>
+---
+
+# Spec Initialization
+
+<instructions>
+## Core Task
+Generate a unique feature name from the project description ($ARGUMENTS) and initialize the specification structure.
+
+## Execution Steps
+1. **Check for Brief**: If `.kiro/specs/{feature-name}/brief.md` exists (created by `/kiro-discovery`), read it. The brief contains problem, approach, scope, and constraints from the discovery session. Use this to pre-fill the project description and skip clarification questions that the brief already answers.
+2. **Clarify Intent**: The Project Description in requirements.md must contain three elements: (a) who has the problem, (b) current situation, (c) what should change. If a brief.md exists and covers these, skip to step 3. Otherwise, ask the user to clarify before proceeding. Ask as many questions as needed; do not fill in gaps with your own assumptions.
+3. **Check Uniqueness**: Verify `.kiro/specs/` for naming conflicts. If the directory already exists with only `brief.md` (no `spec.json`), use that directory (discovery created it).
+4. **Create Directory**: `.kiro/specs/[feature-name]/` (skip if already exists from discovery)
+5. **Initialize Files Using Templates**:
+   - Read `.kiro/settings/templates/specs/init.json`
+   - Read `.kiro/settings/templates/specs/requirements-init.md`
+   - Replace placeholders:
+     - `{{FEATURE_NAME}}` → generated feature name
+     - `{{TIMESTAMP}}` → current ISO 8601 timestamp
+     - `{{PROJECT_DESCRIPTION}}` → from brief.md if available, otherwise $ARGUMENTS
+     - `ja` → language code (detect from user's input language, default to `en`)
+   - Write `spec.json` and `requirements.md` to spec directory
+
+## Important Constraints
+- Do NOT generate requirements, design, or tasks. This skill only creates spec.json and requirements.md.
+</instructions>
+
+## Output Description
+Provide output in the language specified in `spec.json` with the following structure:
+
+1. **Generated Feature Name**: `feature-name` format with 1-2 sentence rationale
+2. **Project Summary**: Brief summary (1 sentence)
+3. **Created Files**: Bullet list with full paths
+4. **Next Step**: Command block showing `/kiro-spec-requirements <feature-name>`
+
+**Format Requirements**:
+- Use Markdown headings (##, ###)
+- Wrap commands in code blocks
+- Keep total output concise (under 250 words)
+- Use clear, professional language per `spec.json.language`
+
+## Safety & Fallback
+- **Ambiguous Feature Name**: If feature name generation is unclear, propose 2-3 options and ask user to select
+- **Template Missing**: If template files don't exist in `.kiro/settings/templates/specs/`, report error with specific missing file path and suggest checking repository setup
+- **Directory Conflict**: If feature name already exists, append numeric suffix (e.g., `feature-name-2`) and notify user of automatic conflict resolution
+- **Write Failure**: Report error with specific path and suggest checking permissions or disk space

--- a/.claude/skills/kiro-spec-quick/SKILL.md
+++ b/.claude/skills/kiro-spec-quick/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: kiro-spec-quick
+description: Quick spec generation with interactive or automatic mode
+allowed-tools: Read, Skill, Bash, Write, Glob, Agent
+argument-hint: <project-description> [--auto]
+---
+
+# Quick Spec Generator
+
+<instructions>
+## CRITICAL: Automatic Mode Execution Rules
+
+**If `--auto` flag is present in `$ARGUMENTS`, you are in AUTOMATIC MODE.**
+
+In Automatic Mode:
+- Execute ALL 4 phases in a continuous loop without stopping
+- Display progress after each phase (e.g., "Phase 1/4 complete: spec initialized")
+- IGNORE any "Next Step" messages from Phase 2-4 (they are for standalone usage)
+- After Phase 4, run the final sanity review before exiting
+- Stop ONLY after the sanity review completes or if error occurs
+
+---
+
+## Core Task
+Execute 4 spec phases sequentially. In automatic mode, execute all phases without stopping. In interactive mode, prompt user for approval between phases.
+
+Before claiming quick generation is complete, run one lightweight sanity review over the generated requirements, design, and tasks. If the host supports fresh subagents, use one. Otherwise run the sanity review inline.
+
+## Execution Steps
+
+### Step 1: Parse Arguments and Initialize
+
+Parse `$ARGUMENTS`:
+- If contains `--auto`: **Automatic Mode** (execute all 4 phases)
+- Otherwise: **Interactive Mode** (prompt at each phase)
+- Extract description (remove `--auto` flag if present)
+
+Example:
+```
+"User profile with avatar upload --auto" → mode=automatic, description="User profile with avatar upload"
+"User profile feature" → mode=interactive, description="User profile feature"
+```
+
+Display mode banner and proceed to Step 2.
+
+### Step 2: Execute Phase Loop
+
+Execute these 4 phases in order:
+
+---
+
+#### Phase 1: Initialize Spec (Direct Implementation)
+
+**Core Logic**:
+
+1. **Check for Brief**:
+   - If `.kiro/specs/{feature-name}/brief.md` exists (created by `/kiro-discovery`), read it for discovery context (problem, approach, scope, constraints)
+   - Use brief content as the project description instead of `$ARGUMENTS`
+
+2. **Generate Feature Name**:
+   - Convert description to kebab-case
+   - Example: "User profile with avatar upload" → "user-profile-avatar-upload"
+   - Keep name concise (2-4 words ideally)
+
+3. **Check Uniqueness**:
+   - Use Glob to check `.kiro/specs/*/`
+   - If directory exists with only `brief.md` (no `spec.json`), use that directory (discovery created it)
+   - Otherwise if feature name exists, append `-2`, `-3`, etc.
+
+4. **Create Directory**:
+   - Use Bash: `mkdir -p .kiro/specs/{feature-name}` (skip if already exists from discovery)
+
+5. **Initialize Files from Templates**:
+
+   a. Read templates:
+   ```
+   - .kiro/settings/templates/specs/init.json
+   - .kiro/settings/templates/specs/requirements-init.md
+   ```
+
+   b. Replace placeholders:
+   ```
+   {{FEATURE_NAME}} → feature-name
+   {{TIMESTAMP}} → current ISO 8601 timestamp (use `date -u +"%Y-%m-%dT%H:%M:%SZ"`)
+   {{PROJECT_DESCRIPTION}} → description
+   ja → language code (detect from user's input language, default to `en`)
+   ```
+
+   c. Write files using Write tool:
+   ```
+   - .kiro/specs/{feature-name}/spec.json
+   - .kiro/specs/{feature-name}/requirements.md
+   ```
+
+6. **Output Progress**: "Phase 1/4 complete: Spec initialized at .kiro/specs/{feature-name}/"
+
+**Automatic Mode**: IMMEDIATELY continue to Phase 2.
+
+**Interactive Mode**: Prompt "Continue to requirements generation? (yes/no)"
+- If "no": Stop, show current state
+- If "yes": Continue to Phase 2
+
+---
+
+#### Phase 2: Generate Requirements
+
+Invoke `/kiro-spec-requirements {feature-name}` via the Skill tool.
+
+Wait for completion. IGNORE any "Next Step" message (it is for standalone usage).
+
+**Output Progress**: "Phase 2/4 complete: Requirements generated"
+
+**Automatic Mode**: IMMEDIATELY continue to Phase 3.
+
+**Interactive Mode**: Prompt "Continue to design generation? (yes/no)"
+- If "no": Stop, show current state
+- If "yes": Continue to Phase 3
+
+---
+
+#### Phase 3: Generate Design
+
+Invoke `/kiro-spec-design {feature-name} -y` via the Skill tool. The `-y` flag auto-approves requirements.
+
+Wait for completion. IGNORE any "Next Step" message.
+
+**Output Progress**: "Phase 3/4 complete: Design generated"
+
+**Automatic Mode**: IMMEDIATELY continue to Phase 4.
+
+**Interactive Mode**: Prompt "Continue to tasks generation? (yes/no)"
+- If "no": Stop, show current state
+- If "yes": Continue to Phase 4
+
+---
+
+#### Phase 4: Generate Tasks
+
+Invoke `/kiro-spec-tasks {feature-name} -y` via the Skill tool.
+
+Note: `-y` flag auto-approves requirements, design, and tasks.
+
+Wait for completion.
+
+**Output Progress**: "Phase 4/4 complete: Tasks generated"
+
+#### Final Sanity Review
+
+After Phase 4, run a lightweight sanity review before claiming completion.
+
+- Review `requirements.md`, `design.md`, and `tasks.md` directly from disk. If `brief.md` exists, use it only as supporting context.
+- Prefer a fresh review subagent when the host supports it. Pass only file paths and the review objective; the reviewer should read the generated files itself.
+- Review focus:
+  - Do requirements, design, and tasks tell a coherent story?
+  - Are there obvious contradictions, missing prerequisites, or missing task coverage for required design work?
+  - Are `_Depends:_`, `_Boundary:_`, and `(P)` markers plausible for implementation?
+- If the review finds only task-plan-local issues, repair or update the generated `tasks.md` once, then re-run the sanity review.
+- If the review finds a real requirements/design gap or contradiction, stop and report follow-up instead of claiming the quick spec is implementation-ready.
+
+**All 4 phases plus sanity review complete.**
+
+Output final completion summary (see Output Description section) and exit.
+
+---
+
+## Important Constraints
+
+### Error Handling
+- Any phase failure stops the workflow
+- Display error and current state
+- Suggest manual recovery command
+
+</instructions>
+
+## Output Description
+
+### Mode Banners
+
+**Interactive Mode**:
+```
+Quick Spec Generation (Interactive Mode)
+
+You will be prompted at each phase.
+Note: Skips gap analysis and design validation.
+```
+
+**Automatic Mode**:
+```
+Quick Spec Generation (Automatic Mode)
+
+All phases execute automatically without prompts.
+Note: Skips optional validations (gap analysis, design review) and user approval prompts. Internal review gates still run.
+Final sanity review still runs.
+```
+
+### Intermediate Output
+
+After each phase, show brief progress:
+```
+Spec initialized at .kiro/specs/{feature}/
+Requirements generated → Continuing to design...
+Design generated → Continuing to tasks...
+```
+
+### Final Completion Summary
+
+Provide output in the language specified in `spec.json`:
+
+```
+Quick Spec Generation Complete!
+
+Generated Files:
+- specs/{feature}/spec.json
+- specs/{feature}/requirements.md ({X} requirements)
+- specs/{feature}/design.md ({Y} components, {Z} endpoints)
+- specs/{feature}/tasks.md ({N} tasks)
+
+Skipped: /kiro-validate-gap, /kiro-validate-design
+
+Sanity review: PASSED | FOLLOW-UP REQUIRED
+
+Next Steps:
+1. Review generated specs (especially design.md)
+2. Optional: `/kiro-validate-gap {feature}`, `/kiro-validate-design {feature}`
+3. Start implementation: `/kiro-impl {feature}`
+```
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Template Missing**:
+- Check `.kiro/settings/templates/specs/` exists
+- Report specific missing file
+- Exit with error
+
+**Directory Creation Failed**:
+- Check permissions
+- Report error with path
+- Exit with error
+
+**Phase Execution Failed** (Phase 2-4):
+- Stop workflow
+- Show current state and completed phases
+- Suggest: "Continue manually from `/kiro-spec-{next-phase} {feature}`"
+
+**Sanity Review Failed**:
+- Stop workflow
+- Report the exact contradiction, missing prerequisite, or task-plan issue
+- Suggest targeted follow-up with `/kiro-spec-design {feature}`, `/kiro-spec-tasks {feature}`, or manual edits depending on the finding
+
+**User Cancellation** (Interactive Mode):
+- Stop gracefully
+- Show completed phases
+- Suggest manual continuation

--- a/.claude/skills/kiro-spec-requirements/SKILL.md
+++ b/.claude/skills/kiro-spec-requirements/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: kiro-spec-requirements
+description: Generate EARS-format requirements based on project description and steering context. Use when generating requirements from project description.
+allowed-tools: Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch, AskUserQuestion
+metadata:
+  shared-rules: "ears-format.md, requirements-review-gate.md"
+---
+
+# kiro-spec-requirements Skill
+
+## Core Mission
+- **Success Criteria**:
+  - Create complete requirements document aligned with steering context
+  - Follow the project's EARS patterns and constraints for all acceptance criteria
+  - Focus on core functionality without implementation details
+  - Make inclusion/exclusion boundaries explicit when scope could otherwise be misread
+  - Update metadata to track generation status
+
+## Execution Steps
+
+### Step 1: Gather Context
+
+If steering/spec context is already available from conversation, skip redundant file reads.
+Otherwise, load all necessary context:
+- Read `.kiro/specs/{feature}/spec.json` for language and metadata
+- Read `.kiro/specs/{feature}/brief.md` if it exists (discovery context: problem, approach, scope decisions, boundary candidates)
+- Read `.kiro/specs/{feature}/requirements.md` for project description
+- Core steering context: `product.md`, `tech.md`, `structure.md`
+- Additional steering files only when directly relevant to feature scope, user personas, business/domain rules, compliance/security constraints, operational constraints, or existing product boundaries
+- Relevant local agent skills or playbooks only when they clearly match the feature's host environment or use case and contain domain terminology or workflow rules that shape user-observable requirements
+
+### Step 2: Read Guidelines
+- Read `rules/ears-format.md` from this skill's directory for EARS syntax rules
+- Read `rules/requirements-review-gate.md` from this skill's directory for pre-write review criteria
+- Read `.kiro/settings/templates/specs/requirements.md` for document structure
+
+#### Parallel Research (subagent dispatch)
+
+The following research areas are independent. Decide the optimal decomposition based on project complexity -- split, merge, add, or skip subagents as needed.
+
+**Delegate to subagent via Agent tool** (keeps exploration out of main context):
+- **Codebase hints** (brownfield projects): Dispatch a subagent to explore existing implementations that inform requirement scope. Example prompt: "Explore this codebase for existing features related to [feature area]. Summarize: (1) what already exists, (2) relevant interfaces/APIs, (3) patterns that new requirements should align with. Return a summary under 150 lines."
+- **Domain research** (when external knowledge is needed): Dispatch a subagent for WebSearch/WebFetch to research domain-specific requirements, standards, or best practices. Return a concise findings summary.
+- **Additional steering and playbooks**: If many steering files or local agent playbooks exist, dispatch a subagent to scan them and return only the sections relevant to this feature.
+
+For greenfield projects with minimal codebase, skip subagent dispatch and load context directly.
+
+After all research completes, synthesize findings in main context before generating requirements.
+
+### Step 3: Generate Requirements Draft
+- Create initial requirements draft based on project description
+- Group related functionality into logical requirement areas
+- Apply EARS format to all acceptance criteria
+- Use language specified in spec.json
+- Preserve terminology continuity across phases:
+  - discovery = `Boundary Candidates`
+  - requirements = explicit inclusion/exclusion and adjacent expectations when needed
+  - design = `Boundary Commitments`
+  - tasks = `_Boundary:_`
+- If scope could be misread, add lightweight boundary context without introducing implementation or architecture ownership detail
+- Keep this as a draft until the review gate passes; do not write `requirements.md` yet
+
+### Step 4: Review Requirements Draft
+- Run the `Requirements Review Gate` from `rules/requirements-review-gate.md`
+- Review coverage, EARS compliance, ambiguity, adjacent expectations, and scope boundaries before finalizing
+- If issues are local to the draft, repair the requirements and review again
+- Keep the review bounded to at most 2 repair passes
+- If the draft exposes a real scope ambiguity or contradiction, stop and ask the user to clarify instead of writing guessed requirements
+
+### Step 5: Finalize and Update Metadata
+- Write `.kiro/specs/{feature}/requirements.md` only after the requirements review gate passes
+- Set `phase: "requirements-generated"`
+- Set `approvals.requirements.generated: true`
+- Update `updated_at` timestamp
+
+## Important Constraints
+
+### Requirements Scope: WHAT, not HOW
+Requirements describe user-observable behavior, not implementation. Use this to decide what belongs here vs. in design:
+
+**Ask the user about (requirements scope):**
+- Functional scope — what is included and what is excluded
+- User-observable behavior — "when X happens, what should the user see/experience?"
+- Business rules and edge cases — limits, error conditions, special cases
+- Non-functional requirements visible to users — response time expectations, availability, security level
+- Adjacent expectations only when they change user-visible behavior or operator expectations — what this feature relies on, and what it explicitly does not own
+
+**Do not ask about (design scope — defer to design phase):**
+- Technology stack choices (database, framework, language)
+- Architecture patterns (microservices, monolith, event-driven)
+- API design, data models, internal component structure
+- How to achieve non-functional requirements (caching strategy, scaling approach)
+- Internal ownership mapping, component seams, or implementation boundaries that belong in design
+
+**Litmus test**: If an EARS acceptance criterion can be written without mentioning any technology, it belongs in requirements. If it requires a technology choice, it belongs in design.
+
+### Other Constraints
+- Each requirement must be testable and unambiguous. If the project description leaves room for multiple interpretations on scope, behavior, or boundary conditions, ask the user to clarify before generating that requirement. Ask as many questions as needed; do not generate requirements that contain your own assumptions.
+- Choose appropriate subject for EARS statements (system/service name for software)
+- Requirement headings in requirements.md MUST include a leading numeric ID only (for example: "Requirement 1", "1.", "2 Feature ..."); do not use alphabetic IDs like "Requirement A".
+
+## Output Description
+Provide output in the language specified in spec.json with:
+
+1. **Generated Requirements Summary**: Brief overview of major requirement areas (3-5 bullets)
+2. **Document Status**: Confirm requirements.md updated and spec.json metadata updated
+3. **Review Gate**: Confirm the requirements review gate passed
+4. **Next Steps**: Guide user on how to proceed (approve and continue, or modify)
+
+**Format Requirements**:
+- Use Markdown headings for clarity
+- Include file paths in code blocks
+- Keep summary concise (under 300 words)
+
+## Safety & Fallback
+
+### Error Scenarios
+- **Missing Project Description**: If requirements.md lacks project description, ask user for feature details
+- **Template Missing**: If template files don't exist, use inline fallback structure with warning
+- **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
+- **Incomplete Requirements**: After generation, explicitly ask user if requirements cover all expected functionality
+- **Steering Directory Empty**: Warn user that project context is missing and may affect requirement quality
+- **Non-numeric Requirement Headings**: If existing headings do not include a leading numeric ID (for example, they use "Requirement A"), normalize them to numeric IDs and keep that mapping consistent (never mix numeric and alphabetic labels).
+
+### Next Phase: Design Generation
+
+**If Requirements Approved**:
+- **Optional Gap Analysis** (for existing codebases):
+  - Run `/kiro-validate-gap {feature}` to analyze implementation gap
+  - Recommended for brownfield projects; skip for greenfield
+- Run `/kiro-spec-design {feature}` to proceed to design phase
+- Or `/kiro-spec-design {feature} -y` to auto-approve requirements and proceed directly
+
+**If Modifications Needed**:
+- Provide feedback and re-run `/kiro-spec-requirements {feature}`

--- a/.claude/skills/kiro-spec-requirements/rules/ears-format.md
+++ b/.claude/skills/kiro-spec-requirements/rules/ears-format.md
@@ -1,0 +1,49 @@
+# EARS Format Guidelines
+
+## Overview
+EARS (Easy Approach to Requirements Syntax) is the standard format for acceptance criteria in spec-driven development.
+
+EARS patterns describe the logical structure of a requirement (condition + subject + response) and are not tied to any particular natural language.  
+All acceptance criteria should be written in the target language configured for the specification (for example, `spec.json.language` / `ja`).  
+Keep EARS trigger keywords and fixed phrases in English (`When`, `If`, `While`, `Where`, `The system shall`, `The [system] shall`) and localize only the variable parts (`[event]`, `[precondition]`, `[trigger]`, `[feature is included]`, `[response/action]`) into the target language. Do not interleave target-language text inside the trigger or fixed English phrases themselves.
+
+## Primary EARS Patterns
+
+### 1. Event-Driven Requirements
+- **Pattern**: When [event], the [system] shall [response/action]
+- **Use Case**: Responses to specific events or triggers
+- **Example**: When user clicks checkout button, the Checkout Service shall validate cart contents
+
+### 2. State-Driven Requirements
+- **Pattern**: While [precondition], the [system] shall [response/action]
+- **Use Case**: Behavior dependent on system state or preconditions
+- **Example**: While payment is processing, the Checkout Service shall display loading indicator
+
+### 3. Unwanted Behavior Requirements
+- **Pattern**: If [trigger], the [system] shall [response/action]
+- **Use Case**: System response to errors, failures, or undesired situations
+- **Example**: If invalid credit card number is entered, then the website shall display error message
+
+### 4. Optional Feature Requirements
+- **Pattern**: Where [feature is included], the [system] shall [response/action]
+- **Use Case**: Requirements for optional or conditional features
+- **Example**: Where the car has a sunroof, the car shall have a sunroof control panel
+
+### 5. Ubiquitous Requirements
+- **Pattern**: The [system] shall [response/action]
+- **Use Case**: Always-active requirements and fundamental system properties
+- **Example**: The mobile phone shall have a mass of less than 100 grams
+
+## Combined Patterns
+- While [precondition], when [event], the [system] shall [response/action]
+- When [event] and [additional condition], the [system] shall [response/action]
+
+## Subject Selection Guidelines
+- **Software Projects**: Use concrete system/service name (e.g., "Checkout Service", "User Auth Module")
+- **Process/Workflow**: Use responsible team/role (e.g., "Support Team", "Review Process")
+- **Non-Software**: Use appropriate subject (e.g., "Marketing Campaign", "Documentation")
+
+## Quality Criteria
+- Requirements must be testable, verifiable, and describe a single behavior.
+- Use objective language: "shall" for mandatory behavior, "should" for recommendations; avoid ambiguous terms.
+- Follow EARS syntax: [condition], the [system] shall [response/action].

--- a/.claude/skills/kiro-spec-requirements/rules/requirements-review-gate.md
+++ b/.claude/skills/kiro-spec-requirements/rules/requirements-review-gate.md
@@ -1,0 +1,51 @@
+# Requirements Review Gate
+
+Before writing `requirements.md`, review the draft requirements and repair local issues until the draft passes or a true scope ambiguity is discovered.
+
+## Boundary Continuity
+
+Use boundary terminology consistently across phases without turning requirements into design:
+
+- **Discovery** identifies `Boundary Candidates`
+- **Requirements** make inclusion, exclusion, and adjacent expectations explicit when scope could be misread
+- **Design** turns those into `Boundary Commitments`
+- **Tasks** use `_Boundary:_` to constrain executable work
+
+Requirements should clarify the feature boundary in user- or operator-observable terms, not in architecture ownership or implementation detail.
+
+## Scope and Coverage Review
+
+- The draft must cover the feature's core user journeys, major scope boundaries, primary error cases, and meaningful edge conditions that are visible to the user or operator.
+- If the feature touches adjacent systems, specs, or workflows, the draft must make clear what this feature expects from them and what it does not own when that distinction affects user-visible behavior or operator expectations.
+- Business/domain rules, compliance constraints, security/privacy expectations, and operational constraints that materially shape user-visible behavior must be reflected explicitly when they are in scope.
+- If coverage is missing because the draft is incomplete, repair the draft and review again.
+- If coverage cannot be completed cleanly because the project description or steering context is ambiguous, contradictory, or underspecified, stop and ask the user to clarify instead of guessing.
+
+## EARS and Testability Review
+
+- Every acceptance criterion must follow the EARS rules defined in `ears-format.md`.
+- Every requirement must be testable, observable, and specific enough that later design and validation can verify it.
+- Remove implementation details that belong in `design.md` rather than `requirements.md`.
+- Requirement headings must use numeric IDs only; do not mix numeric and alphabetic labels.
+
+## Structure and Quality Review
+
+- Group related behaviors into coherent requirement areas without duplicating the same obligation across multiple sections.
+- Make inclusion/exclusion boundaries explicit when the feature scope could otherwise be misread.
+- Keep boundary statements lightweight and observable: describe feature responsibility and adjacent expectations without prescribing components, layers, or internal ownership.
+- Ensure non-functional expectations remain user-observable or operator-observable; move technology choices and internal architecture detail out of requirements.
+- Normalize vague language such as "fast", "robust", or "secure" into concrete user-visible expectations whenever the source material supports it.
+
+## Mechanical Checks
+
+Before applying judgment, verify these mechanically:
+- **Numeric IDs present**: Every requirement heading has a numeric ID (1, 1.1, 2, etc.). Scan the draft for headings without IDs.
+- **Acceptance criteria exist**: Every requirement has at least one EARS-format acceptance criterion. Scan for requirements with no "When/If/While/Where" acceptance statements.
+- **No implementation language**: Scan for technology-specific terms (database names, framework names, API patterns) that belong in design, not requirements. Flag any found.
+
+## Review Loop
+
+- Run mechanical checks first, then judgment-based review.
+- If issues are local to the draft, repair the draft and re-run the review gate.
+- Keep the loop bounded: no more than 2 review-and-repair passes before escalating a real ambiguity back to the user.
+- Write `requirements.md` only after the review gate passes.

--- a/.claude/skills/kiro-spec-status/SKILL.md
+++ b/.claude/skills/kiro-spec-status/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: kiro-spec-status
+description: Show specification status and progress
+allowed-tools: Read, Glob, Grep
+argument-hint: <feature-name>
+---
+
+# kiro-spec-status Skill
+
+## Core Mission
+- **Success Criteria**:
+  - Show current phase and completion status
+  - Identify next actions and blockers
+  - Provide clear visibility into progress
+  - Surface boundary readiness, upstream/downstream context, and likely revalidation needs when available
+
+## Execution Steps
+
+### Step 1: Load Spec Context
+- Read `.kiro/specs/$ARGUMENTS/spec.json` for metadata and phase status
+- Read `.kiro/specs/$ARGUMENTS/brief.md` if it exists
+- Read existing files: `requirements.md`, `design.md`, `tasks.md` (if they exist)
+- Check `.kiro/specs/$ARGUMENTS/` directory for available files
+- Read `.kiro/steering/roadmap.md` if it exists and this spec appears in it
+
+### Step 2: Analyze Status
+
+**Parse each phase**:
+- **Requirements**: Count requirements and acceptance criteria
+- **Design**: Check for architecture, components, diagrams, and whether boundary sections are present
+- **Tasks**: Count completed vs total tasks (parse `- [x]` vs `- [ ]`)
+- **Approvals**: Check approval status in spec.json
+- **Boundary context**:
+  - From brief.md: note `Boundary Candidates`, `Upstream / Downstream`, and `Existing Spec Touchpoints` if present
+  - From design.md: note `Boundary Commitments`, `Out of Boundary`, `Allowed Dependencies`, and `Revalidation Triggers` if present
+  - From roadmap.md: note upstream dependencies and whether this spec is adjacent to `Existing Spec Updates`
+- **Revalidation watchlist**:
+  - Identify downstream specs, neighboring existing-spec updates, or rollout-sensitive design notes that may need revalidation if this spec changes
+  - Call out when the current spec shape looks too broad and may want roadmap/design splitting instead of more local repair
+
+### Step 3: Generate Report
+
+Create report in the language specified in spec.json covering:
+1. **Current Phase & Progress**: Where the spec is in the workflow
+2. **Completion Status**: Percentage complete for each phase
+3. **Task Breakdown**: If tasks exist, show completed/remaining counts
+4. **Boundary Context**: Upstream/downstream, out-of-boundary, and allowed dependency notes when available
+5. **Revalidation Watchlist**: Downstream or adjacent work likely affected by changes to this spec
+6. **Next Actions**: What needs to be done next
+7. **Blockers**: Any issues preventing progress
+
+**Format**: Clear, scannable format with emojis for status
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Spec Not Found**:
+- **Message**: "No spec found for `$ARGUMENTS`. Check available specs in `.kiro/specs/`"
+- **Action**: List available spec directories
+
+**Incomplete Spec**:
+- **Warning**: Identify which files are missing
+- **Suggested Action**: Point to next phase command
+
+### List All Specs
+
+To see all available specs:
+- Run with no argument or use wildcard
+- Shows all specs in `.kiro/specs/` with their status

--- a/.claude/skills/kiro-spec-tasks/SKILL.md
+++ b/.claude/skills/kiro-spec-tasks/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: kiro-spec-tasks
+description: Generate implementation tasks from requirements and design. Use when creating actionable task lists.
+allowed-tools: Read, Write, Edit, Glob, Grep, Agent
+argument-hint: <feature-name> [-y] [--sequential]
+metadata:
+  shared-rules: "tasks-generation.md, tasks-parallel-analysis.md"
+---
+
+# kiro-spec-tasks Skill
+
+## Core Mission
+- **Success Criteria**:
+  - All requirements mapped to specific tasks
+  - Tasks properly sized (1-3 hours each)
+  - Clear task progression with proper hierarchy
+  - Natural language descriptions focused on capabilities
+  - A lightweight task-plan sanity review confirms the task graph is executable before `tasks.md` is written
+
+## Execution Steps
+
+### Step 1: Gather Context
+
+If steering/spec context is already available from conversation, skip redundant file reads.
+Otherwise, load all necessary context:
+- `.kiro/specs/{feature}/spec.json`, `requirements.md`, `design.md`
+- `.kiro/specs/{feature}/tasks.md` (if exists, for merge mode)
+- Core steering context: `product.md`, `tech.md`, `structure.md`
+- Additional steering files only when directly relevant to requirements coverage, design boundaries, runtime prerequisites, or team conventions that affect task executability
+
+- Determine execution mode:
+  - `sequential = (sequential flag is true)`
+
+**Validate approvals**:
+- If auto-approve flag (`-y`) is true: Auto-approve requirements and design in spec.json. Tasks approval is also handled automatically in Step 4.
+- Otherwise: Verify both approved (stop if not, see Safety & Fallback)
+
+### Step 2: Generate Implementation Tasks
+
+- Read `rules/tasks-generation.md` from this skill's directory for principles
+- Read `rules/tasks-parallel-analysis.md` from this skill's directory for parallel judgement criteria
+- Read `.kiro/settings/templates/specs/tasks.md` for format (supports `(P)` markers)
+
+#### Parallel Research
+
+The following research areas are independent and can be executed in parallel:
+1. **Context loading**: Spec documents (requirements.md, design.md), steering files
+2. **Rules loading**: tasks-generation.md, tasks-parallel-analysis.md, tasks template
+
+After all parallel research completes, synthesize findings before generating tasks.
+
+**Generate task list following all rules**:
+- Use language specified in spec.json
+- Map all requirements to tasks and list numeric requirement IDs only (comma-separated) without descriptive suffixes, parentheses, translations, or free-form labels
+- Ensure all design components included
+- Verify task progression is logical and incremental
+- Ensure each executable sub-task includes at least one detail bullet that states what "done" looks like in observable terms
+- Keep normal implementation tasks within a single responsibility boundary; if work crosses boundaries, make it an explicit integration task
+- Apply `(P)` markers to tasks that satisfy parallel criteria when `!sequential`
+- Explicitly note dependencies preventing `(P)` when tasks appear parallel but are not safe
+- If sequential mode is true, omit `(P)` entirely
+- If existing tasks.md found, merge with new content
+
+### Step 3: Review Task Plan
+
+- Keep the draft task plan in working memory; do NOT write `tasks.md` yet
+- Run the `Task Plan Review Gate` from `rules/tasks-generation.md`
+- Review coverage:
+  - Every requirement ID appears in at least one task
+  - Every design component, contract, integration point, runtime prerequisite, and validation concern is represented
+- Review executability:
+  - Each sub-task is an executable 1-3 hour work unit
+  - Each sub-task has a verifiable deliverable
+  - Each executable sub-task includes an observable completion bullet
+  - No implicit prerequisites remain hidden
+  - `_Depends:_`, `_Boundary:_`, and `(P)` markers still match the dependency graph and architecture boundaries
+- If issues are task-plan-local, repair the draft and re-run the review gate before writing
+- Keep the review bounded to at most 2 repair passes
+- If review exposes a real requirements/design gap or contradiction, stop and send the user back to requirements/design instead of inventing filler tasks
+
+### Step 3.5: Run Task-Graph Sanity Review
+
+Before writing `tasks.md`, run one lightweight independent sanity review of the task graph.
+
+- If fresh subagent dispatch is available, spawn one fresh review subagent for this step. Otherwise perform the same review in the current context.
+- Provide only file paths, the draft task plan, and merge context if an existing `tasks.md` is being updated. The reviewer should read `requirements.md`, `design.md`, and the task-generation rules directly instead of relying on a parent-synthesized coverage summary.
+- Check only:
+  - hidden prerequisites or missing setup tasks
+  - dependency or ordering mistakes
+  - boundary overlap or ambiguous ownership between tasks
+  - tasks that are too large, too vague, cross boundaries without being explicit integration tasks, or are missing a verifiable deliverable
+  - contradictions introduced between requirements, design, and the task graph
+- Return one verdict:
+  - `PASS`
+  - `NEEDS_FIXES`
+  - `RETURN_TO_DESIGN`
+- If `NEEDS_FIXES`, repair the draft once and re-run the sanity review one time.
+- If `RETURN_TO_DESIGN`, stop without writing `tasks.md` and point back to the exact gap in requirements/design.
+- Keep this bounded. Do not turn it into a second full planning cycle.
+
+### Step 4: Finalize
+
+**Write tasks.md**:
+- Create/update `.kiro/specs/{feature}/tasks.md`
+- Update spec.json metadata:
+  - Set `phase: "tasks-generated"`
+  - Set `approvals.tasks.generated: true, approved: false`
+  - Set `approvals.requirements.approved: true`
+  - Set `approvals.design.approved: true`
+  - Update `updated_at` timestamp
+
+**Approval**:
+- If auto-approve flag (`-y`) is true:
+  - Set `approvals.tasks.approved: true` in spec.json
+  - Display task summary (task count, major groups, parallel markers)
+  - Respond: "Tasks generated and auto-approved. Start implementation with `/kiro-impl {feature}`"
+- Otherwise (interactive):
+  - Display a summary of the generated tasks (task count, major groups, parallel markers)
+  - Ask the user: "Tasks generated. Approve and proceed to implementation?"
+  - If the user approves:
+    - Set `approvals.tasks.approved: true` in spec.json
+    - Respond: "Tasks approved. Start implementation with `/kiro-impl {feature}`"
+  - If the user wants changes:
+    - Keep `approvals.tasks.approved: false`
+    - Respond with guidance on what to adjust and re-run
+
+## Critical Constraints
+- **Task Integration**: Every task must connect to the system (no orphaned work)
+- **Boundary annotations**: Required for `(P)` tasks, recommended for all (`_Boundary: ComponentName_`)
+- **Explicit dependencies**: Cross-boundary non-obvious dependencies declared with `_Depends: X.X_`
+- **Executable deliverable granularity**: Each task must produce a verifiable deliverable (file, endpoint, UI component, config). Infrastructure tasks (project scaffolding, manifest, host integration, build config) must be explicit — never assume they exist
+- **Observable done state**: Each executable sub-task must include at least one detail bullet that makes the completed state visible without adding new bookkeeping fields
+- **No implicit prerequisites**: If a task requires a runtime, SDK, framework setup, or config file, that setup must be a separate preceding task
+
+## Output Description
+
+Provide brief summary in the language specified in spec.json:
+
+1. **Status**: Confirm tasks generated at `.kiro/specs/{feature}/tasks.md`
+2. **Task Summary**:
+   - Total: X major tasks, Y sub-tasks
+   - All Z requirements covered
+   - Average task size: 1-3 hours per sub-task
+3. **Quality Validation**:
+   - All requirements mapped to tasks
+   - Design coverage and runtime prerequisites reviewed
+   - Task dependencies verified
+   - Task plan review gate passed
+   - Independent task-graph sanity review passed
+   - Testing tasks included
+4. **Next Action**: Review tasks and proceed when ready
+
+**Format**: Concise (under 200 words)
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Requirements or Design Not Approved**:
+- **Stop Execution**: Cannot proceed without approved requirements and design
+- **User Message**: "Requirements and design must be approved before task generation"
+- **Suggested Action**: "Run `/kiro-spec-tasks {feature} -y` to auto-approve all (requirements, design, and tasks) and proceed"
+
+**Missing Requirements or Design**:
+- **Stop Execution**: Both documents must exist
+- **User Message**: "Missing requirements.md or design.md at `.kiro/specs/{feature}/`"
+- **Suggested Action**: "Complete requirements and design phases first"
+
+**Incomplete Requirements Coverage**:
+- **Warning**: "Not all requirements mapped to tasks. Review coverage."
+- **User Action Required**: Confirm intentional gaps or regenerate tasks
+
+**Spec Gap Found During Task Review**:
+- **Stop Execution**: Do not write a patched-over `tasks.md`
+- **User Message**: "Requirements/design do not provide enough clear coverage to generate an executable task plan"
+- **Suggested Action**: "Refine requirements.md or design.md, then re-run `/kiro-spec-tasks {feature}`"
+
+**Template/Rules Missing**:
+- **User Message**: "Template or rules files missing in `.kiro/settings/`"
+- **Fallback**: Use inline basic structure with warning
+- **Suggested Action**: "Check repository setup or restore template files"
+- **Missing Numeric Requirement IDs**:
+  - **Stop Execution**: All requirements in requirements.md MUST have numeric IDs. If any requirement lacks a numeric ID, stop and request that requirements.md be fixed before generating tasks.
+
+### Next Phase: Implementation
+
+Tasks are approved in Step 4 via user confirmation. Once approved:
+- Autonomous implementation: `/kiro-impl {feature}`
+- Specific tasks only: `/kiro-impl {feature} 1.1,1.2`

--- a/.claude/skills/kiro-spec-tasks/rules/tasks-generation.md
+++ b/.claude/skills/kiro-spec-tasks/rules/tasks-generation.md
@@ -1,0 +1,222 @@
+# Task Generation Rules
+
+## Core Principles
+
+### 1. Natural Language Descriptions
+Focus on capabilities and outcomes, not code structure.
+
+**Describe**:
+- What functionality to achieve
+- Business logic and behavior
+- Features and capabilities
+- Domain language and concepts
+- Data relationships and workflows
+
+**Avoid**:
+- File paths and directory structure
+- Function/method names and signatures
+- Type definitions and interfaces
+- Class names and API contracts
+- Specific data structures
+
+**Rationale**: Implementation details (files, methods, types) are defined in design.md. Tasks describe the functional work to be done.
+
+### 2. Task Ordering Principle
+
+**Order implies dependency**: Task N implicitly depends on all tasks before it. This is the primary dependency mechanism.
+
+**Tasks must follow this phase order**:
+1. **Foundation**: Environment setup, test infrastructure, shared utilities, database schema, configuration
+2. **Core**: Primary feature implementation (parallel-capable tasks grouped here)
+3. **Integration**: Wiring components together, cross-boundary connections
+4. **Validation**: E2E tests, edge cases, regression checks
+
+**Rationale**: Foundation work unblocks everything else. Placing setup tasks early prevents downstream blocking. Core tasks can often run in parallel because foundation is already complete.
+
+### 3. Task Integration & Progression
+
+**Every task must**:
+- Build on previous outputs (no orphaned code)
+- Connect to the overall system (no hanging features)
+- Progress incrementally (no big jumps in complexity)
+- Respect architecture boundaries defined in design.md (Architecture Pattern & Boundary Map)
+- Honor interface contracts documented in design.md
+- Use major task summaries sparingly—omit detail bullets if the work is fully captured by child tasks.
+
+**End with integration tasks** to wire everything together.
+
+### 4. Dependency Declaration
+
+**Default**: Sequential ordering handles most dependencies (task N depends on tasks before it).
+
+**Explicit declaration required when**:
+- A task depends on a specific task in a different major-task group (cross-boundary)
+- The dependency is non-obvious from ordering alone
+- A task can skip ahead of its position (declared via `(P)`) but still needs specific prior work
+
+**Format**: `_Depends: 1.2, 2.3_` — placed alongside `_Requirements:_` in task detail sections.
+
+**Do not over-annotate**: If a task simply depends on the task directly before it, ordering alone is sufficient.
+
+### 5. Boundary Scope
+
+**Each task should declare its component boundary** using design.md component/module names:
+- `_Boundary: AuthService_` or `_Boundary: API Layer, UserRepository_`
+- Helps validate parallel safety: tasks with non-overlapping boundaries are parallel candidates
+- Helps agents understand scope: what to touch and what not to touch
+
+**When to use**: Required for tasks marked `(P)` to validate parallel safety. Omit for sequential tasks where scope is obvious from the description.
+
+**Boundary rule**:
+- Each executable task should stay within a single responsibility boundary
+- If work must cross boundaries, make it an explicit integration task rather than a normal implementation task
+- Do not hide cross-boundary coordination inside a task that appears local
+
+### 6. Flexible Task Sizing
+
+**Guidelines**:
+- **Major tasks**: As many sub-tasks as logically needed (group by cohesion)
+- **Sub-tasks**: 1-3 hours each, 3-10 details per sub-task
+- Balance between too granular and too broad
+
+**Don't force arbitrary numbers** - let logical grouping determine structure.
+
+### 7. Requirements Mapping
+
+**End each task detail section with**:
+- `_Requirements: X.X, Y.Y_` listing **only numeric requirement IDs** (comma-separated). Never append descriptive text, parentheses, translations, or free-form labels.
+- For cross-cutting requirements, list every relevant requirement ID. All requirements MUST have numeric IDs in requirements.md. If an ID is missing, stop and correct requirements.md before generating tasks.
+- Reference components/interfaces from design.md when helpful (e.g., `_Contracts: AuthService API`)
+
+### 7.5 Observable Completion
+
+**Each executable task must include at least one detail bullet that describes the observable completed state**:
+- Phrase it as a deliverable, runtime behavior, persisted state, UI state, endpoint behavior, test result, or integration outcome
+- Avoid vague bullets like "implement support", "wire things up", or "handle logic" unless paired with a concrete observable result
+- Prefer making one detail bullet clearly answer: "What will be true when this task is done?"
+- Keep this within the existing task body; do not add extra bookkeeping fields
+
+### 8. Code-Only Focus
+
+**Include ONLY**:
+- Coding tasks (implementation)
+- Testing tasks (unit, integration, E2E)
+- Technical setup tasks (infrastructure, configuration)
+
+**Exclude**:
+- Deployment tasks
+- Documentation tasks
+- User testing
+- Marketing/business activities
+
+## Task Plan Review Gate
+
+Before writing `tasks.md`, review the draft task plan and repair local issues until the plan passes or a true spec gap is discovered.
+
+### Coverage Review
+
+- Every requirement ID from `requirements.md` must appear in at least one task.
+- Every design component, interface/contract, integration point, runtime prerequisite, and validation concern from `design.md` must be represented by at least one task.
+- If coverage is missing because the task plan is incomplete, repair the draft tasks and review again.
+- If coverage cannot be added cleanly because requirements or design are ambiguous, contradictory, or underspecified, stop and return to the requirements/design phase instead of papering over the gap in `tasks.md`.
+
+### Executability Review
+
+- Every sub-task must be executable as written, usually within 1-3 hours.
+- Every sub-task must produce a verifiable deliverable (behavior, artifact, endpoint, UI state, config, migration, test, or integration result).
+- Every executable sub-task must include at least one detail bullet that states the observable completion condition.
+- Split tasks that combine multiple independently verifiable outcomes.
+- Split tasks that combine multiple responsibility boundaries unless they are explicit integration tasks.
+- If many tasks require broad `_Boundary:_` scopes or repeated cross-boundary coordination, stop and return to design or roadmap decomposition instead of forcing the spec through task generation.
+- Merge or collapse tasks that are too small, bookkeeping-only, or not meaningful execution units.
+- Make implicit prerequisites explicit as preceding tasks.
+- Re-check `_Depends:_`, `_Boundary:_`, and `(P)` markers after edits so concurrency claims still match the design boundaries and dependency graph.
+
+### Review Loop
+
+- Run the review gate on the draft task plan before writing `tasks.md`.
+- If issues are task-plan-local, repair the draft and re-run the review gate.
+- Keep the loop bounded: no more than 2 review-and-repair passes before escalating a real spec gap.
+- Write `tasks.md` only after the review gate passes.
+
+### Optional Test Coverage Tasks
+
+- When the design already guarantees functional coverage and rapid MVP delivery is prioritized, mark purely test-oriented follow-up work (e.g., baseline rendering/unit tests) as **optional** using the `- [ ]*` checkbox form.
+- Only apply the optional marker when the sub-task directly references acceptance criteria from requirements.md in its detail bullets.
+- Never mark implementation work or integration-critical verification as optional—reserve `*` for auxiliary/deferrable test coverage that can be revisited post-MVP.
+
+## Task Hierarchy Rules
+
+### Maximum 2 Levels
+- **Level 1**: Major tasks (1, 2, 3, 4...)
+- **Level 2**: Sub-tasks (1.1, 1.2, 2.1, 2.2...)
+- **No deeper nesting** (no 1.1.1)
+- If a major task would contain only a single actionable item, collapse the structure and promote the sub-task to the major level (e.g., replace `1.1` with `1.`).
+- When a major task exists purely as a container, keep the checkbox description concise and avoid duplicating detailed bullets—reserve specifics for its sub-tasks.
+
+### Sequential Numbering
+- Major tasks MUST increment: 1, 2, 3, 4, 5...
+- Sub-tasks reset per major task: 1.1, 1.2, then 2.1, 2.2...
+- Never repeat major task numbers
+
+### Parallel Analysis (default)
+- Assume parallel analysis is enabled unless explicitly disabled (e.g. `--sequential` flag).
+- `(P)` means: this task has no dependency on its immediately preceding peers and can run concurrently with them.
+- Identify tasks that can run concurrently when **all** conditions hold:
+  - No data dependency on other pending tasks
+  - No shared file or resource contention
+  - No prerequisite review/approval from another task
+  - `_Boundary:_` annotations confirm non-overlapping component scopes
+- Foundation-phase tasks (see Task Ordering Principle) are rarely `(P)` — they establish shared prerequisites.
+- Core-phase tasks are the primary candidates for `(P)` since foundation is already complete.
+- Validate that identified parallel tasks operate within separate boundaries defined in the Architecture Pattern & Boundary Map.
+- Confirm API/event contracts from design.md do not overlap in ways that cause conflicts.
+- `(P)` tasks with cross-boundary dependencies must declare `_Depends: X.X_` explicitly.
+- Append `(P)` immediately after the task number for each parallel-capable task:
+  - Example: `- [ ] 2.1 (P) Build background worker`
+  - Apply to both major tasks and sub-tasks when appropriate.
+- If sequential mode is requested, omit `(P)` markers entirely.
+- Group parallel tasks logically (same parent when possible) and highlight any ordering caveats in detail bullets.
+- Explicitly call out dependencies that prevent `(P)` even when tasks look similar.
+
+### Checkbox Format
+```markdown
+- [ ] 1. Foundation: environment and test infrastructure setup
+- [ ] 1.1 Sub-task description
+  - Detail item 1
+  - Detail item 2
+  - Observable completion condition
+  - _Requirements: X.X_
+
+- [ ] 2. Core feature A
+- [ ] 2.1 (P) Sub-task description
+  - Detail items...
+  - Observable completion condition
+  - _Requirements: Y.Y_
+  - _Boundary: AuthService_
+
+- [ ] 2.2 (P) Sub-task description
+  - Detail items...
+  - Observable completion condition
+  - _Requirements: Z.Z_
+  - _Boundary: UserRepository_
+
+- [ ] 3. Integration and wiring
+- [ ] 3.1 Sub-task description
+  - Detail items...
+  - Observable completion condition
+  - _Depends: 2.1, 2.2_
+  - _Requirements: W.W_
+```
+
+## Requirements Coverage
+
+**Mandatory Check**:
+- ALL requirements from requirements.md MUST be covered
+- Cross-reference every requirement ID with task mappings
+- If gaps found: Return to requirements or design phase
+- No requirement should be left without corresponding tasks
+
+Use `N.M`-style numeric requirement IDs where `N` is the top-level requirement number from requirements.md (for example, Requirement 1 → 1.1, 1.2; Requirement 2 → 2.1, 2.2), and `M` is a local index within that requirement group.
+
+Document any intentionally deferred requirements with rationale.

--- a/.claude/skills/kiro-spec-tasks/rules/tasks-parallel-analysis.md
+++ b/.claude/skills/kiro-spec-tasks/rules/tasks-parallel-analysis.md
@@ -1,0 +1,41 @@
+# Parallel Task Analysis Rules
+
+## Purpose
+Provide a consistent way to identify implementation tasks that can be safely executed in parallel while generating `tasks.md`.
+
+## Relationship to Task Ordering
+
+`(P)` means: this task has no dependency on its immediately preceding peers and can run concurrently with them. The Task Ordering Principle (see tasks-generation.md) ensures Foundation-phase tasks run first, making Core-phase tasks the primary `(P)` candidates.
+
+## When to Consider Tasks Parallel
+Only mark a task as parallel-capable when **all** of the following are true:
+
+1. **No data dependency** on pending tasks.
+2. **No conflicting files or shared mutable resources** are touched.
+3. **No prerequisite review/approval** from another task is required beforehand.
+4. **Foundation work complete**: Environment/setup work needed by this task is already satisfied by earlier Foundation-phase tasks.
+5. **Non-overlapping boundaries**: `_Boundary:_` annotations confirm tasks operate on separate components.
+
+## Marking Convention
+- Append `(P)` immediately after the numeric identifier for each qualifying task.
+  - Example: `- [ ] 2.1 (P) Build background worker for emails`
+- Apply `(P)` to both major tasks and sub-tasks when appropriate.
+- If sequential execution is requested (e.g. via `--sequential` flag), omit `(P)` markers entirely.
+- Keep `(P)` **outside** of checkbox brackets to avoid confusion with completion state.
+
+## Grouping & Ordering Guidelines
+- Group parallel tasks under the same parent whenever the work belongs to the same theme.
+- List obvious prerequisites or caveats in the detail bullets (e.g., "Requires schema migration from 1.2").
+- When two tasks look similar but are not parallel-safe, call out the blocking dependency explicitly.
+- Skip marking container-only major tasks (those without their own actionable detail bullets) with `(P)`—evaluate parallel execution at the sub-task level instead.
+
+## Quality Checklist
+Before marking a task with `(P)`, ensure you have:
+
+- Verified that running this task concurrently will not create merge or deployment conflicts.
+- Confirmed `_Boundary:_` annotations show non-overlapping component scopes.
+- Captured any shared state expectations in the detail bullets.
+- Confirmed that the implementation can be tested independently.
+- Added `_Depends: X.X_` if this `(P)` task still requires specific prior work from a different major-task group.
+
+If any check fails, **do not** mark the task with `(P)` and explain the dependency in the task details.

--- a/.claude/skills/kiro-steering-custom/SKILL.md
+++ b/.claude/skills/kiro-steering-custom/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: kiro-steering-custom
+description: Create custom steering documents for specialized project contexts. Use when creating domain-specific steering files.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+metadata:
+  shared-rules: "steering-principles.md"
+---
+
+# kiro-steering-custom Skill
+
+## Role
+You are a specialized skill for creating custom steering documents beyond core files (product, tech, structure).
+
+## Core Mission
+**Role**: Create specialized steering documents beyond core files (product, tech, structure).
+
+**Mission**: Help users create domain-specific project memory for specialized areas.
+
+**Success Criteria**:
+- Custom steering captures specialized patterns
+- Follows same granularity principles as core steering
+- Provides clear value for specific domain
+
+## Execution Steps
+
+### Step 1: Gather Context
+
+If steering context is already available from conversation, skip redundant file reads.
+Otherwise:
+- Check `.kiro/settings/templates/steering-custom/` for available templates
+- Read `rules/steering-principles.md` from this skill's directory for steering principles
+
+## Workflow
+
+1. **Ask user** for custom steering needs:
+   - Domain/topic (e.g., "API standards", "testing approach")
+   - Specific requirements or patterns to document
+
+2. **Check if template exists**:
+   - Load from `.kiro/settings/templates/steering-custom/{name}.md` if available
+   - Use as starting point, customize based on project
+
+3. **Analyze codebase** (JIT) for relevant patterns:
+
+#### Parallel Research
+
+The following research areas are independent and can be executed in parallel:
+1. **Template & principles**: Load matching template and steering-principles.md
+2. **Domain patterns**: Analyze codebase for domain-specific patterns using Glob/Grep/Read
+
+After all parallel research completes, synthesize findings for steering document.
+
+4. **Generate custom steering**:
+   - Follow template structure if available
+   - Apply principles from `rules/steering-principles.md` from this skill's directory
+   - Focus on patterns, not exhaustive lists
+   - Keep to 100-200 lines (2-3 minute read)
+
+5. **Create file** in `.kiro/steering/{name}.md`
+
+## Available Templates
+
+Templates available in `.kiro/settings/templates/steering-custom/`:
+
+1. **api-standards.md** - REST/GraphQL conventions, error handling
+2. **testing.md** - Test organization, mocking, coverage
+3. **security.md** - Auth patterns, input validation, secrets
+4. **database.md** - Schema design, migrations, query patterns
+5. **error-handling.md** - Error types, logging, retry strategies
+6. **authentication.md** - Auth flows, permissions, session management
+7. **deployment.md** - CI/CD, environments, rollback procedures
+
+Load template when needed, customize for project.
+
+## Steering Principles
+
+From `rules/steering-principles.md` (in this skill's directory):
+
+- **Patterns over lists**: Document patterns, not every file/component
+- **Single domain**: One topic per file
+- **Concrete examples**: Show patterns with code
+- **Maintainable size**: 100-200 lines typical
+- **Security first**: Never include secrets or sensitive data
+
+## Tool Guidance
+
+- **Read**: Load template, analyze existing code
+- **Glob**: Find related files for pattern analysis
+- **Grep**: Search for specific patterns
+- **Bash** with `ls`: Understand relevant structure
+
+**JIT Strategy**: Load template only when creating that type of steering.
+
+## Output Description
+
+Chat summary with file location (file created directly).
+
+```
+Custom Steering Created
+
+## Created:
+- .kiro/steering/api-standards.md
+
+## Based On:
+- Template: api-standards.md
+- Analyzed: src/api/ directory patterns
+- Extracted: REST conventions, error format
+
+## Content:
+- Endpoint naming patterns
+- Request/response format
+- Error handling conventions
+- Authentication approach
+
+Review and customize as needed.
+```
+
+## Examples
+
+### Success: API Standards
+**Input**: "Create API standards steering"
+**Action**: Load template, analyze src/api/, extract patterns
+**Output**: api-standards.md with project-specific REST conventions
+
+### Success: Testing Strategy
+**Input**: "Document our testing approach"
+**Action**: Load template, analyze test files, extract patterns
+**Output**: testing.md with test organization and mocking strategies
+
+## Safety & Fallback
+
+- **No template**: Generate from scratch based on domain knowledge
+- **Security**: Never include secrets (load principles)
+- **Validation**: Ensure doesn't duplicate core steering content
+
+## Notes
+
+- Templates are starting points, customize for project
+- Follow same granularity principles as core steering
+- All steering files loaded as project memory
+- Custom files equally important as core files
+- Avoid documenting agent-specific tooling directories (e.g. `.cursor/`, `.gemini/`, `.claude/`)
+- Light references to `.kiro/specs/` and `.kiro/steering/` are acceptable; avoid other `.kiro/` directories

--- a/.claude/skills/kiro-steering-custom/rules/steering-principles.md
+++ b/.claude/skills/kiro-steering-custom/rules/steering-principles.md
@@ -1,0 +1,90 @@
+# Steering Principles
+
+Steering files are **project memory**, not exhaustive specifications.
+
+---
+
+## Content Granularity
+
+### Golden Rule
+> "If new code follows existing patterns, steering shouldn't need updating."
+
+### ✅ Document
+- Organizational patterns (feature-first, layered)
+- Naming conventions (PascalCase rules)
+- Import strategies (absolute vs relative)
+- Architectural decisions (state management)
+- Technology standards (key frameworks)
+
+### ❌ Avoid
+- Complete file listings
+- Every component description
+- All dependencies
+- Implementation details
+- Agent-specific tooling directories (e.g. `.cursor/`, `.gemini/`, `.claude/`)
+- Detailed documentation of `.kiro/` metadata directories (settings, automation)
+
+### Example Comparison
+
+**Bad** (Specification-like):
+```markdown
+- /components/Button.tsx - Primary button with variants
+- /components/Input.tsx - Text input with validation
+- /components/Modal.tsx - Modal dialog
+... (50+ files)
+```
+
+**Good** (Project Memory):
+```markdown
+## UI Components (`/components/ui/`)
+Reusable, design-system aligned primitives
+- Named by function (Button, Input, Modal)
+- Export component + TypeScript interface
+- No business logic
+```
+
+---
+
+## Security
+
+Never include:
+- API keys, passwords, credentials
+- Database URLs, internal IPs
+- Secrets or sensitive data
+
+---
+
+## Quality Standards
+
+- **Single domain**: One topic per file
+- **Concrete examples**: Show patterns with code
+- **Explain rationale**: Why decisions were made
+- **Maintainable size**: 100-200 lines typical
+
+---
+
+## Preservation (when updating)
+
+- Preserve user sections and custom examples
+- Additive by default (add, don't replace)
+- Add `updated_at` timestamp
+- Note why changes were made
+
+---
+
+## Notes
+
+- Templates are starting points, customize as needed
+- Follow same granularity principles as core steering
+- All steering files loaded as project memory
+- Light references to `.kiro/specs/` and `.kiro/steering/` are acceptable; avoid other `.kiro/` directories
+- Custom files equally important as core files
+
+---
+
+## File-Specific Focus
+
+- **product.md**: Purpose, value, business context (not exhaustive features)
+- **tech.md**: Key frameworks, standards, conventions (not all dependencies)
+- **structure.md**: Organization patterns, naming rules (not directory trees)
+- **Custom files**: Specialized patterns (API, testing, security, etc.)

--- a/.claude/skills/kiro-steering/SKILL.md
+++ b/.claude/skills/kiro-steering/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: kiro-steering
+description: Maintain .kiro/steering/ as persistent project memory (bootstrap/sync). Use when initializing or updating steering documents.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+metadata:
+  shared-rules: "steering-principles.md"
+---
+
+# kiro-steering Skill
+
+## Role
+You are a specialized skill for maintaining `.kiro/steering/` as persistent project memory.
+
+## Core Mission
+**Role**: Maintain `.kiro/steering/` as persistent project memory.
+
+**Mission**:
+- Bootstrap: Generate core steering from codebase (first-time)
+- Sync: Keep steering and codebase aligned (maintenance)
+- Preserve: User customizations are sacred, updates are additive
+
+**Success Criteria**:
+- Steering captures patterns and principles, not exhaustive lists
+- Code drift detected and reported
+- All `.kiro/steering/*.md` treated equally (core + custom)
+
+## Execution Steps
+
+### Step 1: Gather Context
+
+If steering context is already available from conversation, skip redundant file reads.
+
+- For Bootstrap mode: Read templates from `.kiro/settings/templates/steering/`
+- For Sync mode: Read all existing `.kiro/steering/*.md` files
+- Read `rules/steering-principles.md` from this skill's directory for steering principles
+
+## Scenario Detection
+
+Check `.kiro/steering/` status:
+
+**Bootstrap Mode**: Empty OR missing core files (product.md, tech.md, structure.md)
+**Sync Mode**: All core files exist
+
+---
+
+## Bootstrap Flow
+
+1. Load templates from `.kiro/settings/templates/steering/`
+2. Analyze codebase (JIT):
+
+#### Parallel Research
+
+The following research areas are independent and can be executed in parallel:
+1. **Product analysis**: README, package.json, documentation files for purpose, value, core capabilities
+2. **Tech analysis**: Config files, dependencies, frameworks for technology patterns and decisions
+3. **Structure analysis**: Directory tree, naming conventions, import patterns for organization
+
+After all parallel research completes, synthesize patterns for steering files.
+
+3. Extract patterns (not lists):
+   - Product: Purpose, value, core capabilities
+   - Tech: Frameworks, decisions, conventions
+   - Structure: Organization, naming, imports
+4. Generate steering files (follow templates)
+5. Load principles from `rules/steering-principles.md` from this skill's directory
+6. Present summary for review
+
+**Focus**: Patterns that guide decisions, not catalogs of files/dependencies.
+
+---
+
+## Sync Flow
+
+1. Load all existing steering (`.kiro/steering/*.md`)
+2. Analyze codebase for changes (JIT)
+3. Detect drift:
+   - **Steering → Code**: Missing elements → Warning
+   - **Code → Steering**: New patterns → Update candidate
+   - **Custom files**: Check relevance
+4. Propose updates (additive, preserve user content)
+5. Report: Updates, warnings, recommendations
+
+**Update Philosophy**: Add, don't replace. Preserve user sections.
+
+---
+
+## Granularity Principle
+
+From `rules/steering-principles.md` (in this skill's directory):
+
+> "If new code follows existing patterns, steering shouldn't need updating."
+
+Document patterns and principles, not exhaustive lists.
+
+**Bad**: List every file in directory tree
+**Good**: Describe organization pattern with examples
+
+## Tool Guidance
+
+- `Glob`: Find source/config files
+- `Read`: Read steering, docs, configs
+- `Grep`: Search patterns
+- `Bash` with `ls`: Analyze structure
+
+**JIT Strategy**: Fetch when needed, not upfront.
+
+## Output Description
+
+Chat summary only (files updated directly).
+
+### Bootstrap:
+```
+Steering Created
+
+## Generated:
+- product.md: [Brief description]
+- tech.md: [Key stack]
+- structure.md: [Organization]
+
+Review and approve as Source of Truth.
+```
+
+### Sync:
+```
+Steering Updated
+
+## Changes:
+- tech.md: React 18 → 19
+- structure.md: Added API pattern
+
+## Code Drift:
+- Components not following import conventions
+
+## Recommendations:
+- Consider api-standards.md
+```
+
+## Examples
+
+### Bootstrap
+**Input**: Empty steering, React TypeScript project
+**Output**: 3 files with patterns - "Feature-first", "TypeScript strict", "React 19"
+
+### Sync
+**Input**: Existing steering, new `/api` directory
+**Output**: Updated structure.md, flagged non-compliant files, suggested api-standards.md
+
+## Safety & Fallback
+
+- **Security**: Never include keys, passwords, secrets (see principles)
+- **Uncertainty**: Report both states, ask user
+- **Preservation**: Add rather than replace when in doubt
+
+## Notes
+
+- All `.kiro/steering/*.md` loaded as project memory
+- Templates and principles are external for customization
+- Focus on patterns, not catalogs
+- "Golden Rule": New code following patterns shouldn't require steering updates
+- `.kiro/settings/` content should NOT be documented in steering files (settings are metadata, not project knowledge)

--- a/.claude/skills/kiro-steering/rules/steering-principles.md
+++ b/.claude/skills/kiro-steering/rules/steering-principles.md
@@ -1,0 +1,90 @@
+# Steering Principles
+
+Steering files are **project memory**, not exhaustive specifications.
+
+---
+
+## Content Granularity
+
+### Golden Rule
+> "If new code follows existing patterns, steering shouldn't need updating."
+
+### ✅ Document
+- Organizational patterns (feature-first, layered)
+- Naming conventions (PascalCase rules)
+- Import strategies (absolute vs relative)
+- Architectural decisions (state management)
+- Technology standards (key frameworks)
+
+### ❌ Avoid
+- Complete file listings
+- Every component description
+- All dependencies
+- Implementation details
+- Agent-specific tooling directories (e.g. `.cursor/`, `.gemini/`, `.claude/`)
+- Detailed documentation of `.kiro/` metadata directories (settings, automation)
+
+### Example Comparison
+
+**Bad** (Specification-like):
+```markdown
+- /components/Button.tsx - Primary button with variants
+- /components/Input.tsx - Text input with validation
+- /components/Modal.tsx - Modal dialog
+... (50+ files)
+```
+
+**Good** (Project Memory):
+```markdown
+## UI Components (`/components/ui/`)
+Reusable, design-system aligned primitives
+- Named by function (Button, Input, Modal)
+- Export component + TypeScript interface
+- No business logic
+```
+
+---
+
+## Security
+
+Never include:
+- API keys, passwords, credentials
+- Database URLs, internal IPs
+- Secrets or sensitive data
+
+---
+
+## Quality Standards
+
+- **Single domain**: One topic per file
+- **Concrete examples**: Show patterns with code
+- **Explain rationale**: Why decisions were made
+- **Maintainable size**: 100-200 lines typical
+
+---
+
+## Preservation (when updating)
+
+- Preserve user sections and custom examples
+- Additive by default (add, don't replace)
+- Add `updated_at` timestamp
+- Note why changes were made
+
+---
+
+## Notes
+
+- Templates are starting points, customize as needed
+- Follow same granularity principles as core steering
+- All steering files loaded as project memory
+- Light references to `.kiro/specs/` and `.kiro/steering/` are acceptable; avoid other `.kiro/` directories
+- Custom files equally important as core files
+
+---
+
+## File-Specific Focus
+
+- **product.md**: Purpose, value, business context (not exhaustive features)
+- **tech.md**: Key frameworks, standards, conventions (not all dependencies)
+- **structure.md**: Organization patterns, naming rules (not directory trees)
+- **Custom files**: Specialized patterns (API, testing, security, etc.)

--- a/.claude/skills/kiro-validate-design/SKILL.md
+++ b/.claude/skills/kiro-validate-design/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: kiro-validate-design
+description: Interactive technical design quality review and validation. Use when reviewing design before implementation.
+allowed-tools: Read, Grep, Glob, AskUserQuestion
+argument-hint: <feature-name>
+metadata:
+  shared-rules: "design-review.md"
+---
+
+# kiro-validate-design Skill
+
+## Role
+You are a specialized skill for conducting interactive quality review of technical design to ensure readiness for implementation.
+
+## Core Mission
+- **Mission**: Conduct interactive quality review of technical design to ensure readiness for implementation
+- **Success Criteria**:
+  - Critical issues identified (maximum 3 most important concerns)
+  - Balanced assessment with strengths recognized
+  - Clear GO/NO-GO decision with rationale
+  - Actionable feedback for improvements if needed
+
+## Execution Steps
+
+### Step 1: Gather Context
+
+If steering/spec context is already available from conversation, skip redundant file reads.
+Otherwise, load all necessary context:
+- Read `.kiro/specs/{feature}/spec.json` for language and metadata
+- Read `.kiro/specs/{feature}/requirements.md` for requirements
+- Read `.kiro/specs/{feature}/design.md` for design document
+- Core steering context: `product.md`, `tech.md`, `structure.md`
+- Additional steering files only when directly relevant to architecture boundaries, integrations, runtime prerequisites, domain rules, security/performance constraints, or team conventions that affect implementation readiness
+- Relevant local agent skills or playbooks only when they clearly match the feature's host environment or use case and provide review-relevant context
+
+#### Parallel Research
+
+The following research areas are independent and can be executed in parallel:
+1. **Context & rules loading**: Spec documents, core steering, task-relevant extra steering, relevant local agent skills/playbooks, and `rules/design-review.md` from this skill's directory for review criteria
+2. **Codebase pattern survey**: Gather existing architecture patterns, naming conventions, and component structure from the codebase to use as reference during review
+
+After all parallel research completes, synthesize findings for review.
+
+### Step 2: Execute Design Review
+- Reference conversation history: leverage prior requirements discussion and user's stated design intent
+- Follow design-review.md process: Analysis → Critical Issues → Strengths → GO/NO-GO
+- Limit to 3 most important concerns
+- Engage interactively with user — ask clarifying questions, propose alternatives
+- Use language specified in spec.json for output
+
+### Step 3: Decision and Next Steps
+- Clear GO/NO-GO decision with rationale
+- Provide specific actionable next steps (see Next Phase below)
+
+## Important Constraints
+- **Quality assurance, not perfection seeking**: Accept acceptable risk
+- **Critical focus only**: Maximum 3 issues, only those significantly impacting success
+- **Conversation-aware**: Leverage discussion history for requirements context and user intent
+- **Interactive approach**: Engage in dialogue, ask clarifying questions, propose alternatives
+- **Balanced assessment**: Recognize both strengths and weaknesses
+- **Actionable feedback**: All suggestions must be implementable
+- **Context Discipline**: Start with core steering and expand only with review-relevant steering or use-case-aligned local agent skills/playbooks
+
+## Tool Guidance
+- **Read first**: Load spec, core steering, relevant local playbooks/agent skills, and rules before review
+- **Grep if needed**: Search codebase for pattern validation or integration checks
+- **Interactive**: Engage with user throughout the review process
+
+## Output Description
+Provide output in the language specified in spec.json with:
+
+1. **Review Summary**: Brief overview (2-3 sentences) of design quality and readiness
+2. **Critical Issues**: Maximum 3, following design-review.md format
+3. **Design Strengths**: 1-2 positive aspects
+4. **Final Assessment**: GO/NO-GO decision with rationale and next steps
+
+**Format Requirements**:
+- Use Markdown headings for clarity
+- Follow design-review.md output format
+- Keep summary concise
+
+## Safety & Fallback
+
+### Error Scenarios
+- **Missing Design**: If design.md doesn't exist, stop with message: "Run `/kiro-spec-design {feature}` first to generate design document"
+- **Design Not Generated**: If design phase not marked as generated in spec.json, warn but proceed with review
+- **Empty Steering Directory**: Warn user that project context is missing and may affect review quality
+- **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
+
+### Next Phase: Task Generation
+
+**If Design Passes Validation (GO Decision)**:
+- Apply any suggested improvements if agreed
+- Run `/kiro-spec-tasks {feature}` to generate implementation tasks
+- Or `/kiro-spec-tasks {feature} -y` to auto-approve and proceed directly
+
+**If Design Needs Revision (NO-GO Decision)**:
+- Address critical issues identified in review
+- Re-run `/kiro-spec-design {feature}` with improvements
+- Re-validate with `/kiro-validate-design {feature}`
+
+**Note**: Design validation is recommended but optional. Quality review helps catch issues early.

--- a/.claude/skills/kiro-validate-design/rules/design-review.md
+++ b/.claude/skills/kiro-validate-design/rules/design-review.md
@@ -1,0 +1,110 @@
+# Design Review Process
+
+## Objective
+Conduct interactive quality review of technical design documents to ensure they are solid enough to proceed to implementation with acceptable risk.
+
+## Review Philosophy
+- **Quality assurance, not perfection seeking**
+- **Critical focus**: Limit to 3 most important concerns
+- **Interactive dialogue**: Engage with designer, not one-way evaluation
+- **Balanced assessment**: Recognize strengths and weaknesses
+- **Clear decision**: Definitive GO/NO-GO with rationale
+
+## Scope & Non-Goals
+
+- Scope: Evaluate the quality of the design document against project context and standards to decide GO/NO-GO.
+- Non-Goals: Do not perform implementation-level design, deep technology research, or finalize technology choices. Defer such items to the design phase iteration.
+
+## Core Review Criteria
+
+### 1. Existing Architecture Alignment (Critical)
+- Integration with existing system boundaries and layers
+- Consistency with established architectural patterns
+- Proper dependency direction and coupling management
+- Alignment with current module organization
+
+### 2. Design Consistency & Standards
+- Adherence to project naming conventions and code standards
+- Consistent error handling and logging strategies
+- Uniform configuration and dependency management
+- Alignment with established data modeling patterns
+
+### 3. Extensibility & Maintainability
+- Design flexibility for future requirements
+- Clear separation of concerns and single responsibility
+- Testability and debugging considerations
+- Appropriate complexity for requirements
+
+### 4. Type Safety & Interface Design
+- Proper type definitions and interface contracts
+- Avoidance of unsafe patterns (e.g., `any` in TypeScript)
+- Clear API boundaries and data structures
+- Input validation and error handling coverage
+
+## Review Process
+
+### Step 1: Analyze
+Analyze design against all review criteria, focusing on critical issues impacting integration, maintainability, complexity, and requirements fulfillment.
+
+### Step 2: Identify Critical Issues (≤3)
+For each issue:
+```
+🔴 **Critical Issue [1-3]**: [Brief title]
+**Concern**: [Specific problem]
+**Impact**: [Why it matters]
+**Suggestion**: [Concrete improvement]
+**Traceability**: [Requirement ID/section from requirements.md]
+**Evidence**: [Design doc section/heading]
+```
+
+### Step 3: Recognize Strengths
+Acknowledge 1-2 strong aspects to maintain balanced feedback.
+
+### Step 4: Decide GO/NO-GO
+- **GO**: No critical architectural misalignment, requirements addressed, clear implementation path, acceptable risks
+- **NO-GO**: Fundamental conflicts, critical gaps, high failure risk, disproportionate complexity
+
+## Traceability & Evidence
+
+- Link each critical issue to the relevant requirement(s) from `requirements.md` (ID or section).
+- Cite evidence locations in the design document (section/heading, diagram, or artifact) to support the assessment.
+- When applicable, reference constraints from steering context to justify the issue.
+
+## Output Format
+
+### Design Review Summary
+2-3 sentences on overall quality and readiness.
+
+### Critical Issues (≤3)
+For each: Issue, Impact, Recommendation, Traceability (e.g., 1.1, 1.2), Evidence (design.md section).
+
+### Design Strengths
+1-2 positive aspects.
+
+### Final Assessment
+Decision (GO/NO-GO), Rationale (1-2 sentences), Next Steps.
+
+### Interactive Discussion
+Engage on designer's perspective, alternatives, clarifications, and necessary changes.
+
+## Length & Focus
+
+- Summary: 2–3 sentences
+- Each critical issue: 5–7 lines total (including Issue/Impact/Recommendation/Traceability/Evidence)
+- Overall review: keep concise (~400 words guideline)
+
+## Review Guidelines
+
+1. **Critical Focus**: Only flag issues that significantly impact success
+2. **Constructive Tone**: Provide solutions, not just criticism
+3. **Interactive Approach**: Engage in dialogue rather than one-way evaluation
+4. **Balanced Assessment**: Recognize both strengths and weaknesses
+5. **Clear Decision**: Make definitive GO/NO-GO recommendation
+6. **Actionable Feedback**: Ensure all suggestions are implementable
+
+## Final Checklist
+
+- **Critical Issues ≤ 3** and each includes Impact and Recommendation
+- **Traceability**: Each issue references requirement ID/section
+- **Evidence**: Each issue cites design doc location
+- **Decision**: GO/NO-GO with clear rationale and next steps

--- a/.claude/skills/kiro-validate-gap/SKILL.md
+++ b/.claude/skills/kiro-validate-gap/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: kiro-validate-gap
+description: Analyze implementation gap between requirements and existing codebase. Use when planning integration with existing systems.
+allowed-tools: Read, Write, Grep, Glob, WebSearch, WebFetch
+argument-hint: <feature-name>
+metadata:
+  shared-rules: "gap-analysis.md"
+---
+
+# kiro-validate-gap Skill
+
+## Role
+You are a specialized skill for analyzing the implementation gap between requirements and existing codebase to inform implementation strategy.
+
+## Core Mission
+- **Mission**: Analyze the gap between requirements and existing codebase to inform implementation strategy
+- **Success Criteria**:
+  - Comprehensive understanding of existing codebase patterns and components
+  - Clear identification of missing capabilities and integration challenges
+  - Multiple viable implementation approaches evaluated
+  - Technical research needs identified for design phase
+
+## Execution Steps
+
+### Step 1: Gather Context
+
+If steering/spec context is already available from conversation, skip redundant file reads.
+Otherwise, load all necessary context:
+- Read `.kiro/specs/{feature}/spec.json` for language and metadata
+- Read `.kiro/specs/{feature}/requirements.md` for requirements
+- Core steering context: `product.md`, `tech.md`, `structure.md`
+- Additional steering files only when directly relevant to the feature's domain rules, integrations, runtime prerequisites, compliance/security constraints, or existing product boundaries
+- Relevant local agent skills or playbooks only when they clearly match the feature's host environment or use case and provide analysis-relevant context
+
+### Step 2: Read Analysis Guidelines
+- Read `rules/gap-analysis.md` from this skill's directory for comprehensive analysis framework
+
+### Step 3: Execute Gap Analysis
+
+#### Parallel Research
+
+The following research areas are independent and can be executed in parallel:
+1. **Codebase analysis**: Existing implementations, architecture patterns, integration points, extension possibilities (using Grep/Glob/Read)
+2. **External dependency research**: Dependency compatibility, version constraints, known integration challenges (using WebSearch/WebFetch when needed)
+3. **Context loading**: Requirements, core steering, task-relevant extra steering, relevant local agent skills/playbooks, and gap-analysis rules
+
+After all parallel research completes, synthesize findings for gap analysis.
+
+- Follow gap-analysis.md framework for thorough investigation
+- Evaluate multiple implementation approaches (extend/new/hybrid)
+- Use language specified in spec.json for output
+
+### Step 4: Generate Analysis Document
+- Create comprehensive gap analysis following the output guidelines in gap-analysis.md
+- Present multiple viable options with trade-offs
+- Flag areas requiring further research
+
+### Step 5: Write Gap Analysis to Disk
+
+**Write the gap analysis to disk so it survives session boundaries and can be referenced during design phase.**
+
+- Use the Write tool to save the gap analysis to `.kiro/specs/{feature}/research.md`
+- If the file already exists, append the new analysis (separated by a horizontal rule `---`) rather than overwriting previous research
+- Verify the file was written by reading it back
+
+## Important Constraints
+- **Information over Decisions**: Provide analysis and options, not final implementation choices
+- **Multiple Options**: Present viable alternatives when applicable
+- **Thorough Investigation**: Use tools to deeply understand existing codebase
+- **Explicit Gaps**: Clearly flag areas needing research or investigation
+- **Context Discipline**: Start with core steering and expand only with analysis-relevant steering or use-case-aligned local agent skills/playbooks
+
+## Tool Guidance
+- **Read first**: Load spec, core steering, relevant local playbooks/agent skills, and rules before analysis
+- **Grep extensively**: Search codebase for patterns, conventions, and integration points
+- **WebSearch/WebFetch**: Research external dependencies and best practices when needed
+- **Write last**: Generate analysis only after complete investigation
+
+## Output Description
+Provide output in the language specified in spec.json with:
+
+1. **Analysis Summary**: Brief overview (3-5 bullets) of scope, challenges, and recommendations
+2. **Document Status**: Confirm analysis approach used
+3. **Next Steps**: Guide user on proceeding to design phase
+
+**Format Requirements**:
+- Use Markdown headings for clarity
+- Keep summary concise (under 300 words)
+- Detailed analysis follows gap-analysis.md output guidelines
+
+## Safety & Fallback
+
+### Error Scenarios
+- **Missing Requirements**: If requirements.md doesn't exist, stop with message: "Run `/kiro-spec-requirements {feature}` first to generate requirements"
+- **Requirements Not Approved**: If requirements not approved, warn user but proceed (gap analysis can inform requirement revisions)
+- **Empty Steering Directory**: Warn user that project context is missing and may affect analysis quality
+- **Complex Integration Unclear**: Flag for comprehensive research in design phase rather than blocking
+- **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
+
+### Next Phase: Design Generation
+
+**If Gap Analysis Complete**:
+- Review gap analysis insights
+- Run `/kiro-spec-design {feature}` to create technical design document
+- Or `/kiro-spec-design {feature} -y` to auto-approve requirements and proceed directly
+
+**Note**: Gap analysis is optional but recommended for brownfield projects to inform design decisions.

--- a/.claude/skills/kiro-validate-gap/rules/gap-analysis.md
+++ b/.claude/skills/kiro-validate-gap/rules/gap-analysis.md
@@ -1,0 +1,144 @@
+# Gap Analysis Process
+
+## Objective
+Analyze the gap between requirements and existing codebase to inform implementation strategy decisions.
+
+## Analysis Framework
+
+### 1. Current State Investigation
+
+- Scan for domain-related assets:
+  - Key files/modules and directory layout
+  - Reusable components/services/utilities
+  - Dominant architecture patterns and constraints
+
+- Extract conventions:
+  - Naming, layering, dependency direction
+  - Import/export patterns and dependency hotspots
+  - Testing placement and approach
+
+- Note integration surfaces:
+  - Data models/schemas, API clients, auth mechanisms
+
+### 2. Requirements Feasibility Analysis
+
+- From EARS requirements, list technical needs:
+  - Data models, APIs/services, UI/components
+  - Business rules/validation
+  - Non-functionals: security, performance, scalability, reliability
+
+- Identify gaps and constraints:
+  - Missing capabilities in current codebase
+  - Unknowns to be researched later (mark as "Research Needed")
+  - Constraints from existing architecture and patterns
+
+- Note complexity signals:
+  - Simple CRUD / algorithmic logic / workflows / external integrations
+
+### 3. Implementation Approach Options
+
+#### Option A: Extend Existing Components
+**When to consider**: Feature fits naturally into existing structure
+
+- **Which files/modules to extend**:
+  - Identify specific files requiring changes
+  - Assess impact on existing functionality
+  - Evaluate backward compatibility concerns
+
+- **Compatibility assessment**:
+  - Check if extension respects existing interfaces
+  - Verify no breaking changes to consumers
+  - Assess test coverage impact
+
+- **Complexity and maintainability**:
+  - Evaluate cognitive load of additional functionality
+  - Check if single responsibility principle is maintained
+  - Assess if file size remains manageable
+
+**Trade-offs**:
+- ✅ Minimal new files, faster initial development
+- ✅ Leverages existing patterns and infrastructure
+- ❌ Risk of bloating existing components
+- ❌ May complicate existing logic
+
+#### Option B: Create New Components
+**When to consider**: Feature has distinct responsibility or existing components are already complex
+
+- **Rationale for new creation**:
+  - Clear separation of concerns justifies new file
+  - Existing components are already complex
+  - Feature has distinct lifecycle or dependencies
+
+- **Integration points**:
+  - How new components connect to existing system
+  - APIs or interfaces exposed
+  - Dependencies on existing components
+
+- **Responsibility boundaries**:
+  - Clear definition of what new component owns
+  - Interfaces with existing components
+  - Data flow and control flow
+
+**Trade-offs**:
+- ✅ Clean separation of concerns
+- ✅ Easier to test in isolation
+- ✅ Reduces complexity in existing components
+- ❌ More files to navigate
+- ❌ Requires careful interface design
+
+#### Option C: Hybrid Approach
+**When to consider**: Complex features requiring both extension and new creation
+
+- **Combination strategy**:
+  - Which parts extend existing components
+  - Which parts warrant new components
+  - How they interact
+
+- **Phased implementation**:
+  - Initial phase: minimal viable changes
+  - Subsequent phases: refactoring or new components
+  - Migration strategy if needed
+
+- **Risk mitigation**:
+  - Incremental rollout approach
+  - Feature flags or configuration
+  - Rollback strategy
+
+**Trade-offs**:
+- ✅ Balanced approach for complex features
+- ✅ Allows iterative refinement
+- ❌ More complex planning required
+- ❌ Potential for inconsistency if not well-coordinated
+### 4. Out-of-Scope for Gap Analysis
+
+- Defer deep research activities to the design phase.
+- Record unknowns as concise "Research Needed" items only.
+
+### 5. Implementation Complexity & Risk
+
+  - Effort:
+    - S (1–3 days): existing patterns, minimal deps, straightforward integration
+    - M (3–7 days): some new patterns/integrations, moderate complexity
+    - L (1–2 weeks): significant functionality, multiple integrations or workflows
+    - XL (2+ weeks): architectural changes, unfamiliar tech, broad impact
+  - Risk:
+    - High: unknown tech, complex integrations, architectural shifts, unclear perf/security path
+    - Medium: new patterns with guidance, manageable integrations, known perf solutions
+    - Low: extend established patterns, familiar tech, clear scope, minimal integration
+
+### Output Checklist
+
+- Requirement-to-Asset Map with gaps tagged (Missing / Unknown / Constraint)
+- Options A/B/C with short rationale and trade-offs
+- Effort (S/M/L/XL) and Risk (High/Medium/Low) with one-line justification each
+- Recommendations for design phase:
+  - Preferred approach and key decisions
+  - Research items to carry forward
+
+## Principles
+
+- **Information over decisions**: Provide analysis and options, not final choices
+- **Multiple viable options**: Offer credible alternatives when applicable
+- **Explicit gaps and assumptions**: Flag unknowns and constraints clearly
+- **Context-aware**: Align with existing patterns and architecture limits
+- **Transparent effort and risk**: Justify labels succinctly

--- a/.claude/skills/kiro-validate-impl/SKILL.md
+++ b/.claude/skills/kiro-validate-impl/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: kiro-validate-impl
+description: Validate feature-level integration after all tasks are implemented. Checks cross-task consistency, full test suite, and overall spec coverage.
+allowed-tools: Read, Bash, Grep, Glob, Agent
+argument-hint: <feature-name> [task-numbers]
+---
+
+# kiro-validate-impl Skill
+
+## Role
+Individual tasks have already been reviewed by the per-task reviewer during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
+
+Boundary terminology continuity:
+- discovery identifies `Boundary Candidates`
+- design fixes `Boundary Commitments`
+- tasks constrain execution with `_Boundary:_`
+- feature validation checks for cross-task `Boundary Violations`
+
+## Core Mission
+- **Success Criteria**:
+  - All tasks marked `[x]` in tasks.md
+  - Full test suite passes (not just per-task tests)
+  - Cross-task integration works (data flows between components, interfaces match)
+  - Requirements coverage is complete across all tasks (no gaps between tasks)
+  - Design structure is reflected end-to-end (not just per-component)
+  - No orphaned code, conflicting implementations, integration seams, or boundary spillover
+
+## What This Skill Does NOT Do
+Per-task checks are the reviewer's responsibility during `/kiro-impl`. This skill does **not** re-check:
+- Individual task acceptance criteria
+- Per-file reality checks (mock/stub detection)
+- Single-task spec alignment
+
+This skill's main question is: when the completed tasks are viewed together, do they still respect the designed boundary seams and dependency direction?
+
+## Execution Steps
+
+### Step 1: Detect Validation Target
+
+**If no arguments provided**:
+- Parse conversation history for `/kiro-impl` commands to detect recently implemented features and tasks
+- Scan `.kiro/specs/` for features with completed tasks `[x]`
+- Report detected implementations (e.g., "user-auth: 1.1, 1.2, 1.3")
+
+**If feature provided** (feature specified, tasks empty):
+- Use specified feature
+- Detect all completed tasks `[x]` in `.kiro/specs/{feature}/tasks.md`
+
+**If both feature and tasks provided** (explicit mode):
+- Validate specified feature and tasks only (e.g., `user-auth 1.1,1.2`)
+
+### Step 2: Gather Context
+
+If steering/spec context is already available from conversation, skip redundant file reads.
+Otherwise, for each detected feature:
+- Read `.kiro/specs/<feature>/spec.json` for metadata
+- Read `.kiro/specs/<feature>/requirements.md` for requirements
+- Read `.kiro/specs/<feature>/design.md` for design structure
+- Read `.kiro/specs/<feature>/tasks.md` for task list and Implementation Notes
+- Core steering context: `product.md`, `tech.md`, `structure.md`
+- Additional steering files only when directly relevant to the validated boundaries, runtime prerequisites, integrations, domain rules, security/performance constraints, or team conventions that affect the GO/NO-GO call
+
+**Discover canonical validation commands**:
+- Inspect repository-local sources of truth in this order: project scripts/manifests (`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, app manifests), task runners (`Makefile`, `justfile`), CI/workflow files, existing e2e/integration configs, then `README*`
+- Derive a feature-level validation set for this repo: `TEST_COMMANDS`, `BUILD_COMMANDS`, and `SMOKE_COMMANDS`
+- Prefer commands already used by repo automation over ad hoc shell pipelines
+- For `SMOKE_COMMANDS`, choose the lightest trustworthy runtime-liveness check for the app shape (for example: root URL load, Electron launch, CLI `--help`, service health endpoint, mobile simulator/e2e harness if one already exists)
+- If multiple candidates exist, prefer the command with the smallest setup cost that still exercises the real built artifact
+
+### Step 3: Execute Integration Validation
+
+#### Subagent Dispatch (parallel)
+
+The following validation dimensions are independent and can be dispatched as **subagents** via the Agent tool. The agent should decide the optimal decomposition based on feature scope — split, merge, or skip subagents as appropriate. Each subagent returns a **structured findings summary** to keep the main context clean for GO/NO-GO synthesis.
+
+**Typical validation dimensions** (adjust as appropriate):
+- **Test execution**: Run the complete test suite, report pass/fail with details
+- **Requirements coverage**: Build requirements → implementation matrix, report gaps
+- **Design alignment**: Verify architecture matches design.md, report drift and dependency violations
+- **Cross-task integration**: Verify data flows, API contracts, shared state consistency
+
+For simple features (few tasks, small scope), run checks in main context without subagent dispatch.
+
+#### Mechanical Checks (run commands, use results)
+
+These checks apply at the feature level. Use command output as the primary signal.
+
+**A. Full Test Suite**
+- Run the discovered canonical full-test command. Use the exit code.
+- If tests fail → NO-GO. No judgment needed.
+- If the canonical test command cannot be identified → `MANUAL_VERIFY_REQUIRED`
+
+**B. Residual TBD/TODO/FIXME**
+- Run: `grep -rn "TBD\|TODO\|FIXME\|HACK\|XXX" <files-in-feature-boundary>`
+- If matches found that were introduced by this feature → flag as Warning
+
+**C. Residual Hardcoded Secrets**
+- Run: `grep -rn "password\s*=\|api_key\s*=\|secret\s*=\|token\s*=" <files-in-feature-boundary>` (case-insensitive)
+- If matches found that aren't environment variable references → flag as Critical
+
+**D. Runtime Liveness (Smoke Boot)**
+- Run the discovered canonical smoke command that proves the built artifact actually starts and reaches its first usable state.
+- Examples if relevant: open the root URL in a headless browser and require zero boot-time console errors; launch Electron and wait for the main process ready signal and first renderer load; run a CLI with `--help`; start a service and hit its health endpoint.
+- If boot produces a runtime crash, unhandled exception, module-load failure, native ABI mismatch, or missing required env/config → NO-GO.
+- If no trustworthy smoke command can be identified, or the required runtime environment is unavailable → `MANUAL_VERIFY_REQUIRED`
+
+#### Judgment Checks (read code, compare to spec)
+
+**E. Cross-Task Integration**
+- Identify where tasks share interfaces, data models, or API contracts
+- Verify that Task A's output format matches Task B's expected input
+- Check for conflicting assumptions between tasks (naming conventions, error codes, data shapes)
+- Verify shared state (database schemas, config, environment) is consistent across tasks
+- Verify integration work happens at the intended seams rather than by leaking one boundary's behavior into another
+
+**F. Requirements Coverage Gaps**
+- Map every requirement section to at least one completed task
+- Identify requirements that no single task fully covers (cross-cutting requirements)
+- Identify requirements partially covered by multiple tasks but not fully by any
+- Use the original section numbering from `requirements.md`; do NOT invent `REQ-*` aliases
+
+**G. Design End-to-End Alignment**
+- Verify the overall component graph matches design.md
+- Check that integration patterns (event flow, API boundaries, dependency injection) work as designed
+- Verify dependency direction follows design.md's architecture (no upward imports)
+- Verify File Structure Plan matches the actual file layout
+- Identify any architectural drift from the original design
+- Use the original section numbering from `design.md`
+
+**G.5 Boundary Audit**
+- Compare completed work against the design's `Boundary Commitments`, `Out of Boundary`, `Allowed Dependencies`, and `Revalidation Triggers`
+- Identify cross-task spillover where one area quietly absorbed another boundary's responsibility
+- Identify downstream-specific workarounds embedded upstream "to make integration easier"
+- Identify new hidden dependencies or shared ownership that were not declared in the design
+- If a revalidation trigger fired, verify the affected adjacent specs or integration points were actually re-checked
+
+**H. Blocked Tasks & Implementation Notes**
+- Check for any tasks still marked `_Blocked:_` — report why and assess impact on feature completeness
+- Review `## Implementation Notes` in tasks.md for cross-cutting insights that need attention
+
+### Step 4: Generate Report
+
+Before returning `GO`, apply the `kiro-verify-completion` protocol to the feature-level claim. Tests alone are insufficient: include full-suite, runtime liveness, coverage, integration, design-alignment, and blocked-task status in the evidence.
+
+Classify concrete failures by ownership before writing remediation:
+- `LOCAL` if the defect belongs to the feature being validated
+- `UPSTREAM` if the root cause belongs to a dependency, foundation, shared platform, or earlier spec
+- `UNCLEAR` if ownership cannot be established from the available evidence
+
+If ownership is `UPSTREAM`, do not collapse the issue into local remediation for this feature. Name the owning upstream spec and explain which dependent specs should be revalidated after that upstream fix lands.
+
+Provide summary in the language specified in spec.json:
+
+```
+## Validation Report
+- DECISION: GO | NO-GO | MANUAL_VERIFY_REQUIRED
+- MECHANICAL_RESULTS:
+  - Tests: PASS | FAIL (command and exit code)
+  - TBD/TODO grep: CLEAN | <count> matches
+  - Secrets grep: CLEAN | <count> matches
+  - Smoke boot: PASS | FAIL | MANUAL_REQUIRED
+- INTEGRATION:
+  - Cross-task contracts: <status>
+  - Shared state consistency: <status>
+  - Boundary audit: <status>
+- COVERAGE:
+  - Requirements mapped: <X/Y sections covered>
+  - Coverage gaps: <list of uncovered requirement sections>
+- DESIGN:
+  - Architecture drift: <findings>
+  - Dependency direction: <violations if any>
+  - File Structure Plan vs actual: <match/mismatch>
+- OWNERSHIP: LOCAL | UPSTREAM | UNCLEAR
+- UPSTREAM_SPEC: <feature-name | N/A>
+- BLOCKED_TASKS: <list and impact assessment>
+- REMEDIATION: <if NO-GO: specific, actionable steps to fix each issue>
+```
+
+If NO-GO, REMEDIATION is mandatory — identify the exact issue and what needs to change. Vague feedback is not acceptable.
+
+## Important Constraints
+- **Strict Final Gate**: Return `GO` only when all integration checks passed; return `NO-GO` for concrete failures and `MANUAL_VERIFY_REQUIRED` when mandatory validation could not be completed
+- **Boundary integrity over convenience**: Do not return `GO` if the feature only works by smearing responsibilities across boundaries, even when tests pass
+
+## Safety & Fallback
+
+### Error Scenarios
+- **No Implementation Found**: If no `[x]` tasks found, report "No implementations detected"
+- **Test Command Unknown**: Return `MANUAL_VERIFY_REQUIRED` and explain which validation command is missing; do not return `GO`
+- **Missing Spec Files**: Stop with error if spec.json/requirements.md/design.md missing
+
+### Next Steps Guidance
+
+**If GO Decision**:
+- Feature validated end-to-end and ready for deployment or next feature
+
+**If NO-GO Decision**:
+- Address issues listed in REMEDIATION
+- Re-run `/kiro-impl {feature} [tasks]` for targeted fixes
+- Re-validate with `/kiro-validate-impl {feature}`
+
+**If MANUAL_VERIFY_REQUIRED**:
+- Do not treat the feature as complete
+- Provide the exact missing validation step or environment prerequisite

--- a/.claude/skills/kiro-verify-completion/SKILL.md
+++ b/.claude/skills/kiro-verify-completion/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: kiro-verify-completion
+description: Verify completion and success claims with fresh evidence. Use before claiming a task is complete, a fix works, tests pass, or a feature is ready for GO.
+allowed-tools: Read, Bash, Grep, Glob
+argument-hint: <claim-type> <claim>
+---
+
+# kiro-verify-completion
+
+## Overview
+
+This skill prevents false completion claims. A task, fix, or feature is only complete when supported by fresh evidence that matches the scope of the claim.
+
+## When to Use
+
+- Before saying a task is complete
+- Before saying a bug is fixed
+- Before saying tests pass
+- Before moving to the next task in autonomous execution
+- Before reporting `GO` from feature-level validation
+- Before trusting another subagent's success report
+
+Do not use this skill for early planning or speculative status updates.
+
+## Inputs
+
+Provide:
+- The exact claim to verify
+- Claim type:
+  - `TASK`
+  - `FIX`
+  - `TEST_OR_BUILD`
+  - `FEATURE_GO`
+- Validation commands discovered by the controller
+- Fresh command output and exit codes
+- Relevant task IDs, requirement IDs, and design refs where applicable
+- For feature-level claims:
+  - requirements coverage status
+  - design alignment status
+  - integration status
+  - blocked task status
+
+## Outputs
+
+Return one of:
+- `VERIFIED`
+- `NOT_VERIFIED`
+- `MANUAL_VERIFY_REQUIRED`
+
+Also return:
+- Claim reviewed
+- Evidence used
+- Scope/evidence mismatch, if any
+
+Use the language specified in `spec.json`.
+
+## Gate Function
+
+1. Identify the exact claim.
+2. Identify the exact command or checklist that proves that claim.
+3. Require fresh evidence from the current code state.
+4. Check exit code, failure count, skipped scope, and missing coverage.
+5. Reject claims that are broader than the evidence.
+6. If mandatory validation cannot be completed, return `MANUAL_VERIFY_REQUIRED`.
+7. Only then allow the claim.
+
+## Claim-Specific Rules
+
+### TASK
+Require:
+- task-local verification evidence
+- no unresolved blocking findings from review
+- evidence aligned with the task boundary
+
+### FIX
+Require:
+- evidence that the original symptom is resolved
+- no broader regressions in the relevant verification scope
+
+### TEST_OR_BUILD
+Require:
+- actual command output
+- exit code
+- no inference from unrelated checks
+
+### FEATURE_GO
+Require:
+- full test suite result
+- runtime smoke boot result showing the built artifact reaches its first usable state
+- requirements coverage assessment
+- cross-task integration assessment
+- design end-to-end alignment assessment
+- blocked tasks assessment
+
+A passing test suite alone is not enough for `FEATURE_GO`.
+
+## Stop / Escalate
+
+Return `MANUAL_VERIFY_REQUIRED` when:
+- No canonical validation command is known
+- The required environment is unavailable
+- A mandatory manual verification step cannot be executed
+
+Return `NOT_VERIFIED` when:
+- The command failed
+- Evidence is stale
+- Evidence is partial
+- The claim exceeds the evidence
+- The feature still has unresolved blocked tasks or uncovered requirements
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| “The subagent said it succeeded” | Reported success is not verification evidence. |
+| “Tests passed earlier” | Fresh evidence only. |
+| “Build should be fine because lint passed” | Lint does not prove build success. |
+| “Tests passed and build succeeded, so it must run” | Type erasure, module loading, native ABI, and boot-time config issues can still fail at runtime. |
+| “The feature is done because all tasks are checked off” | `FEATURE_GO` also requires coverage, integration, and design alignment. |
+
+## Output Format
+
+```md
+## Verification Result
+- STATUS: VERIFIED | NOT_VERIFIED | MANUAL_VERIFY_REQUIRED
+- CLAIM_TYPE: TASK | FIX | TEST_OR_BUILD | FEATURE_GO
+- CLAIM: <exact claim>
+- EVIDENCE: <command/checklist and result>
+- GAPS: <scope/evidence mismatch or missing validation>
+- NOTES: <next action if not verified>
+```

--- a/.kiro/settings/templates/specs/design.md
+++ b/.kiro/settings/templates/specs/design.md
@@ -1,0 +1,331 @@
+# Design Document Template
+
+---
+**Purpose**: Provide sufficient detail to ensure implementation consistency across different implementers, preventing interpretation drift.
+
+**Approach**:
+- Include essential sections that directly inform implementation decisions
+- Omit optional sections unless critical to preventing implementation errors
+- Match detail level to feature complexity
+- Use diagrams and tables over lengthy prose
+
+**Warning**: Approaching 1000 lines indicates excessive feature complexity that may require design simplification or splitting into multiple specs.
+---
+
+> Sections may be reordered (e.g., surfacing Requirements Traceability earlier or moving Data Models nearer Architecture) when it improves clarity. Within each section, keep the flow **Summary → Scope → Decisions → Impacts/Risks** so reviewers can scan consistently.
+
+## Overview 
+2-3 paragraphs max
+**Purpose**: This feature delivers [specific value] to [target users].
+**Users**: [Target user groups] will utilize this for [specific workflows].
+**Impact** (if applicable): Changes the current [system state] by [specific modifications].
+
+
+### Goals
+- Primary objective 1
+- Primary objective 2  
+- Success criteria
+
+### Non-Goals
+- Explicitly excluded functionality
+- Future considerations outside current scope
+- Integration points deferred
+
+## Boundary Commitments
+
+State the responsibility boundary of this spec in concrete terms. Treat this as the anchor for architecture, tasks, and later validation.
+
+### This Spec Owns
+- Capabilities and behaviors this spec is responsible for
+- Data it owns or is authoritative for
+- Interfaces or contracts it defines or stabilizes
+
+### Out of Boundary
+- Related concerns this spec explicitly does NOT own
+- Work deferred to another spec, existing subsystem, or later phase
+- Changes this spec must not absorb as "just one more thing"
+
+### Allowed Dependencies
+- Upstream systems/specs/components this design may depend on
+- Shared infrastructure this design may use
+- Dependency constraints that must not be violated
+
+### Revalidation Triggers
+List the kinds of changes that should force dependent specs or consumers to re-check integration.
+
+- Contract shape changes
+- Data ownership changes
+- Dependency direction changes
+- Startup/runtime prerequisite changes
+
+## Architecture
+
+> Reference detailed discovery notes in `research.md` only for background; keep design.md self-contained for reviewers by capturing all decisions and contracts here.
+> Capture key decisions in text and let diagrams carry structural detail—avoid repeating the same information in prose.
+> Supporting sections below should remain as light as possible unless they materially clarify the responsibility boundary, dependency rules, or integration seams.
+
+### Existing Architecture Analysis (if applicable)
+When modifying existing systems:
+- Current architecture patterns and constraints
+- Existing domain boundaries to be respected
+- Integration points that must be maintained
+- Technical debt addressed or worked around
+
+### Architecture Pattern & Boundary Map
+**RECOMMENDED**: Include Mermaid diagram showing the chosen architecture pattern and system boundaries (required for complex features, optional for simple additions)
+
+**Architecture Integration**:
+- Selected pattern: [name and brief rationale]
+- Domain/feature boundaries: [how responsibilities are separated to avoid conflicts]
+- Existing patterns preserved: [list key patterns]
+- New components rationale: [why each is needed]
+- Steering compliance: [principles maintained]
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Frontend / CLI | | | |
+| Backend / Services | | | |
+| Data / Storage | | | |
+| Messaging / Events | | | |
+| Infrastructure / Runtime | | | |
+
+> Keep rationale concise here and, when more depth is required (trade-offs, benchmarks), add a short summary plus pointer to the Supporting References section and `research.md` for raw investigation notes.
+
+## File Structure Plan
+
+Map the directory structure and file responsibilities for this feature. This section directly drives task `_Boundary:_` annotations and implementation Task Briefs. Use the appropriate level of detail:
+
+- **Small features**: List individual files with responsibilities
+- **Large features**: Describe directory-level structure + per-domain/module pattern, list only non-obvious files individually
+
+### Directory Structure
+```
+src/
+├── domain-a/              # Domain A responsibility
+│   ├── controller.ts      # Endpoint handlers
+│   ├── service.ts         # Business logic
+│   └── types.ts           # Domain types
+├── domain-b/              # Domain B (same pattern as domain-a)
+└── shared/
+    └── cross-cutting.ts   # Non-obvious: why this exists
+```
+
+> For repeated structures, describe the pattern once (e.g., "domain-b follows same pattern as domain-a"). List individual files only when their responsibility isn't obvious from the path.
+
+### Modified Files
+- `path/to/existing.ts` — What changes and why
+
+> Each file should have one clear responsibility. Group files that change together. For repeated structures, describe the pattern once rather than listing every file.
+> Avoid duplicating what Components and Interfaces already describes — focus on the physical file layout that Components maps to.
+
+## System Flows
+
+Provide only the diagrams needed to explain non-trivial flows. Use pure Mermaid syntax. Common patterns:
+- Sequence (multi-party interactions)
+- Process / state (branching logic or lifecycle)
+- Data / event flow (pipelines, async messaging)
+
+Skip this section entirely for simple CRUD changes.
+> Describe flow-level decisions (e.g., gating conditions, retries) briefly after the diagram instead of restating each step.
+
+## Requirements Traceability
+
+Use this section for complex or compliance-sensitive features where requirements span multiple domains. Straightforward 1:1 mappings can rely on the Components summary table.
+
+Map each requirement ID (e.g., `2.1`) to the design elements that realize it.
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | | | | |
+| 1.2 | | | | |
+
+> Omit this section only when a single component satisfies a single requirement without cross-cutting concerns.
+
+## Components and Interfaces
+
+Provide a quick reference before diving into per-component details.
+
+- Summaries can be a table or compact list. Example table:
+  | Component | Domain/Layer | Intent | Req Coverage | Key Dependencies (P0/P1) | Contracts |
+  |-----------|--------------|--------|--------------|--------------------------|-----------|
+  | ExampleComponent | UI | Displays XYZ | 1, 2 | GameProvider (P0), MapPanel (P1) | Service, State |
+- Only components introducing new boundaries (e.g., logic hooks, external integrations, persistence) require full detail blocks. Simple presentation components can rely on the summary row plus a short Implementation Note.
+
+Group detailed blocks by domain or architectural layer. For each detailed component, list requirement IDs as `2.1, 2.3` (omit “Requirement”). When multiple UI components share the same contract, reference a base interface/props definition instead of duplicating code blocks.
+
+### [Domain / Layer]
+
+#### [Component Name]
+
+| Field | Detail |
+|-------|--------|
+| Intent | 1-line description of the responsibility |
+| Requirements | 2.1, 2.3 |
+| Owner / Reviewers | (optional) |
+
+**Responsibilities & Constraints**
+- Primary responsibility
+- Domain boundary and transaction scope
+- Data ownership / invariants
+
+**Dependencies**
+- Inbound: Component/service name — purpose (Criticality)
+- Outbound: Component/service name — purpose (Criticality)
+- External: Service/library — purpose (Criticality)
+
+Summarize external dependency findings here; deeper investigation (API signatures, rate limits, migration notes) lives in `research.md`.
+
+**Contracts**: Service [ ] / API [ ] / Event [ ] / Batch [ ] / State [ ]  ← check only the ones that apply.
+
+##### Service Interface
+```typescript
+interface [ComponentName]Service {
+  methodName(input: InputType): Result<OutputType, ErrorType>;
+}
+```
+- Preconditions:
+- Postconditions:
+- Invariants:
+
+##### API Contract
+| Method | Endpoint | Request | Response | Errors |
+|--------|----------|---------|----------|--------|
+| POST | /api/resource | CreateRequest | Resource | 400, 409, 500 |
+
+##### Event Contract
+- Published events:  
+- Subscribed events:  
+- Ordering / delivery guarantees:
+
+##### Batch / Job Contract
+- Trigger:  
+- Input / validation:  
+- Output / destination:  
+- Idempotency & recovery:
+
+##### State Management
+- State model:  
+- Persistence & consistency:  
+- Concurrency strategy:
+
+**Implementation Notes**
+- Integration: 
+- Validation: 
+- Risks:
+
+## Data Models
+
+Focus on the portions of the data landscape that change with this feature.
+
+### Domain Model
+- Aggregates and transactional boundaries
+- Entities, value objects, domain events
+- Business rules & invariants
+- Optional Mermaid diagram for complex relationships
+
+### Logical Data Model
+
+**Structure Definition**:
+- Entity relationships and cardinality
+- Attributes and their types
+- Natural keys and identifiers
+- Referential integrity rules
+
+**Consistency & Integrity**:
+- Transaction boundaries
+- Cascading rules
+- Temporal aspects (versioning, audit)
+
+### Physical Data Model
+**When to include**: When implementation requires specific storage design decisions
+
+**For Relational Databases**:
+- Table definitions with data types
+- Primary/foreign keys and constraints
+- Indexes and performance optimizations
+- Partitioning strategy for scale
+
+**For Document Stores**:
+- Collection structures
+- Embedding vs referencing decisions
+- Sharding key design
+- Index definitions
+
+**For Event Stores**:
+- Event schema definitions
+- Stream aggregation strategies
+- Snapshot policies
+- Projection definitions
+
+**For Key-Value/Wide-Column Stores**:
+- Key design patterns
+- Column families or value structures
+- TTL and compaction strategies
+
+### Data Contracts & Integration
+
+**API Data Transfer**
+- Request/response schemas
+- Validation rules
+- Serialization format (JSON, Protobuf, etc.)
+
+**Event Schemas**
+- Published event structures
+- Schema versioning strategy
+- Backward/forward compatibility rules
+
+**Cross-Service Data Management**
+- Distributed transaction patterns (Saga, 2PC)
+- Data synchronization strategies
+- Eventual consistency handling
+
+Skip subsections that are not relevant to this feature.
+
+## Error Handling
+
+### Error Strategy
+Concrete error handling patterns and recovery mechanisms for each error type.
+
+### Error Categories and Responses
+**User Errors** (4xx): Invalid input → field-level validation; Unauthorized → auth guidance; Not found → navigation help
+**System Errors** (5xx): Infrastructure failures → graceful degradation; Timeouts → circuit breakers; Exhaustion → rate limiting  
+**Business Logic Errors** (422): Rule violations → condition explanations; State conflicts → transition guidance
+
+**Process Flow Visualization** (when complex business logic exists):
+Include Mermaid flowchart only for complex error scenarios with business workflows.
+
+### Monitoring
+Error tracking, logging, and health monitoring implementation.
+
+## Testing Strategy
+
+### Default sections (adapt names/sections to fit the domain)
+- Unit Tests: 3–5 items from core functions/modules (e.g., auth methods, subscription logic)
+- Integration Tests: 3–5 cross-component flows (e.g., webhook handling, notifications)
+- E2E/UI Tests (if applicable): 3–5 critical user paths (e.g., forms, dashboards)
+- Performance/Load (if applicable): 3–4 items (e.g., concurrency, high-volume ops)
+
+## Optional Sections (include when relevant)
+
+### Security Considerations
+_Use this section for features handling auth, sensitive data, external integrations, or user permissions. Capture only decisions unique to this feature; defer baseline controls to steering docs._
+- Threat modeling, security controls, compliance requirements
+- Authentication and authorization patterns
+- Data protection and privacy considerations
+
+### Performance & Scalability
+_Use this section when performance targets, high load, or scaling concerns exist. Record only feature-specific targets or trade-offs and rely on steering documents for general practices._
+- Target metrics and measurement strategies
+- Scaling approaches (horizontal/vertical)
+- Caching strategies and optimization techniques
+
+### Migration Strategy
+Include a Mermaid flowchart showing migration phases when schema/data movement is required.
+- Phase breakdown, rollback triggers, validation checkpoints
+
+## Supporting References (Optional)
+- Create this section only when keeping the information in the main body would hurt readability (e.g., very long TypeScript definitions, vendor option matrices, exhaustive schema tables). Keep decision-making context in the main sections so the design stays self-contained.
+- Link to the supporting references from the main text instead of inlining large snippets.
+- Background research notes and comparisons continue to live in `research.md`, but their conclusions must be summarized in the main design.

--- a/.kiro/settings/templates/specs/init.json
+++ b/.kiro/settings/templates/specs/init.json
@@ -1,0 +1,24 @@
+{
+  "feature_name": "{{FEATURE_NAME}}",
+  "created_at": "{{TIMESTAMP}}",
+  "updated_at": "{{TIMESTAMP}}",
+  "language": "ja",
+  "phase": "initialized",
+  "approvals": {
+    "requirements": {
+      "generated": false,
+      "approved": false
+    },
+    "design": {
+      "generated": false,
+      "approved": false
+    },
+    "tasks": {
+      "generated": false,
+      "approved": false
+    }
+  },
+  "ready_for_implementation": false
+}
+
+

--- a/.kiro/settings/templates/specs/requirements-init.md
+++ b/.kiro/settings/templates/specs/requirements-init.md
@@ -1,0 +1,9 @@
+# Requirements Document
+
+## Project Description (Input)
+{{PROJECT_DESCRIPTION}}
+
+## Requirements
+<!-- Will be generated in /kiro-spec-requirements phase -->
+
+

--- a/.kiro/settings/templates/specs/requirements.md
+++ b/.kiro/settings/templates/specs/requirements.md
@@ -1,0 +1,32 @@
+# Requirements Document
+
+## Introduction
+{{INTRODUCTION}}
+
+<!-- Optional when scope could be misread or the feature touches adjacent systems/specs -->
+## Boundary Context (Optional)
+- **In scope**: {{IN_SCOPE_BEHAVIORS}}
+- **Out of scope**: {{OUT_OF_SCOPE_BEHAVIORS}}
+- **Adjacent expectations**: {{ADJACENT_SYSTEM_OR_SPEC_EXPECTATIONS}}
+
+## Requirements
+
+### Requirement 1: {{REQUIREMENT_AREA_1}}
+<!-- Requirement headings MUST include a leading numeric ID only (for example: "Requirement 1: ...", "1. Overview", "2 Feature: ..."). Alphabetic IDs like "Requirement A" are not allowed. -->
+**Objective:** As a {{ROLE}}, I want {{CAPABILITY}}, so that {{BENEFIT}}
+
+#### Acceptance Criteria
+1. When [event], the [system] shall [response/action]
+2. If [trigger], then the [system] shall [response/action]
+3. While [precondition], the [system] shall [response/action]
+4. Where [feature is included], the [system] shall [response/action]
+5. The [system] shall [response/action]
+
+### Requirement 2: {{REQUIREMENT_AREA_2}}
+**Objective:** As a {{ROLE}}, I want {{CAPABILITY}}, so that {{BENEFIT}}
+
+#### Acceptance Criteria
+1. When [event], the [system] shall [response/action]
+2. When [event] and [condition], the [system] shall [response/action]
+
+<!-- Additional requirements follow the same pattern -->

--- a/.kiro/settings/templates/specs/research.md
+++ b/.kiro/settings/templates/specs/research.md
@@ -1,0 +1,61 @@
+# Research & Design Decisions Template
+
+---
+**Purpose**: Capture discovery findings, architectural investigations, and rationale that inform the technical design.
+
+**Usage**:
+- Log research activities and outcomes during the discovery phase.
+- Document design decision trade-offs that are too detailed for `design.md`.
+- Provide references and evidence for future audits or reuse.
+---
+
+## Summary
+- **Feature**: `<feature-name>`
+- **Discovery Scope**: New Feature / Extension / Simple Addition / Complex Integration
+- **Key Findings**:
+  - Finding 1
+  - Finding 2
+  - Finding 3
+
+## Research Log
+Document notable investigation steps and their outcomes. Group entries by topic for readability.
+
+### [Topic or Question]
+- **Context**: What triggered this investigation?
+- **Sources Consulted**: Links, documentation, API references, benchmarks
+- **Findings**: Concise bullet points summarizing the insights
+- **Implications**: How this affects architecture, contracts, or implementation
+
+_Repeat the subsection for each major topic._
+
+## Architecture Pattern Evaluation
+List candidate patterns or approaches that were considered. Use the table format where helpful.
+
+| Option | Description | Strengths | Risks / Limitations | Notes |
+|--------|-------------|-----------|---------------------|-------|
+| Hexagonal | Ports & adapters abstraction around core domain | Clear boundaries, testable core | Requires adapter layer build-out | Aligns with existing steering principle X |
+
+## Design Decisions
+Record major decisions that influence `design.md`. Focus on choices with significant trade-offs.
+
+### Decision: `<Title>`
+- **Context**: Problem or requirement driving the decision
+- **Alternatives Considered**:
+  1. Option A — short description
+  2. Option B — short description
+- **Selected Approach**: What was chosen and how it works
+- **Rationale**: Why this approach fits the current project context
+- **Trade-offs**: Benefits vs. compromises
+- **Follow-up**: Items to verify during implementation or testing
+
+_Repeat the subsection for each decision._
+
+## Risks & Mitigations
+- Risk 1 — Proposed mitigation
+- Risk 2 — Proposed mitigation
+- Risk 3 — Proposed mitigation
+
+## References
+Provide canonical links and citations (official docs, standards, ADRs, internal guidelines).
+- [Title](https://example.com) — brief note on relevance
+- ...

--- a/.kiro/settings/templates/specs/tasks.md
+++ b/.kiro/settings/templates/specs/tasks.md
@@ -1,0 +1,24 @@
+# Implementation Plan
+
+## Task Format Template
+
+Use whichever pattern fits the work breakdown:
+
+### Major task only
+- [ ] {{NUMBER}}. {{TASK_DESCRIPTION}}{{PARALLEL_MARK}}
+  - {{DETAIL_ITEM_1}} *(Include details only when needed. If the task stands alone, omit bullet items.)*
+  - _Requirements: {{REQUIREMENT_IDS}}_
+
+### Major + Sub-task structure
+- [ ] {{MAJOR_NUMBER}}. {{MAJOR_TASK_SUMMARY}}
+- [ ] {{MAJOR_NUMBER}}.{{SUB_NUMBER}} {{SUB_TASK_DESCRIPTION}}{{SUB_PARALLEL_MARK}}
+  - {{DETAIL_ITEM_1}}
+  - {{DETAIL_ITEM_2}}
+  - {{OBSERVABLE_COMPLETION_ITEM}} *(At least one detail item should state the observable completion condition for this task.)*
+  - _Requirements: {{REQUIREMENT_IDS}}_ *(IDs only; do not add descriptions or parentheses.)*
+  - _Boundary: {{COMPONENT_NAMES}}_ *(Only for (P) tasks. Omit when scope is obvious.)*
+  - _Depends: {{TASK_IDS}}_ *(Only for non-obvious cross-boundary dependencies. Most tasks omit this.)*
+
+> **Parallel marker**: Append ` (P)` only to tasks that can be executed in parallel. Omit the marker when running in `--sequential` mode.
+>
+> **Optional test coverage**: When a sub-task is deferrable test work tied to acceptance criteria, mark the checkbox as `- [ ]*` and explain the referenced requirements in the detail bullets.

--- a/.kiro/settings/templates/steering-custom/api-standards.md
+++ b/.kiro/settings/templates/steering-custom/api-standards.md
@@ -1,0 +1,69 @@
+# API Standards
+
+[Purpose: consistent API patterns for naming, structure, auth, versioning, and errors]
+
+## Philosophy
+- Prefer predictable, resource-oriented design
+- Be explicit in contracts; minimize breaking changes
+- Secure by default (auth first, least privilege)
+
+## Endpoint Pattern
+```
+/{version}/{resource}[/{id}][/{sub-resource}]
+```
+Examples:
+- `/api/v1/users`
+- `/api/v1/users/:id`
+- `/api/v1/users/:id/posts`
+
+HTTP verbs:
+- GET (read, safe, idempotent)
+- POST (create)
+- PUT/PATCH (update)
+- DELETE (remove, idempotent)
+
+## Request/Response
+
+Request (typical):
+```json
+{ "data": { ... }, "metadata": { "requestId": "..." } }
+```
+
+Success:
+```json
+{ "data": { ... }, "meta": { "timestamp": "...", "version": "..." } }
+```
+
+Error:
+```json
+{ "error": { "code": "ERROR_CODE", "message": "...", "field": "optional" } }
+```
+(See error-handling for rules.)
+
+## Status Codes (pattern)
+- 2xx: Success (200 read, 201 create, 204 delete)
+- 4xx: Client issues (400 validation, 401/403 auth, 404 missing)
+- 5xx: Server issues (500 generic, 503 unavailable)
+Choose the status that best reflects the outcome.
+
+## Authentication
+- Credentials in standard location
+```
+Authorization: Bearer {token}
+```
+- Reject unauthenticated before business logic
+
+## Versioning
+- Version via URL/header/media-type
+- Breaking change → new version
+- Non-breaking → same version
+- Provide deprecation window and comms
+
+## Pagination/Filtering (if applicable)
+- Pagination: `page`, `pageSize` or cursor-based
+- Filtering: explicit query params
+- Sorting: `sort=field:asc|desc`
+Return pagination metadata in `meta`.
+
+---
+_Focus on patterns and decisions, not endpoint catalogs._

--- a/.kiro/settings/templates/steering-custom/authentication.md
+++ b/.kiro/settings/templates/steering-custom/authentication.md
@@ -1,0 +1,67 @@
+# Authentication & Authorization Standards
+
+[Purpose: unify auth model, token/session lifecycle, permission checks, and security]
+
+## Philosophy
+- Clear separation: authentication (who) vs authorization (what)
+- Secure by default: least privilege, fail closed, short-lived tokens
+- UX-aware: friction where risk is high, smooth otherwise
+
+## Authentication
+
+### Method (choose + rationale)
+- Options: JWT, Session, OAuth2, hybrid
+- Choice: [our method] because [reason]
+
+### Flow (high-level)
+```
+1) User proves identity (credentials or provider)
+2) Server verifies and issues token/session
+3) Client sends token per request
+4) Server verifies token and proceeds
+```
+
+### Token/Session Lifecycle
+- Storage: httpOnly cookie or Authorization header
+- Expiration: short-lived access, longer refresh (if used)
+- Refresh: rotate tokens; respect revocation
+- Revocation: blacklist/rotate on logout/compromise
+
+### Security Pattern
+- Enforce TLS; never expose tokens to JS when avoidable
+- Bind token to audience/issuer; include minimal claims
+- Consider device binding and IP/risk checks for sensitive actions
+
+## Authorization
+
+### Permission Model
+- Choose one: RBAC / ABAC / ownership-based / hybrid
+- Define roles/attributes centrally; avoid hardcoding across codebase
+
+### Checks (where to enforce)
+- Route/middleware: coarse-grained gate
+- Domain/service: fine-grained decisions
+- UI: conditional rendering (no security reliance)
+
+Example pattern:
+```typescript
+requirePermission('resource:action'); // route
+if (!user.can('resource:action')) throw ForbiddenError(); // domain
+```
+
+### Ownership
+- Pattern: owner OR privileged role can act
+- Verify on entity boundary before mutation
+
+## Passwords & MFA
+- Passwords: strong policy, hashed (bcrypt/argon2), never plaintext
+- Reset: time-limited token, single-use, notify user
+- MFA: step-up for risky operations (policy-driven)
+
+## API-to-API Auth
+- Use API keys or OAuth client credentials
+- Scope keys minimally; rotate and audit usage
+- Rate limit by identity (user/key)
+
+---
+_Focus on patterns and decisions. No library-specific code._

--- a/.kiro/settings/templates/steering-custom/database.md
+++ b/.kiro/settings/templates/steering-custom/database.md
@@ -1,0 +1,46 @@
+# Database Standards
+
+[Purpose: guide schema design, queries, migrations, and integrity]
+
+## Philosophy
+- Model the domain first; optimize after correctness
+- Prefer explicit constraints; let database enforce invariants
+- Query only what you need; measure before optimizing
+
+## Naming & Types
+- Tables: `snake_case`, plural (`users`, `order_items`)
+- Columns: `snake_case` (`created_at`, `user_id`)
+- FKs: `{table}_id` referencing `{table}.id`
+- Types: timezone-aware timestamps; strong IDs; precise money types
+
+## Relationships
+- 1:N: FK in child
+- N:N: join table with compound key
+- 1:1: FK + UNIQUE
+
+## Migrations
+- Immutable migrations; always add rollback
+- Small, focused steps; test on non-prod first
+- Naming: `{seq}_{action}_{object}` (e.g., `002_add_email_index`)
+
+## Query Patterns
+- ORM for simple CRUD and safety; raw SQL for complex/perf-critical
+- Avoid N+1 (eager load/batching); paginate large sets
+- Index FKs and frequently filtered/sorted columns
+
+## Connection & Transactions
+- Use pooling (size/timeouts based on workload)
+- One connection per unit of work; close/return promptly
+- Wrap multi-step changes in transactions
+
+## Data Integrity
+- Use NOT NULL/UNIQUE/CHECK/FK constraints
+- Validate at DB when appropriate (defense in depth)
+- Prefer generated columns for consistent derivations
+
+## Backup & Recovery
+- Regular backups with retention; test restores
+- Document RPO/RTO targets; monitor backup jobs
+
+---
+_Focus on patterns and decisions. No environment-specific settings._

--- a/.kiro/settings/templates/steering-custom/deployment.md
+++ b/.kiro/settings/templates/steering-custom/deployment.md
@@ -1,0 +1,54 @@
+# Deployment Standards
+
+[Purpose: safe, repeatable releases with clear environment and pipeline patterns]
+
+## Philosophy
+- Automate; test before deploy; verify after deploy
+- Prefer incremental rollout with fast rollback
+- Production changes must be observable and reversible
+
+## Environments
+- Dev: fast iteration; debugging enabled
+- Staging: mirrors prod; release validation
+- Prod: hardened; monitored; least privilege
+
+## CI/CD Flow
+```
+Code → Test → Build → Scan → Deploy (staged) → Verify
+```
+Principles:
+- Fail fast on tests/scans; block deploy
+- Artifact builds are reproducible (lockfiles, pinned versions)
+- Manual approval for prod; auditable trail
+
+## Deployment Strategies
+- Rolling: gradual instance replacement
+- Blue-Green: switch traffic between two pools
+- Canary: small % users first, expand on health
+Choose per risk profile; document default.
+
+## Zero-Downtime & Migrations
+- Health checks gate traffic; graceful shutdown
+- Backwards-compatible DB changes during rollout
+- Separate migration step; test rollback paths
+
+## Rollback
+- Keep previous version ready; automate revert
+- Rollback faster than fix-forward; document triggers
+
+## Configuration & Secrets
+- 12-factor config via env; never commit secrets
+- Secret manager; rotate; least privilege; audit access
+- Validate required env vars at startup
+
+## Health & Monitoring
+- Endpoints: `/health`, `/health/live`, `/health/ready`
+- Monitor latency, error rate, throughput, saturation
+- Alerts on SLO breaches/spikes; tune to avoid fatigue
+
+## Incident Response & DR
+- Standard playbook: detect → assess → mitigate → communicate → resolve → post-mortem
+- Backups with retention; test restore; defined RPO/RTO
+
+---
+_Focus on rollout patterns and safeguards. No provider-specific steps._

--- a/.kiro/settings/templates/steering-custom/error-handling.md
+++ b/.kiro/settings/templates/steering-custom/error-handling.md
@@ -1,0 +1,59 @@
+# Error Handling Standards
+
+[Purpose: unify how errors are classified, shaped, propagated, logged, and monitored]
+
+## Philosophy
+- Fail fast where possible; degrade gracefully at system boundaries
+- Consistent error shape across the stack (human + machine readable)
+- Handle known errors close to source; surface unknowns to a global handler
+
+## Classification (decide handling by source)
+- Client: Input/validation/user action issues → 4xx
+- Server: System failures/unexpected exceptions → 5xx
+- Business: Rule/state violations → 4xx (e.g., 409)
+- External: 3rd-party/network failures → map to 5xx or 4xx with context
+
+## Error Shape (single canonical format)
+```json
+{
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable message",
+    "requestId": "trace-id",
+    "timestamp": "ISO-8601"
+  }
+}
+```
+Principles: stable code enums, no secrets, include trace info.
+
+## Propagation (where to convert)
+- API layer: Convert domain errors → HTTP status + canonical body
+- Service layer: Throw typed business errors, avoid stringly-typed errors
+- Data/external layer: Wrap provider errors with safe, actionable codes
+- Unknown errors: Bubble to global handler → 500 + generic message
+
+Example pattern:
+```typescript
+try { return await useCase(); }
+catch (e) {
+  if (e instanceof BusinessError) return respondMapped(e);
+  logError(e); return respondInternal();
+}
+```
+
+## Logging (context over noise)
+Log: operation, userId (if available), code, message, stack, requestId, minimal context.
+Do not log: passwords, tokens, secrets, full PII, full bodies with sensitive data.
+Levels: ERROR (failures), WARN (recoverable/edge), INFO (key events), DEBUG (diagnostics).
+
+## Retry (only when safe)
+Retry when: network/timeouts/transient 5xx AND operation is idempotent.
+Do not retry: 4xx, business errors, non-idempotent flows.
+Strategy: exponential backoff + jitter, capped attempts; require idempotency keys.
+
+## Monitoring & Health
+Track: error rates by code/category, latency, saturation; alert on spikes/SLI breaches.
+Expose health: `/health` (live), `/health/ready` (ready). Link errors to traces.
+
+---
+_Focus on patterns and decisions. No implementation details or exhaustive lists._

--- a/.kiro/settings/templates/steering-custom/security.md
+++ b/.kiro/settings/templates/steering-custom/security.md
@@ -1,0 +1,55 @@
+# Security Standards
+
+[Purpose: define security posture with patterns for validation, authz, secrets, and data]
+
+## Philosophy
+- Defense in depth; least privilege; secure by default; fail closed
+- Validate at boundaries; sanitize for context; never trust input
+- Separate authentication (who) and authorization (what)
+
+## Input & Output
+- Validate at API boundaries and UI forms; enforce types and constraints
+- Sanitize/escape based on destination (HTML, SQL, shell, logs)
+- Prefer allow-lists over block-lists; reject early with minimal detail
+
+## Authentication & Authorization
+- Authentication: verify identity; issue short-lived tokens/sessions
+- Authorization: check permissions before actions; deny by default
+- Centralize policies; avoid duplicating checks across code
+
+Pattern:
+```typescript
+if (!user.hasPermission('resource:action')) throw ForbiddenError();
+```
+
+## Secrets & Configuration
+- Never commit secrets; store in secret manager or env
+- Rotate regularly; audit access; scope minimal
+- Validate required env vars at startup; fail fast on missing
+
+## Sensitive Data
+- Minimize collection; mask/redact in logs; encrypt at rest and in transit
+- Restrict access by role/need-to-know; track access to sensitive records
+
+## Session/Token Security
+- httpOnly + secure cookies where possible; TLS everywhere
+- Short expiration; rotate on refresh; revoke on logout/compromise
+- Bind tokens to audience/issuer; include minimal claims
+
+## Logging (security-aware)
+- Log auth attempts, permission denials, and sensitive operations
+- Never log passwords, tokens, secrets, full PII; avoid full bodies
+- Include requestId and context to correlate events
+
+## Headers & Transport
+- Enforce TLS; HSTS
+- Set security headers (CSP, X-Frame-Options, X-Content-Type-Options)
+- Prefer modern crypto; disable weak protocols/ciphers
+
+## Vulnerability Posture
+- Prefer secure libraries; keep dependencies updated
+- Static/dynamic scans in CI; track and remediate
+- Educate team on common classes; encode as patterns above
+
+---
+_Focus on patterns and principles. Link concrete configs to ops docs._

--- a/.kiro/settings/templates/steering-custom/testing.md
+++ b/.kiro/settings/templates/steering-custom/testing.md
@@ -1,0 +1,47 @@
+# Testing Standards
+
+[Purpose: guide what to test, where tests live, and how to structure them]
+
+## Philosophy
+- Test behavior, not implementation
+- Prefer fast, reliable tests; minimize brittle mocks
+- Cover critical paths deeply; breadth over 100% pursuit
+
+## Organization
+Options:
+- Co-located: `component.tsx` + `component.test.tsx`
+- Separate: `/src/...` and `/tests/...`
+Pick one as default; allow exceptions with rationale.
+
+Naming:
+- Files: `*.test.*` or `*.spec.*`
+- Suites: what is under test; Cases: expected behavior
+
+## Test Types
+- Unit: single unit, mocked dependencies, very fast
+- Integration: multiple units together, mock externals only
+- E2E: full flows, minimal mocks, only for critical journeys
+
+## Structure (AAA)
+```typescript
+it('does X when Y', () => {
+  // Arrange
+  const input = setup();
+  // Act
+  const result = act(input);
+  // Assert
+  expect(result).toEqual(expected);
+});
+```
+
+## Mocking & Data
+- Mock externals (API/DB); never mock the system under test
+- Use factories/fixtures; reset state between tests
+- Keep test data minimal and intention-revealing
+
+## Coverage
+- Target: [% overall]; higher for critical domains
+- Enforce thresholds in CI; exceptions require review rationale
+
+---
+_Focus on patterns and decisions. Tool-specific config lives elsewhere._

--- a/.kiro/settings/templates/steering/product.md
+++ b/.kiro/settings/templates/steering/product.md
@@ -1,0 +1,18 @@
+# Product Overview
+
+[Brief description of what this product does and who it serves]
+
+## Core Capabilities
+
+[3-5 key capabilities, not exhaustive features]
+
+## Target Use Cases
+
+[Primary scenarios this product addresses]
+
+## Value Proposition
+
+[What makes this product unique or valuable]
+
+---
+_Focus on patterns and purpose, not exhaustive feature lists_

--- a/.kiro/settings/templates/steering/structure.md
+++ b/.kiro/settings/templates/steering/structure.md
@@ -1,0 +1,41 @@
+# Project Structure
+
+## Organization Philosophy
+
+[Describe approach: feature-first, layered, domain-driven, etc.]
+
+## Directory Patterns
+
+### [Pattern Name]
+**Location**: `/path/`  
+**Purpose**: [What belongs here]  
+**Example**: [Brief example]
+
+### [Pattern Name]
+**Location**: `/path/`  
+**Purpose**: [What belongs here]  
+**Example**: [Brief example]
+
+## Naming Conventions
+
+- **Files**: [Pattern, e.g., PascalCase, kebab-case]
+- **Components**: [Pattern]
+- **Functions**: [Pattern]
+
+## Import Organization
+
+```typescript
+// Example import patterns
+import { Something } from '@/path'  // Absolute
+import { Local } from './local'     // Relative
+```
+
+**Path Aliases**:
+- `@/`: [Maps to]
+
+## Code Organization Principles
+
+[Key architectural patterns and dependency rules]
+
+---
+_Document patterns, not file trees. New files following patterns shouldn't require updates_

--- a/.kiro/settings/templates/steering/tech.md
+++ b/.kiro/settings/templates/steering/tech.md
@@ -1,0 +1,45 @@
+# Technology Stack
+
+## Architecture
+
+[High-level system design approach]
+
+## Core Technologies
+
+- **Language**: [e.g., TypeScript, Python]
+- **Framework**: [e.g., React, Next.js, Django]
+- **Runtime**: [e.g., Node.js 20+]
+
+## Key Libraries
+
+[Only major libraries that influence development patterns]
+
+## Development Standards
+
+### Type Safety
+[e.g., TypeScript strict mode, no `any`]
+
+### Code Quality
+[e.g., ESLint, Prettier rules]
+
+### Testing
+[e.g., Jest, coverage requirements]
+
+## Development Environment
+
+### Required Tools
+[Key tools and version requirements]
+
+### Common Commands
+```bash
+# Dev: [command]
+# Build: [command]
+# Test: [command]
+```
+
+## Key Technical Decisions
+
+[Important architectural choices and rationale]
+
+---
+_Document standards and patterns, not every dependency_

--- a/.kiro/specs/lib-build-pipeline/brief.md
+++ b/.kiro/specs/lib-build-pipeline/brief.md
@@ -1,0 +1,132 @@
+# Brief: lib-build-pipeline
+
+Tracks GitHub issue #30. Milestone: v1.0. Size: L.
+
+## Problem
+
+`kind = "lib"` is reserved at the schema level (ADR 0023, PR #172) but rejected at
+parse time with "not yet implemented". Users cannot express library projects today,
+which blocks:
+
+- `kolt publish` (#21) — a library is the thing publishing makes sense for.
+- ADR 0018 self-host endgame — the long-term plan is for `kolt-compiler-daemon/`
+  to be a kolt-built library, not a Gradle subproject.
+
+## Current State
+
+- **Parser**: `validateKind` in `src/nativeMain/kotlin/kolt/config/Config.kt:128-140`
+  explicitly errors on `kind = "lib"` with "reserved but not yet implemented (ADR
+  0023)".
+- **`[build] main`**: declared non-nullable in `RawBuildSection.main`
+  (`Config.kt:106`), so ktoml deserialization fails if it is missing. FQN format is
+  further checked by `validateMainFqn` (`Config.kt:186`).
+- **Build pipeline (Native)**: `Builder.kt:68-124` always runs both stages —
+  `nativeLibraryCommand` (stage 1, `.klib`) followed by `nativeLinkCommand` (stage 2,
+  `.kexe`). There is no path that stops after stage 1.
+- **Build pipeline (JVM)**: `jarCommand` (`Builder.kt:221-227`) already produces a
+  thin jar via plain `jar cf`. There is no Main-Class manifest today, but the jar
+  contents are produced on the assumption that `main` exists.
+- **`kolt run`**: `doRun` (`BuildCommands.kt:406-435`) assumes an executable exists
+  (resolves `outputKexePath` for native, derives `jvmMainClass` for JVM). No
+  kind-aware gate.
+- **Tests**: `ConfigTest.kt:311-336` pins the current "not yet implemented" rejection
+  — this test must be replaced, not just deleted.
+
+## Desired Outcome
+
+A kolt.toml with `kind = "lib"` parses, builds, and produces a library artifact
+on both JVM and Native targets. Running a library fails fast with a clear error.
+
+- Parser accepts `kind = "lib"`.
+- `[build] main` is required iff `kind = "app"`, and forbidden when `kind = "lib"`
+  with the ADR 0023 §1 error: `main has no meaning for a library; remove it`.
+- `kolt build` for `kind = "lib"`:
+  - **JVM**: thin `.jar` (no `-include-runtime`, no Main-Class attribute).
+  - **Native**: stops after stage 1 (`.klib`), no `.kexe` link.
+- `kolt run` against `kind = "lib"` errors with `library projects cannot be run`.
+
+## Approach
+
+Minimal, surgical edits along the existing responsibility seams. No new modules.
+
+1. **Parser** (`kolt.config`):
+   - Change `RawBuildSection.main` to nullable.
+   - Replace `validateKind`'s lib-rejection with acceptance.
+   - Add conditional validation: `main` required for app, forbidden for lib, with
+     the exact ADR 0023 §1 error text.
+   - Carry `kind` through to the parsed `Config` (already present per ADR 0023).
+2. **Build pipeline** (`kolt.build.Builder`):
+   - Branch on `config.kind` before invoking stage 2 on native (`nativeLinkCommand`
+     is skipped for lib).
+   - For JVM, the current thin-jar output already matches lib semantics; assert
+     no Main-Class for lib and leave app-side path undisturbed.
+3. **CLI guard** (`kolt.cli.BuildCommands.doRun`):
+   - Check `config.kind == "lib"` at the top of `doRun`, return the rejection
+     error before any path resolution.
+4. **Tests**:
+   - Replace `kindLibIsRejectedAsNotYetImplemented` with `kindLibIsAccepted` plus
+     coverage for the conditional-`main` matrix (app+main OK / app+no-main err /
+     lib+no-main OK / lib+main err).
+   - Add build-pipeline tests: native lib stops after `.klib`; JVM lib produces
+     thin jar without Main-Class; `kolt run` on lib errors.
+
+## Scope
+
+- **In**:
+  - Parser: `kind = "lib"` accept + `main` conditional validation.
+  - JVM build: thin-jar path for lib (no Main-Class, no `-include-runtime`).
+  - Native build: klib-only path for lib (skip stage 2 link).
+  - CLI: `kolt run` rejection for lib.
+
+- **Out (tracked as separate issues)**:
+  - `kolt publish` (#21) — consumes this spec's output.
+  - `fat_jar = false` for `kind = "app"` — orthogonal thin-app variant.
+  - `kolt new --lib` scaffolding (#28).
+
+## Boundary Candidates
+
+- **Config parser** (`kolt.config`): kind + conditional main validation.
+- **Build pipeline** (`kolt.build.Builder`): kind-aware stage 2 / manifest skip.
+- **CLI guard** (`kolt.cli`): run-on-lib rejection.
+
+These three seams are already separated in the codebase (see structure.md) and can
+be implemented and reviewed as independent tasks within the same spec.
+
+## Out of Boundary
+
+- Publishing mechanics, POM/metadata generation, Maven coordinate derivation — all
+  belong to `kolt publish` (#21).
+- Making `fat_jar` configurable for apps — separate axis from kind.
+- Scaffolding (`kolt new --lib`) — separate UX concern.
+- Changing the existing native two-stage flow itself — ADR 0014 is load-bearing and
+  out of scope; this spec only chooses when to stop.
+
+## Upstream / Downstream
+
+- **Upstream**:
+  - ADR 0023 §1 (target/kind schema, merged via #167/#172).
+  - ADR 0014 (native two-stage library+link) — the `.klib` stage already exists.
+  - ADR 0018 (distribution / self-host path) — motivates the work but is not a
+    prerequisite.
+- **Downstream**:
+  - #21 `kolt publish` — needs lib artifacts to publish.
+  - ADR 0018 follow-through: migrating `kolt-compiler-daemon/` to a kolt-built lib.
+  - #28 `kolt new --lib` — depends on a working lib path.
+
+## Existing Spec Touchpoints
+
+- **Extends**: none (no prior specs exist; this is the first).
+- **Adjacent**: none currently. Future `kolt-publish` spec will sit immediately
+  downstream and must not redefine the lib artifact contract set here.
+
+## Constraints
+
+- **No pre-v1 migration shims**: v0.13.0 is pre-v1, breaking `kolt.toml` shape
+  changes are permitted (`main` becoming optional is not a break — existing app
+  configs keep working).
+- **ADR 0023 §1 error text is canonical**: the "`main` has no meaning for a
+  library; remove it" phrasing is specified by the ADR; don't paraphrase.
+- **Native toolchain**: klib-only requires no new konanc flags — stage 1
+  (`-p library -nopack`) already produces the artifact. Verify with a real
+  `./gradlew check` after implementation.
+- **Kotlin version**: 2.3.x (per steering/tech.md); no version bump needed.

--- a/.kiro/specs/lib-build-pipeline/design.md
+++ b/.kiro/specs/lib-build-pipeline/design.md
@@ -1,0 +1,645 @@
+# Technical Design: lib-build-pipeline
+
+## Overview
+
+**Purpose**: Deliver end-to-end support for library projects (`kind = "lib"`)
+across kolt's config parser, build pipeline, and run command. Unblock
+`kolt publish` (#21) and the ADR 0018 self-host endgame where
+`kolt-compiler-daemon/` becomes a kolt-built library rather than a Gradle
+subproject.
+
+**Users**: kolt project authors who want to publish or share a Kotlin
+library without an application entry point, and the kolt project itself as
+it dogfoods toward self-host.
+
+**Impact**: The `kolt.toml` schema becomes shape-variant by `kind` —
+`[build] main` transitions from universally required to conditional
+(required for `kind = "app"`, forbidden for `kind = "lib"`). The native
+build pipeline gains a single gate that stops after ADR 0014 stage 1 for
+libraries. `kolt run` gains a pre-flight kind check. JVM library builds
+produce the same thin jar shape that `kolt` already produces for apps.
+
+### Goals
+- Parser accepts `kind = "lib"` with correctly enforced conditional-`main`.
+- Native library build stops at `.klib` and never produces `.kexe`.
+- JVM library build produces a thin jar with no Main-Class manifest.
+- `kolt run` against libraries fails fast with ADR-aligned error text.
+- `kolt test` for libraries continues to work without requiring `[build] main`.
+
+### Non-Goals
+- `kolt publish` and Maven metadata generation (covered by #21).
+- `fat_jar = false` for `kind = "app"` (separate axis).
+- `kolt new --lib` scaffolding (covered by #28).
+- New `kind` values beyond `"app"` and `"lib"`.
+- Cross-target kind compatibility matrices (all existing targets accept
+  both kinds without additional guards).
+
+## Boundary Commitments
+
+### This Spec Owns
+- The runtime semantics of `KoltConfig.kind`: how parser, builder, and CLI
+  interpret `"app"` vs `"lib"`.
+- The conditional shape of `[build] main`: required-for-app,
+  forbidden-for-lib, with the ADR 0023 §1 canonical rejection text.
+- The observable `kolt build` output kind for a `kind = "lib"` project
+  (`.klib` on native, thin `.jar` on JVM; never `.kexe`).
+- The `kolt run` rejection contract for libraries (message + early-exit).
+- Non-regression assertions that `kolt test`, `kolt check`, `kolt fmt`,
+  `kolt deps`, and LSP workspace generation continue to work for libraries.
+
+### Out of Boundary
+- How library artifacts are published externally (`kolt publish`, #21).
+- Any POM, Gradle module metadata, or Maven-Central coordinate derivation.
+- Scaffolding commands: `kolt init` stays app-default, `kolt new --lib`
+  is tracked by #28.
+- Third-party consumption of kolt-built libraries (downstream of publish).
+- Internal changes to ADR 0014's stage 1 or stage 2 command construction
+  (`nativeLibraryCommand`, `nativeLinkCommand` are not modified).
+- Changes to ADR 0013's test flow; this spec relies on its existing
+  decoupling from `config.build.main`.
+
+### Allowed Dependencies
+- `kolt.config` reads and validates `kolt.toml`; no dependency on build/cli.
+- `kolt.build` reads parsed `KoltConfig`; depends only on `kolt.resolve`
+  and `kolt.infra`.
+- `kolt.cli` orchestrates; depends on `kolt.config` and `kolt.build`.
+- Dependency direction `cli → build → config/resolve/infra` is preserved;
+  no new cross-package edges.
+- No new external dependencies. No version bumps.
+
+### Revalidation Triggers
+- Any change to the canonical error strings (`LIB_WITH_MAIN_ERROR`,
+  `APP_WITHOUT_MAIN_ERROR`, the run-reject message) — test suites match
+  on substring.
+- Any change that would make `[build] main` optional for `kind = "app"`
+  breaks R1.
+- Any new `kind` value — parser contract would need re-settlement.
+- Any change to ADR 0014 that merges stages 1 and 2 — invalidates the
+  "stop at stage 1" gate.
+- Any change making `kolt test` depend on `config.build.main` — breaks R5.
+- Any change to the `BuildResult` data class shape — current design
+  relies on it staying unchanged.
+
+## Architecture
+
+### Existing Architecture Analysis
+
+Kolt follows the `cli → build → config/resolve/infra` dependency
+direction (see `steering/structure.md`). The three responsibility seams
+for this spec are already separated:
+
+- **Config layer** (`kolt.config.Config`): `validateKind` and
+  `validateMainFqn` are the existing validation entry points;
+  `RawBuildSection` is the ktoml-deserialized shape; `KoltConfig` is the
+  post-validation domain model.
+- **Build layer** (`kolt.build.Builder`): `nativeLibraryCommand` (ADR 0014
+  stage 1) and `nativeLinkCommand` (stage 2) are paired; `doNativeBuild`
+  in `kolt.cli.BuildCommands` orchestrates them.
+- **CLI layer** (`kolt.cli.BuildCommands`): thin entry points (`doBuild`,
+  `doRun`, `doTest`, `doCheck`) parse `KoltConfig` via `loadProjectConfig`
+  and delegate.
+
+ADR 0014, ADR 0013, ADR 0023 §1 remain in force. The decoupling of
+`kolt test`, `kolt check`, `kolt fmt`, `kolt deps`, and LSP workspace
+generation from `config.build.main` is an existing property confirmed in
+gap analysis — no work is needed in those paths.
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph LR
+    TOML[kolt.toml]
+    Parser[kolt.config.Config<br/>validateKind plus conditional main]
+    Config[KoltConfig<br/>kind plus build.main nullable]
+    BuildCmd[kolt.cli.BuildCommands<br/>doNativeBuild kind gate]
+    JvmCompile[JVM kotlinc plus jar cf<br/>already thin]
+    NativeLib[nativeLibraryCommand<br/>stage 1]
+    NativeLink[nativeLinkCommand<br/>stage 2]
+    RunCmd[kolt.cli.BuildCommands.doRun<br/>isLibrary guard]
+    TestCmd[kolt.cli.BuildCommands.doTest<br/>unchanged]
+
+    TOML --> Parser --> Config
+    Config --> BuildCmd
+    BuildCmd --> JvmCompile
+    BuildCmd --> NativeLib
+    NativeLib -. app only .-> NativeLink
+    Config --> RunCmd
+    Config --> TestCmd
+```
+
+**Architecture Integration**:
+- Pattern: existing layered architecture; no new layers.
+- Domain boundaries: `kind` is a read-only discriminator threaded from
+  parser into three downstream consumers; no shared ownership.
+- Preserved patterns: ADR 0014 two-stage native, ADR 0013 test flow,
+  sealed-ADT error modeling, `Result<V, E>` on fallible paths, `jar cf`
+  thin-jar construction, explicit no-wildcard imports.
+- New components: none. All changes are conditional edits inside existing
+  functions, plus one extension helper.
+- Steering compliance: `cli → build → config` direction preserved;
+  ADR-citation comments accompany new conditionals; error messages reuse
+  the existing `ConfigError.ParseFailed` variant rather than fragmenting
+  the sealed hierarchy.
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| CLI | kotlin-native 2.3.x, existing `kolt.kexe` | Hosts `kolt build`, `kolt run`, `kolt test`; gains `isLibrary` guard in `doRun` and `watchRunLoop` | No new CLI flags |
+| Config parser | ktoml-core 0.7.1 (existing) | Parses `kolt.toml`; `BuildSection.main` and `RawBuildSection.main` change from `String` to `String?` | ktoml supports nullable strings natively |
+| Build pipeline | kotlinc / konanc (existing) | Native stage 2 is gated off for lib; JVM jar step unchanged | No new flags; stage 2 call site becomes conditional |
+| Error handling | kotlin-result 2.3.x (existing) | Canonical error strings emitted via `ConfigError.ParseFailed` and via `eprintln` + `Err(EXIT_CONFIG_ERROR)` | Errors-as-values per ADR 0001; no new exit codes |
+
+## File Structure Plan
+
+### Modified Files
+- `src/nativeMain/kotlin/kolt/config/Config.kt`
+  - `RawBuildSection.main: String` → `String?` (line 106).
+  - `BuildSection.main: String` → `String?` (line 62).
+  - `validateKind` (line 128): remove the `"lib"` rejection branch; keep
+    the unknown-kind rejection.
+  - `parseConfig`: after kind validation, apply the conditional-`main`
+    rule — `kind == "lib" && raw.build.main != null` rejects;
+    `kind == "app" && raw.build.main == null` rejects; `validateMainFqn`
+    runs only when `main != null`.
+  - New extension: `fun KoltConfig.isLibrary(): Boolean = kind == "lib"`
+    (file-local, non-public API).
+  - New top-level `private const val` canonical error strings (two):
+    `LIB_WITH_MAIN_ERROR` and `APP_WITHOUT_MAIN_ERROR`. Both carry ADR
+    0023 §1 citation in a one-line comment above.
+
+- `src/nativeMain/kotlin/kolt/cli/BuildCommands.kt`
+  - `doNativeBuild` (line 228): between the successful `nativeLibraryCommand`
+    call and the `nativeLinkCommand` call, branch on `config.isLibrary()` —
+    skip the link step and return `Ok(BuildResult(...))` directly.
+  - `doRun`: prepend `if (config.isLibrary()) { eprintln(...); return
+    Err(EXIT_CONFIG_ERROR) }` as the first statement after
+    `loadProjectConfig()`, before any artifact resolution or `doBuild`
+    invocation.
+  - Build-success message for a library should identify the artifact as a
+    library (e.g., "built library build/<name>.klib" vs the existing
+    "built executable build/<name>.kexe"), purely a stdout affordance.
+
+- `src/nativeMain/kotlin/kolt/cli/WatchLoop.kt`
+  - `watchRunLoop` entry: prepend the same `isLibrary` guard so the
+    rejection fires once and the loop exits cleanly instead of emitting
+    the error on every source-change tick.
+
+### Minimal signature change
+- `src/nativeMain/kotlin/kolt/build/Builder.kt` — `nativeLinkCommand`
+  takes an explicit `main: String` parameter in place of reading
+  `config.build.main` internally. `nativeLibraryCommand` is untouched.
+  This is the only behavior-preserving refactor required to keep ADR
+  0001 compliance after `BuildSection.main` becomes nullable.
+
+### Affected but Not Modified
+- `src/nativeMain/kotlin/kolt/build/Workspace.kt` (LSP), `Formatter.kt`
+  (`kolt fmt`), `kolt/cli/DependencyCommands.kt` (`kolt deps`) — all
+  already kind-agnostic (gap-analysis verified).
+- `src/nativeMain/kotlin/kolt/config/Init.kt` — `kolt init` keeps
+  emitting `kind = "app"` (default) with `main = "main"`; lib scaffolding
+  is #28.
+- ADR 0014 / ADR 0013 machinery — untouched.
+
+### New Test Files
+- `src/nativeTest/kotlin/kolt/config/ConfigKindTest.kt` — kind acceptance
+  plus the `main`-conditional matrix (five cases).
+- `src/nativeTest/kotlin/kolt/cli/BuildLibraryTest.kt` — integration
+  coverage: native lib build stops at `.klib`; JVM lib jar has no
+  `Main-Class`; `-include-runtime` never appears in kotlinc JVM args.
+- `src/nativeTest/kotlin/kolt/cli/RunLibraryRejectionTest.kt` — `doRun`
+  against lib fixture returns `EXIT_CONFIG_ERROR` with canonical message;
+  no artifact resolution attempted.
+- `src/nativeTest/kotlin/kolt/cli/TestLibraryNonRegressionTest.kt` —
+  `doTest` against lib fixture exits 0 and does not read
+  `config.build.main`.
+
+### Removed / Replaced
+- `ConfigTest.kindLibIsRejectedAsNotYetImplemented` (current
+  `ConfigTest.kt:311-336`) — removed; its behavior is being inverted.
+
+## System Flows
+
+### `kolt build` kind branching
+
+```mermaid
+flowchart TD
+    Start[kolt build]
+    Parse[loadProjectConfig]
+    NativeTarget{target is native?}
+    JvmPath[JVM compile plus jar cf]
+    Stage1[konanc stage 1 klib]
+    LibCheck{isLibrary?}
+    Stage2[konanc stage 2 kexe]
+    Done[Build succeeds]
+
+    Start --> Parse --> NativeTarget
+    NativeTarget -->|JVM| JvmPath --> Done
+    NativeTarget -->|native| Stage1 --> LibCheck
+    LibCheck -->|lib| Done
+    LibCheck -->|app| Stage2 --> Done
+```
+
+**Key decisions**:
+- JVM path is shared across kinds — the existing `jar cf` output is
+  already thin and emits no Main-Class; no branching at the jar step.
+- Native kind gate lives between stage 1 and stage 2 in `doNativeBuild`,
+  not inside `nativeLinkCommand`. Keeping the gate at the caller
+  preserves ADR 0014's stage helpers as pure commands.
+- A failed stage 1 surfaces identically for app and lib.
+
+### `kolt run` lib rejection
+
+```mermaid
+sequenceDiagram
+    User->>CLI: kolt run
+    CLI->>Config: loadProjectConfig
+    alt config.isLibrary
+        CLI-->>User: stderr library projects cannot be run; exit EXIT_CONFIG_ERROR
+    else config kind is app
+        CLI->>Builder: doBuild
+        Builder-->>CLI: Ok
+        CLI->>Runtime: exec artifact
+        Runtime-->>User: program output
+    end
+```
+
+**Key decisions**:
+- Rejection happens before `doBuild` and before any artifact path
+  resolution; watch-run applies the same guard at loop entry.
+- Exit code reuses `EXIT_CONFIG_ERROR` — semantically a misuse of a
+  valid config, matching the existing error category.
+
+## Requirements Traceability
+
+| Requirement | Summary | Component | Contract / Flow |
+|-------------|---------|-----------|-----------------|
+| 1.1 | lib without `main` parses | Config parser | `parseConfig` conditional rule |
+| 1.2 | lib with `main` rejects, message includes canonical text | Config parser | `ConfigError.ParseFailed(LIB_WITH_MAIN_ERROR)` |
+| 1.3 | app without `main` rejects with canonical text | Config parser | `ConfigError.ParseFailed(APP_WITHOUT_MAIN_ERROR)` |
+| 1.4 | app with `main` parses | Config parser | Existing happy path preserved |
+| 1.5 | Missing `kind` defaults to `"app"` | Config parser | Existing default logic preserved |
+| 2.1 | JVM lib produces `.jar` | JVM jar step (existing) | `jarCommand` unchanged |
+| 2.2 | JVM lib jar excludes runtime + deps | JVM compile + jar step | Invariant: no `-include-runtime` anywhere |
+| 2.3 | JVM lib jar has no `Main-Class` | JVM jar step | `jar cf` without manifest attribute |
+| 2.4 | JVM app jar unchanged | JVM jar step | Existing path, existing tests |
+| 3.1 | Native lib produces `.klib` | `doNativeBuild` + stage 1 | ADR 0014 stage 1 call retained |
+| 3.2 | Native lib emits no `.kexe` | `doNativeBuild` kind gate | New conditional |
+| 3.3 | Native lib skips link step | `doNativeBuild` kind gate | New conditional |
+| 3.4 | Native app unchanged | `doNativeBuild` | Existing stages 1+2 path |
+| 4.1 | `kolt run` on lib errs with canonical message | `doRun` guard | `eprintln(RUN_LIB_ERROR)` + `EXIT_CONFIG_ERROR` |
+| 4.2 | Rejection before artifact resolution | `doRun` guard | Guard position (first statement) |
+| 4.3 | Rejection target-agnostic | `doRun` guard | Single check regardless of target |
+| 4.4 | `kolt run` on app unchanged | `doRun` | Existing flow retained |
+| 5.1 | Tests compile and run for lib | `doTest` / `doNativeTest` | Existing flow, non-regression |
+| 5.2 | Test flow does not require `main` | Existing test path | Non-regression assertion |
+| 5.3 | Tests for app unchanged | `doTest` | Existing flow retained |
+
+## Components and Interfaces
+
+| Component | Layer | Intent | Req Coverage | Key Dependencies | Contracts |
+|-----------|-------|--------|--------------|------------------|-----------|
+| Config parser kind+main rule | config | Accept lib; make `main` conditional | 1.1, 1.2, 1.3, 1.4, 1.5 | ktoml (P0), KoltConfig consumers (P0) | State |
+| Native build kind gate | build/cli | Skip stage 2 for lib | 3.1, 3.2, 3.3, 3.4 | `nativeLibraryCommand`/`nativeLinkCommand` (P0) | Service |
+| JVM thin-jar invariants | build | Lock thin-jar + no-`Main-Class` for lib | 2.1, 2.2, 2.3, 2.4 | `jar cf` (P0), kotlinc JVM (P0) | State (invariant) |
+| Run command kind guard | cli | Reject lib-run before build | 4.1, 4.2, 4.3, 4.4 | KoltConfig (P0) | Service |
+| Test non-regression | cli/tests | Prove tests work for lib without `main` | 5.1, 5.2, 5.3 | Existing `doTest` (P0) | State (invariant) |
+
+### Config layer
+
+#### Config parser kind+main rule
+
+**Responsibilities & Constraints**
+- Parse `kolt.toml` into `KoltConfig` where `kind ∈ {"app", "lib"}`
+  (default `"app"`) and `BuildSection.main: String?`.
+
+**Validation Order** (must be implemented in this sequence so error
+messages are deterministic for tests and users):
+
+1. `validateKind(raw.kind)` — reject unknown `kind` values (existing).
+2. Conditional `main` presence — pairwise rejection:
+   - `kind == "lib"` and `raw.build.main != null` → `Err(ConfigError.ParseFailed(LIB_WITH_MAIN_ERROR))`.
+   - `kind == "app"` and `raw.build.main == null` → `Err(ConfigError.ParseFailed(APP_WITHOUT_MAIN_ERROR))`.
+3. When `main != null`, run existing `validateMainFqn(main)`. (FQN
+   validation never runs for libraries, so a malformed FQN on a lib
+   config surfaces as the step-2 rejection rather than an FQN error.)
+4. `validateTarget(raw.build.target)` and the remaining existing
+   validations.
+5. Construct `KoltConfig` / `BuildSection` with `main: String?`.
+
+**Canonical Error Strings**
+- `LIB_WITH_MAIN_ERROR = "main has no meaning for a library; remove it"`
+  — cites ADR 0023 §1.
+- `APP_WITHOUT_MAIN_ERROR = "[build] main is required for kind = \"app\""`
+  — explicit rejection introduced by this spec, replacing ktoml's raw
+  `MissingRequiredPropertyException` surface. This is the substring
+  R1.3 tests will match.
+
+Both are `private const val` at the top of `Config.kt`, each with a
+one-line comment citing ADR 0023 §1.
+
+**Dependencies**
+- Inbound: `kolt.cli.BuildCommands.loadProjectConfig` (P0).
+- Outbound: ktoml-core (P0, existing), `kolt.config.validateMainFqn`
+  (P0, existing, invoked only when `main != null`).
+
+**Contracts**: State [x]
+
+##### Data contract
+
+```kotlin
+// kolt.config
+sealed class ConfigError {
+    data class ParseFailed(val message: String) : ConfigError()
+    // No new variant — lib+main reuses ParseFailed with canonical message.
+}
+
+data class BuildSection(
+    val target: String,
+    val jvmTarget: String = "17",
+    val jdk: String? = null,
+    val main: String?,        // was: String
+    val sources: List<String>,
+    // ... unchanged fields
+)
+
+data class KoltConfig(
+    val name: String,
+    val version: String,
+    val kind: String = "app",
+    val kotlin: KotlinSection,
+    val build: BuildSection,
+    // ... unchanged fields
+)
+
+internal fun KoltConfig.isLibrary(): Boolean = kind == "lib"
+
+fun parseConfig(source: String): Result<KoltConfig, ConfigError>
+```
+
+- Preconditions: `source` is syntactically valid TOML.
+- Postconditions: On `Ok(KoltConfig)`, the invariant
+  `kind == "lib" ⇒ build.main == null` holds, and
+  `kind == "app" ⇒ build.main != null` holds. `kind ∈ {"app", "lib"}`.
+- Invariants: Unknown kinds still rejected by `validateKind`; unknown
+  targets still rejected by `validateTarget` (both existing).
+
+**Implementation Notes**
+- Place canonical error string as `private const val LIB_WITH_MAIN_ERROR`
+  next to `validateKind` with a comment citing ADR 0023 §1.
+- Do not salvage — reject eagerly when the combination is invalid.
+- The `when (error) { is ConfigError.ParseFailed -> ... }` in
+  `loadProjectConfig` (`BuildCommands.kt:53-55`) stays exhaustive
+  without modification.
+
+### Build / CLI layer
+
+#### Native build kind gate
+
+**Responsibilities & Constraints**
+- `doNativeBuild` (`BuildCommands.kt:228`) runs `nativeLibraryCommand` for
+  every native build. Its success produces a `.klib` at the existing
+  output location.
+- After stage 1 succeeds, inspect `config.isLibrary()`. If true, return
+  `Ok(BuildResult(config, classpath = null, javaPath = null))` immediately
+  — mirroring the existing success shape.
+- If false, extract the entry-point FQN safely and invoke the link step:
+  ```kotlin
+  val main = config.build.main
+      ?: return Err(EXIT_BUILD_ERROR)   // unreachable: parser invariant
+  val link = nativeLinkCommand(config, main, ...)
+  ```
+  The `?: return` is a defensive-but-ADR-0001-safe path. It cannot trip
+  at runtime because `parseConfig` guarantees `kind == "app" ⇒ main != null`,
+  but Kotlin null-safety forces the compiler check without falling back
+  to `!!` (forbidden).
+- `nativeLinkCommand` gains one signature change: take `main: String` as
+  an explicit parameter instead of reading `config.build.main` internally.
+  Every existing call site that reads `config.build.main` via the link
+  helper must be updated to pass `main` through. No behavioral change —
+  same `-e main` token is emitted.
+- `kolt build` user-facing success message should distinguish artifact
+  kind ("library" / "executable") — stdout affordance only.
+
+**Dependencies**
+- Inbound: `kolt.cli.BuildCommands.doBuild` (P0).
+- Outbound: existing `CompilerBackend` implementations via
+  `nativeLibraryCommand` and `nativeLinkCommand` (P0).
+
+**Contracts**: Service [x]
+
+##### Service interface (unchanged signature)
+
+```kotlin
+private fun doNativeBuild(
+    config: KoltConfig,
+    useDaemon: Boolean
+): Result<BuildResult, Int>
+```
+
+- Preconditions: `config` is the output of a successful `parseConfig`,
+  so the `kind × main` invariants hold.
+- Postconditions: For `kind == "lib"`, `BuildResult` is returned after
+  stage 1; no `.kexe` is written at the canonical output path. For
+  `kind == "app"`, behavior is byte-identical to today.
+- Invariants: `BuildResult` shape remains `(config, classpath, javaPath)`.
+
+**Implementation Notes**
+- Place a one-line comment next to the new gate citing ADR 0014 (two-stage
+  flow) and ADR 0023 §1 (kind schema).
+- No change to stage-1 command-building — the `.klib` produced is already
+  the artifact R3.1 requires.
+
+#### JVM thin-jar invariants
+
+**Responsibilities & Constraints**
+- Existing JVM compile step must not pass `-include-runtime` to kotlinc
+  for either kind (current behavior; this spec locks it in via test).
+- Existing `jarCommand` uses `jar cf` without a manifest attribute —
+  retains R2.3 for libraries, and for apps (R2.4 — current behavior).
+- No code change in this component. The contribution is an assertion
+  contract plus integration tests.
+
+**Contracts**: State [x] (invariant assertion)
+
+**Implementation Notes**
+- Test reads the produced jar's `META-INF/MANIFEST.MF` and asserts
+  absence of `Main-Class`.
+- Test greps the kotlinc command line (either via daemon request or
+  subprocess args) and asserts no `-include-runtime` token.
+
+#### Run command kind guard
+
+**Responsibilities & Constraints**
+- `doRun`, first statement after `loadProjectConfig()`:
+  ```kotlin
+  if (config.isLibrary()) {
+      eprintln("error: library projects cannot be run")
+      return Err(EXIT_CONFIG_ERROR)
+  }
+  ```
+- Guard is target-agnostic — a single check before any JVM/native
+  dispatch.
+- No artifact resolution (`outputKexePath`, `jvmMainClass`) is performed
+  for a library.
+- `watchRunLoop` applies the same guard at loop entry; emits the error
+  once, exits cleanly. Does not enter the rebuild poll.
+
+**Dependencies**
+- Inbound: `kolt.cli.Main.doRun` dispatch (P0).
+- Outbound: `kolt.config.KoltConfig.isLibrary` (P0).
+
+**Contracts**: Service [x]
+
+##### Service interface (unchanged signature)
+
+```kotlin
+internal fun doRun(args: List<String>): Result<Unit, Int>
+// Same for watchRunLoop entry.
+```
+
+- Preconditions: `loadProjectConfig` succeeded.
+- Postconditions: For `kind == "lib"`, returns `Err(EXIT_CONFIG_ERROR)`
+  with the canonical stderr line, emits no build output. For
+  `kind == "app"`, behavior unchanged.
+
+**Implementation Notes**
+- Canonical error string as `private const val RUN_LIB_ERROR =
+  "library projects cannot be run"` near `doRun`, with ADR 0023 §1
+  citation comment.
+- Do not wrap the guard behind a `when (config.kind)` — match the
+  existing CLI pattern of early-return guards.
+
+#### Test non-regression
+
+**Responsibilities & Constraints**
+- Existing `doTest` (`BuildCommands.kt:437`) and `doNativeTest`
+  (`BuildCommands.kt:492-572`) paths do not reference `config.build.main`
+  (gap-analysis verified). No code change.
+- Contribution is a non-regression integration test that exercises the
+  full `doTest` flow on a `kind = "lib"` fixture config.
+
+**Contracts**: State [x] (invariant assertion)
+
+## Data Models
+
+### `KoltConfig` (post-change)
+
+```kotlin
+data class KoltConfig(
+    val name: String,
+    val version: String,
+    val kind: String = "app",          // domain: {"app", "lib"}
+    val kotlin: KotlinSection,
+    val build: BuildSection,           // BuildSection.main now nullable
+    val fmt: FmtSection = FmtSection(),
+    val dependencies: Map<String, String> = emptyMap(),
+    val testDependencies: Map<String, String> = emptyMap(),
+    val repositories: Map<String, String> = mapOf("central" to MAVEN_CENTRAL_BASE),
+    val cinterop: List<CinteropConfig> = emptyList()
+)
+
+data class BuildSection(
+    val target: String,
+    val jvmTarget: String = "17",
+    val jdk: String? = null,
+    val main: String?,                 // was: String
+    val sources: List<String>,
+    val testSources: List<String> = listOf("test"),
+    val resources: List<String> = emptyList(),
+    val testResources: List<String> = emptyList()
+)
+```
+
+- `kind`: enum-like string domain `{"app", "lib"}`. Unknown values
+  rejected at `validateKind`.
+- `main`: nullable. Post-`parseConfig` invariant
+  `kind == "app" ⇒ main != null` holds unconditionally.
+
+### `BuildResult` (unchanged)
+
+`BuildResult(config, classpath, javaPath)` is kept as-is; a library build
+returns one with `classpath = null, javaPath = null` on the native lib
+path. Sum-type alternatives (`NativeLibrary` / `NativeExecutable` / `JvmJar`
+variants) were considered and rejected in synthesis to minimize change
+surface (see `research.md` synthesis section).
+
+## Error Handling
+
+### Error Strategy
+
+Two canonical errors, both reusing existing project patterns.
+
+| Error | Canonical message (substring) | Emitter | Surface |
+|-------|-------------------------------|---------|---------|
+| lib+`main` rejection | `main has no meaning for a library; remove it` | `parseConfig` step 2 | `Err(ConfigError.ParseFailed(LIB_WITH_MAIN_ERROR))` → `loadProjectConfig` → `eprintln("error: ...")` → `Err(EXIT_CONFIG_ERROR)` |
+| app+no-`main` rejection | `[build] main is required for kind = "app"` | `parseConfig` step 2 | `Err(ConfigError.ParseFailed(APP_WITHOUT_MAIN_ERROR))` → `loadProjectConfig` → `eprintln("error: ...")` → `Err(EXIT_CONFIG_ERROR)` |
+| library-run rejection | `library projects cannot be run` | `doRun` | `eprintln("error: ...")` → `Err(EXIT_CONFIG_ERROR)` |
+
+### Error Categories and Responses
+
+- **Configuration errors** (lib+`main`): user edits `kolt.toml` to remove
+  `[build] main`. The message itself is self-remediating.
+- **Invocation errors** (library-run): implicit remediation — use
+  `kolt build` / `kolt test` instead. Watch-run exits cleanly after one
+  rejection, no poll-spam.
+
+Error constants live alongside their emitters (`Config.kt` for the
+parser constant, `BuildCommands.kt` for the run-guard constant), each
+with a one-line comment citing ADR 0023 §1.
+
+## Testing Strategy
+
+All tests live in `src/nativeTest/kotlin/` mirroring production package
+structure, per `steering/structure.md`. Use `kotlin.test.*` assertions;
+integration tests use the existing `testfixture` subpackage pattern.
+
+### Unit — Config (R1)
+1. `kind = "lib"` without `[build] main` → parses, `config.isLibrary()`
+   true, `config.build.main` null (R1.1).
+2. `kind = "lib"` with `[build] main = "com.example.main"` → `Err`,
+   message contains `main has no meaning for a library; remove it`
+   (R1.2).
+3. `kind = "app"` without `[build] main` → `Err`, message contains
+   `[build] main is required for kind = "app"` (R1.3).
+4. `kind = "app"` with `[build] main` → parses, existing behavior (R1.4).
+5. `kind` field omitted → defaults to `"app"`, rule (4) applies (R1.5).
+
+### Unit — Builder native gate (R3)
+1. `doNativeBuild` with `kind = "lib"` linuxX64 fixture → captures the
+   commands invoked; asserts `nativeLibraryCommand` was invoked exactly
+   once and `nativeLinkCommand` was never invoked; result is `Ok`
+   (R3.1, R3.2, R3.3).
+2. `doNativeBuild` with `kind = "app"` linuxX64 fixture → asserts both
+   commands invoked; existing behavior preserved (R3.4).
+
+### Unit — JVM invariants (R2)
+1. JVM lib build → produced jar's `META-INF/MANIFEST.MF` contains no
+   `Main-Class` attribute (R2.3).
+2. JVM compile command for a lib config does not contain the token
+   `-include-runtime` (R2.2).
+3. JVM lib build emits a `.jar` at `build/<name>.jar` (R2.1).
+4. JVM app build — existing tests cover R2.4; no new unit needed.
+
+### Integration (end-to-end fixtures)
+1. Native lib fixture end-to-end: `kolt build` → `build/<name>.klib`
+   exists, `build/<name>.kexe` does not exist (R3.1, R3.2).
+2. JVM lib fixture end-to-end: `kolt build` → `build/<name>.jar` exists,
+   manifest clean (R2.1–R2.3).
+3. Run rejection: `kolt run` on both JVM and native lib fixtures exits
+   non-zero with `library projects cannot be run` in stderr; no build
+   output generated (R4.1–R4.3).
+4. App non-regression: existing `kind = "app"` fixtures (the kolt repo
+   itself after removing the current `kindLibIsRejected` unit test)
+   continue to build, run, and test identically (R2.4, R3.4, R4.4, R5.3).
+
+### Non-regression — `kolt test` (R5)
+1. `kolt test` on a `kind = "lib"` fixture exits 0; tests compile and
+   execute (R5.1, R5.2).
+
+### Dogfood Gate (non-blocking)
+Before tagging a release, rebuild a small throwaway `kind = "lib"`
+fixture and confirm the produced `.klib` / thin `.jar` is sane. This is
+distinct from the actual migration of `kolt-compiler-daemon/` to a
+kolt-built library, which is follow-up under ADR 0018 and outside this
+spec's scope.

--- a/.kiro/specs/lib-build-pipeline/requirements.md
+++ b/.kiro/specs/lib-build-pipeline/requirements.md
@@ -1,0 +1,125 @@
+# Requirements Document
+
+## Introduction
+
+Tracks GitHub issue #30 (milestone v1.0, size L). ADR 0023 §1 reserved
+`kind = "lib"` at the schema level, but the parser still rejects it with a
+"not yet implemented" error and the build pipeline assumes an application
+entry point on every path. This spec lifts the placeholder rejection, makes
+`[build] main` conditional on `kind`, and threads the library path through
+the JVM build (thin jar), the native build (`.klib`-only, stopping before
+ADR 0014's link stage), and `kolt run` (rejection). It unblocks `kolt
+publish` (#21) and the ADR 0018 self-host endgame where
+`kolt-compiler-daemon/` becomes a kolt-built library rather than a Gradle
+subproject.
+
+## Boundary Context
+
+- **In scope**: config parsing for `kind = "lib"` and conditional `[build] main`
+  validation; JVM library build output (thin jar, no Main-Class); native
+  library build output (`.klib` only, no `.kexe`); `kolt run` rejection for
+  libraries; non-regression for every existing `kind = "app"` behavior;
+  continued testability of library projects via `kolt test`.
+- **Out of scope**: `kolt publish` (#21) and any publish metadata / POM
+  generation; a thin-jar variant for `kind = "app"` (orthogonal `fat_jar`
+  axis); `kolt new --lib` scaffolding (#28); the semantics of consuming a
+  kolt-built library from another kolt project (covered by the downstream
+  publish spec, not here).
+- **Adjacent expectations**: ADR 0023 §1 is authoritative for the `main`-on-
+  library error wording; ADR 0014's native two-stage library+link flow
+  remains unchanged — this spec only chooses when to stop; ADR 0013's
+  native test flow remains unchanged — tests stay runnable for libraries.
+
+## Requirements
+
+### Requirement 1: Config parser accepts `kind = "lib"` with conditional `main`
+
+**Objective:** As a kolt user, I want to declare `kind = "lib"` in
+`kolt.toml` without providing `[build] main`, so that I can express a
+library project that has no application entry point.
+
+#### Acceptance Criteria
+
+1. When `kolt.toml` declares `kind = "lib"` without `[build] main`, the kolt
+   config parser shall parse the config successfully.
+2. If `kolt.toml` declares `kind = "lib"` together with `[build] main`, the
+   kolt config parser shall reject the config with an error whose message
+   contains `main has no meaning for a library; remove it`.
+3. When `kolt.toml` declares `kind = "app"` without `[build] main`, the kolt
+   config parser shall reject the config with a missing-`main` error.
+4. When `kolt.toml` declares `kind = "app"` together with `[build] main`,
+   the kolt config parser shall parse the config successfully.
+5. When `kolt.toml` omits `kind`, the kolt config parser shall default `kind`
+   to `"app"` and apply the `kind = "app"` rules above.
+
+### Requirement 2: JVM library build produces a thin jar
+
+**Objective:** As a kolt user of a JVM library project, I want `kolt build`
+to produce a plain class jar, so that the artifact can later be published
+and consumed as a Maven-compatible library.
+
+#### Acceptance Criteria
+
+1. When `kolt build` runs against a `kind = "lib"` config targeting the JVM,
+   the kolt build pipeline shall produce a `.jar` in the project's build
+   output directory containing the project's compiled classes.
+2. The kolt build pipeline shall produce a `kind = "lib"` JVM jar that does
+   not bundle the Kotlin standard library or any resolved dependency
+   classes.
+3. The kolt build pipeline shall produce a `kind = "lib"` JVM jar that does
+   not declare a `Main-Class` manifest attribute.
+4. When `kolt build` runs against a `kind = "app"` config targeting the JVM,
+   the kolt build pipeline shall produce the same jar shape and manifest
+   entries as it does today.
+
+### Requirement 3: Native library build stops at the `.klib` stage
+
+**Objective:** As a kolt user of a native library project, I want
+`kolt build` to stop after producing a `.klib`, so that no executable is
+linked from a library that has no entry point.
+
+#### Acceptance Criteria
+
+1. When `kolt build` runs against a `kind = "lib"` config targeting a native
+   platform, the kolt build pipeline shall produce a `.klib` artifact in the
+   project's build output directory.
+2. The kolt build pipeline shall not produce a `.kexe` artifact for a
+   `kind = "lib"` native project.
+3. The kolt build pipeline shall not invoke a native link step for a
+   `kind = "lib"` native project.
+4. When `kolt build` runs against a `kind = "app"` config targeting a native
+   platform, the kolt build pipeline shall continue to produce both the
+   `.klib` and the `.kexe` as it does today.
+
+### Requirement 4: `kolt run` rejects library projects
+
+**Objective:** As a kolt user, I want `kolt run` against a library project
+to fail fast with a clear message, so that I am not left debugging a missing
+executable.
+
+#### Acceptance Criteria
+
+1. If `kolt run` is invoked against a `kind = "lib"` config, the kolt CLI
+   shall exit with a non-zero status and emit an error whose message
+   contains `library projects cannot be run`.
+2. The kolt CLI shall emit the library-run rejection before attempting to
+   resolve a runnable artifact and before invoking the build pipeline.
+3. The kolt CLI shall apply the library-run rejection regardless of whether
+   the library targets the JVM or a native platform.
+4. When `kolt run` is invoked against a `kind = "app"` config, the kolt CLI
+   shall execute the existing run flow unchanged.
+
+### Requirement 5: `kolt test` continues to work for library projects
+
+**Objective:** As a kolt user of a library project, I want `kolt test` to
+compile and run tests, so that a library without `[build] main` remains
+testable.
+
+#### Acceptance Criteria
+
+1. When `kolt test` runs against a `kind = "lib"` config, the kolt test
+   pipeline shall compile the project's tests and execute them.
+2. The kolt test pipeline shall not require `[build] main` to be present
+   when `kind = "lib"`.
+3. When `kolt test` runs against a `kind = "app"` config, the kolt test
+   pipeline shall continue to work unchanged.

--- a/.kiro/specs/lib-build-pipeline/research.md
+++ b/.kiro/specs/lib-build-pipeline/research.md
@@ -1,0 +1,187 @@
+# Gap Analysis: lib-build-pipeline
+
+Source: requirements.md (R1–R5). Codebase at 2026-04-22 (ccsdd branch).
+
+## TL;DR
+
+- **The work is smaller than the issue description implies.** The JVM jar path
+  is already thin (`-include-runtime` is not used anywhere in the codebase).
+  The native flow already produces a `.klib` in stage 1. The real code delta
+  is: parser (~lift rejection + conditional `main`), native builder (skip
+  stage 2 when `kind = "lib"`), CLI guard (`kolt run` reject before work).
+- **One hard coupling point**: `Builder.kt:112` hardcodes `-e config.build.main`
+  in `nativeLinkCommand`. All other non-build commands are already decoupled
+  from `main`.
+- **Option A (extend)** is the clear fit. The three seams are already
+  separated (`kolt.config`, `kolt.build`, `kolt.cli`) per structure.md.
+- **Effort**: S–M (3–5 days). **Risk**: Low.
+
+## Requirement-to-Asset Map
+
+| Req | Subsystem | Current asset | Gap / change |
+|-----|-----------|---------------|--------------|
+| R1 parser | `kolt.config.Config` | `validateKind` (`Config.kt:128-140`) rejects lib. `RawBuildSection.main` (`Config.kt:106`) is non-nullable. `validateMainFqn` (`Config.kt:186`). Default kind = "app". | **Missing**: lib acceptance; nullable `main`; conditional main rule with exact ADR 0023 §1 text. |
+| R1 tests | `ConfigTest.kt` | `kindLibIsRejectedAsNotYetImplemented` (`ConfigTest.kt:311-336`) pins current reject behavior. `MainTest.kt` covers FQN validation. | **Replace** `kindLibIsRejectedAsNotYetImplemented`; **add** lib+no-main OK / lib+main error / app+no-main error / app+main OK matrix. |
+| R2 JVM build | `kolt.build.Builder` | `jarCommand` (`Builder.kt:221-227`) = `jar cf <output> -C <classes> .` — already thin, no `-include-runtime` anywhere (grep: 0 matches). | **Mostly already satisfied**. Add assertion test that jar for lib has no `Main-Class` manifest. Confirm kotlinc JVM compile path doesn't emit Main-Class either (verify; current JVM build is already "classes only"). |
+| R3 Native build | `kolt.build.Builder` | `nativeLibraryCommand` (`Builder.kt:68-94`) = stage 1 klib. `nativeLinkCommand` (`Builder.kt:96-124`) = stage 2, uses `-e config.build.main` (`Builder.kt:112`). | **Missing**: kind-branch in `doNativeBuild` (skip stage 2 when lib). `-e main` reference at `Builder.kt:112` requires `main` be present — effectively keeps stage 2 app-only. |
+| R3 tests | `BuildCommandsTest.kt:225-327`, `NativeDaemonIntegrationTest.kt:46-100` | Existing tests pin `-e com.example.main` in link output (app path). | **Keep** app-path tests. **Add** lib-path test asserting stage 2 is not invoked / no `.kexe` materializes. |
+| R4 run guard | `kolt.cli.BuildCommands.doRun` (`BuildCommands.kt:406-435`) | No kind check; assumes executable exists. | **Missing**: top-of-function kind guard, emit `library projects cannot be run`, return non-zero before `outputKexePath` / `jvmMainClass` resolution. Applies to both native and JVM paths. Watch-run (`WatchLoop.kt:261-330`) delegates to `doBuild`+`doRun` so the same guard covers `kolt run --watch`. |
+| R5 test | `kolt.cli.BuildCommands.doNativeTest` (`BuildCommands.kt:492-572`), `doTest` (`BuildCommands.kt:437`), `TestBuilder.kt:12-36` | **Already decoupled from `main`.** Native test uses `-generate-test-runner` (not `-e main`). JVM test uses JUnit Platform. | **No code change expected**. Requirement is a non-regression assertion — add a test confirming `kolt test` works against a lib config. |
+| Adjacent: LSP | `kolt.build.Workspace.generateWorkspaceJson` (`Workspace.kt:13-106`) | Never references `config.main`. | No change. `--check`/IDE workspace for libs works out of the box. |
+| Adjacent: fmt/check/deps | `Formatter.kt`, `doCheck` (`BuildCommands.kt:60-83`), `DependencyCommands.kt:205-293` | None reference `config.main`. | No change. |
+| Adjacent: `kolt init` | `kolt.config.Init.generateKoltToml` (`Init.kt:9-21`) | Unconditionally emits `main = "main"`. | **No change** — app default is still correct. Lib scaffolding is #28, out of scope. |
+| Adjacent: watch | `WatchLoop.watchCommandLoop` / `watchRunLoop` | Delegates to `doBuild` / `doRun`. | Inherits kind-branching and run-guard for free; no direct change. |
+
+## Gaps, Unknowns, Constraints
+
+- **Missing**: parser lib-path, parser conditional-`main`, native builder kind-branch at stage 2, CLI lib-run guard. All four are surgical edits inside existing functions.
+- **Unknowns** (Research Needed for design phase):
+  1. **Exact error-string formatting**: ADR 0023 §1 prose uses backticks around `main` (`` `main` has no meaning for a library; remove it ``). The actual runtime error constant may or may not keep backticks. Requirements use substring match (`main has no meaning for a library; remove it`) which is format-agnostic — design should pick one concrete string and lock it in.
+  2. **Where the kind branch lives for native**: at the `Builder`-level (conditional composition inside `doNativeBuild`) vs. at the `CompilerBackend` selection layer. The cheapest fix is `doNativeBuild`-level: call `nativeLibraryCommand` then gate `nativeLinkCommand` on kind. `CompilerBackend` already abstracts over daemon/subprocess; it does not decompose library-vs-link. Leaving the gate at the Builder level preserves the existing seam.
+  3. **Whether `kolt run --watch` should prompt reject per tick or once**: current `watchRunLoop` calls `doBuild` then `doRun`. If `doRun` rejects with the lib error, the watch loop will emit the error on every change tick. Design should decide: detect kind at watch entry and reject immediately (cleaner UX) vs. let the per-tick rejection surface naturally (less code). Recommend the former.
+- **Constraints**:
+  - ADR 0014 native two-stage flow stays untouched; this spec only chooses when to stop (aligns with steering/structure.md "this spec only chooses when to stop").
+  - ADR 0023 §1 error text is authoritative — verify against `docs/adr/0023-target-and-kind-schema.md` when writing the constant.
+  - Pre-v1: no migration shim. Making `RawBuildSection.main` nullable is a breaking change only for third-party tooling that deserializes `RawBuildSection` directly, which does not exist outside this repo.
+  - No cross-validation of `kind × target` needed — lib works on all supported targets (jvm, linuxX64) without additional guards.
+
+## Implementation Approach Options
+
+### Option A: Extend existing components (RECOMMENDED)
+
+**Fit**: the three responsibility seams (`kolt.config`, `kolt.build`, `kolt.cli`)
+are already separated. Each change is a small, local edit inside an
+existing function.
+
+- `Config.kt`: make `RawBuildSection.main` nullable, lift the lib reject in
+  `validateKind`, add conditional-`main` rule in `parseConfig` using ADR
+  0023 §1 canonical text.
+- `Builder.kt`: add `if (config.kind != "lib")` gate around the stage 2 call
+  in `doNativeBuild`; JVM path stays as is (already thin, no Main-Class).
+- `BuildCommands.kt`: prepend a kind check in `doRun`; also prepend in
+  `watchRunLoop` to avoid per-tick error spam.
+- `ConfigTest.kt`: replace the `kindLibIsRejectedAsNotYetImplemented`
+  fixture with the new matrix (lib+no-main OK / lib+main error / app+no-main
+  error / app+main OK / kind default).
+- Add end-to-end fixtures: a lib JVM project produces thin jar without
+  Main-Class; a lib native project produces `.klib` but no `.kexe`;
+  `kolt run` on a lib rejects.
+
+**Trade-offs**:
+- ✅ No new files, no new abstractions.
+- ✅ Each seam stays below existing size; no bloat.
+- ✅ Preserves ADR 0014 / ADR 0013 stage layering.
+- ❌ Parser `parseConfig` grows by one validation rule — still small.
+
+### Option B: Create new components
+
+Introduce e.g. `LibraryBuilder` / `ApplicationBuilder` sealed variants of a
+new `KindBuilder` interface, dispatching from the top of `doBuild`.
+
+- ✅ Cleaner long-term if a third kind (`kmp-lib`, `plugin`) gets added.
+- ❌ Overkill for two variants with 90% shared code. The library path
+  literally just omits stage 2 — splitting into siblings duplicates the
+  shared stage 1 invocation.
+- ❌ Deviates from Option A's "minimum code delta" principle without
+  earning a concrete future use case (no third kind is planned).
+
+### Option C: Hybrid
+
+Extend `Config` and `doRun` (Option A), but introduce a minimal
+`NativeBuildPlan` record that names `{ stage1, stage2? }` in `Builder`.
+
+- ✅ Makes the "stop after stage 1" decision explicit and testable in
+  isolation.
+- ✅ Leaves room for future variants (e.g., static-binary toggle).
+- ❌ Nontrivial refactor to existing `Builder` code surface; higher risk of
+  touching ADR 0014 machinery.
+- ❌ Current call site is already read as "call stage1 then stage2"; the
+  proposed record is documentation, not abstraction gain.
+
+**Recommendation**: Option A. Revisit Option C if a second "stop early"
+case appears post-v1 (e.g. `kolt check` wanting stage 1 artifacts).
+
+## Effort & Risk
+
+- **Effort: S–M (3–5 days)**. Code changes total ~80 LOC across 3 files;
+  the bulk is test fixtures and the `ConfigTest` matrix. One extra day for
+  integration dogfooding (build the `kolt-compiler-daemon/` or a throwaway
+  lib to confirm `.klib`-only output).
+- **Risk: Low**. Existing patterns, well-bounded issue, ADR-guided, pre-v1
+  so no migration concerns. The only reversible concern is locking in the
+  runtime error text — trivially changeable later if design chooses wrong.
+
+## Recommendations for Design Phase
+
+- **Prefer Option A**.
+- **Key design decisions to commit**:
+  1. Exact error constants (parser + run-reject), living as private `const val`
+     next to their emitter. Cite ADR 0023 §1 in the comment.
+  2. Kind-branch placement: inside `doNativeBuild` at the `Builder` layer
+     (not at `CompilerBackend`), matching the discovery recon path.
+  3. `kolt run --watch` behaviour: reject at watch entry, not per-tick.
+  4. Nullable shape of `RawBuildSection.main`: `String?` with a single
+     conditional-validation gate in `parseConfig`.
+- **Research items to carry forward**: none external. All open points are
+  local to the design choices listed above.
+- **Test fixtures to build**:
+  - Unit: `ConfigTest` matrix replacement.
+  - Native: a `testfixture` minimal lib kolt.toml + assertion that the
+    produced artifact tree has `.klib` only.
+  - JVM: a minimal lib kolt.toml + assertion that the jar manifest has no
+    `Main-Class` and contains no non-project classes.
+  - CLI: `BuildCommandsTest` coverage for `doRun` lib reject.
+
+---
+
+## Synthesis Outcomes (Design Phase)
+
+Applied generalization / build-vs-adopt / simplification lenses before
+writing `design.md`.
+
+### Generalization
+- R1 (parser) / R3 (native build) / R4 (run reject) all branch on the same
+  signal: `KoltConfig.kind == "lib"`. Rather than sprinkling the string
+  literal at each call site, introduce a single `fun KoltConfig.isLibrary():
+  Boolean` (file-local in `Config.kt`) and use it everywhere. This is
+  interface-level generalization with no implementation cost.
+- R5 (`kolt test`) is a pure non-regression: the test flow already does
+  not read `config.build.main`. No design-level generalization buys
+  anything there; it is satisfied by existing decoupling.
+
+### Build vs. Adopt
+- Nothing external to adopt. ADR 0014 two-stage flow already exists.
+  ktoml supports `String?` natively. `jar cf` already produces the thin
+  jar shape R2 requires. There is no library or protocol to bring in.
+
+### Simplification
+- **Reject**: adding a sealed `BuildOutput` sum type to discriminate
+  `NativeLibrary` / `NativeExecutable` / `JvmJar` at the `doBuild` return
+  boundary. The existing `BuildResult(config, classpath, javaPath)` is
+  sufficient — success is success; artifact kind is derivable from
+  `config.kind` + `config.build.target` at the call sites that format
+  output messages.
+- **Reject**: introducing a new `ConfigError.LibraryWithMain` variant.
+  Reuse the existing `ConfigError.ParseFailed(message)` — the canonical
+  ADR 0023 §1 string is the `message`. The `when (error) { is ParseFailed -> ... }`
+  in `loadProjectConfig` stays exhaustive without a refactor.
+- **Reject**: introducing a new exit code constant for the lib-run
+  rejection. Reuse `EXIT_CONFIG_ERROR` — the invocation itself is a
+  misuse of a valid config, which matches the existing error category.
+- **Reject**: introducing a new top-level `RunError` ADT for `doRun`.
+  The project's CLI pattern emits errors via `eprintln(...)` + `return
+  Err(EXIT_*)` where `EXIT_*: Int`. Follow that pattern.
+- **Accept**: the three-line change surface (parser / native builder /
+  run guard) + `isLibrary()` helper is the minimum that satisfies all
+  requirements. No new types, no new files for production code; only
+  new test files.
+
+### Code Grounding Confirmed
+- `KoltConfig` (not `Config`) is the public data class; `kind: String =
+  "app"` lives at the top level (line 82).
+- `BuildSection.main: String` (line 62) and `RawBuildSection.main: String`
+  (line 106) both become `String?`.
+- `validateKind` (line 128) is the single place that gates `"lib"`.
+- `doNativeBuild` (`BuildCommands.kt:228`) returns
+  `Result<BuildResult, Int>`. Kind gate fits inside before the link step.
+- `BuildResult` (`BuildCommands.kt:28`) is unchanged by this spec.

--- a/.kiro/specs/lib-build-pipeline/spec.json
+++ b/.kiro/specs/lib-build-pipeline/spec.json
@@ -1,0 +1,22 @@
+{
+    "feature_name": "lib-build-pipeline",
+    "created_at": "2026-04-22T00:55:00Z",
+    "updated_at": "2026-04-22T01:40:00Z",
+    "language": "en",
+    "phase": "tasks-generated",
+    "approvals": {
+        "requirements": {
+            "generated": true,
+            "approved": true
+        },
+        "design": {
+            "generated": true,
+            "approved": true
+        },
+        "tasks": {
+            "generated": true,
+            "approved": true
+        }
+    },
+    "ready_for_implementation": true
+}

--- a/.kiro/specs/lib-build-pipeline/tasks.md
+++ b/.kiro/specs/lib-build-pipeline/tasks.md
@@ -26,14 +26,14 @@ convention, red/green/refactor do not need to be separate commits).
 
 ## 2. Native build — stop after stage 1 for libraries
 
-- [ ] 2.1 Add failing tests for the native kind gate
+- [x] 2.1 Add failing tests for the native kind gate
   - Assert that the native build orchestration invokes only stage 1 (library compile) when the config is a library, and writes no `.kexe` artifact
   - Assert that an app native config still invokes both stages and produces the executable at the canonical output path
   - Use scoped fixture configs created inside the test; do not reuse or mutate the repository's own kolt.toml
   - Observable: the two new test cases exist, compile, and fail against current production code.
   - _Requirements: 3.1, 3.2, 3.3, 3.4_
 
-- [ ] 2.2 Add the kind gate in native build orchestration
+- [x] 2.2 Add the kind gate in native build orchestration
   - After stage 1 succeeds, return early when `isLibrary()` is true — do not invoke the link helper
   - On the app path, extract the entry-point FQN using a defensive `?: return Err(EXIT_BUILD_ERROR)` (ADR 0001 safe; unreachable by parser invariant) and pass it into the link helper whose signature was already adjusted in 1.2
   - Distinguish artifact kind ("library" / "executable") in the user-facing build-success stdout message
@@ -87,6 +87,12 @@ convention, red/green/refactor do not need to be separate commits).
   - Execute `./gradlew check` end-to-end (unit tests, daemon version verification, linuxX64 tests) and confirm no regressions in existing app paths
   - Build a throwaway `kind = "lib"` fixture against both the JVM and linuxX64 targets; confirm artifacts match the design invariants (`.klib` on native with no `.kexe`; thin `.jar` on JVM with no `Main-Class`)
   - Record the fixture contents and produced artifact listings in the PR description so reviewers can replay
-  - Observable: `./gradlew check` exits zero; fixture artifacts at `build/<name>.klib` and `build/<name>.jar` match the documented invariants.
+  - Observable: `./gradlew check` exits zero; fixture artifacts at `build/<name>-klib` (directory, stage 1 `-nopack` output) and `build/<name>.jar` match the documented invariants.
   - _Requirements: 2.4, 3.4, 4.4, 5.3_
   - _Depends: 2.2, 3.2, 4.1, 5.1_
+
+## Implementation Notes
+
+- **Task 1.1/1.2 and 2.1/2.2 were executed as atomic RED/GREEN pairs** in single implementer dispatches. Splitting into separate reviewer cycles would have mechanically rejected the RED-only state (reviewer check #1 runs the test suite).
+- **Native library artifact path**: kolt's stage 1 emits with `-p library -nopack`, so the library artifact is a DIRECTORY at `build/<name>-klib`, not a packed `.klib` file. Design §6.1 wording was written with the packed form in mind; updated to reflect the actual convention.
+- **Follow-up refactor candidate**: `NativeStagePlan` (`BuildCommands.kt`) uses `linkMain: String?` + `artifactKind: String` to discriminate library vs application. Consider migrating to a sealed hierarchy (`object Library` / `data class Application(val main: String)`) post-v1 to match `steering/structure.md`'s preference for ADTs over primitive-obsession.

--- a/.kiro/specs/lib-build-pipeline/tasks.md
+++ b/.kiro/specs/lib-build-pipeline/tasks.md
@@ -6,14 +6,14 @@ convention, red/green/refactor do not need to be separate commits).
 
 ## 1. Config parser — accept `kind = "lib"` with conditional `[build] main`
 
-- [ ] 1.1 Replace the "not yet implemented" rejection test with the new kind × main matrix
+- [x] 1.1 Replace the "not yet implemented" rejection test with the new kind × main matrix
   - Remove the existing `kindLibIsRejectedAsNotYetImplemented` case from the config test suite
   - Add unit coverage for five cases: lib without main parses; lib with main rejects with canonical text; app without main rejects with canonical text; app with main parses; missing kind defaults to app
   - Each rejecting assertion matches the canonical error string from design.md as a substring (`main has no meaning for a library; remove it` / `[build] main is required for kind = "app"`)
   - Observable: the new test file compiles and runs; every case fails against current production code before 1.2 lands.
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
 
-- [ ] 1.2 Update the parser to make `main` nullable, accept `kind = "lib"`, enforce the conditional rule, and propagate the type ripple to the native link helper
+- [x] 1.2 Update the parser to make `main` nullable, accept `kind = "lib"`, enforce the conditional rule, and propagate the type ripple to the native link helper
   - Make the `main` field nullable in both the raw deserialization shape and the parsed build section; neither ktoml nor downstream callers should require a value for libraries
   - Remove the `"lib"` rejection branch from kind validation; leave the unknown-kind rejection in place
   - Introduce the two canonical error strings as top-level `private const val` with one-line ADR 0023 §1 citation comments

--- a/.kiro/specs/lib-build-pipeline/tasks.md
+++ b/.kiro/specs/lib-build-pipeline/tasks.md
@@ -83,7 +83,7 @@ convention, red/green/refactor do not need to be separate commits).
 
 ## 6. Regression verification and dogfood
 
-- [ ] 6.1 Run full Gradle check and a throwaway library fixture build
+- [x] 6.1 Run full Gradle check and a throwaway library fixture build
   - Execute `./gradlew check` end-to-end (unit tests, daemon version verification, linuxX64 tests) and confirm no regressions in existing app paths
   - Build a throwaway `kind = "lib"` fixture against both the JVM and linuxX64 targets; confirm artifacts match the design invariants (`.klib` on native with no `.kexe`; thin `.jar` on JVM with no `Main-Class`)
   - Record the fixture contents and produced artifact listings in the PR description so reviewers can replay
@@ -96,3 +96,4 @@ convention, red/green/refactor do not need to be separate commits).
 - **Task 1.1/1.2 and 2.1/2.2 were executed as atomic RED/GREEN pairs** in single implementer dispatches. Splitting into separate reviewer cycles would have mechanically rejected the RED-only state (reviewer check #1 runs the test suite).
 - **Native library artifact path**: kolt's stage 1 emits with `-p library -nopack`, so the library artifact is a DIRECTORY at `build/<name>-klib`, not a packed `.klib` file. Design §6.1 wording was written with the packed form in mind; updated to reflect the actual convention.
 - **Follow-up refactor candidate**: `NativeStagePlan` (`BuildCommands.kt`) uses `linkMain: String?` + `artifactKind: String` to discriminate library vs application. Consider migrating to a sealed hierarchy (`object Library` / `data class Application(val main: String)`) post-v1 to match `steering/structure.md`'s preference for ADTs over primitive-obsession.
+- **Task 6.1 dogfood evidence** (2026-04-22): `./gradlew check` exits 0. Replay fixtures live under `spike/lib-dogfood/{jvm,native,app-native}` with a top-level `README.md` documenting the replay + canonical-error probes. Confirmed invariants: JVM lib jar contains only `dogfood/Util.class` + `META-INF/MANIFEST.MF` with no `Main-Class` attribute, no `kotlin/` entries, and no resolved dependency classes (R2.1, R2.2, R2.3); native lib produces `build/<name>-klib/` directory with `.kexe` absent (R3.1, R3.2, R3.3); `kolt run` on both JVM and native libs exits 2 with canonical `library projects cannot be run` (R4.1, R4.3); `kolt test` on both libs exits 0 with tests executing (R5.1); native app non-regression produces and runs `.kexe` (R3.4, R4.4). The `APP_WITHOUT_MAIN_ERROR` and `LIB_WITH_MAIN_ERROR` canonical rejections were both probed via temporary fixture mutation and reverted.

--- a/.kiro/specs/lib-build-pipeline/tasks.md
+++ b/.kiro/specs/lib-build-pipeline/tasks.md
@@ -60,7 +60,7 @@ convention, red/green/refactor do not need to be separate commits).
 
 ## 4. JVM library thin-jar invariants
 
-- [ ] 4.1 (P) Assert JVM library jars are thin and declare no Main-Class
+- [x] 4.1 (P) Assert JVM library jars are thin and declare no Main-Class
   - Using a library fixture config and the JVM target, drive the build end-to-end
   - Inspect `META-INF/MANIFEST.MF` in the produced jar and assert there is no `Main-Class` attribute
   - Assert the jar contains no Kotlin standard library entries and no resolved dependency classes

--- a/.kiro/specs/lib-build-pipeline/tasks.md
+++ b/.kiro/specs/lib-build-pipeline/tasks.md
@@ -44,14 +44,14 @@ convention, red/green/refactor do not need to be separate commits).
 
 ## 3. Run command — reject libraries before build work
 
-- [ ] 3.1 Add failing tests for the library-run rejection
+- [x] 3.1 Add failing tests for the library-run rejection
   - Assert that the run command against a library config exits with the config-error exit code and emits the canonical `library projects cannot be run` substring to stderr
   - Assert the rejection occurs before any artifact resolution or build invocation
   - Assert that run-watch against a library rejects once and exits cleanly (no per-source-change error spam)
   - Observable: three new failing tests in a dedicated file.
   - _Requirements: 4.1, 4.2, 4.3, 4.4_
 
-- [ ] 3.2 Add the kind guard in the run command and the run-watch loop entry
+- [x] 3.2 Add the kind guard in the run command and the run-watch loop entry
   - Introduce the canonical run-rejection message as a top-level `private const val` near the run command with an ADR 0023 §1 citation comment
   - As the first statement after config parsing in both the single-shot run command and the run-watch loop entry, check `isLibrary()` and return `Err(EXIT_CONFIG_ERROR)` with the canonical stderr line
   - Observable: the 3.1 tests pass; existing run-command tests for apps stay green; no build work executes when a library is asked to run.

--- a/.kiro/specs/lib-build-pipeline/tasks.md
+++ b/.kiro/specs/lib-build-pipeline/tasks.md
@@ -72,7 +72,7 @@ convention, red/green/refactor do not need to be separate commits).
 
 ## 5. Test command — non-regression for libraries
 
-- [ ] 5.1 (P) Assert the test command works against a library configuration
+- [x] 5.1 (P) Assert the test command works against a library configuration
   - Using a library fixture config with no `[build] main` declared, drive the test command end-to-end against both JVM and native targets
   - Assert exit code 0 and that fixture tests compile and execute
   - Assert via a captured path-read that the test flow does not read the `main` field when the field is null (confirms R5.2 structurally, not just behaviorally)

--- a/.kiro/specs/lib-build-pipeline/tasks.md
+++ b/.kiro/specs/lib-build-pipeline/tasks.md
@@ -1,0 +1,92 @@
+# Implementation Plan
+
+Execute in TDD order inside each task: red test subtask first, implementation
+subtask second. Commit granularity is left to the implementer (per project
+convention, red/green/refactor do not need to be separate commits).
+
+## 1. Config parser — accept `kind = "lib"` with conditional `[build] main`
+
+- [ ] 1.1 Replace the "not yet implemented" rejection test with the new kind × main matrix
+  - Remove the existing `kindLibIsRejectedAsNotYetImplemented` case from the config test suite
+  - Add unit coverage for five cases: lib without main parses; lib with main rejects with canonical text; app without main rejects with canonical text; app with main parses; missing kind defaults to app
+  - Each rejecting assertion matches the canonical error string from design.md as a substring (`main has no meaning for a library; remove it` / `[build] main is required for kind = "app"`)
+  - Observable: the new test file compiles and runs; every case fails against current production code before 1.2 lands.
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+
+- [ ] 1.2 Update the parser to make `main` nullable, accept `kind = "lib"`, enforce the conditional rule, and propagate the type ripple to the native link helper
+  - Make the `main` field nullable in both the raw deserialization shape and the parsed build section; neither ktoml nor downstream callers should require a value for libraries
+  - Remove the `"lib"` rejection branch from kind validation; leave the unknown-kind rejection in place
+  - Introduce the two canonical error strings as top-level `private const val` with one-line ADR 0023 §1 citation comments
+  - Apply the 5-step validation order from design.md: kind → conditional main → FQN (only when main present) → target → config construction
+  - Add a file-local `isLibrary()` extension on the parsed config so downstream code reads intent rather than string literals
+  - Mechanical ripple (same change, kept atomic so the tree compiles): update the native link helper to take the entry-point FQN as an explicit `String` parameter instead of reading the now-nullable `build.main`, and update its existing call site and direct unit tests to match; no behavioral change, no kind gating yet
+  - Observable: the 1.1 matrix passes; `./gradlew check` stays green; no `"lib"` reserved-but-unimplemented rejection remains in the source.
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+  - _Boundary: kolt.config, kolt.build (link helper signature ripple only)_
+
+## 2. Native build — stop after stage 1 for libraries
+
+- [ ] 2.1 Add failing tests for the native kind gate
+  - Assert that the native build orchestration invokes only stage 1 (library compile) when the config is a library, and writes no `.kexe` artifact
+  - Assert that an app native config still invokes both stages and produces the executable at the canonical output path
+  - Use scoped fixture configs created inside the test; do not reuse or mutate the repository's own kolt.toml
+  - Observable: the two new test cases exist, compile, and fail against current production code.
+  - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+- [ ] 2.2 Add the kind gate in native build orchestration
+  - After stage 1 succeeds, return early when `isLibrary()` is true — do not invoke the link helper
+  - On the app path, extract the entry-point FQN using a defensive `?: return Err(EXIT_BUILD_ERROR)` (ADR 0001 safe; unreachable by parser invariant) and pass it into the link helper whose signature was already adjusted in 1.2
+  - Distinguish artifact kind ("library" / "executable") in the user-facing build-success stdout message
+  - Cite ADR 0014 (two-stage flow) and ADR 0023 §1 (kind schema) in a one-line comment at the gate
+  - Observable: the 2.1 cases pass; existing native-link unit tests still pass; app builds continue to produce `.kexe` and lib builds stop at `.klib`.
+  - _Requirements: 3.1, 3.2, 3.3, 3.4_
+  - _Depends: 1.2_
+
+## 3. Run command — reject libraries before build work
+
+- [ ] 3.1 Add failing tests for the library-run rejection
+  - Assert that the run command against a library config exits with the config-error exit code and emits the canonical `library projects cannot be run` substring to stderr
+  - Assert the rejection occurs before any artifact resolution or build invocation
+  - Assert that run-watch against a library rejects once and exits cleanly (no per-source-change error spam)
+  - Observable: three new failing tests in a dedicated file.
+  - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+- [ ] 3.2 Add the kind guard in the run command and the run-watch loop entry
+  - Introduce the canonical run-rejection message as a top-level `private const val` near the run command with an ADR 0023 §1 citation comment
+  - As the first statement after config parsing in both the single-shot run command and the run-watch loop entry, check `isLibrary()` and return `Err(EXIT_CONFIG_ERROR)` with the canonical stderr line
+  - Observable: the 3.1 tests pass; existing run-command tests for apps stay green; no build work executes when a library is asked to run.
+  - _Requirements: 4.1, 4.2, 4.3, 4.4_
+  - _Depends: 1.2_
+
+## 4. JVM library thin-jar invariants
+
+- [ ] 4.1 (P) Assert JVM library jars are thin and declare no Main-Class
+  - Using a library fixture config and the JVM target, drive the build end-to-end
+  - Inspect `META-INF/MANIFEST.MF` in the produced jar and assert there is no `Main-Class` attribute
+  - Assert the jar contains no Kotlin standard library entries and no resolved dependency classes
+  - Inspect the kotlinc command line (as recorded via the daemon request or subprocess args) and assert there is no `-include-runtime` token
+  - Observable: a new JVM-lib integration test passes without any production-code change beyond what task 1 already delivered.
+  - _Requirements: 2.1, 2.2, 2.3, 2.4_
+  - _Boundary: kolt.cli integration tests_
+  - _Depends: 1.2_
+
+## 5. Test command — non-regression for libraries
+
+- [ ] 5.1 (P) Assert the test command works against a library configuration
+  - Using a library fixture config with no `[build] main` declared, drive the test command end-to-end against both JVM and native targets
+  - Assert exit code 0 and that fixture tests compile and execute
+  - Assert via a captured path-read that the test flow does not read the `main` field when the field is null (confirms R5.2 structurally, not just behaviorally)
+  - Observable: a new non-regression test passes without any production-code change beyond what task 1 already delivered.
+  - _Requirements: 5.1, 5.2, 5.3_
+  - _Boundary: kolt.cli integration tests_
+  - _Depends: 1.2_
+
+## 6. Regression verification and dogfood
+
+- [ ] 6.1 Run full Gradle check and a throwaway library fixture build
+  - Execute `./gradlew check` end-to-end (unit tests, daemon version verification, linuxX64 tests) and confirm no regressions in existing app paths
+  - Build a throwaway `kind = "lib"` fixture against both the JVM and linuxX64 targets; confirm artifacts match the design invariants (`.klib` on native with no `.kexe`; thin `.jar` on JVM with no `Main-Class`)
+  - Record the fixture contents and produced artifact listings in the PR description so reviewers can replay
+  - Observable: `./gradlew check` exits zero; fixture artifacts at `build/<name>.klib` and `build/<name>.jar` match the documented invariants.
+  - _Requirements: 2.4, 3.4, 4.4, 5.3_
+  - _Depends: 2.2, 3.2, 4.1, 5.1_

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,51 @@
+# Product Overview
+
+kolt is a lightweight, no-ceremony build tool for Kotlin — a purpose-built alternative
+to Gradle for individual developers and small teams who value fast startup, predictable
+builds, and a simple mental model over plugin-ecosystem flexibility. It targets the
+same niche for Kotlin that `go build` or `cargo build` fill for their languages.
+
+## Core Capabilities
+
+- **Declarative TOML config**: `kolt.toml` replaces Kotlin-DSL build scripts; no script
+  compilation step, no task graph to evaluate.
+- **Warm compiler daemons**: persistent JVM daemon amortizes kotlinc startup; warm
+  builds are bounded by compilation time itself, not orchestration tax. Native
+  compiler daemon is in progress.
+- **Integrated dependency resolution**: Maven Central + custom repos, transitive
+  resolution with exclusions and version intervals, lockfile with SHA-256 verification.
+- **Single-binary CLI**: Kotlin/Native `kolt.kexe`; JDK required only for JVM-target
+  compilation, not for invoking kolt itself.
+- **Full day-to-day task coverage**: `build`, `run`, `test` (JUnit Platform), `check`,
+  `fmt` (ktfmt), `add`, `deps`, `toolchain`, `daemon`, each with `--watch` where it
+  makes sense.
+
+## Target Use Cases
+
+- JVM applications and CLI tools where Gradle's overhead dominates iteration time.
+- Kotlin/Native binaries on Linux (macOS and linuxArm64 planned, not yet supported).
+- Teams transitioning from Gradle who can trade plugin ecosystem for predictability.
+- Contexts requiring reproducible, auditable builds via lockfile pins.
+
+## Value Proposition
+
+kolt's distinctness is not more features — it is fewer. Gradle's flexibility (Kotlin
+DSL, plugin ecosystem, multi-module orchestration) is deliberately out of scope where
+it would cost startup speed, auditability, or mental-model simplicity.
+
+- **No startup tax**: CLI responsiveness is immediate; heavy work is delegated to the
+  warm daemon.
+- **Transparent config**: TOML is easier to audit and diff than DSL metaprogramming.
+- **Baseline performance**: warm-build latency approaches kotlinc's own lower bound.
+- **Low barrier to entry**: a simpler mental model than Gradle's task abstraction.
+
+## Current Maturity
+
+Pre-1.0 (current: v0.13.0). Breaking changes are expected and explicitly permitted.
+kolt does not ship migration shims or legacy probes for its own earlier versions —
+v1.0 is the first stability anchor.
+
+Scope gaps tracked toward v1.0 include library packaging / `kolt publish`, macOS and
+linuxArm64 targets, private repositories, multi-module projects, and mixed Kotlin/Java
+sources. Development uses Kiro-style spec-driven workflow (`.kiro/specs/`) against
+persistent steering (`.kiro/steering/`).

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,92 @@
+# Project Structure
+
+## Organization Philosophy
+
+**Native-first multiplatform with JVM sidecars as separate builds.** The root project
+only has `nativeMain` / `nativeTest` source sets; JVM daemon code lives in two
+included Gradle builds (`kolt-compiler-daemon/`, `kolt-native-daemon/`) with their
+own build files. Packages inside the native source are split **by responsibility**,
+not by layer.
+
+## Top-Level Layout
+
+- `src/nativeMain/kotlin/` — production code (native linuxX64).
+- `src/nativeTest/kotlin/` — tests, mirroring the production package tree.
+- `src/nativeInterop/cinterop/` — C FFI (e.g. `libcurl.def`).
+- `kolt-compiler-daemon/` — JVM daemon, independent Gradle build.
+- `kolt-native-daemon/` — native-compiler daemon sidecar, independent Gradle build.
+- `docs/` — prose docs and ADRs (`docs/adr/`).
+- `spike/` — experimental probes and benchmark harnesses. May be deleted freely;
+  should never be imported from production code.
+- `scripts/` — dev and release scripts.
+- `kolt.toml`, `build.gradle.kts` — build configuration (kolt self-host config +
+  Gradle bootstrap).
+
+`.kiro/` and `.claude/` hold spec-driven-development metadata and agent tooling. They
+are load-bearing for the workflow but out of scope for production code patterns.
+
+## Package Organization
+
+Root package: `kolt`. Subpackages split by responsibility, with a strict downward
+dependency direction: **cli → build → resolve / infra**.
+
+- `kolt.cli` — command entry points (`Main.kt`, `BuildCommands.kt`,
+  `DependencyCommands.kt`, etc.). Thin — parses args, dispatches to `kolt.build` or
+  `kolt.resolve`.
+- `kolt.build` — compilation orchestration, workspace generation, formatter
+  integration. The `CompilerBackend` sealed interface unifies daemon vs. subprocess
+  execution.
+- `kolt.build.daemon` — JVM daemon preconditions, JAR resolution, bootstrap JDK
+  handling, IC state lifecycle.
+- `kolt.build.nativedaemon` — native-compiler daemon backend (mirrors
+  `kolt.build.daemon`).
+- `kolt.resolve` — dependency resolution kernel. Pure domain logic: `Coordinate`,
+  `Dependency`, `Resolution` (immutable fixpoint state), POM and Gradle-metadata
+  parsers, transitive resolver. This package does not depend on `kolt.build` or
+  `kolt.cli`.
+- `kolt.config` — `kolt.toml` deserialization and validation.
+- `kolt.daemon.wire` — daemon IPC codec (sealed `Message` / `Compile` / `CompileResult`
+  / `Ping` / `Pong`), serialized via kotlinx.serialization.
+- `kolt.infra` — OS primitives: file I/O, process spawning, Unix sockets, sha256.
+- `kolt.tool` — toolchain management (kotlinc / JDK install and version resolution).
+
+## Naming Conventions
+
+- **Files**: one public type per file, filename matches the type (`Dependency.kt`,
+  `DaemonCompilerBackend.kt`).
+- **Classes**: CamelCase, no Hungarian-style prefix. Domain errors are sealed ADTs
+  (`DaemonJarResolution.Found` / `.Missing` / ...).
+- **Functions**: camelCase. Pure helpers sometimes suffixed `Pure`
+  (`resolveDaemonJarPure`) to distinguish from their side-effecting callers.
+- **Constants**: `UPPER_SNAKE_CASE` (`BOOTSTRAP_JDK_VERSION`, `SUN_PATH_CAPACITY`).
+- **Tests**: `FooTest.kt` for unit, `FooIntegrationTest.kt` for integration.
+- **Test fixtures**: `testfixture` subpackage
+  (`kolt.infra.net.testfixture.UnixEchoServer`). Reusable across tests.
+
+## Import Organization
+
+- **No wildcard imports.** Each symbol imported explicitly.
+- **Result chain style**: `kotlin-result`'s `getOrElse` / `getError` / `isErr` —
+  **not** `is Ok` / `is Err` (kotlin-result 2.x `Result` is a value class).
+- **Serialization**: `@Serializable` on sealed hierarchies for wire protocol and
+  `kolt.toml` model.
+- Intra-project imports follow the cli → build → resolve direction; reverse
+  dependencies are a structural smell.
+
+## Code Organization Principles
+
+- **Sealed interfaces + ADTs** for domain polymorphism (`CompilerBackend`,
+  `DaemonJarResolution`, `Message`). Preferred over enums when variants carry data,
+  preferred over open inheritance always.
+- **Pure resolution kernel**: `kolt.resolve` has no I/O; callers inject network and
+  cache adapters. The kernel is the reliability floor — treat it with Gradle/Maven-
+  spec parity in mind.
+- **Explicit fallback policy**: all daemon failures except `CompilationFailed` fall
+  back to subprocess. Retry budgets (e.g. 10..200ms within 3s) are inlined with ADR
+  references rather than hidden in framework code.
+- **Daemon version sync**: the Kotlin version pinned in the root `build.gradle.kts`
+  and in each daemon's own `Main.kt` must match. `verifyDaemonKotlinVersion`
+  enforces this in `./gradlew check`.
+- **ADR citations in code**: when a block encodes a non-obvious decision (link
+  stages, fallback routing, retry budgets), reference the ADR number in a comment so
+  a reader can pull the rationale without git archaeology.

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,115 @@
+# Technology Stack
+
+## Architecture
+
+kolt is a **native-first CLI with JVM sidecar daemons**. The user-facing binary is
+Kotlin/Native (`kolt.kexe`, linuxX64); compilation work is delegated to JVM daemon
+processes over Unix sockets to amortize kotlinc startup cost.
+
+Self-hosting is partial as of v0.13.0: the native binary rebuilds itself from
+`kolt.toml`, but the daemon JARs still require Gradle to build. Full self-host is on
+the v1.0 path.
+
+Top-level build layout uses Gradle `includeBuild()` to decouple three pieces: the root
+native project, `kolt-compiler-daemon/` (JVM daemon), and `kolt-native-daemon/`
+(proposed native-compiler sidecar).
+
+## Core Technologies
+
+- **Language**: Kotlin 2.3.x (pinned in both `build.gradle.kts` and `kolt.toml`). The
+  Kotlin compiler version used for user builds is independently overridable via
+  `[kotlin] compiler = "..."` so users can pin an older API.
+- **JVM target**: JDK 21 for daemon JARs and Gradle builds.
+- **Native target**: linuxX64 via Kotlin/Native (konanc). Two-stage library+link
+  compile flow (ADR 0014) to keep plugin registrars working on native.
+
+## Key Libraries
+
+Only the libraries that shape development patterns — not the full dependency set.
+
+- **kotlin-result 2.3.x** — `Result<V, E>` for all fallible paths. Exceptions are not
+  the project convention (ADR 0001). Note: kotlin-result 2.x is a value class, so
+  `is Ok` / `is Err` do not work — use `getOrElse`, `getError`, `isErr`.
+- **libcurl cinterop** — HTTP in native contexts (ADR 0006, chosen over ktor-client).
+- **kotlincrypto.hash sha2-256** — lockfile SHA-256 verification.
+- **kotlinx.serialization** — JSON lockfile format, daemon wire protocol
+  (`@Serializable` sealed Message types).
+- **ktoml-core** — `kolt.toml` parsing.
+- **kotlin.test** — test framework (`Test`, `assertEquals`, `assertIs`, etc.).
+
+## Development Standards
+
+### Error Handling
+`Result<V, E>` is mandatory across layers. Do not throw. Domain errors are modelled
+as sealed ADTs (e.g., `DaemonJarResolution`). The CLI's `main` returns an `ExitCode`
+enum rather than raising.
+
+### Formatting
+**ktfmt** (user-selectable style) via `kolt fmt` / `kolt fmt --check`. No static
+linter (no detekt) — formatter + compiler warnings are the quality gate.
+
+### Testing
+Tests live in `nativeTest/kotlin/` mirroring production package structure. `*Test.kt`
+for unit, `*IntegrationTest.kt` for integration. Shared utilities go in
+`testfixture` subpackages.
+
+### Code Style
+No wildcard imports — every symbol is imported explicitly. ADR numbers are cited in
+comments when the code encodes a design decision that would otherwise read as
+arbitrary (retry budgets, fallback policy, native link stages).
+
+### Language Policy
+Code, comments, commit messages, ADRs, and specification documents are written in
+English. Conversation with contributors may be bilingual, but anything checked into
+the repo is English-first.
+
+## Development Environment
+
+### Required Tools
+- **JDK** (host or `[build] jdk`-managed). Daemon pins JDK 21.
+- **kotlinc** — auto-downloaded to `~/.kolt/toolchains/kotlinc/{version}/` on first
+  run; falls back to system kotlinc if present.
+- **konanc** — auto-installed on first native build; also provisioned by Gradle
+  during development.
+- **libcurl** (Linux native build): `libcurl4-openssl-dev` headers.
+- **Gradle 8.12** — only for building the daemon JARs / doing dev work; end users of
+  kolt never see Gradle.
+
+### Common Commands
+
+User-facing CLI:
+```
+kolt init [name]                  # create project
+kolt build    [--watch]           # compile
+kolt run      [--watch]           # build + run
+kolt test     [--watch]           # build + run tests
+kolt check    [--watch]           # type-check only
+kolt fmt      [--check]           # ktfmt format (or verify in CI)
+kolt add <dep>                    # add dependency to kolt.toml
+kolt deps [install|update|tree]   # resolve / inspect deps
+kolt toolchain install            # provision kotlinc for pinned version
+kolt daemon stop [--all]          # stop warm daemon
+kolt daemon reap                  # clean stale sockets
+```
+
+Development (for working on kolt itself):
+```
+./gradlew build                                # build native binary + daemon JARs
+./gradlew linuxX64Test                          # unit tests
+./gradlew check                                # tests + daemon version verification
+./gradlew linkDebugExecutableLinuxX64 \
+  && ./build/bin/linuxX64/debugExecutable/kolt.kexe build   # self-host smoke test
+```
+
+## Key Technical Decisions
+
+Authoritative ADRs live in `docs/adr/`. The load-bearing ones:
+
+- **ADR 0001** — `Result<V, E>` for all error paths; no exceptions.
+- **ADR 0016** — Warm JVM compiler daemon with shared URLClassLoader.
+- **ADR 0019** — Incremental JVM compilation via kotlin-build-tools-api (BTA).
+- **ADR 0018** — Distribution layout and self-host path.
+- **ADR 0024** — Native compiler daemon (proposed) for konanc warm path.
+
+When changing code that encodes one of these decisions, update the ADR in the same
+commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,37 @@
+# kolt
+
+Lightweight build tool written in Kotlin/Native (linuxX64).
+Reads `kolt.toml`, compiles with `kotlinc`, and runs with `java -jar`.
+
+## Build & Test
+
+```bash
+./gradlew build              # Build + test + binary
+./gradlew linuxX64Test       # Tests only
+./gradlew compileKotlinLinuxX64  # Compile only
+```
+
+## Key Rules
+
+- **Exception throwing is prohibited** — use kotlin-result `Result<V, E>` for all error handling
+- **Follow TDD** (Red -> Green -> Refactor)
+- **No backward compatibility until v1.0** — kolt is pre-v1. Do not add migration shims, legacy-layout probes, or deprecation warnings for older kolt versions. Cut breaking changes cleanly; document upgrade steps in the release note and expect users to run them (e.g. `rm -rf ~/.kolt/daemon/`). Cross-version-of-external-tools compat (Kotlin compiler family, Gradle metadata) is different and still required.
+- **Comments default to deletion** — keep only design invariants, "why-not" decisions, and anchored external-tool gotchas. See `/kolt-dev`.
+- **Write all code, comments, documentation, and commit messages in English**
+- Place test files in `src/nativeTest/kotlin/kolt/<package>/XxxTest.kt` mirroring main source structure
+- Annotate POSIX API usage with `@OptIn(ExperimentalForeignApi::class)` at function level
+
+## Issue & PR writing
+
+- Issues: problem, definition of done, scope. Skip project background and tech prerequisites — the reader already knows what kolt is.
+- PRs: what changed and where the reviewer should focus (judgment calls, places to double-check). Don't restate what the diff shows. Don't repeat the issue's background.
+- Write prose, not checklists. Don't mechanically fill a `## Summary` / `## Test plan` template — default `gh pr create` scaffolding is fine to discard.
+
+## Skills
+
+- `/kolt-usage` — How to use kolt (commands, kolt.toml configuration, dependencies)
+- `/kolt-dev` — Development guide (architecture, error handling policy, testing patterns)
+
 # Agentic SDLC and Spec-Driven Development
 
 Kiro-style Spec-Driven Development on an agentic SDLC

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,33 +1,61 @@
-# kolt
+# Agentic SDLC and Spec-Driven Development
 
-Lightweight build tool written in Kotlin/Native (linuxX64).
-Reads `kolt.toml`, compiles with `kotlinc`, and runs with `java -jar`.
+Kiro-style Spec-Driven Development on an agentic SDLC
 
-## Build & Test
+## Project Context
 
-```bash
-./gradlew build              # Build + test + binary
-./gradlew linuxX64Test       # Tests only
-./gradlew compileKotlinLinuxX64  # Compile only
-```
+### Paths
+- Steering: `.kiro/steering/`
+- Specs: `.kiro/specs/`
 
-## Key Rules
+### Steering vs Specification
 
-- **Exception throwing is prohibited** — use kotlin-result `Result<V, E>` for all error handling
-- **Follow TDD** (Red -> Green -> Refactor)
-- **No backward compatibility until v1.0** — kolt is pre-v1. Do not add migration shims, legacy-layout probes, or deprecation warnings for older kolt versions. Cut breaking changes cleanly; document upgrade steps in the release note and expect users to run them (e.g. `rm -rf ~/.kolt/daemon/`). Cross-version-of-external-tools compat (Kotlin compiler family, Gradle metadata) is different and still required.
-- **Comments default to deletion** — keep only design invariants, "why-not" decisions, and anchored external-tool gotchas. See `/kolt-dev`.
-- **Write all code, comments, documentation, and commit messages in English**
-- Place test files in `src/nativeTest/kotlin/kolt/<package>/XxxTest.kt` mirroring main source structure
-- Annotate POSIX API usage with `@OptIn(ExperimentalForeignApi::class)` at function level
+**Steering** (`.kiro/steering/`) - Guide AI with project-wide rules and context
+**Specs** (`.kiro/specs/`) - Formalize development process for individual features
 
-## Issue & PR writing
+### Active Specifications
+- Check `.kiro/specs/` for active specifications
+- Use `/kiro-spec-status [feature-name]` to check progress
 
-- Issues: problem, definition of done, scope. Skip project background and tech prerequisites — the reader already knows what kolt is.
-- PRs: what changed and where the reviewer should focus (judgment calls, places to double-check). Don't restate what the diff shows. Don't repeat the issue's background.
-- Write prose, not checklists. Don't mechanically fill a `## Summary` / `## Test plan` template — default `gh pr create` scaffolding is fine to discard.
+## Development Guidelines
+- Think in English, generate responses in Japanese. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).
 
-## Skills
+## Minimal Workflow
+- Phase 0 (optional): `/kiro-steering`, `/kiro-steering-custom`
+- Discovery: `/kiro-discovery "idea"` — determines action path, writes brief.md + roadmap.md for multi-spec projects
+- Phase 1 (Specification):
+  - Single spec: `/kiro-spec-quick {feature} [--auto]` or step by step:
+    - `/kiro-spec-init "description"`
+    - `/kiro-spec-requirements {feature}`
+    - `/kiro-validate-gap {feature}` (optional: for existing codebase)
+    - `/kiro-spec-design {feature} [-y]`
+    - `/kiro-validate-design {feature}` (optional: design review)
+    - `/kiro-spec-tasks {feature} [-y]`
+  - Multi-spec: `/kiro-spec-batch` — creates all specs from roadmap.md in parallel by dependency wave
+- Phase 2 (Implementation): `/kiro-impl {feature} [tasks]`
+  - Without task numbers: autonomous mode (subagent per task + independent review + final validation)
+  - With task numbers: manual mode (selected tasks in main context, still reviewer-gated before completion)
+  - `/kiro-validate-impl {feature}` (standalone re-validation)
+- Progress check: `/kiro-spec-status {feature}` (use anytime)
 
-- `/kolt-usage` — How to use kolt (commands, kolt.toml configuration, dependencies)
-- `/kolt-dev` — Development guide (architecture, error handling policy, testing patterns)
+## Skills Structure
+Skills are located in `.claude/skills/kiro-*/SKILL.md`
+- Each skill is a directory with a `SKILL.md` file
+- Skills run inline with access to conversation context
+- Skills may delegate parallel research to subagents for efficiency
+- Additional files (templates, examples) can be added to skill directories
+- `kiro-review` — task-local adversarial review protocol used by reviewer subagents
+- `kiro-debug` — root-cause-first debug protocol used by debugger subagents
+- `kiro-verify-completion` — fresh-evidence gate before success or completion claims
+- **If there is even a 1% chance a skill applies to the current task, invoke it.** Do not skip skills because the task seems simple.
+
+## Development Rules
+- 3-phase approval workflow: Requirements → Design → Tasks → Implementation
+- Human review required each phase; use `-y` only for intentional fast-track
+- Keep steering current and verify alignment with `/kiro-spec-status`
+- Follow the user's instructions precisely, and within that scope act autonomously: gather the necessary context and complete the requested work end-to-end in this run, asking questions only when essential information is missing or the instructions are critically ambiguous.
+
+## Steering Configuration
+- Load entire `.kiro/steering/` as project memory
+- Default files: `product.md`, `tech.md`, `structure.md`
+- Custom files are supported (managed via `/kiro-steering-custom`)

--- a/docs/adr/0025-library-artifact-layout.md
+++ b/docs/adr/0025-library-artifact-layout.md
@@ -1,0 +1,227 @@
+# ADR 0025: Library artifact layout for native and JVM targets
+
+## Status
+
+Implemented (2026-04-22).
+
+## Summary
+
+- `kind = "lib"` (ADR 0023 §1) ships in #30, but ADR 0023 deliberately
+  deferred the **artifact shape** question. This ADR pins it: native
+  libraries emit a `build/<name>-klib` **directory**; JVM libraries emit a
+  thin `build/<name>.jar` with no `Main-Class` manifest attribute and no
+  bundled runtime or dependency classes (§1).
+- Native lib reuses the existing ADR 0014 stage 1 command unchanged.
+  `konanc -p library -nopack` already produces the directory form; no
+  repack step is introduced (§2).
+- JVM lib reuses the existing `jar cf <output> -C <classes> .` jar-packaging
+  invocation. No `-include-runtime` anywhere in the pipeline; the default
+  JDK manifest (`Manifest-Version` + `Created-By`) is accepted as-is (§3).
+- The `build/<name>` stem is derived from `KoltConfig.name`; callers that
+  need to locate the artifact use `outputNativeKlibPath(config)` /
+  `outputJarPath(config)` rather than reconstructing the path (§4).
+- The directory-not-file choice for native is the load-bearing one for
+  downstream specs. `kolt publish` (#21), `kolt new --lib` (#28), and the
+  ADR 0018 self-host migration of `kolt-compiler-daemon/` all consume this
+  contract; changing it later would fan out into each of them (§5).
+
+## Context and Problem Statement
+
+ADR 0023 §1 reserved `kind = "lib"` at the TOML schema layer and explicitly
+deferred the question of what a library build *produces*. Issue #30 delivered
+the end-to-end pipeline, and during Task 6 dogfood the artifact shape was
+forced into the open:
+
+- On native, the existing ADR 0014 two-stage flow runs stage 1 with
+  `konanc -p library -nopack`, which emits an **unpacked klib directory**
+  (`default/{ir, linkdata, manifest, resources, targets/…}`) rather than a
+  packed `.klib` file. kolt's internal helpers (`outputNativeKlibPath`,
+  stage 1 `-o` flag) were already wired to the directory form — the
+  library-build-pipeline spec inherited that convention without declaring
+  it.
+- On JVM, `jar cf` had already been producing a thin class jar without a
+  `Main-Class` attribute. The library path simply keeps this shape; a
+  potential future `fat_jar = false` axis for apps (currently out of scope)
+  would not disturb libraries.
+
+`kolt publish` (#21), `kolt new --lib` (#28), and the ADR 0018 self-host
+migration of `kolt-compiler-daemon/` into a kolt-built library all need a
+definitive answer for the artifact shape and path layout they are
+consuming. Writing this ADR closes the gap so those downstream specs don't
+each re-derive the contract.
+
+## Decision Drivers
+
+- **Reuse existing pipeline**: no repack step or new linker invocation if
+  avoidable; the existing ADR 0014 stage 1 command should remain the one
+  entry point for native library output.
+- **No breaking change to `kolt.toml`**: artifact layout must be derivable
+  from the current `name` + `kind` + `target` fields, no new required keys.
+- **Predictable path derivation**: build-tool consumers (IDE, publish
+  pipeline, `kolt run` reject path) must be able to compute the artifact
+  path from `KoltConfig` alone, without running the build.
+- **Forward compatibility with `kolt publish`**: whatever the shape is must
+  be either directly publishable (Maven Central, `.klib` packaged form) or
+  repackable with a declared step.
+
+## Considered Options
+
+- **Option A** — Native: unpacked klib directory; JVM: thin jar.
+  (What the existing pipeline already produces.)
+- **Option B** — Native: packed `.klib` file (run stage 1 without
+  `-nopack`, or repack after stage 1); JVM: thin jar.
+- **Option C** — Native: both (directory for build cache, packed file for
+  publish); JVM: thin jar.
+
+## Decision Outcome
+
+Chosen option: **Option A**, because it requires zero new pipeline code,
+keeps ADR 0014 stage helpers untouched, and meets every decision driver.
+Packed-form conversion is a `kolt publish` concern and can be layered on
+top without revisiting the build contract.
+
+### §1 Canonical artifact paths
+
+| Target | Kind | Artifact | Path |
+|--------|------|----------|------|
+| linuxX64 | `lib` | directory | `build/<name>-klib/` |
+| linuxX64 | `app` | file | `build/<name>.kexe` |
+| jvm | `lib` | file | `build/<name>.jar` |
+| jvm | `app` | file | `build/<name>.jar` |
+
+`<name>` is `KoltConfig.name` verbatim. Directory vs file is observable to
+the user — `kolt build` stdout names the artifact kind ("built library
+build/<name>-klib ..." vs "built executable build/<name>.kexe ...").
+
+### §2 Native library build
+
+Stage 1 runs unchanged (`konanc -p library -nopack -o build/<name>-klib
+<sources…>`). The library path stops here — no stage 2 link, no
+`.kexe`. The ADR 0014 stage helpers (`nativeLibraryCommand`,
+`nativeLinkCommand`) are not modified by this ADR; the kind gate lives at
+the `doNativeBuild` orchestration layer (see `src/nativeMain/kotlin/kolt/
+cli/BuildCommands.kt`, function `nativeStagePlan` / `doNativeBuild`).
+
+The directory layout matches what `konanc -nopack` emits:
+
+```
+build/<name>-klib/
+└── default/
+    ├── ir/
+    ├── linkdata/
+    ├── manifest
+    ├── resources/
+    └── targets/linux_x64/
+```
+
+No repack into a `.klib` zip archive is performed. Downstream tools that
+require the packed form (notably `kolt publish`) run their own repack; it
+is out of scope here.
+
+### §3 JVM library build
+
+Compile step: existing `kotlinc -d build/classes <sources…>` invocation.
+kolt does **not** pass `-include-runtime` for either kind, now or in the
+future — `JvmLibraryInvariantsTest` pins this as a regression trap.
+
+Jar step: existing `jar cf build/<name>.jar -C build/classes .`
+invocation. No `-m` / `--manifest` / `Main-Class` arguments. The JDK `jar`
+tool emits a default `META-INF/MANIFEST.MF` containing only
+`Manifest-Version` and `Created-By`; those two attributes are accepted.
+
+Jar contents for a library build are strictly:
+
+- `META-INF/MANIFEST.MF`
+- `META-INF/<module>.kotlin_module` (emitted by kotlinc)
+- Compiled project classes under their package directories
+
+Resolved dependency classes and Kotlin stdlib classes are **not** bundled
+into the jar. The `.kolt.lock` + the user's downstream consumer handles
+resolution.
+
+### §4 Path helpers are the API
+
+Consumers (test harnesses, IDE integration, publish pipeline) compute
+artifact paths via `outputNativeKlibPath(config)` and `outputJarPath(config)`,
+not by string-concatenating `"build/" + config.name + ...`. The helpers
+are the single source of truth for the layout defined in §1.
+
+If this ADR is revised to move artifacts (e.g. a `target/<triple>/`
+subdirectory per `cargo build` style, under Rust-compat future work), only
+the helpers change; call sites are unaffected.
+
+### §5 Downstream contract scope
+
+Three specs consume this layout today:
+
+- **`kolt publish` (#21)** — reads the built artifact(s) and produces
+  Maven-compatible publications. For native libs it owns the repack to
+  `.klib` (or whatever the future Kotlin/Native convention turns out to
+  be); for JVM libs the thin `.jar` is directly publishable. `kolt publish`
+  is a consumer of this ADR, not a modifier of it.
+- **`kolt new --lib` (#28)** — scaffolds a library project. The generated
+  `kolt.toml` only needs `kind = "lib"` and no `[build] main`; nothing
+  about the artifact layout needs templating into the scaffold.
+- **ADR 0018 self-host migration** — `kolt-compiler-daemon/` becoming a
+  kolt-built library consumes the JVM `.jar` contract (§3). The existing
+  Gradle subproject publishes a plain class jar; the kolt-built form
+  matches byte-wise modulo the `jvmTarget` and `kotlinc` version.
+
+### Consequences
+
+**Positive**
+- Zero new pipeline code for the library case — every path listed in §1
+  was already wired up by pre-Task-1 code or by Tasks 2–4 of #30.
+- `kolt publish`, `kolt new --lib`, and the self-host plan can land without
+  first relitigating the artifact shape.
+- Regression tests (`JvmLibraryInvariantsTest`, `NativeStagePlanTest`, and
+  the `spike/lib-dogfood/` fixtures) pin the contract end-to-end; a future
+  change to the layout trips at least one of them.
+
+**Negative**
+- Native libs are a directory on disk, which surprises users coming from
+  Kotlin/JVM (where libs are always single files). The `kolt build` stdout
+  line ("built library build/<name>-klib …") is the primary user-facing
+  affordance; documentation should call this out when `kolt publish` ships.
+- The repack to packed `.klib` is deferred to `kolt publish`. Users who
+  manually cp the artifact around will cp a directory — expected, but
+  documented only in this ADR until `kolt publish` lands.
+
+### Confirmation
+
+- `JvmLibraryInvariantsTest.libraryJvmJarOutputPathIsBuildNameJar` and
+  related cases in `src/nativeTest/kotlin/kolt/cli/BuildLibraryTest.kt`
+  enforce the JVM lib layout.
+- `NativeStagePlanTest` pins the native branching — lib returns the klib
+  directory path, app returns the `.kexe` path.
+- `spike/lib-dogfood/{jvm,native}/README.md` captures the on-disk layout
+  for reviewers and is replayable.
+- A future PR that changes `outputNativeKlibPath` or `outputJarPath`
+  shape trips these tests and should revisit this ADR before merging.
+
+## Alternatives considered
+
+1. **Packed `.klib` file for native libraries.** Rejected. Would require
+   either switching stage 1 off `-nopack` (untested path; `K2Native`'s
+   behavior with packed output plus incremental cache has not been
+   validated) or introducing a repack step after stage 1 (new code for no
+   build-time benefit, because kolt itself never consumes its own libraries
+   in packed form). `kolt publish` will own the repack when it needs to.
+2. **Both forms (directory for cache, packed for publish).** Rejected as
+   premature. Producing both doubles stage 1 output without a concrete
+   consumer today. `kolt publish` has not been designed yet; whichever
+   form it prefers can be produced on demand rather than eagerly.
+
+## Related
+
+- #30 — tracking issue ("Implement `kind = \"lib\"` build pipeline").
+- ADR 0014 — native two-stage library+link flow (this ADR relies on stage
+  1 being unchanged).
+- ADR 0018 — distribution / self-host endgame (this ADR's JVM §3 is the
+  contract `kolt-compiler-daemon/` migrates onto).
+- ADR 0023 §1 — target/kind schema (this ADR extends the "reserved lib"
+  slot with a concrete artifact definition).
+- #21 — `kolt publish` (downstream consumer of §1 and §5).
+- #28 — `kolt new --lib` (downstream consumer of §5).
+- `.kiro/specs/lib-build-pipeline/` — spec artifacts, design, tasks.
+- `spike/lib-dogfood/README.md` — replayable on-disk evidence for §1.

--- a/spike/lib-dogfood/.gitignore
+++ b/spike/lib-dogfood/.gitignore
@@ -1,0 +1,5 @@
+# Build outputs — regenerated on every replay.
+build/
+kolt.lock
+kls-classpath
+workspace.json

--- a/spike/lib-dogfood/README.md
+++ b/spike/lib-dogfood/README.md
@@ -1,0 +1,96 @@
+# lib-dogfood — Task 6.1 regression / invariant fixtures
+
+Throwaway fixtures used to dogfood `kind = "lib"` end-to-end for spec
+`lib-build-pipeline` (issue #30). Covers Requirements 2.4, 3.4, 4.4, 5.3
+plus end-to-end closure of 2.1 and 3.1.
+
+## Replay
+
+Build the kolt binary once:
+
+```bash
+./gradlew linkReleaseExecutableLinuxX64
+export KOLT=$PWD/build/bin/linuxX64/releaseExecutable/kolt.kexe
+```
+
+### JVM library (R2.1, R2.2, R2.3)
+
+```bash
+cd spike/lib-dogfood/jvm
+"$KOLT" build
+# → built build/jvmlibdog.jar in ~6s
+unzip -l build/jvmlibdog.jar
+#   META-INF/MANIFEST.MF
+#   META-INF/kolt-<hash>.kotlin_module
+#   dogfood/Util.class
+unzip -p build/jvmlibdog.jar META-INF/MANIFEST.MF
+#   Manifest-Version: 1.0
+#   Created-By: 21.0.7 (Amazon.com Inc.)
+#   (no Main-Class line — R2.3)
+# (no kotlin/ or dependency packages — R2.2)
+
+"$KOLT" test
+# → tests passed; exit 0 (R5.1, R5.3)
+
+"$KOLT" run
+# → error: library projects cannot be run
+# → exit 2 (R4.1, R4.3)
+```
+
+### Native library (R3.1, R3.2, R3.3)
+
+```bash
+cd spike/lib-dogfood/native
+"$KOLT" build
+# → built library build/nativelibdog-klib in ~5s
+ls build/
+#   nativelibdog-klib/   ← directory (stage 1 -nopack output)
+#   .kolt-state.json
+#   (no nativelibdog.kexe — R3.2)
+
+"$KOLT" test
+# → tests passed; exit 0 (R5.1)
+
+"$KOLT" run
+# → error: library projects cannot be run
+# → exit 2 (R4.1, R4.3)
+```
+
+### Native app — non-regression (R3.4, R4.4)
+
+```bash
+cd spike/lib-dogfood/app-native
+"$KOLT" build
+# → built executable build/nativeappdog.kexe in ~7s
+./build/nativeappdog.kexe
+# → hello from native app
+```
+
+## Canonical error probes
+
+Temporarily mutate `kind` or `main` in a fixture's `kolt.toml` to
+observe the two parser rejections (each revert has been verified to
+rebuild cleanly):
+
+- `kind = "app"` + no `[build] main` →
+  `error: [build] main is required for kind = "app"` (exit 2)
+- `kind = "lib"` + `main = "..."` →
+  `error: main has no meaning for a library; remove it` (exit 2)
+
+## Artifact inventory (2026-04-22 run)
+
+| Fixture | Command | Output | Size / shape |
+|---|---|---|---|
+| jvm | build | `build/jvmlibdog.jar` | 1336 B, 5 entries, no `Main-Class`, no `kotlin/` |
+| jvm | test | exit 0, 1 test run | — |
+| jvm | run | exit 2, canonical stderr | — |
+| native | build | `build/nativelibdog-klib/` (directory) | klib with `default/{ir,linkdata,manifest,resources,targets}` |
+| native | build | `build/nativelibdog.kexe` | ABSENT — R3.2 holds |
+| native | test | exit 0, 1 test run | — |
+| native | run | exit 2, canonical stderr | — |
+| app-native | build | `build/nativeappdog.kexe` | 897952 B, runs and prints `hello from native app` |
+
+## Baseline
+
+`./gradlew check` exits 0 on branch `30/lib-build-pipeline` at task 6.1
+entry — captured 2026-04-22.

--- a/spike/lib-dogfood/app-native/kolt.toml
+++ b/spike/lib-dogfood/app-native/kolt.toml
@@ -1,0 +1,10 @@
+name = "nativeappdog"
+version = "0.0.1"
+
+[kotlin]
+version = "2.3.20"
+
+[build]
+target = "linuxX64"
+main = "dogfood.main"
+sources = ["src/main"]

--- a/spike/lib-dogfood/app-native/src/main/Main.kt
+++ b/spike/lib-dogfood/app-native/src/main/Main.kt
@@ -1,0 +1,5 @@
+package dogfood
+
+fun main() {
+    println("hello from native app")
+}

--- a/spike/lib-dogfood/jvm/kolt.toml
+++ b/spike/lib-dogfood/jvm/kolt.toml
@@ -1,0 +1,11 @@
+name = "jvmlibdog"
+version = "0.0.1"
+kind = "lib"
+
+[kotlin]
+version = "2.3.20"
+
+[build]
+target = "jvm"
+sources = ["src/main"]
+test_sources = ["test"]

--- a/spike/lib-dogfood/jvm/src/main/Util.kt
+++ b/spike/lib-dogfood/jvm/src/main/Util.kt
@@ -1,0 +1,5 @@
+package dogfood
+
+object Util {
+    fun greet(): String = "hello from jvm lib"
+}

--- a/spike/lib-dogfood/jvm/test/UtilTest.kt
+++ b/spike/lib-dogfood/jvm/test/UtilTest.kt
@@ -1,0 +1,11 @@
+package dogfood
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UtilTest {
+    @Test
+    fun greet_returns_canonical_message() {
+        assertEquals("hello from jvm lib", Util.greet())
+    }
+}

--- a/spike/lib-dogfood/native/kolt.toml
+++ b/spike/lib-dogfood/native/kolt.toml
@@ -1,0 +1,11 @@
+name = "nativelibdog"
+version = "0.0.1"
+kind = "lib"
+
+[kotlin]
+version = "2.3.20"
+
+[build]
+target = "linuxX64"
+sources = ["src/main"]
+test_sources = ["test"]

--- a/spike/lib-dogfood/native/src/main/Util.kt
+++ b/spike/lib-dogfood/native/src/main/Util.kt
@@ -1,0 +1,5 @@
+package dogfood
+
+object Util {
+    fun greet(): String = "hello from native lib"
+}

--- a/spike/lib-dogfood/native/test/UtilTest.kt
+++ b/spike/lib-dogfood/native/test/UtilTest.kt
@@ -1,0 +1,11 @@
+package dogfood
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UtilTest {
+    @Test
+    fun greet_returns_canonical_message() {
+        assertEquals("hello from native lib", Util.greet())
+    }
+}

--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -93,8 +93,12 @@ fun nativeLibraryCommand(
     return BuildCommand(args = args, outputPath = outputBase)
 }
 
+// `main` is passed explicitly (not read from `config.build.main`) because
+// `BuildSection.main` became nullable in the lib-build-pipeline spec; the
+// kind gate and null-check live at the caller per ADR 0001.
 fun nativeLinkCommand(
     config: KoltConfig,
+    main: String,
     konancPath: String? = null,
     klibs: List<String> = emptyList()
 ): BuildCommand {
@@ -109,7 +113,7 @@ fun nativeLinkCommand(
         add("-p")
         add("program")
         add("-e")
-        add(config.build.main)
+        add(main)
         for (klib in klibs) {
             add("-l")
             add(klib)

--- a/src/nativeMain/kotlin/kolt/build/Runner.kt
+++ b/src/nativeMain/kotlin/kolt/build/Runner.kt
@@ -7,15 +7,19 @@ data class RunCommand(
     val args: List<String>
 )
 
+// `main` is passed explicitly (not read from `config.build.main`) because
+// `BuildSection.main` became nullable in the lib-build-pipeline spec; the
+// kind gate and null-check live at the caller per ADR 0001.
 fun runCommand(
     config: KoltConfig,
+    main: String,
     classpath: String? = null,
     appArgs: List<String> = emptyList(),
     javaPath: String? = null
 ): RunCommand {
     val cp = if (!classpath.isNullOrEmpty()) "$CLASSES_DIR:$classpath" else CLASSES_DIR
     return RunCommand(
-        args = listOf(javaPath ?: "java", "-cp", cp, jvmMainClass(config.build.main)) + appArgs
+        args = listOf(javaPath ?: "java", "-cp", cp, jvmMainClass(main)) + appArgs
     )
 }
 

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -31,6 +31,34 @@ internal data class BuildResult(
     val javaPath: String? = null,
 )
 
+// Kind-gated plan for a native build (ADR 0014 two-stage × ADR 0023 §1).
+// `linkMain == null` ⇒ skip stage 2 (library), stage 1 klib is the artifact.
+// `linkMain != null` ⇒ run stage 2 (app link) with that entry-point FQN.
+internal data class NativeStagePlan(
+    val linkMain: String?,
+    val artifactKind: String,
+    val artifactPath: String,
+)
+
+// ADR 0023 §1: library kind has no entry point; app kind must carry one
+// (parser invariant). The `?: return` keeps ADR 0001 safe without `!!`;
+// it is unreachable for apps produced by `parseConfig`.
+internal fun nativeStagePlan(config: KoltConfig): Result<NativeStagePlan, Int> {
+    if (config.isLibrary()) {
+        return Ok(NativeStagePlan(
+            linkMain = null,
+            artifactKind = "library",
+            artifactPath = outputNativeKlibPath(config),
+        ))
+    }
+    val main = config.build.main ?: return Err(EXIT_BUILD_ERROR)
+    return Ok(NativeStagePlan(
+        linkMain = main,
+        artifactKind = "executable",
+        artifactPath = outputKexePath(config),
+    ))
+}
+
 internal fun filterExistingDirs(
     paths: List<String>,
     kind: String,
@@ -231,12 +259,18 @@ private fun doNativeBuild(config: KoltConfig, useDaemon: Boolean): Result<BuildR
     val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_BUILD_ERROR) }
     val managedKonancBin = ensureKonancBin(config.kotlin.effectiveCompiler, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
 
-    val kexePath = outputKexePath(config)
+    // ADR 0014 (two-stage native) × ADR 0023 §1 (kind schema): library
+    // kind stops at stage 1 (the `-klib` directory), app kind continues
+    // into stage 2 (`.kexe`). Artifact path drives both the up-to-date
+    // check and the success message so lib builds don't chase a missing
+    // `.kexe`.
+    val stagePlan = nativeStagePlan(config).getOrElse { return Err(it) }
+    val artifactPath = stagePlan.artifactPath
     val defNewestMtime = newestDefMtime(config)
     val currentState = BuildState(
         configMtime = fileMtime(KOLT_TOML) ?: 0L,
         sourcesNewestMtime = newestMtime(config.build.sources),
-        classesDirMtime = if (fileExists(kexePath)) fileMtime(kexePath) else null,
+        classesDirMtime = if (fileExists(artifactPath)) fileMtime(artifactPath) else null,
         lockfileMtime = null,
         resourcesNewestMtime = null,
         defNewestMtime = defNewestMtime
@@ -291,33 +325,34 @@ private fun doNativeBuild(config: KoltConfig, useDaemon: Boolean): Result<BuildR
         return Err(EXIT_BUILD_ERROR)
     }
 
-    ensureDirectoryRecursive(NATIVE_IC_CACHE_DIR).getOrElse { error ->
-        eprintln("error: could not create directory ${error.path}")
+    // ADR 0014 stage 2 × ADR 0023 §1: skip the native link step for library
+    // kind; stage 1 already produced the `.klib` artifact.
+    if (stagePlan.linkMain != null) {
+        ensureDirectoryRecursive(NATIVE_IC_CACHE_DIR).getOrElse { error ->
+            eprintln("error: could not create directory ${error.path}")
+            return Err(EXIT_BUILD_ERROR)
+        }
+
+        val linkCmd = nativeLinkCommand(config, main = stagePlan.linkMain, konancPath = managedKonancBin, klibs = klibs)
+        println("linking ${config.name} (native)...")
+        runNativeLinkWithIcFallback(backend, linkCmd.args.drop(1)).getOrElse { error ->
+            reportNativeCompileError(error, "linking")
+            return Err(EXIT_BUILD_ERROR)
+        }
+    }
+
+    if (!fileExists(artifactPath)) {
+        eprintln("error: $artifactPath not produced by konanc")
         return Err(EXIT_BUILD_ERROR)
     }
 
-    // Parser invariant `kind == "app" ⇒ main != null` guarantees non-null;
-    // the `?: return` keeps ADR 0001 safe until the Task 2.2 kind gate lands.
-    val main = config.build.main ?: return Err(EXIT_BUILD_ERROR)
-    val linkCmd = nativeLinkCommand(config, main = main, konancPath = managedKonancBin, klibs = klibs)
-    println("linking ${config.name} (native)...")
-    runNativeLinkWithIcFallback(backend, linkCmd.args.drop(1)).getOrElse { error ->
-        reportNativeCompileError(error, "linking")
-        return Err(EXIT_BUILD_ERROR)
-    }
-
-    if (!fileExists(kexePath)) {
-        eprintln("error: $kexePath not produced by konanc")
-        return Err(EXIT_BUILD_ERROR)
-    }
-
-    val newState = currentState.copy(classesDirMtime = fileMtime(kexePath))
+    val newState = currentState.copy(classesDirMtime = fileMtime(artifactPath))
     writeFileAsString(BUILD_STATE_FILE, serializeBuildState(newState)).getOrElse {
         eprintln("warning: could not write build state file")
     }
 
     val elapsed = startMark.elapsedNow()
-    println("built $kexePath in ${formatDuration(elapsed)}")
+    println("built ${stagePlan.artifactKind} $artifactPath in ${formatDuration(elapsed)}")
     return Ok(BuildResult(config, classpath = null, javaPath = null))
 }
 

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -296,7 +296,10 @@ private fun doNativeBuild(config: KoltConfig, useDaemon: Boolean): Result<BuildR
         return Err(EXIT_BUILD_ERROR)
     }
 
-    val linkCmd = nativeLinkCommand(config, konancPath = managedKonancBin, klibs = klibs)
+    // Parser invariant `kind == "app" ⇒ main != null` guarantees non-null;
+    // the `?: return` keeps ADR 0001 safe until the Task 2.2 kind gate lands.
+    val main = config.build.main ?: return Err(EXIT_BUILD_ERROR)
+    val linkCmd = nativeLinkCommand(config, main = main, konancPath = managedKonancBin, klibs = klibs)
     println("linking ${config.name} (native)...")
     runNativeLinkWithIcFallback(backend, linkCmd.args.drop(1)).getOrElse { error ->
         reportNativeCompileError(error, "linking")
@@ -424,7 +427,10 @@ internal fun doRun(config: KoltConfig, classpath: String?, appArgs: List<String>
         return Err(EXIT_BUILD_ERROR)
     }
 
-    val cmd = runCommand(config, classpath, appArgs, javaPath = javaPath)
+    // Parser invariant `kind == "app" ⇒ main != null` guarantees non-null;
+    // the `?: return` keeps ADR 0001 safe until the Task 3.2 kind gate lands.
+    val jvmMain = config.build.main ?: return Err(EXIT_BUILD_ERROR)
+    val cmd = runCommand(config, main = jvmMain, classpath = classpath, appArgs = appArgs, javaPath = javaPath)
     executeCommand(cmd.args).getOrElse { error ->
         return Err(when (error) {
             is ProcessError.NonZeroExit -> error.exitCode

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -441,7 +441,29 @@ private fun runCinterop(config: KoltConfig, paths: KoltPaths): Result<List<Strin
     return Ok(klibs)
 }
 
+// ADR 0023 §1: library kind has no entry point; `kolt run` pre-empts the
+// build pipeline with this canonical stderr line.
+private const val RUN_LIB_ERROR = "library projects cannot be run"
+
+// Pure kind guard for `kolt run` / `kolt run --watch`. Returns
+// `Err(EXIT_CONFIG_ERROR)` for library configs (ADR 0023 §1) and `Ok`
+// for apps. Lifted to a top-level helper so `doRun` and `watchRunLoop`
+// share one rejection path and the guard can be tested hermetically
+// per design.md §Testing Strategy.
+internal fun rejectIfLibrary(
+    config: KoltConfig,
+    eprint: (String) -> Unit = ::eprintln,
+): Result<Unit, Int> {
+    if (!config.isLibrary()) return Ok(Unit)
+    eprint("error: $RUN_LIB_ERROR")
+    return Err(EXIT_CONFIG_ERROR)
+}
+
 internal fun doRun(config: KoltConfig, classpath: String?, appArgs: List<String> = emptyList(), javaPath: String? = null): Result<Unit, Int> {
+    // ADR 0023 §1 kind gate: reject libraries before any artifact lookup
+    // or process launch. Target-agnostic by design (R4.3).
+    rejectIfLibrary(config).getOrElse { return Err(it) }
+
     if (config.build.target in NATIVE_TARGETS) {
         val kexePath = outputKexePath(config)
         if (!fileExists(kexePath)) {
@@ -463,7 +485,8 @@ internal fun doRun(config: KoltConfig, classpath: String?, appArgs: List<String>
     }
 
     // Parser invariant `kind == "app" ⇒ main != null` guarantees non-null;
-    // the `?: return` keeps ADR 0001 safe until the Task 3.2 kind gate lands.
+    // the kind gate above pre-empts libs, so this `?: return` is ADR 0001
+    // safety for the parser invariant and is unreachable on apps at runtime.
     val jvmMain = config.build.main ?: return Err(EXIT_BUILD_ERROR)
     val cmd = runCommand(config, main = jvmMain, classpath = classpath, appArgs = appArgs, javaPath = javaPath)
     executeCommand(cmd.args).getOrElse { error ->

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -37,6 +37,11 @@ fun main(args: Array<String>) {
             if (watch) {
                 watchRunLoop(useDaemon, appArgs)
             } else {
+                // ADR 0023 §1 kind gate: reject libraries before the
+                // build pipeline runs (R4.2). doRun has the same guard
+                // for defense-in-depth when called through other paths.
+                val parsed = loadProjectConfig().getOrElse { exitProcess(it) }
+                rejectIfLibrary(parsed).getOrElse { exitProcess(it) }
                 val (config, classpath, javaPath) = doBuild(useDaemon = useDaemon).getOrElse { exitProcess(it) }
                 doRun(config, classpath, appArgs, javaPath).getOrElse { exitProcess(it) }
             }

--- a/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
+++ b/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
@@ -284,7 +284,13 @@ internal fun watchRunLoop(
         val runCmd = if (buildResult.config.build.target in NATIVE_TARGETS) {
             nativeRunCommand(buildResult.config, appArgs)
         } else {
-            runCommand(buildResult.config, buildResult.classpath, appArgs, javaPath = buildResult.javaPath)
+            // Parser invariant `kind == "app" ⇒ main != null` guarantees
+            // non-null; Task 3.2 will add an early lib rejection upstream.
+            val jvmMain = buildResult.config.build.main ?: run {
+                eprintln("error: [build] main is required to run")
+                break
+            }
+            runCommand(buildResult.config, main = jvmMain, classpath = buildResult.classpath, appArgs = appArgs, javaPath = buildResult.javaPath)
         }
         val childPid = spawnInProcessGroup(runCmd.args)
         if (childPid < 0) {

--- a/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
+++ b/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
@@ -1,6 +1,7 @@
 package kolt.cli
 
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
 import kolt.build.nativeRunCommand
 import kolt.build.runCommand
@@ -261,11 +262,17 @@ private fun reapChild(pid: Int): Boolean {
 internal fun watchRunLoop(
     useDaemon: Boolean,
     appArgs: List<String> = emptyList(),
+    eprint: (String) -> Unit = ::eprintln,
 ) {
     val config = loadProjectConfig().getOrElse {
-        eprintln("error: cannot start watch mode with invalid config")
+        eprint("error: cannot start watch mode with invalid config")
         return
     }
+    // ADR 0023 §1 kind gate: emit the canonical rejection once at entry
+    // and return cleanly so a library invocation does not enter the
+    // rebuild-poll loop (R4.2 "no per-source-change error spam").
+    if (rejectIfLibrary(config, eprint).getError() != null) return
+
     val watchDirs = collectWatchPaths(config, "run")
     val setup = setupWatches(watchDirs, config) ?: return
     val watcher = setup.watcher
@@ -285,7 +292,9 @@ internal fun watchRunLoop(
             nativeRunCommand(buildResult.config, appArgs)
         } else {
             // Parser invariant `kind == "app" ⇒ main != null` guarantees
-            // non-null; Task 3.2 will add an early lib rejection upstream.
+            // non-null; the lib kind gate at loop entry pre-empts libraries,
+            // so this `?: run` is ADR 0001 safety for the parser invariant
+            // and is unreachable on apps at runtime.
             val jvmMain = buildResult.config.build.main ?: run {
                 eprintln("error: [build] main is required to run")
                 break

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -23,6 +23,12 @@ val VALID_TARGETS = setOf("jvm") + NATIVE_TARGETS
 
 val VALID_KINDS = setOf("app", "lib")
 
+// ADR 0023 §1: `kind = "lib"` forbids `[build] main`.
+private const val LIB_WITH_MAIN_ERROR = "main has no meaning for a library; remove it"
+
+// ADR 0023 §1: `kind = "app"` requires `[build] main`.
+private const val APP_WITHOUT_MAIN_ERROR = "[build] main is required for kind = \"app\""
+
 // Maps a schema-level KonanTarget identifier (camelCase, e.g. `linuxX64`) to
 // the snake_case form used by both konanc CLI (`-target linux_x64`) and the
 // `org.jetbrains.kotlin.native.target` attribute in Gradle Module Metadata.
@@ -59,7 +65,7 @@ data class BuildSection(
     val target: String,
     @SerialName("jvm_target") val jvmTarget: String = "17",
     val jdk: String? = null,
-    val main: String,
+    val main: String?,
     val sources: List<String>,
     @SerialName("test_sources") val testSources: List<String> = listOf("test"),
     val resources: List<String> = emptyList(),
@@ -103,7 +109,7 @@ private data class RawBuildSection(
     val target: String? = null,
     @SerialName("jvm_target") val jvmTarget: String = "17",
     val jdk: String? = null,
-    val main: String,
+    val main: String? = null,
     val sources: List<String>,
     @SerialName("test_sources") val testSources: List<String> = listOf("test"),
     val resources: List<String> = emptyList(),
@@ -126,11 +132,6 @@ private data class RawKoltConfig(
 )
 
 private fun validateKind(kind: String): Result<Unit, ConfigError> {
-    if (kind == "lib") {
-        return Err(ConfigError.ParseFailed(
-            "kind = \"lib\" is reserved but not yet implemented (ADR 0023)"
-        ))
-    }
     if (kind !in VALID_KINDS) {
         return Err(ConfigError.ParseFailed(
             "invalid kind '$kind' (valid kinds: ${VALID_KINDS.joinToString(", ")})"
@@ -180,10 +181,20 @@ private fun resolveEffectiveTarget(raw: RawBuildSection): Result<String, ConfigE
 fun parseConfig(tomlString: String): Result<KoltConfig, ConfigError> {
     return try {
         val raw = toml.decodeFromString(RawKoltConfig.serializer(), tomlString)
+        // Validation order is load-bearing: tests match on canonical error
+        // substrings per design.md §Components → Config parser kind+main rule.
         validateKind(raw.kind).getError()?.let { return Err(it) }
+        if (raw.kind == "lib" && raw.build.main != null) {
+            return Err(ConfigError.ParseFailed(LIB_WITH_MAIN_ERROR))
+        }
+        if (raw.kind == "app" && raw.build.main == null) {
+            return Err(ConfigError.ParseFailed(APP_WITHOUT_MAIN_ERROR))
+        }
+        raw.build.main?.let { main ->
+            validateMainFqn(main).getError()?.let { return Err(it) }
+        }
         val effectiveTarget = resolveEffectiveTarget(raw.build).getOrElse { return Err(it) }
         validateTarget(effectiveTarget).getError()?.let { return Err(it) }
-        validateMainFqn(raw.build.main).getError()?.let { return Err(it) }
         raw.kotlin.compiler?.let { compiler ->
             if (compareVersions(compiler, raw.kotlin.version) < 0) {
                 return Err(ConfigError.ParseFailed(
@@ -225,3 +236,5 @@ fun parseConfig(tomlString: String): Result<KoltConfig, ConfigError> {
         Err(ConfigError.ParseFailed("failed to parse kolt.toml: ${e.message}"))
     }
 }
+
+internal fun KoltConfig.isLibrary(): Boolean = kind == "lib"

--- a/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
@@ -223,7 +223,7 @@ class BuilderTest {
 
     @Test
     fun nativeLinkCommandLinksKlibToProgramKexe() {
-        val cmd = nativeLinkCommand(testConfig(target = "linuxX64"))
+        val cmd = nativeLinkCommand(testConfig(target = "linuxX64"), main = "com.example.main")
 
         assertEquals(
             listOf(
@@ -243,7 +243,7 @@ class BuilderTest {
 
     @Test
     fun nativeLinkCommandWithProjectName() {
-        val cmd = nativeLinkCommand(testConfig(name = "hello", target = "linuxX64"))
+        val cmd = nativeLinkCommand(testConfig(name = "hello", target = "linuxX64"), main = "com.example.main")
 
         assertEquals("build/hello.kexe", cmd.outputPath)
         assertEquals(
@@ -264,7 +264,7 @@ class BuilderTest {
     @Test
     fun nativeLinkCommandWithManagedKonancPath() {
         val managedKonanc = "/home/user/.kolt/toolchains/konanc/2.1.0/bin/konanc"
-        val cmd = nativeLinkCommand(testConfig(target = "linuxX64"), konancPath = managedKonanc)
+        val cmd = nativeLinkCommand(testConfig(target = "linuxX64"), main = "com.example.main", konancPath = managedKonanc)
 
         assertEquals(managedKonanc, cmd.args.first())
     }
@@ -277,6 +277,7 @@ class BuilderTest {
         // transitive klibs on the library path at link time.
         val cmd = nativeLinkCommand(
             testConfig(target = "linuxX64"),
+            main = "com.example.main",
             klibs = listOf("/cache/a.klib", "/cache/b.klib")
         )
 
@@ -299,7 +300,7 @@ class BuilderTest {
 
     @Test
     fun nativeLinkCommandEmptyKlibsOmitsLibraryFlag() {
-        val cmd = nativeLinkCommand(testConfig(target = "linuxX64"), klibs = emptyList())
+        val cmd = nativeLinkCommand(testConfig(target = "linuxX64"), main = "com.example.main", klibs = emptyList())
 
         assertFalse(cmd.args.contains("-l"))
     }
@@ -309,7 +310,7 @@ class BuilderTest {
         // config.main is already a Kotlin function FQN (validated by parseConfig),
         // so konanc -e consumes it verbatim. Without -e, konanc looks for `main`
         // in the root package and fails when the function lives in a named package.
-        val cmd = nativeLinkCommand(testConfig(target = "linuxX64"))
+        val cmd = nativeLinkCommand(testConfig(target = "linuxX64"), main = "com.example.main")
 
         val eIndex = cmd.args.indexOf("-e")
         assertTrue(eIndex >= 0, "Expected -e in: ${cmd.args}")
@@ -319,7 +320,7 @@ class BuilderTest {
     @Test
     fun nativeLinkCommandEmitsRootPackageEntryPoint() {
         val base = testConfig(target = "linuxX64")
-        val cmd = nativeLinkCommand(base.copy(build = base.build.copy(main = "main")))
+        val cmd = nativeLinkCommand(base, main = "main")
 
         val eIndex = cmd.args.indexOf("-e")
         assertTrue(eIndex >= 0)

--- a/src/nativeTest/kotlin/kolt/build/RunnerTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/RunnerTest.kt
@@ -8,13 +8,13 @@ class RunnerTest {
 
     @Test
     fun runCommandUsesClassesDirAsClasspath() {
-        val cmd = runCommand(testConfig(), null)
+        val cmd = runCommand(testConfig(), main = "com.example.main", classpath = null)
         assertEquals(listOf("java", "-cp", "build/classes", "com.example.MainKt"), cmd.args)
     }
 
     @Test
     fun runCommandWithClasspathAppendedToClassesDir() {
-        val cmd = runCommand(testConfig(), "/cache/lib.jar:/cache/util.jar")
+        val cmd = runCommand(testConfig(), main = "com.example.main", classpath = "/cache/lib.jar:/cache/util.jar")
         assertEquals(
             listOf("java", "-cp", "build/classes:/cache/lib.jar:/cache/util.jar", "com.example.MainKt"),
             cmd.args
@@ -23,7 +23,7 @@ class RunnerTest {
 
     @Test
     fun runCommandWithAppArgs() {
-        val cmd = runCommand(testConfig(), null, listOf("--port", "8080"))
+        val cmd = runCommand(testConfig(), main = "com.example.main", classpath = null, appArgs = listOf("--port", "8080"))
         assertEquals(
             listOf("java", "-cp", "build/classes", "com.example.MainKt", "--port", "8080"),
             cmd.args
@@ -32,13 +32,13 @@ class RunnerTest {
 
     @Test
     fun runCommandWithEmptyAppArgs() {
-        val cmd = runCommand(testConfig(), null, emptyList())
+        val cmd = runCommand(testConfig(), main = "com.example.main", classpath = null, appArgs = emptyList())
         assertEquals(listOf("java", "-cp", "build/classes", "com.example.MainKt"), cmd.args)
     }
 
     @Test
     fun runCommandEmptyClasspathIsIgnored() {
-        val cmd = runCommand(testConfig(), "")
+        val cmd = runCommand(testConfig(), main = "com.example.main", classpath = "")
         assertEquals(listOf("java", "-cp", "build/classes", "com.example.MainKt"), cmd.args)
     }
 
@@ -46,7 +46,7 @@ class RunnerTest {
     fun runCommandWithManagedJavaPathUsesItAsJava() {
         val managedJavaBin = "/home/user/.kolt/toolchains/jdk/21/bin/java"
 
-        val cmd = runCommand(testConfig(), null, javaPath = managedJavaBin)
+        val cmd = runCommand(testConfig(), main = "com.example.main", classpath = null, javaPath = managedJavaBin)
 
         assertEquals(
             listOf(managedJavaBin, "-cp", "build/classes", "com.example.MainKt"),
@@ -56,7 +56,7 @@ class RunnerTest {
 
     @Test
     fun runCommandWithNullJavaPathDefaultsToSystemJava() {
-        val cmd = runCommand(testConfig(), null, javaPath = null)
+        val cmd = runCommand(testConfig(), main = "com.example.main", classpath = null, javaPath = null)
 
         assertEquals("java", cmd.args.first())
     }
@@ -65,7 +65,7 @@ class RunnerTest {
     fun runCommandWithManagedJavaAndClasspath() {
         val managedJavaBin = "/home/user/.kolt/toolchains/jdk/21/bin/java"
 
-        val cmd = runCommand(testConfig(), "/cache/lib.jar", javaPath = managedJavaBin)
+        val cmd = runCommand(testConfig(), main = "com.example.main", classpath = "/cache/lib.jar", javaPath = managedJavaBin)
 
         assertEquals(
             listOf(managedJavaBin, "-cp", "build/classes:/cache/lib.jar", "com.example.MainKt"),
@@ -119,7 +119,7 @@ class RunnerTest {
     fun runCommandWithManagedJavaAndAppArgs() {
         val managedJavaBin = "/home/user/.kolt/toolchains/jdk/21/bin/java"
 
-        val cmd = runCommand(testConfig(), null, listOf("--port", "8080"), javaPath = managedJavaBin)
+        val cmd = runCommand(testConfig(), main = "com.example.main", classpath = null, appArgs = listOf("--port", "8080"), javaPath = managedJavaBin)
 
         assertEquals(
             listOf(managedJavaBin, "-cp", "build/classes", "com.example.MainKt", "--port", "8080"),

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
@@ -162,7 +162,7 @@ class CinteropNativeBuildIntegrationTest {
         val libLIdx = libraryCmd.args.indexOf("-l")
         assertEquals("build/libcurl.klib", libraryCmd.args[libLIdx + 1])
 
-        val linkCmd = nativeLinkCommand(config, klibs = listOf(klibPath))
+        val linkCmd = nativeLinkCommand(config, main = "com.example.main", klibs = listOf(klibPath))
         val linkLIdx = linkCmd.args.indexOf("-l")
         assertEquals("build/libcurl.klib", linkCmd.args[linkLIdx + 1])
         assertEquals("build/myapp.kexe", linkCmd.outputPath)

--- a/src/nativeTest/kotlin/kolt/cli/BuildLibraryTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildLibraryTest.kt
@@ -1,0 +1,53 @@
+package kolt.cli
+
+import com.github.michaelbull.result.get
+import kolt.build.outputKexePath
+import kolt.build.outputNativeKlibPath
+import kolt.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * R3 matrix: native build kind gate (ADR 0014 two-stage × ADR 0023 §1 kind).
+ *
+ * `nativeStagePlan` is the pure decision the `doNativeBuild` orchestrator
+ * consults after stage 1 succeeds: library kind stops at the `.klib`
+ * (stage 2 link is skipped), app kind continues into the link step with
+ * the entry-point FQN. Scoped fixture configs are built in each test —
+ * the repository's own `kolt.toml` is never read.
+ */
+class NativeStagePlanTest {
+
+    // R3.1 / R3.2 / R3.3: lib config plans stage 1 only, targets the
+    // canonical `.klib` path, and carries no entry-point FQN for link.
+    @Test
+    fun libraryConfigSkipsLinkAndTargetsKlibArtifact() {
+        val base = testConfig(name = "mylib", target = "linuxX64")
+        val config = base.copy(
+            kind = "lib",
+            build = base.build.copy(main = null),
+        )
+
+        val plan = assertNotNull(nativeStagePlan(config).get())
+
+        assertNull(plan.linkMain, "library plan must not carry an entry-point FQN")
+        assertEquals("library", plan.artifactKind)
+        assertEquals(outputNativeKlibPath(config), plan.artifactPath)
+    }
+
+    // R3.4: app config plans both stages, forwards the entry-point FQN,
+    // and targets the canonical `.kexe` path.
+    @Test
+    fun applicationConfigDrivesLinkStageWithEntryPointAndKexeArtifact() {
+        val config = testConfig(name = "myapp", target = "linuxX64")
+            .copy(kind = "app")
+
+        val plan = assertNotNull(nativeStagePlan(config).get())
+
+        assertEquals("com.example.main", plan.linkMain)
+        assertEquals("executable", plan.artifactKind)
+        assertEquals(outputKexePath(config), plan.artifactPath)
+    }
+}

--- a/src/nativeTest/kotlin/kolt/cli/BuildLibraryTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildLibraryTest.kt
@@ -1,11 +1,14 @@
 package kolt.cli
 
 import com.github.michaelbull.result.get
+import kolt.build.checkCommand
+import kolt.build.jarCommand
 import kolt.build.outputKexePath
 import kolt.build.outputNativeKlibPath
 import kolt.testConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -49,5 +52,141 @@ class NativeStagePlanTest {
         assertEquals("com.example.main", plan.linkMain)
         assertEquals("executable", plan.artifactKind)
         assertEquals(outputKexePath(config), plan.artifactPath)
+    }
+}
+
+/**
+ * R2 matrix: JVM library thin-jar invariants (design.md §Components and
+ * Interfaces → JVM thin-jar invariants; design.md §Testing Strategy →
+ * Unit — JVM invariants).
+ *
+ * The JVM build path in `doBuild` is shared between `kind = "lib"` and
+ * `kind = "app"` — no kind branching at the jar step. The thin-jar shape
+ * is therefore expressed by two existing pure helpers:
+ *
+ * - `checkCommand` / the inline `CompileRequest.extraArgs` at the JVM
+ *   compile step — kotlinc args must not contain `-include-runtime`
+ *   (R2.2), so the produced classes carry no Kotlin stdlib or dependency
+ *   bytecode.
+ * - `jarCommand` — `jar cf <out> -C build/classes .`; no `-m` / manifest
+ *   argument, so the JDK `jar` tool writes only a default manifest with
+ *   `Manifest-Version` and `Created-By`, never `Main-Class` (R2.3). The
+ *   `-C build/classes .` root is `build/classes` only, so the jar never
+ *   includes resolved dependency jars (R2.2).
+ *
+ * R2.1 (`.jar` at `build/<name>.jar`) is verified at the helper layer
+ * via `jarCommand(...).outputPath`. The on-disk end-to-end artifact check
+ * is covered by Task 6.1's dogfood gate (requires a live JDK + kotlinc).
+ *
+ * R2.4 (app JVM jar unchanged) is locked by the same helpers — the
+ * existing `BuilderTest` suite already asserts the exact argv shape for
+ * `checkCommand` and `jarCommand` on the default (app) `testConfig`, so
+ * the non-regression bar is: these lib-config argvs match the same shape
+ * the app path produces today.
+ */
+class JvmLibraryInvariantsTest {
+
+    // R2.1: a `kind = "lib"` JVM build targets `build/<name>.jar`. The
+    // jarCommand output path is the single source of truth consulted by
+    // doBuild's success message — any drift here surfaces as a missing
+    // artifact on disk.
+    @Test
+    fun libraryJvmJarOutputPathIsBuildNameJar() {
+        val base = testConfig(name = "mylib", target = "jvm")
+        val libConfig = base.copy(kind = "lib", build = base.build.copy(main = null))
+
+        val cmd = jarCommand(libConfig)
+
+        assertEquals("build/mylib.jar", cmd.outputPath)
+    }
+
+    // R2.2: the JVM compile command for a lib config must not pass
+    // `-include-runtime` to kotlinc; otherwise kotlinc would bundle the
+    // Kotlin stdlib and any `-cp` entries into the classes output, which
+    // the subsequent `jar cf` would then package into the jar.
+    //
+    // `checkCommand` is the pure helper mirroring the JVM compile argv
+    // shape; `doBuild` constructs the same `-jvm-target` + plugin args
+    // set via `CompileRequest.extraArgs` (BuildCommands.kt:211-215). No
+    // code path in the repo adds `-include-runtime` (grep: 0 matches in
+    // src/ and kolt-compiler-daemon/), so this test locks that invariant.
+    @Test
+    fun libraryJvmCompileCommandDoesNotIncludeRuntime() {
+        val base = testConfig(name = "mylib", target = "jvm")
+        val libConfig = base.copy(kind = "lib", build = base.build.copy(main = null))
+
+        val cmd = checkCommand(libConfig)
+
+        assertFalse(
+            cmd.contains("-include-runtime"),
+            "JVM lib compile command must not bundle the Kotlin runtime: $cmd",
+        )
+    }
+
+    // R2.3: `jar cf` without a `-m` manifest argument makes the JDK jar
+    // tool emit only a default manifest (Manifest-Version + Created-By),
+    // never a `Main-Class` attribute. Asserting the absence of every
+    // manifest-related `jar` flag is equivalent to asserting the produced
+    // `META-INF/MANIFEST.MF` carries no `Main-Class`.
+    @Test
+    fun libraryJvmJarCommandDoesNotDeclareMainClassManifest() {
+        val base = testConfig(name = "mylib", target = "jvm")
+        val libConfig = base.copy(kind = "lib", build = base.build.copy(main = null))
+
+        val cmd = jarCommand(libConfig)
+
+        assertFalse(cmd.args.contains("-m"), "lib jar command must not attach a manifest: ${cmd.args}")
+        assertFalse(cmd.args.contains("--manifest"), "lib jar command must not attach a manifest: ${cmd.args}")
+        assertFalse(
+            cmd.args.any { it.contains("Main-Class", ignoreCase = true) },
+            "lib jar command must not declare a Main-Class attribute: ${cmd.args}",
+        )
+        assertEquals(
+            listOf("jar", "cf", "build/mylib.jar", "-C", "build/classes", "."),
+            cmd.args,
+            "lib jar command must match the thin-jar invariant shape",
+        )
+    }
+
+    // R2.2: `jar cf <out> -C build/classes .` roots the jar contents at
+    // `build/classes` — the kotlinc output directory. Dependency jars
+    // resolved into the kolt cache are never referenced by the jar step,
+    // so the produced jar cannot contain any resolved dependency class.
+    @Test
+    fun libraryJvmJarCommandOnlyPackagesClassesDir() {
+        val base = testConfig(name = "mylib", target = "jvm")
+        val libConfig = base.copy(kind = "lib", build = base.build.copy(main = null))
+
+        val cmd = jarCommand(libConfig)
+
+        val cIdx = cmd.args.indexOf("-C")
+        assertEquals(3, cIdx, "jar command must use `-C <dir> .` after `cf <out>`: ${cmd.args}")
+        assertEquals("build/classes", cmd.args[cIdx + 1])
+        assertEquals(".", cmd.args[cIdx + 2])
+    }
+
+    // R2.4: the same thin-jar invariants hold on the app-config JVM path
+    // — proving lifting the lib kind gate did not alter the shared JVM
+    // compile/jar helpers. The canonical argv shape for apps is locked
+    // separately in BuilderTest; this test re-asserts the no-runtime /
+    // no-Main-Class contract so any future drift that re-introduced
+    // `-include-runtime` for apps would also break here.
+    @Test
+    fun applicationJvmBuildHelpersPreserveThinJarInvariants() {
+        val appConfig = testConfig(name = "myapp", target = "jvm").copy(kind = "app")
+
+        val compile = checkCommand(appConfig)
+        val jar = jarCommand(appConfig)
+
+        assertFalse(
+            compile.contains("-include-runtime"),
+            "app JVM compile command must stay thin (R2.4): $compile",
+        )
+        assertFalse(jar.args.contains("-m"), "app jar command must not attach a manifest: ${jar.args}")
+        assertFalse(
+            jar.args.any { it.contains("Main-Class", ignoreCase = true) },
+            "app jar command must not declare a Main-Class attribute: ${jar.args}",
+        )
+        assertEquals("build/myapp.jar", jar.outputPath)
     }
 }

--- a/src/nativeTest/kotlin/kolt/cli/RunLibraryRejectionTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/RunLibraryRejectionTest.kt
@@ -1,0 +1,169 @@
+package kolt.cli
+
+import com.github.michaelbull.result.getError
+import kolt.infra.fileExists
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kolt.testConfig
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.chdir
+import platform.posix.getcwd
+import platform.posix.mkdtemp
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * R4 matrix: `kolt run` must reject library projects before any artifact
+ * resolution or build invocation (ADR 0023 §1 kind schema). Coverage:
+ *
+ * - R4.1 canonical stderr substring + `EXIT_CONFIG_ERROR` exit code.
+ * - R4.2 rejection pre-empts the build pipeline / artifact path lookup.
+ * - R4.3 rejection is target-agnostic (JVM + native).
+ * - R4.2 watch-variant: the guard fires once at entry, not per poll tick.
+ */
+@OptIn(ExperimentalForeignApi::class)
+class RunLibraryRejectionTest {
+
+    // R4.1 + R4.3: the run-guard rejects both JVM and native library
+    // configs with `EXIT_CONFIG_ERROR` and emits the canonical stderr
+    // substring once per invocation.
+    @Test
+    fun rejectIfLibraryReturnsConfigErrorWithCanonicalMessageForJvmAndNative() {
+        for (target in listOf("jvm", "linuxX64")) {
+            val base = testConfig(name = "mylib", target = target)
+            val libConfig = base.copy(kind = "lib", build = base.build.copy(main = null))
+            val stderr = mutableListOf<String>()
+
+            val exit = rejectIfLibrary(libConfig, eprint = { stderr.add(it) }).getError()
+
+            assertEquals(EXIT_CONFIG_ERROR, exit, "target=$target must exit with EXIT_CONFIG_ERROR")
+            assertEquals(1, stderr.size, "target=$target must emit exactly one stderr line")
+            assertTrue(
+                stderr[0].contains("library projects cannot be run"),
+                "target=$target stderr must contain canonical substring, got: ${stderr[0]}",
+            )
+        }
+    }
+
+    // Non-regression guardrail: app configs flow through the guard
+    // untouched (R4.4 path), no stderr emitted.
+    @Test
+    fun rejectIfLibraryPassesThroughAppConfigsWithoutStderr() {
+        for (target in listOf("jvm", "linuxX64")) {
+            val config = testConfig(name = "myapp", target = target).copy(kind = "app")
+            val stderr = mutableListOf<String>()
+
+            val outcome = rejectIfLibrary(config, eprint = { stderr.add(it) })
+
+            assertTrue(outcome.isOk, "target=$target app config must pass the guard")
+            assertTrue(stderr.isEmpty(), "target=$target app config must emit no stderr")
+        }
+    }
+
+    // R4.2: the guard fires before `doRun` looks at any artifact. Pre-
+    // guard, a library config would hit the JVM `?: return Err(EXIT_BUILD_ERROR)`
+    // or the native `!fileExists(kexePath)` branch — both yield
+    // `EXIT_BUILD_ERROR`. The guard upgrades that to `EXIT_CONFIG_ERROR`
+    // and short-circuits before any filesystem check.
+    @Test
+    fun doRunRejectsLibraryWithConfigErrorBeforeArtifactResolution() {
+        for (target in listOf("jvm", "linuxX64")) {
+            val base = testConfig(name = "mylib", target = target)
+            val libConfig = base.copy(kind = "lib", build = base.build.copy(main = null))
+
+            val exit = doRun(libConfig, classpath = null).getError()
+
+            assertEquals(
+                EXIT_CONFIG_ERROR, exit,
+                "target=$target doRun on library must return EXIT_CONFIG_ERROR, not EXIT_BUILD_ERROR",
+            )
+        }
+    }
+}
+
+/**
+ * R4.2 watch-variant: `watchRunLoop` must surface the rejection once and
+ * return cleanly without entering the rebuild-poll loop. Drives the loop
+ * via a real `kolt.toml` fixture in a temp directory; a non-entry guard
+ * would attempt `setupWatches` and block on `pollEvents`.
+ */
+@OptIn(ExperimentalForeignApi::class)
+class WatchRunLoopLibraryRejectionTest {
+
+    private var originalCwd: String = ""
+    private var tmpDir: String = ""
+
+    @BeforeTest
+    fun setUp() {
+        originalCwd = memScoped {
+            val buf = allocArray<ByteVar>(PATH_MAX)
+            getcwd(buf, PATH_MAX.toULong())?.toKString() ?: error("getcwd failed")
+        }
+        tmpDir = createTempDir("kolt-run-lib-reject-")
+        check(chdir(tmpDir) == 0) { "chdir to $tmpDir failed" }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        chdir(originalCwd)
+        if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
+            removeDirectoryRecursive(tmpDir)
+        }
+    }
+
+    // R4.2 (watch): rejection fires at loop entry, exactly once, without
+    // blocking on inotify setup or the poll loop.
+    @Test
+    fun watchRunLoopRejectsLibraryOnceAtEntryAndReturns() {
+        writeFileAsString(KOLT_TOML, LIB_TOML).getError()
+            ?.let { error("seed failed: $it") }
+
+        val stderr = mutableListOf<String>()
+
+        // If the entry guard is present, watchRunLoop must return
+        // immediately without installing inotify or spawning a child.
+        watchRunLoop(useDaemon = false, appArgs = emptyList(), eprint = { stderr.add(it) })
+
+        val rejections = stderr.count { it.contains("library projects cannot be run") }
+        assertEquals(1, rejections, "watch-run must emit the library rejection exactly once; stderr=$stderr")
+        assertFalse(
+            stderr.any { it.contains("watching for changes") },
+            "watch-run must not enter the poll loop for a library; stderr=$stderr",
+        )
+    }
+
+    private fun createTempDir(prefix: String): String {
+        val template = "/tmp/${prefix}XXXXXX"
+        val buf = template.encodeToByteArray().copyOf(template.length + 1)
+        buf.usePinned { pinned ->
+            val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+            return result.toKString()
+        }
+    }
+
+    companion object {
+        private val LIB_TOML = """
+            name = "mylib"
+            version = "0.1.0"
+            kind = "lib"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            sources = ["src"]
+        """.trimIndent()
+    }
+}

--- a/src/nativeTest/kotlin/kolt/cli/TestLibraryNonRegressionTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/TestLibraryNonRegressionTest.kt
@@ -1,0 +1,239 @@
+package kolt.cli
+
+import kolt.build.nativeTestLibraryCommand
+import kolt.build.nativeTestLinkCommand
+import kolt.build.nativeTestRunCommand
+import kolt.build.outputNativeTestKexePath
+import kolt.build.outputNativeTestKlibPath
+import kolt.build.testBuildCommand
+import kolt.build.testRunCommand
+import kolt.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * R5 matrix: `kolt test` non-regression for libraries (design.md §Components
+ * and Interfaces → Test non-regression; design.md §Testing Strategy →
+ * Non-regression — `kolt test` (R5)).
+ *
+ * The test pipeline is already decoupled from `config.build.main` in the
+ * gap-analysis verified paths:
+ *
+ * - JVM: `doTest` (BuildCommands.kt:501) → `testBuildCommand` /
+ *   `testRunCommand` — neither reads `config.build.main`.
+ * - Native: `doNativeTest` (BuildCommands.kt:556) → `nativeTestLibraryCommand`
+ *   / `nativeTestLinkCommand` / `nativeTestRunCommand` — the link step
+ *   uses `-generate-test-runner`, never `-e <FQN>`.
+ *
+ * This file locks that invariant: test-pipeline helpers must not surface
+ * `config.build.main` in their emitted argv for either kind. Construction
+ * of the commands succeeds for a `kind = "lib"` config with `main = null`
+ * (R5.1, R5.2), and for a `kind = "app"` config with a poisoned FQN the
+ * FQN is absent from every test-path argv (R5.3).
+ *
+ * The end-to-end "exit 0 + tests execute" check requires a live JDK +
+ * kotlinc/konanc toolchain and is covered by task 6.1's dogfood gate. The
+ * invariant tested here — that no test-path code reads `build.main` — is
+ * the structural contract R5.2 pins.
+ */
+class TestLibraryNonRegressionTest {
+
+    // R5.1 / R5.2: the JVM test-compile argv for a `kind = "lib"` config
+    // with `main = null` is well-formed and carries no `-e` entry-point
+    // flag and no `Main-Class` / `-include-runtime` affordance. Command
+    // construction succeeds without reading `build.main`.
+    @Test
+    fun jvmLibraryTestBuildCommandIsConstructedWithoutReadingMain() {
+        val base = testConfig(name = "mylib", target = "jvm")
+        val libConfig = base.copy(kind = "lib", build = base.build.copy(main = null))
+
+        val cmd = testBuildCommand(libConfig, classesDir = "build/classes")
+
+        assertFalse(
+            cmd.args.contains("-e"),
+            "JVM lib test-compile must not carry an entry-point flag: ${cmd.args}",
+        )
+        assertFalse(
+            cmd.args.contains("-include-runtime"),
+            "JVM lib test-compile must stay thin (no -include-runtime): ${cmd.args}",
+        )
+        assertTrue(
+            cmd.args.containsAll(libConfig.build.testSources),
+            "JVM lib test-compile must reference every test source dir: ${cmd.args}",
+        )
+        assertEquals("build/test-classes", cmd.outputPath)
+    }
+
+    // R5.1 / R5.2: the JVM test-run argv is a junit-console-launcher
+    // invocation; neither the classpath nor the `java` argv carries the
+    // project's `main` FQN. `testRunCommand` takes no `main` parameter at
+    // all, so the R5.2 structural contract is enforced by construction.
+    @Test
+    fun jvmLibraryTestRunCommandDoesNotReferenceMainFqn() {
+        val base = testConfig(name = "mylib", target = "jvm")
+        val libConfig = base.copy(kind = "lib", build = base.build.copy(main = null))
+
+        val cmd = testRunCommand(
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
+            consoleLauncherPath = "/fake/junit-console-launcher.jar",
+        )
+
+        assertFalse(
+            cmd.args.contains("-e"),
+            "JVM test-run must not carry an entry-point flag: ${cmd.args}",
+        )
+        assertFalse(
+            cmd.args.any { it.endsWith("MainKt") },
+            "JVM test-run must not invoke the project Main-Class facade: ${cmd.args}",
+        )
+        assertTrue(
+            cmd.args.contains("--scan-class-path"),
+            "JVM test-run must use the junit-console scan-class-path discovery: ${cmd.args}",
+        )
+        // Double-check: the lib config carries no main; just assert the
+        // argv is constructible and references the test classes dir.
+        assertTrue(
+            cmd.args.any { it.contains("build/test-classes") },
+            "JVM test-run classpath must include the test-classes dir: ${cmd.args}",
+        )
+        assertEquals(null, libConfig.build.main)
+    }
+
+    // R5.1 / R5.2: the native test stage-1 (library) argv for a
+    // `kind = "lib"` config with `main = null` compiles the main + test
+    // sources without any entry-point reference. The command emits the
+    // canonical `-p library -nopack` shape used by ADR 0013.
+    @Test
+    fun nativeLibraryTestLibraryCommandIsConstructedWithoutReadingMain() {
+        val base = testConfig(name = "mylib", target = "linuxX64")
+        val libConfig = base.copy(kind = "lib", build = base.build.copy(main = null))
+
+        val cmd = nativeTestLibraryCommand(libConfig)
+
+        assertFalse(
+            cmd.args.contains("-e"),
+            "native lib test stage-1 must not carry an entry-point flag: ${cmd.args}",
+        )
+        assertTrue(
+            cmd.args.contains("library"),
+            "native lib test stage-1 must compile with `-p library`: ${cmd.args}",
+        )
+        assertTrue(
+            cmd.args.contains("-nopack"),
+            "native lib test stage-1 must preserve the `-nopack` convention: ${cmd.args}",
+        )
+        assertEquals(outputNativeTestKlibPath(libConfig), cmd.outputPath)
+    }
+
+    // R5.1 / R5.2: the native test-link argv for a `kind = "lib"` config
+    // uses `-generate-test-runner` (ADR 0013) — NOT `-e <FQN>`. This is
+    // the load-bearing structural guarantee that `doNativeTest` does not
+    // require `config.build.main`. A single `-e` appearance here would
+    // flag a regression that re-coupled the test path to `main`.
+    @Test
+    fun nativeLibraryTestLinkCommandUsesGeneratedTestRunnerAndNeverE() {
+        val base = testConfig(name = "mylib", target = "linuxX64")
+        val libConfig = base.copy(kind = "lib", build = base.build.copy(main = null))
+
+        val cmd = nativeTestLinkCommand(libConfig)
+
+        assertFalse(
+            cmd.args.contains("-e"),
+            "native lib test-link must not carry an entry-point flag: ${cmd.args}",
+        )
+        assertTrue(
+            cmd.args.contains("-generate-test-runner"),
+            "native lib test-link must use the generated test runner: ${cmd.args}",
+        )
+        assertEquals(outputNativeTestKexePath(libConfig), cmd.outputPath)
+    }
+
+    // R5.1 / R5.2: the native test-run argv is the path of the test-kexe
+    // followed by forwarded args. `nativeTestRunCommand` takes no `main`
+    // parameter and reads only `config.name` from the config, so the
+    // structural contract is enforced by construction.
+    @Test
+    fun nativeLibraryTestRunCommandInvokesTestKexeByPath() {
+        val base = testConfig(name = "mylib", target = "linuxX64")
+        val libConfig = base.copy(kind = "lib", build = base.build.copy(main = null))
+
+        val cmd = nativeTestRunCommand(libConfig)
+
+        assertEquals(outputNativeTestKexePath(libConfig), cmd.args.first())
+        assertFalse(
+            cmd.args.contains("-e"),
+            "native lib test-run must not carry an entry-point flag: ${cmd.args}",
+        )
+    }
+
+    // R5.3: for a `kind = "app"` config, the test-pipeline argv must not
+    // reference the app's `main` FQN anywhere. Using a poisoned FQN
+    // (`com.example.poisonedMain`) turns any accidental read of
+    // `config.build.main` into a substring match that this test would
+    // catch. This is the app-side companion to R5.2 — the test pipeline
+    // must stay decoupled from `main` regardless of kind.
+    @Test
+    fun applicationTestPipelineDoesNotLeakMainFqnIntoAnyArgv() {
+        val poisonFqn = "com.example.poisonedMain"
+        val base = testConfig(name = "myapp", target = "jvm")
+        val appConfig = base.copy(
+            kind = "app",
+            build = base.build.copy(main = poisonFqn),
+        )
+
+        val jvmBuild = testBuildCommand(appConfig, classesDir = "build/classes")
+        val jvmRun = testRunCommand(
+            classesDir = "build/classes",
+            testClassesDir = "build/test-classes",
+            consoleLauncherPath = "/fake/junit-console-launcher.jar",
+        )
+
+        assertFalse(
+            jvmBuild.args.any { it.contains(poisonFqn) },
+            "JVM app test-compile must not reference the `main` FQN: ${jvmBuild.args}",
+        )
+        assertFalse(
+            jvmRun.args.any { it.contains(poisonFqn) },
+            "JVM app test-run must not reference the `main` FQN: ${jvmRun.args}",
+        )
+    }
+
+    // R5.3: same poisoned-FQN guard for the native test-pipeline helpers.
+    // `-generate-test-runner` is what decouples ADR 0013's native test
+    // flow from the app entry point; this test pins it.
+    @Test
+    fun applicationNativeTestPipelineDoesNotLeakMainFqnIntoAnyArgv() {
+        val poisonFqn = "com.example.poisonedMain"
+        val base = testConfig(name = "myapp", target = "linuxX64")
+        val appConfig = base.copy(
+            kind = "app",
+            build = base.build.copy(main = poisonFqn),
+        )
+
+        val library = nativeTestLibraryCommand(appConfig)
+        val link = nativeTestLinkCommand(appConfig)
+        val run = nativeTestRunCommand(appConfig)
+
+        for ((label, args) in listOf(
+            "stage-1 library" to library.args,
+            "test-link" to link.args,
+            "test-run" to run.args,
+        )) {
+            assertFalse(
+                args.any { it.contains(poisonFqn) },
+                "native app $label must not reference the `main` FQN: $args",
+            )
+            assertFalse(
+                args.contains("-e"),
+                "native app $label must not carry an entry-point flag: $args",
+            )
+        }
+        assertTrue(
+            link.args.contains("-generate-test-runner"),
+            "native app test-link must use the generated test runner: ${link.args}",
+        )
+    }
+}

--- a/src/nativeTest/kotlin/kolt/config/ConfigKindTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigKindTest.kt
@@ -1,0 +1,136 @@
+package kolt.config
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * R1 matrix: `kind` × `[build] main` validation.
+ *
+ * Replaces the former `kindLibIsRejectedAsNotYetImplemented` case.
+ * Canonical error strings per ADR 0023 §1 / design.md (§Components and
+ * Interfaces → Config parser kind+main rule):
+ *   - LIB_WITH_MAIN_ERROR    = "main has no meaning for a library; remove it"
+ *   - APP_WITHOUT_MAIN_ERROR = "[build] main is required for kind = \"app\""
+ *
+ * Substring matching keeps these tests stable against incidental wording
+ * changes allowed by design.md.
+ */
+class ConfigKindTest {
+
+    // R1.1: kind = "lib" without [build] main → parses.
+    @Test
+    fun kindLibWithoutMainParses() {
+        val toml = """
+            name = "my-lib"
+            version = "0.1.0"
+            kind = "lib"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            sources = ["src"]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals("lib", config.kind)
+        assertNull(config.build.main)
+    }
+
+    // R1.2: kind = "lib" with [build] main → rejects with canonical text.
+    @Test
+    fun kindLibWithMainRejectsWithCanonicalText() {
+        val toml = """
+            name = "my-lib"
+            version = "0.1.0"
+            kind = "lib"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            main = "com.example.main"
+            sources = ["src"]
+        """.trimIndent()
+
+        val result = parseConfig(toml)
+
+        assertNull(result.get())
+        val error = assertIs<ConfigError.ParseFailed>(result.getError())
+        assertContains(error.message, "main has no meaning for a library; remove it")
+    }
+
+    // R1.3: kind = "app" without [build] main → rejects with canonical text.
+    @Test
+    fun kindAppWithoutMainRejectsWithCanonicalText() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kind = "app"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            sources = ["src"]
+        """.trimIndent()
+
+        val result = parseConfig(toml)
+
+        assertNull(result.get())
+        val error = assertIs<ConfigError.ParseFailed>(result.getError())
+        assertContains(error.message, "[build] main is required for kind = \"app\"")
+    }
+
+    // R1.4: kind = "app" with [build] main → parses.
+    @Test
+    fun kindAppWithMainParses() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+            kind = "app"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            main = "com.example.main"
+            sources = ["src"]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals("app", config.kind)
+        assertEquals("com.example.main", config.build.main)
+    }
+
+    // R1.5: omitted kind → defaults to "app"; with [build] main it parses.
+    @Test
+    fun missingKindDefaultsToApp() {
+        val toml = """
+            name = "my-app"
+            version = "0.1.0"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            main = "com.example.main"
+            sources = ["src"]
+        """.trimIndent()
+
+        val config = assertNotNull(parseConfig(toml).get())
+        assertEquals("app", config.kind)
+        assertEquals("com.example.main", config.build.main)
+    }
+}

--- a/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
@@ -308,34 +308,6 @@ class ConfigTest {
     }
 
     @Test
-    fun kindLibIsRejectedAsNotYetImplemented() {
-        val toml = """
-            name = "my-lib"
-            version = "0.1.0"
-            kind = "lib"
-
-            [kotlin]
-            version = "2.1.0"
-
-            [build]
-            target = "jvm"
-            main = "com.example.main"
-            sources = ["src"]
-        """.trimIndent()
-
-        val result = parseConfig(toml)
-
-        assertNull(result.get())
-        val error = assertIs<ConfigError.ParseFailed>(result.getError())
-        assertTrue(error.message.contains("kind"), "missing 'kind' in: ${error.message}")
-        assertTrue(error.message.contains("lib"), "missing 'lib' in: ${error.message}")
-        assertTrue(
-            error.message.contains("not yet implemented"),
-            "missing 'not yet implemented' in: ${error.message}"
-        )
-    }
-
-    @Test
     fun unknownKindReturnsErr() {
         val toml = """
             name = "my-app"


### PR DESCRIPTION
Closes #30.

Opens the `kind = "lib"` path end-to-end: parser accepts the new kind, the build pipeline stops after ADR 0014 stage 1 on native and emits a thin jar on JVM, `kolt run` rejects before any build work, and `kolt test` continues to work for libraries without `[build] main`. Unblocks `kolt publish` (#21) and the ADR 0018 self-host endgame where `kolt-compiler-daemon/` can become a kolt-built library rather than a Gradle subproject.

## Where the boundary lives

- **Parser** (`Config.kt`): `BuildSection.main` is now nullable; `validateKind` drops the "not yet implemented" branch; `parseConfig` applies the 5-step order (kind → conditional main pairwise → FQN only when main present → target → construction). Two canonical error strings from ADR 0023 §1 live as top-level `private const val` — `main has no meaning for a library; remove it` and `[build] main is required for kind = "app"` — so tests match on substring and reviewers can grep for regressions.
- **Native build** (`BuildCommands.doNativeBuild` + `nativeStagePlan` helper): after stage 1 succeeds, lib returns `Ok` with no link stage. App path preserves the existing `-e <main>` argv byte-identically; `main` is extracted via a defensive `?: return Err(EXIT_BUILD_ERROR)` that is unreachable given the parser invariant (ADR 0001, no throw).
- **Run guard** (`rejectIfLibrary` at three sites — `Main.kt` pre-`doBuild`, `doRun` first statement, `watchRunLoop` entry): single-shot and watch-mode reject libraries with `error: library projects cannot be run` + `EXIT_CONFIG_ERROR` before any artifact resolution.

## Reviewer focus

- The `Main.kt` change threading a parse-before-build is load-bearing for R4.2 ("rejection before invoking the build pipeline"). `doBuild` is shared with `kolt build` (which Task 2 made lib-aware), so the guard cannot live inside `doBuild` without breaking lib builds.
- `nativeStagePlan` is a data class with `linkMain: String?` + `artifactKind: String` — the fields are redundant (null signals library) and `steering/structure.md` prefers sealed ADTs for this pattern. Left as a post-v1 refactor candidate; flagged in `.kiro/specs/lib-build-pipeline/tasks.md` Implementation Notes.
- Native lib artifact is the **directory** `build/<name>-klib` (stage 1 `-p library -nopack` output), not a packed `.klib` file. The existing `outputNativeKlibPath` helper already encoded this, but the design wording had suggested a packed file — cleaned up in the spec's Implementation Notes.
- The Task-1 ripple touches `Runner.kt`'s `runCommand` signature too (not originally listed in the design's File Structure Plan). It was forced by `BuildSection.main: String → String?` and is behavior-preserving.

## Dogfood evidence

`spike/lib-dogfood/{jvm,native,app-native}/` holds replayable fixtures with a `README.md`:

- JVM lib: `build/jvmlibdog.jar` is 1336 B, 5 entries, manifest lacks `Main-Class`, contents are `META-INF/*` + `dogfood/Util.class` only.
- Native lib: `build/nativelibdog-klib/` directory with standard klib layout; no `.kexe`.
- Native app (non-regression): `.kexe` runs and prints `hello from native app`.
- `kolt run` on both lib fixtures: exit 2, stderr `error: library projects cannot be run`.
- `kolt test` on both lib fixtures: exit 0, fixture test executes.

`./gradlew check` green. Canonical parser errors probed by mutate-and-revert; full matrix pinned by `ConfigKindTest`, `NativeStagePlanTest`, `JvmLibraryInvariantsTest`, `RunLibraryRejectionTest`, `TestLibraryNonRegressionTest`.

## Commit shape

8 commits, 1 infrastructure + 7 feature. `e35905d kiro init` drops the Kiro SDD tooling (`.claude/skills/kiro-*/`, `.kiro/settings/templates/`) that the rest of this spec depends on. If you would prefer that infra as its own PR, say the word — easy to split via a second branch targeting main with just that commit, then rebasing this branch.

- `e35905d` kiro init — Kiro spec-driven-development tooling
- `7df85e1` docs: spec artifacts (brief, requirements, research, design, tasks)
- `580510f` feat: parser accepts `kind = "lib"` with conditional `[build] main`
- `b8866c6` feat: skip native link step for `kind = "lib"`
- `1398af2` feat: reject `kolt run` against library projects
- `b9f8db0` test: lock JVM library thin-jar invariants
- `782c07a` test: lock `kolt test` non-regression for libraries
- `9d52081` test: dogfood library pipeline end-to-end

Out of scope (tracked separately): `kolt publish` (#21), `fat_jar = false` for `kind = "app"`, `kolt new --lib` (#28).