### PR TITLE
Close daemon self-host gap (#97)

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -93,3 +93,109 @@ jobs:
           path: ./build/bin/linuxX64/debugExecutable/kolt.kexe
           if-no-files-found: error
           retention-days: 1
+
+  # Companion job — exercises the full self-host path end to end on top of the
+  # kolt.kexe that the `self-host` job just uploaded: 3 × `kolt build` + the
+  # assemble-dist stitcher + a tarball install + a fixture smoke build via the
+  # installed `bin/kolt`. A failure in any step fails the job (and therefore
+  # the workflow) by GHA default + `set -euo pipefail` in each shell block.
+  self-host-post:
+    name: Self-host post-migration path
+    needs: self-host
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      # libcurl headers are required by the libcurl cinterop binding; kolt.kexe
+      # links against the runner's libcurl at load time.
+      - name: Install libcurl dev headers
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev
+
+      # kolt downloads its own kotlinc / konanc / JDK into ~/.kolt on first
+      # run. Share the cache key with the native self-host job so warm runs
+      # skip the ~minute of first-boot toolchain fetches.
+      - name: Cache kolt toolchains
+        uses: actions/cache@v4
+        with:
+          path: ~/.kolt
+          key: kolt-${{ runner.os }}-${{ hashFiles('kolt.toml') }}
+          restore-keys: |
+            kolt-${{ runner.os }}-
+
+      - name: Download kolt.kexe artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: kolt-kexe
+          path: ./bootstrap-kexe
+
+      - name: Prepare kolt.kexe
+        run: |
+          set -euo pipefail
+          chmod +x ./bootstrap-kexe/kolt.kexe
+          ./bootstrap-kexe/kolt.kexe --version
+
+      - name: kolt build at root
+        run: |
+          set -euo pipefail
+          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build
+
+      - name: kolt build at kolt-jvm-compiler-daemon
+        run: |
+          set -euo pipefail
+          cd kolt-jvm-compiler-daemon
+          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build
+
+      - name: kolt build at kolt-native-compiler-daemon
+        run: |
+          set -euo pipefail
+          cd kolt-native-compiler-daemon
+          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build
+
+      - name: Assemble tarball
+        run: |
+          set -euo pipefail
+          KOLT="$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" ./scripts/assemble-dist.sh
+
+      - name: Extract tarball to install dir
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/kolt-install
+          tar xzf dist/kolt-*-linux-x64.tar.gz -C /tmp/kolt-install
+          ls -la /tmp/kolt-install/
+
+      # Resolve the `@KOLT_LIBEXEC@` placeholder the stitcher wrote into each
+      # argfile (ADR 0018 §1: tarball is install-location agnostic). In a real
+      # install this is `install.sh`'s job; here we inline the equivalent
+      # `sed -i` pass so the argfiles are directly usable from the install dir.
+      - name: Substitute KOLT_LIBEXEC placeholder in argfiles
+        run: |
+          set -euo pipefail
+          INSTALL_DIR=$(ls -d /tmp/kolt-install/kolt-*-linux-x64)
+          LIBEXEC="${INSTALL_DIR}/libexec"
+          for argfile in "${LIBEXEC}/classpath/"*.argfile; do
+            sed -i "s|@KOLT_LIBEXEC@|${LIBEXEC}|g" "${argfile}"
+          done
+
+      # Fixture smoke (Task 4.1): drive `<install>/bin/kolt build` on a
+      # minimal JVM app. Success here is the end-to-end signal that the 3 ×
+      # kolt build → assemble-dist → tarball → extract chain produced a
+      # working install.
+      - name: Smoke-build fixture with installed kolt
+        run: |
+          set -euo pipefail
+          INSTALL_DIR=$(ls -d /tmp/kolt-install/kolt-*-linux-x64)
+          cd spike/daemon-self-host-smoke
+          rm -rf build
+          "${INSTALL_DIR}/bin/kolt" build
+          test -f build/smoke.jar

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -85,3 +85,11 @@ jobs:
           version=$(./build/kolt.kexe --version)
           echo "$version"
           echo "$version" | grep -Eq '^kolt [0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'
+
+      - name: Upload kolt kexe artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kolt-kexe
+          path: ./build/bin/linuxX64/debugExecutable/kolt.kexe
+          if-no-files-found: error
+          retention-days: 1

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 **/build/
 !gradle/wrapper/gradle-wrapper.jar
 
+# assemble-dist.sh release staging
+/dist/
+
 # IDE
 .idea/
 *.iml

--- a/.kiro/specs/daemon-self-host/design.md
+++ b/.kiro/specs/daemon-self-host/design.md
@@ -1,0 +1,735 @@
+# Technical Design: daemon-self-host
+
+## Overview
+
+**Purpose**: kolt が自身の 2 JVM daemon を build できる self-host ループを
+閉じ、`scripts/assemble-dist.sh` が release tarball layout を組み立てられる
+ようにすることで Issue #97 の DoD を満たす。
+
+**Users**: kolt のメンテナ (self-host 経路の保守)、リリース担当 (tarball
+生成)、CI 運用者 (self-host-smoke workflow)。
+
+**Impact**: 既存の JVM `kind = "app"` build path に runtime classpath
+manifest の emit 1 ステップを足し、2 daemon に `kolt.toml` を追加し、
+`scripts/assemble-dist.sh` と CI companion job を新規作成する。新規の設計
+選択は含まない (ADR 0018 / 0025 / 0027 / 0026 で pin 済み)。
+
+### Goals
+
+- ADR 0027 に準拠した runtime classpath manifest を JVM `kind = "app"`
+  build で emit する。
+- 2 daemon の `kolt.toml` を追加し、`./bin/kolt build` (既存 `kolt.kexe`)
+  で両 daemon の thin jar を生成できる。
+- `scripts/assemble-dist.sh` が 3 プロジェクトを stitch し、ADR 0018 §1 の
+  tarball layout を生成する。
+- `self-host-smoke.yml` に companion job を追加し、self-host path を
+  PR 毎に検証する。
+
+### Non-Goals
+
+- `install.sh` / `curl | sh` / GitHub Release への tarball upload
+  (ADR 0018 §4 別トラック)。
+- `shadowJar` / `verifyShadowJar` / `stageBtaImplJars` の除去 (段階的撤去
+  作業は別 issue)。
+- daemon unit tests の kolt 移行 (`:ic` の fixture classpath 3 本、
+  `BtaImplJarResolver` 経路含む)。
+- Multi-module `kolt.toml` schema (#4、ADR 0018 §5 で off)。
+- macOS / Windows support (linuxX64 のみ)。
+- `kolt daemon ping` のような新 CLI サブコマンド (後述 Simplification
+  参照)。
+
+## Boundary Commitments
+
+### This Spec Owns
+
+- JVM `kind = "app"` build における `build/<name>-runtime.classpath` の
+  生成 (ADR 0027 準拠の format / sort / tiebreak / self 除外)。
+- Artifact path helper `outputRuntimeClasspathPath` の新規追加。
+- `kolt.cli.DependencyResolution.resolveDependencies` の戻り値を拡張
+  (classpath 文字列に加え解決済み jar list を公開)。
+- 2 daemon プロジェクトの `kolt.toml` ファイル (source 配列、依存、
+  plugin 設定)。
+- `scripts/assemble-dist.sh` 本体 (3 × `kolt build` stitcher、`-impl` の
+  Maven 直取得、tarball layout の組立て、argfile 生成)。
+- `.github/workflows/self-host-smoke.yml` への companion job 追加。
+
+### Out of Boundary
+
+- Resolver kernel (`kolt.resolve.*`) の動作変更。stdlib skip policy
+  (ADR 0011)、transitive closure 計算、lockfile schema (ADR 0003) はすべて
+  現状維持。
+- `shadowJar` / `verifyShadowJar` / `stageBtaImplJars` の削除または修正。
+  2 daemon の Gradle build は完全に並走維持する。
+- `DaemonJarResolver.DevFallback` / `BtaImplJarResolver.DevFallback` の
+  解決経路。既存の `build/libs/*.jar` / `build/bta-impl-jars/*.jar` 参照
+  をそのまま使い続ける。
+- `kolt.toml` の schema 拡張。新フィールドは追加しない
+  (`BuildSection.jdk` 等は既存)。
+- daemon IPC protocol (`Message` / `Ping` / `Pong` / `Compile` 等) の
+  変更。
+
+### Allowed Dependencies
+
+- Upstream (読み取り可):
+  - `kolt.resolve.Resolver.resolve` の戻り値 (`List<ResolvedDep>`)。
+    既存の `resolveDependencies` 関数経由でアクセス。
+  - `kolt.config.KoltConfig`、`BuildSection`、`kind` フィールド。
+- Shared infrastructure:
+  - `kolt.build.Builder.kt` の既存 helper (`outputJarPath` など) と同じ
+    層 (`kolt.build`) に新 helper を追加。
+  - `kolt.infra.writeFileAsString` 等のファイル I/O プリミティブ。
+- Constraints:
+  - `kolt.cli` → `kolt.build` → `kolt.resolve` の下向き依存方向を遵守
+    (steering `structure.md`)。
+  - kotlin-result `Result<V, E>` による error handling (ADR 0001)。
+  - 例外 throw は禁止。
+
+### Revalidation Triggers
+
+以下の変更が入った場合、本スペックの consumer (assemble-dist.sh、CI
+companion、将来の `kolt publish` / `kolt package`) は再検証が必要:
+
+- Manifest file 名 (`<name>-runtime.classpath`) または path 規約の変更。
+- Manifest 内のフォーマット変更 (sort / separator / self 含有など)。
+- 依存 jar の実体 cache layout (`~/.kolt/cache`) の変更。manifest に
+  絶対パスを書き込むため、cache layout が変わると manifest も変わる。
+- `BuildSection` の `target` / `kind` vocabulary の変更 (ADR 0023 領域)。
+- `resolveDependencies` の戻り値形状のさらなる変更。
+
+## Architecture
+
+### Existing Architecture Analysis
+
+- **Package layout** (steering `structure.md`): `cli → build → resolve`
+  の下向き依存、各層は概念単位で分離。新規 manifest emit は build 層に
+  収まる。
+- **既存 helper**: `Builder.kt:15-23` に `outputJarPath` /
+  `outputNativeKlibPath` 等の path helper 集約。`outputRuntimeClasspathPath`
+  も同ファイルに並置。
+- **既存 resolver フロー**: `DependencyResolution.kt:36-93`
+  `resolveDependencies` が `Result<String?, Int>` (classpath 文字列 or
+  null) を返す。内部で `resolveResult.deps.map { it.cachePath }` が既に
+  絶対パスリストを持つ。
+- **既存 daemon Gradle builds**: `includeBuild` で 2 daemon を独立 build
+  として扱う (ADR 0018 §3)。本スペック実装期間中は並走。
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+    UserCLI[User CLI] --> KoltKexe[kolt kexe]
+    KoltKexe --> CliLayer[kolt cli]
+    CliLayer --> BuildLayer[kolt build]
+    CliLayer --> ResolveLayer[kolt resolve]
+    BuildLayer --> ResolveLayer
+
+    BuildLayer -. writes .-> JarFile[build name jar]
+    BuildLayer -. writes .-> ManifestFile[build name-runtime classpath]
+
+    Stitcher[scripts assemble-dist sh] -. reads .-> JarFile
+    Stitcher -. reads .-> ManifestFile
+    Stitcher --> Tarball[dist tarball libexec and bin]
+
+    CICompanion[self-host-smoke companion job] --> Stitcher
+    CICompanion --> TarballSmoke[installed kolt build smoke]
+
+    subgraph SpecOwns[This spec owns]
+        direction TB
+        ManifestEmit[manifest emit path]
+        DaemonTomls[daemon kolt tomls]
+        Stitcher
+        CICompanion
+    end
+
+    subgraph Untouched[Out of boundary]
+        direction TB
+        ResolverKernel[resolver kernel]
+        DaemonGradle[daemon Gradle builds]
+        DaemonIpc[daemon IPC protocol]
+    end
+```
+
+**Architecture Integration**:
+
+- Pattern: 既存の `cli → build → resolve` 下向き依存直線を維持。新規 I/O
+  ポイントを build 層の書き出し 1 箇所に集約。
+- Boundary: 「build output を書き出す」責務は build 層、「tarball を
+  組み立てる」責務はシェルスクリプト、「IPC が通るか検証する」責務は CI
+  job。各境界は 1 つの artifact (manifest / tarball / CI log) で接続
+  される。
+- 新規 component の理由: `Builder.kt` への helper 追加は既存 naming
+  convention、`scripts/assemble-dist.sh` は ADR 0018 §4 が要求、CI
+  companion は Req 4。
+- Steering compliance: `structure.md` の「responsibility split」、
+  `tech.md` の `Result<V, E>`、ADR 0001 / 0003 / 0011 / 0018 / 0025 /
+  0027 を全部維持。
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| CLI (native) | Kotlin/Native 2.3.20 (既存) | `outputRuntimeClasspathPath` helper、JVM kind=app 経路での manifest emit | 新規コードは `kolt.build` / `kolt.cli` 内 |
+| Build pipeline | kotlinc + `jar cf` (既存) | JVM compile + thin jar は変更なし。manifest 書き出しを追加 | Main-Class 属性は引き続き付与しない |
+| Resolver | kolt 既存 `Resolver.resolve` | jar 絶対パスリスト供給 | 変更範囲は `resolveDependencies` 戻り値拡張のみ |
+| Release scripting | POSIX shell (bash) | `scripts/assemble-dist.sh` の 2 モード | separator `:` 固定 (linuxX64 only)、`tar czf` で tarball 生成 |
+| CI runner | GitHub Actions (ubuntu-latest) | companion job | 既存 `self-host-smoke.yml` に追加 |
+
+新規依存なし。
+
+## File Structure Plan
+
+### Directory Structure
+
+```
+src/nativeMain/kotlin/kolt/
+├── build/
+│   └── Builder.kt                          # +outputRuntimeClasspathPath helper and +writeRuntimeClasspathManifest
+├── cli/
+│   ├── BuildCommands.kt                    # +manifest emit call on JVM kind=app tail
+│   └── DependencyResolution.kt             # resolveDependencies returns JvmResolutionOutcome
+src/nativeTest/kotlin/kolt/
+├── build/
+│   └── RuntimeClasspathManifestTest.kt     # NEW: emit format / sort / tiebreak
+└── cli/
+    ├── JvmAppBuildTest.kt                  # NEW: emit matrix (app=yes, lib/native=no)
+    └── KoltRunManifestIndependenceTest.kt  # NEW: kolt run works after manifest delete
+
+kolt-jvm-compiler-daemon/
+└── kolt.toml                               # NEW: :ic sources merged in
+
+kolt-native-compiler-daemon/
+└── kolt.toml                               # NEW
+
+scripts/
+└── assemble-dist.sh                        # NEW: 3-project stitcher
+
+.github/workflows/
+└── self-host-smoke.yml                     # +companion job
+```
+
+### Modified Files
+
+- `src/nativeMain/kotlin/kolt/build/Builder.kt` — `outputRuntimeClasspathPath(config)` helper と `writeRuntimeClasspathManifest(config, jarPaths)` emit 関数を追加 (既存 `outputJarPath` 等と同じ internal visibility)。
+- `src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt` — `resolveDependencies` の戻り値型を `Result<String?, Int>` から `Result<JvmResolutionOutcome, Int>` に変更 (classpath 文字列と jar list を同時に返す)。callers を追従修正。
+- `src/nativeMain/kotlin/kolt/cli/BuildCommands.kt` — JVM `kind = "app"` の build 完了後に manifest を書き出す分岐を追加。既存の JVM 経路最終ステップ (jar 生成直後) に 1 ブロック。`kolt run` / `kind = "lib"` / native 経路には変更なし。
+- `.github/workflows/self-host-smoke.yml` — 既存 native job の下に companion job を追加。native job の kexe artifact を upload して companion job で download する step を挟む。
+- `docs/adr/0027-runtime-classpath-manifest.md` — §1 末尾の helper 参照先を `kolt/config/Config.kt` から `kolt/build/Builder.kt` に 1 行修正 (既存 `output*Path` helper 集の配置と整合)。
+
+### New Files
+
+- `kolt-jvm-compiler-daemon/kolt.toml` — `target = "jvm"`、`kind = "app"`、`main = "kolt.daemon.main"`、`sources = ["src/main/kotlin", "ic/src/main/kotlin"]`、`jvm_target = "21"`、`jdk = "21"`、依存: `kotlin-build-tools-api`, `kotlinx-serialization-json`, `kotlin-result`, `ktoml-core`、`[kotlin.plugins] serialization = true`。
+- `kolt-native-compiler-daemon/kolt.toml` — `target = "jvm"`、`kind = "app"`、`main = "kolt.nativedaemon.main"`、`sources = ["src/main/kotlin"]`、`jvm_target = "21"`、`jdk = "21"`、依存: `kotlinx-serialization-json`, `kotlin-result`、`[kotlin.plugins] serialization = true`。
+- `scripts/assemble-dist.sh` — 3 × `kolt build` を直列に呼び、`kotlin-build-tools-impl` を curl で Maven Central から取得、失敗 fail-fast、tarball layout 生成、argfile 生成。
+- Tests 3 本 — 後述 Testing Strategy。
+
+## System Flows
+
+### Flow 1: JVM `kind = "app"` build と manifest emit
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Cli as kolt cli
+    participant Resolve as resolveDependencies
+    participant Build as Builder
+    participant FS as filesystem
+
+    User->>Cli: kolt build
+    Cli->>Resolve: resolveDependencies config
+    Resolve->>Resolve: resolve Maven deps
+    Resolve-->>Cli: JvmResolutionOutcome classpath and jarPaths
+    Cli->>Build: kotlinc compile classes
+    Build->>FS: write build classes
+    Cli->>Build: jar cf build name jar
+    Build->>FS: write build name jar
+    alt kind equals app and target equals jvm
+        Cli->>Build: writeRuntimeClasspathManifest jarPaths
+        Build->>FS: write build name runtime classpath
+    end
+    Cli-->>User: built build name jar
+```
+
+**Key decisions**:
+- Manifest 書き出しは jar 生成の直後、同一 `doBuild` スコープ内で行う。失敗時は jar 成果物を残したまま非ゼロ終了 (部分的な build 成果物が残ることを許容、既存 `jar cf` の失敗時挙動と同じポリシー)。
+- `kind = "lib"` / native 経路では `writeRuntimeClasspathManifest` を呼ばない。呼ばない分岐は `kind` と `target` を見て決め、既存 `NATIVE_TARGETS` gate と同じ段で処理する。
+
+### Flow 2: `assemble-dist.sh` stitcher
+
+```mermaid
+flowchart TB
+    Start[assemble-dist sh] --> BuildRoot[cd root and kolt build]
+    BuildRoot --> BuildJvm[cd kolt-jvm-compiler-daemon and kolt build]
+    BuildJvm --> BuildNative[cd kolt-native-compiler-daemon and kolt build]
+    BuildNative --> FetchImpl[curl kotlin-build-tools-impl from Maven Central]
+    FetchImpl --> Layout[build tarball layout]
+    Layout --> CopyBin[copy kolt kexe to bin kolt]
+    CopyBin --> CopyJars[copy daemon jars and deps and impl jars]
+    CopyJars --> WriteArgfile[generate argfiles]
+    WriteArgfile --> WriteVersion[write VERSION file]
+    WriteVersion --> Tar[tar czf]
+    Tar --> End[dist tarball tar gz]
+
+    BuildRoot -. fail .-> Abort[non-zero exit]
+    BuildJvm -. fail .-> Abort
+    BuildNative -. fail .-> Abort
+    FetchImpl -. fail .-> Abort
+```
+
+**Key decisions**:
+- 単一モード: 常に 3 プロジェクトを `kolt build` で直列に build する。`./gradlew build` を呼ぶ pre-self-host モードは含めない (本スペックは `kolt.toml` を 2 daemon に追加してから landing するため、そちらで build 可能な状態が前提)。
+- tarball 名は `kolt-<version>-linux-x64.tar.gz` (ADR 0018 §1 命名)。`<version>` はルートの `kolt.toml` の `version` フィールドから読む。
+- `kotlin-build-tools-impl:2.3.20` は kolt の resolver を経由せず、shell script 内の `curl -fsSL` で Maven Central から直接取得する。ADR 0019 §3 の classloader isolation により `-impl` は daemon の thin jar + deps には混ぜられないため、独立した取得路が必要。シェルで取得する理由は (i) 新規 kolt CLI を追加しないで済む、(ii) GAV 一式 (impl + transitive の最低限) がバージョン固定で明確、(iii) assemble-dist.sh が kolt の cache layout から独立するという Req 3.5 の制約と整合。
+
+### Flow 3: CI companion job
+
+```mermaid
+sequenceDiagram
+    participant Native as self-host native job
+    participant Companion as self-host companion job
+    participant FS as runner fs
+
+    Native->>Native: gradlew linkDebugExecutableLinuxX64
+    Native->>Native: kolt kexe build self-host
+    Native->>FS: upload-artifact kolt kexe
+    Native-->>Companion: artifact available
+    Companion->>FS: download-artifact kolt kexe
+    Companion->>FS: chmod +x kolt kexe
+    Companion->>Companion: kolt build at root
+    Companion->>Companion: kolt build at kolt-jvm-compiler-daemon
+    Companion->>Companion: kolt build at kolt-native-compiler-daemon
+    Companion->>Companion: assemble-dist sh
+    Companion->>FS: tar xzf dist tarball
+    Companion->>Companion: installed kolt kexe build sample project
+    Companion-->>FS: smoke pass
+```
+
+**Key decisions**:
+- native job と companion job は同一 `kolt.kexe` artifact を使う (重複 build 回避、Req 4.6)。
+- companion job の final smoke は「展開した tarball の `bin/kolt` を使って、適当な fixture project を 1 つ build する」。このビルドが成功すれば classpath launch から daemon IPC まで含めた end-to-end が動いている証拠になる。`kolt daemon ping` のような専用コマンドは追加しない (Simplification, Req 4.4 の AC はこの smoke で cover)。
+- Fixture project: 既存の `spike/lib-dogfood/` または新規の最小 JVM app を 1 つ用意 (tasks phase で決定)。
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | `kolt-jvm-compiler-daemon/kolt.toml` で build 成功 | 新規 `kolt.toml` + 既存 JVM pipeline | `KoltConfig`, `BuildSection` | Flow 1 |
+| 1.2 | `kolt-native-compiler-daemon/kolt.toml` で build 成功 | 新規 `kolt.toml` + 既存 JVM pipeline | 同上 | Flow 1 |
+| 1.3 | `:ic` ソース merge | `kolt-jvm-compiler-daemon/kolt.toml` の `sources` 配列 | `BuildSection.sources` | Flow 1 |
+| 1.4 | Gradle 並走維持 | 変更しない制約 (Out of Boundary) | - | - |
+| 1.5 | schema 違反で停止 | 既存 `parseConfig` の `LIB_WITH_MAIN_ERROR` / `APP_WITHOUT_MAIN_ERROR` | `parseConfig` | - |
+| 2.1 | manifest emit トリガ | `BuildCommands.kt` JVM app tail | `writeRuntimeClasspathManifest` | Flow 1 |
+| 2.2 | UTF-8 LF plain text | `writeRuntimeClasspathManifest` | 同上 | - |
+| 2.3 | self jar 除外 | 同上 | 同上 | - |
+| 2.4 | file name alphabetical | 同上 (stdlib `sortedBy`) | 同上 | - |
+| 2.5 | GAV tiebreak | 同上 (2 次 sort key) | 同上 | - |
+| 2.6 | resolver 結果そのまま stdlib 含む | `JvmResolutionOutcome.jarPaths` | `resolveDependencies` | Flow 1 |
+| 2.7 | lib / native で emit しない | `BuildCommands.kt` の kind/target 分岐 | - | Flow 1 alt branch |
+| 2.8 | `kolt run` は manifest を読まない | 変更しない経路 (`runCommand` in-process classpath) | `runCommand` | - |
+| 3.1 | 3 project を `kolt build` で順次実行 | `scripts/assemble-dist.sh` | - | Flow 2 |
+| 3.2 | `kotlin-build-tools-impl` を curl 直ダウンロード | 同上 (`fetch_bta_impl` step) | Maven Central GAV URL | Flow 2 |
+| 3.3 | fail-fast | `set -euo pipefail` + 明示 `exit 1` | - | Flow 2 |
+| 3.4 | tarball layout (impl jar 配置含む) | 同上 (copy / argfile / VERSION step) | - | Flow 2 |
+| 3.5 | stitcher は kolt cache layout 知らない | manifest のみ入力とする constraint、`-impl` は独立取得 | `build/<name>-runtime.classpath` | Flow 2 |
+| 3.6 | manifest を deps/ 生成元として消費 | 同上 | 同上 | Flow 2 |
+| 4.1 | PR 毎に companion 実行 | `self-host-smoke.yml` trigger (既存) | - | Flow 3 |
+| 4.2 | 3 project build → assemble | companion job の step 列 | - | Flow 3 |
+| 4.3 | tarball 展開 → classpath launch | 同上 | - | Flow 3 |
+| 4.4 | IPC 健全性の検証 | installed kolt.kexe で fixture build 成功 | - | Flow 3 |
+| 4.5 | fail は CI 失敗 | `set -euo pipefail` + GHA デフォルト | - | Flow 3 |
+| 4.6 | kexe 共有 | `actions/upload-artifact` + `download-artifact` | - | Flow 3 |
+| 5.1 | `./gradlew build` 成功維持 | 変更しない制約 (Out of Boundary) | - | - |
+| 5.2 | native smoke job 維持 | 変更しない制約 | - | - |
+| 5.3 | `[dependencies]` 制限 | 2 daemon の `kolt.toml` に `-impl` / fixture を書かない | 2 `kolt.toml` | - |
+
+## Components and Interfaces
+
+| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies | Contracts |
+|-----------|--------------|--------|--------------|------------------|-----------|
+| `outputRuntimeClasspathPath` helper | build | `build/<name>-runtime.classpath` の絶対パスを返す | 2.1 | `KoltConfig` (P0) | Service |
+| `JvmResolutionOutcome` data class | cli | classpath 文字列と jar list を同時保持 | 2.1, 2.6 | resolve (P0) | State |
+| `writeRuntimeClasspathManifest` emit 関数 | build | jarPaths を sort / tiebreak / self 除外して書き出す | 2.1-2.7 | `JvmResolutionOutcome`, `writeFileAsString` (P0) | Service |
+| `BuildCommands` JVM app tail branch | cli | kind/target を見て emit を呼ぶ / 呼ばない | 2.1, 2.7 | `outputRuntimeClasspathPath`, `writeRuntimeClasspathManifest` (P0) | Service |
+| `kolt-jvm-compiler-daemon/kolt.toml` | 設定ファイル | JVM kind=app 仕様で daemon を記述、`:ic` を sources merge | 1.1, 1.3, 5.3 | kolt parser (P0) | State |
+| `kolt-native-compiler-daemon/kolt.toml` | 設定ファイル | JVM kind=app 仕様で native daemon を記述 | 1.2, 5.3 | kolt parser (P0) | State |
+| `scripts/assemble-dist.sh` | release 配管 | 3 project を stitch + `-impl` を curl 取得 + tarball を生成 | 3.1-3.6 | kolt.kexe (P0), Maven Central (P0) | Batch |
+| CI companion job | CI | self-host path の regression 検知 | 4.1-4.6 | self-host-smoke.yml (P0), assemble-dist.sh (P0) | Batch |
+
+### build
+
+#### `outputRuntimeClasspathPath` helper
+
+| Field | Detail |
+|-------|--------|
+| Intent | manifest の絶対パス (`build/<name>-runtime.classpath`) を返す |
+| Requirements | 2.1 |
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+internal fun outputRuntimeClasspathPath(config: KoltConfig): String
+```
+
+- Preconditions: `config.build.target == "jvm" && config.kind == "app"`
+  (呼び出し側で kind/target 分岐済みの想定)。
+- Postconditions: `"$BUILD_DIR/${config.name}-runtime.classpath"`
+  を返す。副作用なし。
+- Invariants: 戻り値は `outputJarPath(config)` と同じディレクトリを指す。
+
+**Implementation Notes**
+- 既存 `Builder.kt:15-23` の path helper 集と同じ形式 (internal、1 行関数)。
+
+#### `writeRuntimeClasspathManifest` emit 関数
+
+| Field | Detail |
+|-------|--------|
+| Intent | 解決済み jar list を ADR 0027 準拠の manifest として書き出す |
+| Requirements | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6 |
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+internal fun writeRuntimeClasspathManifest(
+    config: KoltConfig,
+    jarPaths: List<ResolvedJar>
+): Result<Unit, ManifestWriteError>
+
+internal data class ResolvedJar(
+    val cachePath: String,
+    val groupArtifactVersion: String
+)
+
+internal sealed class ManifestWriteError {
+    data class WriteFailed(val path: String, val reason: String) : ManifestWriteError()
+}
+```
+
+- Preconditions: 引数 `jarPaths` は resolver が返した post-BFS /
+  post-exclusion / post-version-interval リスト。self jar は含まれない
+  想定 (caller の resolver API が self jar を返さないのは現行挙動)。
+- Postconditions:
+  - エントリを `cachePath` の最終 path segment (file name) で
+    alphabetical sort。
+  - ファイル名が同一の 2 エントリは `groupArtifactVersion` の辞書順で
+    tiebreak。
+  - UTF-8 / LF / 末尾空行なし / 1 行 1 絶対パスで
+    `outputRuntimeClasspathPath(config)` に書き出す。
+- Invariants: 同じ jarPaths 入力に対して byte-for-byte 同一の出力。
+
+**Implementation Notes**
+- Sort は Kotlin stdlib `sortedWith(compareBy(..., ...))`。ADR 0027 §1
+  に "alphabetical by last path component、tiebreak by GAV" と一致。
+- `writeFileAsString` 既存 infra を使用。
+- Manifest 書き込みが失敗した場合、jar は既に emit 済みだが build 全体
+  は非ゼロ終了にする (ADR 0001: 例外は投げず `Err` を伝搬)。
+
+### cli
+
+#### `JvmResolutionOutcome` data class
+
+| Field | Detail |
+|-------|--------|
+| Intent | classpath 文字列と解決済み jar list を 1 関数で返すための容れ物 |
+| Requirements | 2.1, 2.6 |
+
+**Contracts**: State [x]
+
+##### State Management
+
+```kotlin
+internal data class JvmResolutionOutcome(
+    val classpath: String?,
+    val resolvedJars: List<ResolvedJar>
+)
+```
+
+- State model: immutable data class。
+- Persistence: なし (関数戻り値)。
+- Concurrency: resolver 呼び出し内で構築、呼び出し側で消費。共有状態なし。
+
+**Implementation Notes**
+- `resolveDependencies` の戻り値を `Result<String?, Int>` から
+  `Result<JvmResolutionOutcome, Int>` に変更。callers (BuildCommands の
+  JVM 経路、test 経由) は `.classpath` を参照するように追従。
+- `classpath` が null のときは依存なし (既存の null 意味論を維持)。
+
+#### `BuildCommands` JVM app tail branch
+
+| Field | Detail |
+|-------|--------|
+| Intent | JVM `kind = "app"` でのみ manifest emit を呼び、それ以外は呼ばない |
+| Requirements | 2.1, 2.7 |
+
+**Contracts**: Service [x]
+
+**Responsibilities & Constraints**
+- 既存 `doBuild` (JVM 経路) の末尾、jar 生成直後に 1 ブロック追加。
+- kind/target 分岐:
+  - `kind == "app" && target == "jvm"` → emit する
+  - それ以外 (lib、native) → emit せず、既に manifest ファイルが残って
+    いれば **削除する** (stale manifest が assemble-dist.sh に拾われる事故
+    を防ぐ、AC 2.7 強化)。
+- 失敗時: emit の `Result.Err` を `doBuild` の戻り値に伝搬。
+
+**Implementation Notes**
+- 既存の `NATIVE_TARGETS` gate と同じ段で書く (BuildCommands.kt:92, 143,
+  467, 503 付近の pattern に合わせる)。
+- stale manifest の削除は「過去の kind=app build が残した manifest が、
+  kind を lib に変更した後も残る」という状況をカバーする。
+
+### 設定ファイル
+
+#### `kolt-jvm-compiler-daemon/kolt.toml`
+
+| Field | Detail |
+|-------|--------|
+| Intent | kolt が JVM compiler daemon を build するための宣言 |
+| Requirements | 1.1, 1.3, 5.3 |
+
+**Contracts**: State [x]
+
+##### State Management
+
+```toml
+name = "kolt-jvm-compiler-daemon"
+version = "<root と同期>"
+kind = "app"
+
+[kotlin]
+version = "2.3.20"
+
+[kotlin.plugins]
+serialization = true
+
+[build]
+target = "jvm"
+jvm_target = "21"
+jdk = "21"
+main = "kolt.daemon.main"
+sources = ["src/main/kotlin", "ic/src/main/kotlin"]
+test_sources = []
+
+[dependencies]
+"org.jetbrains.kotlin:kotlin-build-tools-api" = "2.3.20"
+"org.jetbrains.kotlinx:kotlinx-serialization-json" = "1.7.3"
+"com.michael-bull.kotlin-result:kotlin-result" = "2.3.1"
+"com.akuleshov7:ktoml-core" = "0.7.1"
+```
+
+**Implementation Notes**
+- `version` は release cut 時に root `kolt.toml` と手動同期 (v1 前は
+  両者の version pin は release note レベルで運用)。
+- `kotlin-build-tools-impl` は **含めない** (Req 5.3、ADR 0019 §3 の
+  classloader isolation を維持)。`-impl` は `assemble-dist.sh` が別途
+  Maven 解決して `libexec/kolt-bta-impl/` に配置する責務 (ADR 0018 §4
+  stitcher の拡張範囲)。
+- fixture classpath 3 本 (`fixtureClasspath` / `serializationPluginClasspath`
+  / `serializationRuntimeClasspath`) は test 経路のみで使われるため、
+  daemon unit tests の kolt 移行を行わない本スペックでは記述不要 (Gradle
+  経由のテストで引き続きカバー)。
+
+#### `kolt-native-compiler-daemon/kolt.toml`
+
+| Field | Detail |
+|-------|--------|
+| Intent | kolt が native compiler daemon を build するための宣言 |
+| Requirements | 1.2, 5.3 |
+
+**Implementation Notes**
+- `kolt-jvm-compiler-daemon/kolt.toml` と同形式。差分は name、main
+  (`kolt.nativedaemon.main`)、sources、依存 (kotlin-build-tools-api /
+  ktoml-core を含まない)。
+- `kotlin-native-compiler-embeddable` は **含めない** (ADR 0024 §8)。
+  runtime に `--konanc-jar` でロードするため、kolt 側は daemon jar 自身の
+  dependencies として扱わない。
+
+### release 配管
+
+#### `scripts/assemble-dist.sh`
+
+| Field | Detail |
+|-------|--------|
+| Intent | 3 project を `kolt build` で stitch し、`-impl` を Maven から取得し、ADR 0018 §1 の tarball layout を生成 |
+| Requirements | 3.1-3.6 |
+
+**Contracts**: Batch [x]
+
+##### Batch / Job Contract
+
+- Trigger: 手動呼び出し (`scripts/assemble-dist.sh`、引数なし)。
+- Input / validation:
+  - ルート `kolt.toml` と 2 daemon `kolt.toml` が揃っていること
+    (Phase 2 以降の前提)。
+  - `./build/bin/linuxX64/<config>/kolt.kexe` が存在するか、環境変数
+    `KOLT` で絶対パス指定済みであること。
+- Output / destination:
+  - `dist/kolt-<version>-linux-x64/` 配下に tarball layout を展開。
+  - `dist/kolt-<version>-linux-x64.tar.gz` を生成。
+- Idempotency & recovery:
+  - 冪等: 既存 `dist/` は事前削除してから展開 (rerun safe)。
+  - Recovery: 途中失敗時は `dist/` 以下の中間物をそのまま残す (デバッグ用)。
+
+**Implementation Notes**
+- Shell: `#!/usr/bin/env bash`、`set -euo pipefail`。
+- 各 project で `${KOLT:-./build/bin/linuxX64/releaseExecutable/kolt.kexe} build`
+  を順次呼び、fail-fast。
+- `fetch_bta_impl` step: `kotlin-build-tools-impl:2.3.20` とその最小
+  runtime 依存 (例: `kotlin-build-tools-api` は既に daemon の
+  `[dependencies]` 経由で `deps/` に入るので除外) を
+  `https://repo1.maven.org/maven2/...` から `curl -fsSL` で取得し
+  `dist/kolt-<version>-linux-x64/libexec/kolt-bta-impl/` へ配置。
+  SHA-256 は `~/.kolt/cache` の lockfile 検証に依存せず、script 内に
+  ハードコードされたチェックサム定数で検証する (supply chain 安全策、
+  Req 3.2)。
+- 取得対象 GAV はスクリプト冒頭で配列として定数定義。2.3.20 版の
+  `-impl` transitive で実際に必要な jar は ADR 0019 §3 の動作確認で
+  既に `kolt-jvm-compiler-daemon/build/bta-impl-jars/` に列挙されて
+  いるため、そのファイル名集合をそのまま定数にする (Phase 3 タスクで
+  Gradle 側 `stageBtaImplJars` の出力を参照して pin する)。
+- Argfile 生成: `printf '%s\n' '-cp' "$CPATH" "$MAIN"` パターン。
+  Separator は `:` 固定 (linuxX64 前提)。
+- VERSION ファイル: ルート `kolt.toml` の `version = "..."` を grep で
+  抜き出して単行で出力。
+- 依存: `tar`, `cp`, `mkdir`, `grep`, `printf`, `curl`, `sha256sum`。
+  ubuntu-latest runner と一般的な Linux distro で揃う標準ツール。
+
+### CI
+
+#### self-host-smoke.yml companion job
+
+| Field | Detail |
+|-------|--------|
+| Intent | self-host 経路を PR 毎に検証 |
+| Requirements | 4.1-4.6 |
+
+**Contracts**: Batch [x]
+
+##### Batch / Job Contract
+
+- Trigger: 既存 `self-host-smoke.yml` の push/PR トリガに相乗り。
+- Input / validation:
+  - `self-host` job (既存) が成功し、`kolt.kexe` を artifact として upload
+    している状態。
+- Output / destination:
+  - `dist/kolt-*.tar.gz` 生成の成功、fixture project build 成功。
+  - 失敗時は該当 step の stderr を GHA ログへ。
+- Idempotency & recovery:
+  - 冪等: runner clean start 前提。
+  - Recovery: step 失敗はその場で全体 fail。
+
+**Implementation Notes**
+- 新規 job 名: `self-host-post`。
+- 依存: `needs: self-host`。
+- steps:
+  1. `actions/checkout`
+  2. `actions/download-artifact` で `kolt.kexe` を取得
+  3. `chmod +x ./build/bin/linuxX64/debugExecutable/kolt.kexe`
+  4. 3 × `kolt build` (root / kolt-jvm-compiler-daemon / kolt-native-compiler-daemon)
+  5. `scripts/assemble-dist.sh`
+  6. `tar xzf dist/kolt-*-linux-x64.tar.gz -C /tmp/kolt-install/`
+  7. Fixture project directory に移動し `/tmp/kolt-install/.../bin/kolt build`
+- native job 側で `actions/upload-artifact` step を追加 (既存 job の
+  末尾、`--version` 検証の後)。
+
+## Error Handling
+
+### Error Strategy
+
+既存の `Result<V, E>` ポリシー (ADR 0001) をそのまま使用。本スペックで
+追加される error types は以下:
+
+- `ManifestWriteError.WriteFailed` — ファイル I/O 失敗。`doBuild` から
+  `EXIT_BUILD_ERROR` (既存 exit code) に mapping。
+
+### Error Categories and Responses
+
+- **User errors** (schema 違反):
+  - `kolt.toml` に `kind = "app"` だが `main` 欠落 → 既存
+    `APP_WITHOUT_MAIN_ERROR` メッセージ。
+  - `target = "jvm"` 以外で本スペックは関与しない (既存挙動のまま)。
+- **System errors**:
+  - Manifest 書き込み失敗 → `ManifestWriteError.WriteFailed` を emit、
+    `doBuild` が `EXIT_BUILD_ERROR` で終了。
+  - `assemble-dist.sh` の依存サブコマンド失敗 → `set -euo pipefail` で
+    即時終了、非ゼロ exit code を返す。
+- **Business logic errors**:
+  - 該当なし (本スペックにビジネスロジックなし)。
+
+### Monitoring
+
+- kolt 側: 既存の stdout (`built build/...`) 経路で emit 行を追加 (例:
+  `emitted build/<name>-runtime.classpath`)。verbose flag は既存のまま。
+- CI 側: GHA の step ログのみ。追加の metric / logging は導入しない。
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **`outputRuntimeClasspathPath` helper の path 構築**
+   (`RuntimeClasspathManifestTest.kt`、2.1): `KoltConfig(name = "foo")` →
+   `build/foo-runtime.classpath`。
+2. **`writeRuntimeClasspathManifest` の sort と self 除外**
+   (`RuntimeClasspathManifestTest.kt`、2.3, 2.4): ランダム順の
+   `ResolvedJar` 入力に対して file-name sort が働き、self jar
+   (`outputJarPath(config)`) が引数に含まれていても出力から除外される。
+3. **`writeRuntimeClasspathManifest` の GAV tiebreak**
+   (`RuntimeClasspathManifestTest.kt`、2.5): 同一 file name で
+   `groupArtifactVersion` が異なる 2 エントリの sort 順が stable。
+4. **`writeRuntimeClasspathManifest` の format invariants**
+   (`RuntimeClasspathManifestTest.kt`、2.2): UTF-8 / LF / 末尾空行
+   なしを byte-level で検証。
+
+### Integration Tests
+
+1. **JVM `kind = "app"` で manifest が emit される**
+   (`JvmAppBuildTest.kt`、2.1, 2.6): fixture project を build して
+   `build/<name>-runtime.classpath` が存在し、行数 > 0 で stdlib が含まれる。
+2. **JVM `kind = "lib"` で manifest が emit されない**
+   (`JvmAppBuildTest.kt`、2.7): fixture project を build して manifest が
+   存在しない (もしくは stale 削除されている)。
+3. **native target で manifest が emit されない**
+   (`JvmAppBuildTest.kt`、2.7): linuxX64 fixture を build しても
+   manifest が生成されない。
+
+### Smoke Tests
+
+1. **`kolt run` が manifest 削除後も動く**
+   (`KoltRunManifestIndependenceTest.kt`、2.8): `kolt build` 後に
+   `rm build/*-runtime.classpath` し、`kolt run` が success する。
+2. **stale manifest の自動 cleanup**
+   (`KoltRunManifestIndependenceTest.kt` or `JvmAppBuildTest.kt`、2.7): 
+   `kind = "app"` で build → kolt.toml を `kind = "lib"` に変更して
+   再 build → manifest が削除されている。
+
+### E2E Tests (CI companion)
+
+1. **self-host path 全体** (Req 4 全般): companion job の step 列
+   そのまま。tarball 展開から fixture build 成功までが 1 本の緑赤。
+
+### Non-scope (defer)
+
+- `:ic` 側の fixture classpath を伴う daemon unit tests を kolt で回す
+  こと。別スペック。
+- assemble-dist.sh 自身の unit 分解 (BATS 等)。手動回帰で十分。
+
+## Migration Strategy
+
+本スペックは breaking change を伴わない (既存コードの戻り値型変更のみ、
+外部 API には影響なし)。段階的 landing:
+
+1. **Phase 1**: `JvmResolutionOutcome` 導入 + manifest emit + tests
+   (kolt 内の kolt 内部変更のみ)。
+2. **Phase 2**: 2 daemon の `kolt.toml` 追加 (設定ファイル追加のみ)。
+3. **Phase 3**: `scripts/assemble-dist.sh` 新規追加 (shell script のみ)。
+4. **Phase 4**: CI companion job 追加 (ワークフロー変更のみ)。
+
+各 Phase は独立 PR として landing 可能。Phase 2 以降は Phase 1 の
+manifest emit が前提 (assemble-dist.sh が使用する)。Phase 1 を
+landing してから Phase 2 〜 4 を順次進める。
+
+Rollback: 各 Phase は単独でロールバック可能 (コード / ファイル単位で
+revert)。`JvmResolutionOutcome` の revert は caller 2 箇所の戻り値型戻し
+だけで済む。

--- a/.kiro/specs/daemon-self-host/requirements.md
+++ b/.kiro/specs/daemon-self-host/requirements.md
@@ -1,0 +1,178 @@
+# Requirements Document
+
+## Project Description (Input)
+
+### 誰の問題か
+kolt プロジェクト本体の開発・配布。kolt は自身の native binary (`kolt.kexe`) は
+`kolt.toml` で self-host しているが、2 つの JVM daemon
+(`kolt-jvm-compiler-daemon`, `kolt-native-compiler-daemon`) の JVM jar だけは
+Gradle + shadowJar でしか build できず、self-host のループが閉じていない
+(Issue #97)。
+
+### 現状
+ADR 0018 (#224/#225)、ADR 0025 (#222)、ADR 0026 (#227)、ADR 0027 が揃い、
+2026-04-22 dogfood spike で 2 daemon とも `kolt build` が一発で thin jar を
+emit することを確認済み。残る実装ギャップは runtime classpath manifest の
+emit、`scripts/assemble-dist.sh` の stitcher 実装、self-host-smoke CI の
+companion job。
+
+### 何を変えるか
+Issue #97 の DoD を閉じる。`install.sh` / tarball release CI / shadowJar 除去
+/ daemon unit tests の kolt 移行 / multi-module `kolt.toml` はスコープ外。
+
+## Introduction
+
+本スペックは kolt が自分自身の 2 daemon JVM jar を build し、リリース
+タルボールの layout を組み立て、CI で self-host 経路を検証できる状態に
+することで、Issue #97 の self-host gap を閉じる。ADR 0018 / 0025 / 0027 で
+既に pin されている決定を実装に落とし込む位置づけで、新規の設計選択は
+含まない。
+
+## Boundary Context
+
+- **In scope**:
+  - `kolt-jvm-compiler-daemon/kolt.toml` と `kolt-native-compiler-daemon/kolt.toml`
+    の追加 (`:ic` ソース merge を含む)。
+  - JVM `kind = "app"` build における runtime classpath manifest の emit
+    (ADR 0027 準拠)。
+  - `scripts/assemble-dist.sh` による 3 プロジェクト stitcher 実装
+    (ADR 0018 §4)。
+  - `self-host-smoke.yml` に self-host path を検証する companion job を
+    追加。
+- **Out of scope**:
+  - `install.sh` / `curl | sh` 経路 / GitHub Release への tarball upload
+    (ADR 0018 §4 first release cut 別トラック)。
+  - `shadowJar` 除去と関連 Gradle task の削除 (ADR 0018 Confirmation の
+    段階的撤去)。daemon の Gradle build は本スペック期間中は並走維持。
+  - daemon unit tests の kolt 移行 (`:ic` の fixture classpath 3 本、
+    BtaImplJarResolver 経路含む)。
+  - `install.sh` 不在下での `~/.local/share/kolt/` layout / symlink 管理。
+  - Multi-module `kolt.toml` schema (#4)。
+- **Adjacent expectations**:
+  - 依存 resolver: JVM 経路で Kotlin stdlib を transitive closure に含める
+    現状挙動に依存する (ADR 0011 skip は native 限定)。本スペックは resolver
+    を変更しない。
+  - `kolt.toml` schema: `[build]` の `target = "jvm"` / `jvm_target` / `jdk` /
+    `main` / `sources` は既に `BuildSection` に存在する前提で使用。
+  - `kolt run` / `kolt build` の kind/target 分岐は既存 `BuildCommands.kt` の
+    orchestration 層に追従する。
+
+## Requirements
+
+### Requirement 1: Daemon の kolt.toml による build 可能性
+
+**Objective:** kolt メンテナとして、2 つの daemon を `kolt build` でビルド
+できるようにし、Gradle なしでも self-host ループを閉じられる状態にしたい。
+
+#### Acceptance Criteria
+
+1. Where `kolt-jvm-compiler-daemon/kolt.toml` が存在する場合、the kolt CLI shall
+   当該ディレクトリで `kolt build` を実行したときに `build/kolt-jvm-compiler-daemon.jar`
+   を Gradle を起動せずに emit する。
+2. Where `kolt-native-compiler-daemon/kolt.toml` が存在する場合、the kolt CLI
+   shall 当該ディレクトリで `kolt build` を実行したときに
+   `build/kolt-native-compiler-daemon.jar` を Gradle を起動せずに emit する。
+3. When `kolt-jvm-compiler-daemon/` 配下で `kolt build` を実行した時、the
+   kolt CLI shall daemon 本体のソースと `:ic` 相当のソース
+   (`ic/src/main/kotlin`) を単一 build の入力として取り込む。
+4. While daemon の Gradle build (`build.gradle.kts`) がリポジトリに残存して
+   いる間、the kolt CLI shall Gradle の build path の成功を阻害せず両経路が
+   正常終了する状態を保つ。
+5. If daemon の `kolt.toml` に kind/target/main の schema 違反がある場合、
+   the kolt CLI shall build 開始前にエラーで停止し、原因を示す。
+
+### Requirement 2: Runtime classpath manifest の emit
+
+**Objective:** `assemble-dist.sh` などの外部ランチャーとして、依存解決を
+再実行せずに daemon 起動に必要な jar 一覧を取得したい。
+
+#### Acceptance Criteria
+
+1. When JVM `kind = "app"` の `kolt build` が成功した時、the kolt CLI shall
+   `build/<name>-runtime.classpath` を emit する。
+2. The manifest shall UTF-8 / LF line endings のプレーンテキストで、1 行に
+   1 つの絶対パス jar を含み、末尾に空行を持たない。
+3. The manifest shall `build/<name>.jar` (self jar) を含まず、解決済み依存
+   jar のみを列挙する。
+4. The manifest shall エントリをファイル名 (path の最終要素) でアルファベット
+   順にソートして出力する。
+5. If 複数のエントリが同一ファイル名を持つ場合、the kolt CLI shall
+   `group:artifact:version` 文字列による辞書順で tie-break する。
+6. The manifest shall JVM 経路で resolver が返す transitive closure
+   (post-BFS / post-exclusion / post-version-interval) をそのまま反映し、
+   Kotlin stdlib を含む。
+7. Where `kind = "lib"` または target が native の場合、the kolt CLI shall
+   manifest を emit してはならない。
+8. While `kolt run` の JVM app 経路が実行されている間、the kolt CLI shall
+   manifest ファイルを読み取らず、resolver の戻り値から in-process で
+   classpath を組み立てる。
+
+### Requirement 3: assemble-dist.sh stitcher
+
+**Objective:** リリース担当者として、単一コマンドで 3 プロジェクトを
+`kolt build` で build し、ADR 0018 §1 の tarball layout を組み立てたい。
+
+#### Acceptance Criteria
+
+1. When `scripts/assemble-dist.sh` が引数なしで実行された時、the stitcher
+   shall `./`、`./kolt-jvm-compiler-daemon/`、`./kolt-native-compiler-daemon/`
+   の 3 プロジェクトで `kolt build` を順次実行する。
+2. When 3 プロジェクトの build が成功した時、the stitcher shall
+   `kotlin-build-tools-impl:2.3.20` を Maven Central (`repo1.maven.org`) から
+   HTTP GET で直接取得し、`libexec/kolt-bta-impl/` に配置する。取得はその
+   transitive 依存を含めた最小集合とし、kolt の resolver を経由しない。
+3. If いずれかのプロジェクト build または `-impl` 取得が非ゼロ終了した
+   場合、the stitcher shall 以降のステップを実行せず、非ゼロで終了する。
+4. When 3 プロジェクトの build および `-impl` 取得が成功した時、the
+   stitcher shall 出力先ディレクトリ (`dist/kolt-<version>-linux-x64/`) に
+   以下を配置する: `bin/kolt`、`libexec/<daemon>/<daemon>.jar`、
+   `libexec/<daemon>/deps/*.jar` (manifest 記載順にコピー、ファイル名維持)、
+   `libexec/kolt-bta-impl/*.jar`、`libexec/classpath/<daemon>.argfile`
+   (platform separator 適用、最終行に main class FQN)、`VERSION`
+   (semver 単行)。
+5. The stitcher shall `~/.kolt/cache` の layout 知識を持たず、各プロジェクト
+   の `build/<name>.jar` と `build/<name>-runtime.classpath` のみを kolt
+   build 成果物の入力として動作する (`-impl` は独立した Maven 取得路)。
+6. When 実行された時、the stitcher shall Req 2 が定める manifest を
+   `libexec/<daemon>/deps/` の生成元として使用する。
+
+### Requirement 4: Self-host smoke CI companion job
+
+**Objective:** CI の運用者として、self-host 経路の regression を毎 PR で
+検知したい。
+
+#### Acceptance Criteria
+
+1. When プルリクエストが `main` ブランチ向けに open または update された時、
+   the self-host-smoke workflow shall self-host path (3 × `kolt build` +
+   assemble-dist.sh + classpath launch) を検証する companion job を実行
+   する。
+2. The companion job shall ビルド済みの `kolt.kexe` を使って 3 プロジェクトを
+   `kolt build` で順次 build し、`scripts/assemble-dist.sh` を実行する。
+3. When assemble-dist.sh が成功した時、the companion job shall 生成された
+   tarball を一時ディレクトリに展開し、`libexec/classpath/<daemon>.argfile`
+   を用いて daemon を classpath launch で起動する。
+4. While daemon が起動している間、the companion job shall `Ping` を送信し、
+   `Pong` が返ることを確認する。
+5. If companion job のいずれかのステップが非ゼロ終了した場合、the CI
+   workflow shall 全体として fail する。
+6. Where native self-host smoke job が同 workflow に存在する場合、the
+   companion job shall 同一 `kolt.kexe` artifact を再利用し、重複する
+   native build を行わない。
+
+### Requirement 5: 並走運用中の Gradle 依存の健全性
+
+**Objective:** 本スペック実装中に既存の Gradle build / CI が壊れない状態で
+段階的に移行したい。
+
+#### Acceptance Criteria
+
+1. While 本スペックが実装中の任意時点で、the Gradle build
+   (`./gradlew build`) shall 成功し、既存の daemon fat jar (`shadowJar`
+   成果物) と `bta-impl-jars/` を従来通り生成する。
+2. While 本スペックが実装中の任意時点で、the existing self-host smoke job
+   (native 側) shall 合格状態を維持する。
+3. The daemon `kolt.toml` shall Gradle build 側の configuration 分離
+   (`buildToolsImpl` / fixture classpath 等) を覆さない。具体的には、
+   `[dependencies]` には daemon 本体 runtime に必要な jar のみを列挙し、
+   `kotlin-build-tools-impl` および test fixture 用 classpath は含めない。

--- a/.kiro/specs/daemon-self-host/research.md
+++ b/.kiro/specs/daemon-self-host/research.md
@@ -1,0 +1,277 @@
+# Gap Analysis: daemon-self-host
+
+**実施日:** 2026-04-22
+
+## 要約
+
+- 設計決定は ADR 0018 / 0025 / 0026 / 0027 で揃っており、本スペックでの
+  新規設計選択はない。2026-04-22 spike で 2 daemon が既存 `kind = "lib"`
+  pipeline を経由して一発で thin jar を emit することを確認済み。
+- 主な変更点は (i) `outputRuntimeClasspathPath` ヘルパーと emit 呼び出しの
+  追加、(ii) resolver の戻り値から jar list を manifest 用途に取り出す経路
+  の整備、(iii) 2 daemon の `kolt.toml` 追加 (`:ic` ソース merge)、
+  (iv) `scripts/assemble-dist.sh` の新規作成、(v) `self-host-smoke.yml`
+  companion job の追加。
+- リスクは低い。新規 public schema は ADR 0027 で pin 済み、
+  `shadowJar` 経路は温存、既存 CI job は touch しない。
+- 複雑度は M (3〜5 日) 目安。assemble-dist.sh の platform separator
+  処理と `jdk = "21"` provisioning 配線の有無が主要な研究項目。
+
+## 現状調査
+
+### 既存アセット
+
+| 要素 | 場所 | 現状 | 関連 |
+|---|---|---|---|
+| JVM compile + thin jar pipeline | `kolt.build.Builder.kt:225` `jarCommand`、`kolt.cli.BuildCommands.kt` の JVM 経路 | 完成済み、Main-Class 属性なし (ADR 0025 §3 / ADR 0018 §2 と整合) | Req 1, 2 |
+| Artifact path helper | `kolt.build.Builder.kt:15-23` `outputJarPath` / `outputNativeKlibPath` / `outputKexePath` / `outputNativeTestKlibPath` | `outputRuntimeClasspathPath` は未実装 | Req 2 |
+| Dependency resolver | `kolt.resolve.Resolver.kt` / `TransitiveResolver.kt`、JVM は stdlib を skip しない | classpath 文字列は返る (`buildClasspath`)、jar list そのものは内部 (`resolveResult.deps.map { it.cachePath }`) | Req 2 |
+| `resolveDependencies` API | `kolt.cli.DependencyResolution.kt:36-93` | `Result<String?, Int>` を返す。jar list は関数スコープで consume されて外に出ない | Req 2 |
+| `kolt.toml` schema | `kolt.config.Config.kt:63-73` `BuildSection` | `target = "jvm"`, `jvm_target`, `jdk`, `main`, `sources` 等すべて揃う | Req 1 |
+| Daemon Gradle build | `kolt-jvm-compiler-daemon/build.gradle.kts`、`kolt-native-compiler-daemon/build.gradle.kts` | `shadowJar` + `verifyShadowJar` + `stageBtaImplJars`。JDK 21 toolchain | Req 5 (並走) |
+| `:ic` subproject | `kolt-jvm-compiler-daemon/settings.gradle.kts:3` `include(":ic")`、`ic/build.gradle.kts` (java-library + kotlin serialization + `buildToolsImpl` / `fixtureClasspath` 等) | `implementation(project(":ic"))` で daemon 本体から参照 | Req 1 (merge 戦略) |
+| `self-host-smoke.yml` | `.github/workflows/self-host-smoke.yml` | native 自己 rebuild 1 job のみ。Gradle bootstrap → `kolt.kexe build` → `--version` 確認 | Req 4 |
+| `scripts/` ディレクトリ | (存在しない) | 新規作成 | Req 3 |
+| `kolt run` JVM app 経路 | `BuildCommands.kt` 487-491 周辺 | resolver 戻り値を in-process に渡す。manifest ファイルは経由しない | Req 2 (AC 8) |
+
+### コードの規約と制約
+
+- `kolt.cli` → `kolt.build` → `kolt.resolve` の下向き依存方向 (steering
+  structure.md)。manifest emit は `kolt.build` 層が自然。
+- ADR 0011: Kotlin stdlib skip は **native resolver 限定**。JVM 経路では
+  transitive closure に stdlib がそのまま含まれる。Req 2 AC 6 と整合。
+- `kolt.toml` の `sources` は複数ディレクトリ配列を受け付ける。`:ic` の
+  ソース merge は `sources = ["src/main/kotlin", "ic/src/main/kotlin"]`
+  で宣言できる (spike で確認済み)。
+- daemon の Gradle build は並走維持すべき (Req 5)。`shadowJar` /
+  `stageBtaImplJars` / `verifyShadowJar` は一切触らない。
+
+## Requirement to Asset Map
+
+### Req 1: Daemon の kolt.toml による build 可能性
+
+- **Exists**: JVM `kind = "app"` pipeline (lib pipeline と同一経路)。
+  `BuildSection` に必要なフィールド (`target`, `jvm_target`, `jdk`,
+  `main`, `sources`) すべて揃う。spike で 2 daemon 一発通過。
+- **Missing**:
+  - `kolt-jvm-compiler-daemon/kolt.toml` (新規、`:ic` を `sources` 配列に merge)。
+  - `kolt-native-compiler-daemon/kolt.toml` (新規)。
+- **Constraint**: daemon Gradle build との並走維持 (Req 5)。daemon 側
+  Gradle configuration (`buildToolsImpl` / `fixtureClasspath`) は
+  `kolt.toml` に引き込まない (ADR 0019 §3 の classloader isolation を
+  実行時仕様として維持)。
+
+### Req 2: Runtime classpath manifest の emit
+
+- **Exists**: `resolveResult.deps.map { it.cachePath }` で jar 絶対パス
+  リストを計算済み。`outputJarPath` の helper 慣習が `Builder.kt` に
+  ある。
+- **Missing**:
+  - `outputRuntimeClasspathPath(config)` helper (`kolt.build.Builder.kt`
+    に追加。ADR 0027 は `kolt.config.Config.kt` と書いたが、実装先は
+    他 `output*Path` と同じ `Builder.kt` が一貫する。ADR 0027 §1 の
+    参照先は design 段階で 1 行修正)。
+  - JVM `kind = "app"` build 終端で manifest を emit する呼び出し。
+  - Resolver 戻り値を manifest 用途で取得するための API 調整。
+    現状 `resolveDependencies` は classpath 文字列 1 つだけ返すので、
+    jar list も別途取れる形にする必要あり (後述 Option 参照)。
+- **Constraint**: `kolt run` JVM app 経路が manifest を**読まない**
+  という AC 8 の非対称性を、コードで明示 (Req 2 AC 8、ADR 0027 §5)。
+- **Research Needed**: `resolveDependencies` の戻り値形状変更が最小か、
+  新しい関数を別途追加するか (design phase で決める)。
+
+### Req 3: `scripts/assemble-dist.sh` stitcher
+
+- **Exists**: `scripts/` ディレクトリは存在しない。tarball layout 仕様
+  は ADR 0018 §1、stitcher model は ADR 0018 §4 で pin 済み。
+- **Missing**: スクリプト本体。
+  - pre-self-host モード (`./gradlew build` 1 回) の実装。
+  - post-self-host モード (`kolt build` × 3) の実装。
+  - tarball layout 組立て (`bin/`, `libexec/<daemon>/{<name>.jar,deps/*.jar}`,
+    `libexec/classpath/<daemon>.argfile`, `VERSION`)。
+  - argfile 生成 (platform separator `<SEP>`、main class FQN)。
+- **Research Needed**:
+  - モード切替方法 (環境変数 / `--mode` flag / 自動検出)。自動検出は
+    daemon `kolt.toml` 存在有無で判定可能。design phase で決める。
+  - argfile の platform 対応 (`:` vs `;`)。シェルスクリプトとして
+    cross-platform にするか、Linux / macOS 前提で割り切るか
+    (現状 kolt は linuxX64 のみ支援、macOS / Windows は v1 前の話)。
+  - Self jar path の扱い: `libexec/<daemon>/<daemon>.jar` と deps の
+    argfile 中での順序は ADR 0027 では pin されていない。stitcher が
+    self + deps の順に並べる前提で design phase で明記する。
+
+### Req 4: Self-host smoke CI companion job
+
+- **Exists**: `self-host-smoke.yml` に native self-host job が 1 つ。
+  Gradle bootstrap → kexe build path は確立。
+- **Missing**:
+  - Companion job の step 列 (3 × `kolt build` → assemble-dist.sh →
+    tarball 展開 → daemon spawn → Ping/Pong)。
+  - Ping/Pong を CI で送る簡易クライアント。既存テストコードに daemon
+    client 相当が存在するか要確認 (design phase)。
+- **Research Needed**:
+  - Ping/Pong 確認の最小クライアント (`kolt daemon` サブコマンド経由で
+    済むか、独立バイナリが要るか)。
+  - native job と companion job の artifact 共有 (`actions/upload-artifact`
+    + `actions/download-artifact`) のコスト。
+
+### Req 5: Gradle 並走の健全性
+
+- **Exists**: `./gradlew build` が daemon fat jar + `stageBtaImplJars` を
+  生成する既存経路。
+- **Missing**: なし (並走維持のための能動的作業は不要)。
+- **Constraint**: 本スペックの変更が `shadowJar` / `verifyShadowJar` /
+  `stageBtaImplJars` / `DaemonJarResolver` の DevFallback 経路を一切
+  変えないこと。チェック手段は既存 `unit-tests.yml` の jar assertion。
+
+## 実装アプローチの選択肢
+
+### Option A: 既存 pipeline を最小拡張 (推奨)
+
+- **内容**:
+  - `Builder.kt` に `outputRuntimeClasspathPath(config)` を追加。
+  - `resolveDependencies` が返す classpath 文字列に加え、jar list
+    (`List<String>`) も公開する。単一戻り値を `Pair<String?, List<String>>`
+    か data class に切り替える、あるいは別関数 (`resolveJvmRuntimeJars`)
+    を追加するのいずれか (design 段階で選定)。
+  - `BuildCommands.kt` の JVM `kind = "app"` 経路末尾で、Req 2 AC 1-8
+    を満たす manifest を書き出す (sort、tie-break、self 除外、
+    native/lib で emit しない)。
+  - 2 daemon `kolt.toml` を新規作成。
+  - `scripts/assemble-dist.sh` を新規作成 (pre/post モード両対応)。
+  - `self-host-smoke.yml` に companion job を追加。
+- **トレードオフ**:
+  - ✅ 既存の下向き依存方向 (cli → build → resolve) を崩さない。
+  - ✅ 変更範囲が既存層の中に収まる (新規パッケージ不要)。
+  - ✅ ADR 0027 の pin にそのまま乗る。
+  - ❌ `resolveDependencies` の戻り値変更は 2 〜 3 callers に波及する。
+    (design phase でシグネチャを具体化)。
+
+### Option B: Manifest 専用の新モジュール
+
+- **内容**: `kolt.build.manifest` パッケージを新設し、manifest 生成
+  ロジックを分離。`BuildCommands.kt` からは薄く呼ぶ。
+- **トレードオフ**:
+  - ✅ manifest の schema 変更に対する変更範囲が局所化される。
+  - ❌ 現時点の manifest ロジックは「sort して書く」程度で、専用
+    パッケージを切るほどの厚みがない。steering structure.md の
+    「responsibility で分ける」基準に対して over-engineering 気味。
+  - ❌ Option A と比べて追加ファイルが増えるが、得られる隔離効果は
+    限定的。
+
+### Option C: Hybrid (Option A + assemble-dist.sh を段階リリース)
+
+- **内容**: Req 1, 2 (kolt 内の emit) を先に landing、Req 3, 4
+  (assemble-dist.sh + CI companion) を次の PR で追加。
+- **トレードオフ**:
+  - ✅ 小さい PR で landing でき、レビュー集中が効く。
+  - ✅ 万一 manifest schema を実装段階で微調整する必要が出ても、
+    assemble-dist.sh 側の修正を後追いで済ませられる。
+  - ❌ #97 の DoD を閉じる順序が複数 PR に跨る。issue 閉じまで時間が
+    かかる。
+
+**推奨**: **Option A を軸に、タスク粒度で C を採用** (Option A の
+技術方針で実装しつつ、landing は 2 〜 3 PR に分ける)。理由:
+
+1. 設計は ADR で pin 済みなので、新モジュール分離の必然性がない (B 却下)。
+2. `resolveDependencies` の戻り値変更が波及するので、その単独変更を
+   独立 PR にするとレビューコストが下がる (C の分割アプローチ)。
+3. `scripts/assemble-dist.sh` + CI companion は build pipeline の内側
+   ロジックとは切り離して review できる (C の分割アプローチ)。
+
+## 複雑度と Risk
+
+- **Effort: M (3〜5 日)**
+  - 既存 pattern に沿う最小拡張が主体。spike で spec の実現可能性は
+    確認済み。
+  - `scripts/assemble-dist.sh` の新規作成と CI companion 配線が最多の
+    新規コードだが、schema は pin されており迷いなく書ける。
+- **Risk: Low**
+  - 新規 public schema (manifest 形式) は ADR 0027 で pin。
+  - Gradle 並走経路を一切触らない前提 (Req 5)。
+  - 既存 `self-host-smoke.yml` job を temper しない (companion 追加のみ)。
+
+## Research Needed (design phase で決めること)
+
+1. `resolveDependencies` の API 形状変更方法 (戻り値拡張 vs 別関数追加)。
+   callers (`BuildCommands.kt` JVM / native 双方) への波及を見て最小
+   変更を選ぶ。
+2. `assemble-dist.sh` のモード切替方式 (flag / env var / 自動検出)。
+   daemon `kolt.toml` の存在有無による自動検出が最も軽量。
+3. argfile の platform separator 扱い (linuxX64 only 前提で `:` 固定、
+   または `uname` で判定)。現状サポート target は linuxX64 のみ。
+4. CI companion job での Ping/Pong 検証クライアント (`kolt daemon`
+   サブコマンドの既存機能で代替できるかを design 段階で確認)。
+5. ADR 0017 (bootstrap JDK provisioning) と `[build] jdk = "21"` の
+   配線が、`kolt-jvm-compiler-daemon/kolt.toml` で実効的に効くか。
+   spike は host の system JDK 21 が利用可能だったため素通り。
+   design 段階でコード検索して配線の有無を確定する。
+
+## 次フェーズへの持ち越し
+
+- **Design phase** で ADR 0027 §1 の `outputRuntimeClasspathPath` 参照
+  先を `kolt/config/Config.kt` ではなく `kolt/build/Builder.kt` に
+  訂正する (1 行修正、別 commit)。
+- **Design phase** で `resolveDependencies` のシグネチャ案を固め、
+  `kolt run` が manifest を読まない invariant をコード上で担保する
+  方法を具体化する (Req 2 AC 8)。
+- **Tasks phase** で Option C に従った PR 分割案を提示する。
+
+---
+
+# Design Phase Synthesis (2026-04-22)
+
+## Synthesis outcomes
+
+### Generalization
+- `outputRuntimeClasspathPath` は `outputJarPath` / `outputNativeKlibPath` /
+  `outputKexePath` の延長として同 `Builder.kt` に置く。新しい抽象層を
+  挟まず、既存 path-helper pattern を素直に拡張。
+- Manifest format (sort + tiebreak + self 除外) は Kotlin stdlib の
+  `sortedWith(compareBy(..., ...))` で宣言的に表現でき、ロジックを
+  専用パッケージに切り出す必要はない。
+
+### Build vs Adopt
+- **Adopt**: 既存 `resolveDependencies` の内部 jar list (`resolveResult.deps`)、
+  既存 `installJdkToolchain` による `jdk = "21"` プロビジョニング配線
+  (`ToolchainCommands.kt:44-45` で確認済み、spec 側で新規配線不要)、
+  既存 daemon Gradle build (並走維持)。
+- **Build**: `JvmResolutionOutcome` data class は resolver と emit の間の
+  型安全な境界として新規。小ぶり (2 フィールド) のため build。
+- **Not Build (Simplification)**: `kolt daemon ping` 新 CLI サブコマンド
+  は追加しない。Req 4.4 の IPC 健全性 verification は「installed
+  `bin/kolt` で fixture project を build 成功させる」で cover できる。
+  `kolt build` 内部で既に daemon IPC が使われるため、build 成功は IPC
+  往復の正常性を含意する。
+
+### Simplification
+- Req 4 CI companion の Ping/Pong 検証は fixture build 成功で代替。
+  専用 IPC チェックツール不要。
+- assemble-dist.sh の pre/post モード共有化は見送り。pre モードは
+  Gradle 経由で生成された fat jar を `libexec/<daemon>/<daemon>.jar` に
+  直置きする簡易 layout、post モードは ADR 0018 §1 の deps/ 展開 layout、
+  と明示的に二分岐。
+- stale manifest (kind 変更で app→lib になったあと残った manifest) は
+  kolt 側で自動削除。assemble-dist.sh に「念のため古い manifest を
+  disregard」のようなロジックを持ち込まない。
+
+## Research-needed items — resolved
+
+| # | 項目 | 決定 |
+|---|------|------|
+| 1 | `resolveDependencies` API 形状変更 | `JvmResolutionOutcome(classpath: String?, resolvedJars: List<ResolvedJar>)` data class を導入。戻り値型を `Result<String?, Int>` から `Result<JvmResolutionOutcome, Int>` に拡張、2〜3 callers を追従修正 |
+| 2 | assemble-dist.sh モード切替 | 自動検出 (2 daemon `kolt.toml` 両方存在 → post、一方でも欠落 → pre)。`--mode=pre\|post` フラグで明示上書き可能 |
+| 3 | argfile platform 対応 | `:` 固定、linuxX64 only 前提。macOS / Windows 対応時に separator ロジック追加 (本スペック out of scope) |
+| 4 | Ping/Pong 検証クライアント | 専用コマンド追加せず。CI companion が installed `bin/kolt` で fixture build を走らせ、成功を IPC 健全性の evidence とする |
+| 5 | `jdk = "21"` 配線 | 既存 `ToolchainCommands.kt:44-45` で `installJdkToolchain(config.build.jdk, paths)` が呼ばれることを確認済み。本スペックで追加配線不要 |
+
+## Design-phase follow-ups to record
+
+- ADR 0027 §1 の helper 参照先 `kolt/config/Config.kt` を
+  `kolt/build/Builder.kt` に 1 行修正する (Phase 1 タスクに含める)。
+- 既存 daemon Gradle build の `shadowJar` / `verifyShadowJar` /
+  `stageBtaImplJars` / `ic/build.gradle.kts` は本スペックの変更範囲に
+  含まない (Req 5)。assemble-dist.sh が BTA impl jars を取得する
+  ロジックは ADR 0019 §3 を守る形で別途設計するが、pre モードでは
+  Gradle 生成物をそのまま流用して済む (post モードでは `-impl` を
+  Maven 解決するコードを追加、本スペックでは Phase 3 タスクに含める)。

--- a/.kiro/specs/daemon-self-host/spec.json
+++ b/.kiro/specs/daemon-self-host/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "daemon-self-host",
+  "created_at": "2026-04-22T10:53:40Z",
+  "updated_at": "2026-04-22T11:41:09Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -31,7 +31,7 @@
   - _Requirements: 2.8_
   - _Boundary: kolt.cli.BuildCommands tests_
 
-- [ ] 1.5 (P) ADR 0027 §1 の helper 参照先を訂正
+- [x] 1.5 (P) ADR 0027 §1 の helper 参照先を訂正
   - `docs/adr/0027-runtime-classpath-manifest.md` §1 末尾の「Helper `outputRuntimeClasspathPath(config): String` in `kolt/config/Config.kt`」を `kolt/build/Builder.kt` に 1 行修正。
   - ADR テキストと実装配置が一致し、diff を読めば修正意図が明確な状態。
   - _Requirements: 2.1_

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -16,7 +16,7 @@
   - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6_
   - _Boundary: kolt.build.Builder_
 
-- [ ] 1.3 JVM `kind = "app"` 経路に manifest emit 呼び出しと stale cleanup を組み込む
+- [x] 1.3 JVM `kind = "app"` 経路に manifest emit 呼び出しと stale cleanup を組み込む
   - `BuildCommands.kt` の JVM 経路で jar 生成直後に `kind == "app" && target == "jvm"` の分岐を追加し、`writeRuntimeClasspathManifest` を呼び出す。
   - 同分岐の else 側 (lib / native) で、`outputRuntimeClasspathPath(config)` に対応する既存ファイルがあれば削除する (kind 変更による stale manifest 防止)。
   - `JvmAppBuildTest.kt` で emit マトリクス (jvm+app → 出る / jvm+lib → 出ない / native → 出ない / kind を app→lib に変えて rebuild → 削除される) をフィクスチャベースで pin。

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -76,7 +76,7 @@
   - _Requirements: 3.2, 3.3_
   - _Boundary: scripts/assemble-dist.sh_
 
-- [ ] 3.3 Tarball layout 組立て、argfile 生成、tar czf パッケージング
+- [x] 3.3 Tarball layout 組立て、argfile 生成、tar czf パッケージング
   - `dist/kolt-<version>-linux-x64/` 配下に `bin/` と `libexec/<daemon>/`、`libexec/<daemon>/deps/`、`libexec/classpath/` を作成。
   - ルート `kolt.kexe` を `bin/kolt` にコピー (ADR 0018 §1 naming)。
   - 各 daemon について、self jar を `libexec/<daemon>/<daemon>.jar`、manifest 記載の jar 列を `libexec/<daemon>/deps/` にファイル名保持でコピー。

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -39,7 +39,7 @@
   - _Depends: 1.2_
 
 - [ ] 2. Daemon `kolt.toml` 導入
-- [ ] 2.1 (P) `kolt-jvm-compiler-daemon/kolt.toml` を追加
+- [x] 2.1 (P) `kolt-jvm-compiler-daemon/kolt.toml` を追加
   - `target = "jvm"`, `kind = "app"`, `main = "kolt.daemon.main"`, `jvm_target = "21"`, `jdk = "21"` を設定し、`sources = ["src/main/kotlin", "ic/src/main/kotlin"]` で `:ic` ソースを merge する。
   - 依存は `kotlin-build-tools-api:2.3.20` / `kotlinx-serialization-json:1.7.3` / `kotlin-result:2.3.1` / `ktoml-core:0.7.1` の 4 本のみ (Req 5.3 により `-impl` / fixture classpath は入れない)。
   - `[kotlin.plugins] serialization = true` を付与。

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -101,7 +101,7 @@
   - _Requirements: 4.6, 5.2_
   - _Boundary: .github/workflows/self-host-smoke.yml (native job)_
 
-- [ ] 4.3 Companion job (`self-host-post`) を追加し self-host path 全体を検証
+- [x] 4.3 Companion job (`self-host-post`) を追加し self-host path 全体を検証
   - `.github/workflows/self-host-smoke.yml` に `self-host-post` job を追加 (`needs: self-host`、ubuntu-latest)。
   - Steps: checkout → `actions/download-artifact@v4` で `kolt-kexe` 取得 → `chmod +x` → ルート + 2 daemon で `kolt build` 順次実行 → `scripts/assemble-dist.sh` を実行 → 生成 tarball を `/tmp/kolt-install/` 配下に展開 → fixture project (4.1) の dir で展開後の `bin/kolt build` を実行。
   - いずれの step も `set -euo pipefail` 相当で fail-fast。

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -1,7 +1,7 @@
 # Implementation Plan
 
 - [ ] 1. Manifest emit pipeline
-- [ ] 1.1 `JvmResolutionOutcome` data class 導入と `resolveDependencies` の戻り値型移行
+- [x] 1.1 `JvmResolutionOutcome` data class 導入と `resolveDependencies` の戻り値型移行
   - `resolveDependencies` の戻り値を `Result<String?, Int>` から `Result<JvmResolutionOutcome, Int>` に変更し、`classpath` と `resolvedJars` を同時に保持する。
   - 既存 callers (`BuildCommands.kt` の JVM 経路および関連する test harness) を `.classpath` 参照に追従させる。`resolveNativeDependencies` は変更しない。
   - `resolveDependencies` のユニットテストを JvmResolutionOutcome 形で更新し、既存 callers がコンパイル可能な状態でテストスイートが全緑。

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -94,7 +94,7 @@
   - _Requirements: 4.4_
   - _Boundary: spike/daemon-self-host-smoke_
 
-- [ ] 4.2 既存 native self-host job に `kolt.kexe` の upload-artifact step を追加
+- [x] 4.2 既存 native self-host job に `kolt.kexe` の upload-artifact step を追加
   - `.github/workflows/self-host-smoke.yml` の `self-host` job 末尾 (`--version` 検証の後) に `actions/upload-artifact@v4` step を追加し、`./build/bin/linuxX64/debugExecutable/kolt.kexe` を artifact 名 `kolt-kexe` で export する。
   - 既存の `--version` 検証 step は変更せず合格状態を維持する。
   - PR CI で native self-host job の完了時に `kolt-kexe` artifact がリストされる。既存の緑判定は崩れない。

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -48,7 +48,7 @@
   - _Boundary: kolt-jvm-compiler-daemon config_
   - _Depends: 1.3_
 
-- [ ] 2.2 (P) `kolt-native-compiler-daemon/kolt.toml` を追加
+- [x] 2.2 (P) `kolt-native-compiler-daemon/kolt.toml` を追加
   - `target = "jvm"`, `kind = "app"`, `main = "kolt.nativedaemon.main"`, `jvm_target = "21"`, `jdk = "21"`, `sources = ["src/main/kotlin"]`。
   - 依存は `kotlinx-serialization-json:1.7.3` / `kotlin-result:2.3.1` のみ。`kotlin-native-compiler-embeddable` は含めない (ADR 0024 §8)。
   - `[kotlin.plugins] serialization = true` を付与。

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -8,7 +8,7 @@
   - _Requirements: 2.1, 2.6_
   - _Boundary: kolt.cli.DependencyResolution_
 
-- [ ] 1.2 `outputRuntimeClasspathPath` ヘルパーと `writeRuntimeClasspathManifest` emit 関数を追加
+- [x] 1.2 `outputRuntimeClasspathPath` ヘルパーと `writeRuntimeClasspathManifest` emit 関数を追加
   - `Builder.kt` に既存 `output*Path` helper と同じ internal visibility で `outputRuntimeClasspathPath(config): String` を追加し `"$BUILD_DIR/${config.name}-runtime.classpath"` を返す。
   - `writeRuntimeClasspathManifest(config, resolvedJars)` を Builder.kt に実装する。resolvedJars を file-name (path 最終要素) でアルファベット sort、同一ファイル名の場合は `group:artifact:version` 文字列でタイブレークする。self jar (`outputJarPath(config)`) は出力から除外。
   - UTF-8 / LF / 末尾空行なしで write し、failure は `ManifestWriteError.WriteFailed` で返す (例外 throw 禁止)。

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -58,7 +58,7 @@
   - _Depends: 1.3_
 
 - [ ] 3. `scripts/assemble-dist.sh` stitcher
-- [ ] 3.1 スクリプト骨格: 3 プロジェクトの直列 `kolt build` と `dist/` 準備
+- [x] 3.1 スクリプト骨格: 3 プロジェクトの直列 `kolt build` と `dist/` 準備
   - `#!/usr/bin/env bash`、`set -euo pipefail` で新規作成。
   - 起動時に既存 `dist/` を wipe し、ルート `kolt.toml` から `version` を grep で抜き出し、`dist/kolt-<version>-linux-x64/` を作成するのみ。配下サブディレクトリ (`bin/`, `libexec/`) の作成と内容書き込みは 3.2 / 3.3 の担当。
   - `${KOLT:-./build/bin/linuxX64/releaseExecutable/kolt.kexe} build` をルート / `kolt-jvm-compiler-daemon/` / `kolt-native-compiler-daemon/` の順で実行。

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -88,7 +88,7 @@
   - _Boundary: scripts/assemble-dist.sh_
 
 - [ ] 4. Self-host smoke CI companion job
-- [ ] 4.1 (P) Companion 用の最小 JVM fixture プロジェクト
+- [x] 4.1 (P) Companion 用の最小 JVM fixture プロジェクト
   - `spike/daemon-self-host-smoke/` に最小構成 (`kolt.toml` に `target = "jvm"`, `kind = "app"`, main 1 つ + `[dependencies]` なし or 最小)、`src/main/kotlin/Hello.kt` 等) を配置。
   - 既存 `kolt.kexe build` でこのディレクトリが build 成功し、`build/<name>.jar` が生成される (動作原理の smoke 用なので、テスト対象は通過)。
   - _Requirements: 4.4_

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -25,7 +25,7 @@
   - _Requirements: 1.5, 2.1, 2.7_
   - _Boundary: kolt.cli.BuildCommands_
 
-- [ ] 1.4 `kolt run` が manifest を読まないことの回帰テスト
+- [x] 1.4 `kolt run` が manifest を読まないことの回帰テスト
   - `KoltRunManifestIndependenceTest.kt` を追加し、(a) `kolt build` 後に `build/<name>-runtime.classpath` を削除、(b) `kolt run` を起動、(c) 正常終了することを検証する。
   - テストが緑 (manifest 削除が `kolt run` の経路に影響しないことが CI で保証される)。
   - _Requirements: 2.8_

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -68,7 +68,7 @@
   - _Boundary: scripts/assemble-dist.sh_
   - _Depends: 2.1, 2.2_
 
-- [ ] 3.2 `kotlin-build-tools-impl` の GAV/SHA pin 集合を決定し、curl で Maven Central から取得
+- [x] 3.2 `kotlin-build-tools-impl` の GAV/SHA pin 集合を決定し、curl で Maven Central から取得
   - pin 元資材の準備: 実装開始時に `./gradlew :kolt-jvm-compiler-daemon:stageBtaImplJars` を 1 回実行して `kolt-jvm-compiler-daemon/build/bta-impl-jars/` に配置される jar 集合を観測し、ファイル名 (GAV) と `sha256sum` をスクリプト内定数として転記する。pin 後は Gradle 成果物への依存はない。
   - スクリプト冒頭に GAV 配列と対応する SHA-256 定数を定義する。最低集合は `kotlin-build-tools-impl:2.3.20` + その transitive (daemon の `[dependencies]` で既に `deps/` に入るものは除外)。
   - `curl -fsSL` で `https://repo1.maven.org/maven2/...` から各 jar を `dist/kolt-<version>-linux-x64/libexec/kolt-bta-impl/` に配置し、`sha256sum` で定数と一致を検証する。不一致は非ゼロ終了。

--- a/.kiro/specs/daemon-self-host/tasks.md
+++ b/.kiro/specs/daemon-self-host/tasks.md
@@ -1,0 +1,111 @@
+# Implementation Plan
+
+- [ ] 1. Manifest emit pipeline
+- [ ] 1.1 `JvmResolutionOutcome` data class 導入と `resolveDependencies` の戻り値型移行
+  - `resolveDependencies` の戻り値を `Result<String?, Int>` から `Result<JvmResolutionOutcome, Int>` に変更し、`classpath` と `resolvedJars` を同時に保持する。
+  - 既存 callers (`BuildCommands.kt` の JVM 経路および関連する test harness) を `.classpath` 参照に追従させる。`resolveNativeDependencies` は変更しない。
+  - `resolveDependencies` のユニットテストを JvmResolutionOutcome 形で更新し、既存 callers がコンパイル可能な状態でテストスイートが全緑。
+  - _Requirements: 2.1, 2.6_
+  - _Boundary: kolt.cli.DependencyResolution_
+
+- [ ] 1.2 `outputRuntimeClasspathPath` ヘルパーと `writeRuntimeClasspathManifest` emit 関数を追加
+  - `Builder.kt` に既存 `output*Path` helper と同じ internal visibility で `outputRuntimeClasspathPath(config): String` を追加し `"$BUILD_DIR/${config.name}-runtime.classpath"` を返す。
+  - `writeRuntimeClasspathManifest(config, resolvedJars)` を Builder.kt に実装する。resolvedJars を file-name (path 最終要素) でアルファベット sort、同一ファイル名の場合は `group:artifact:version` 文字列でタイブレークする。self jar (`outputJarPath(config)`) は出力から除外。
+  - UTF-8 / LF / 末尾空行なしで write し、failure は `ManifestWriteError.WriteFailed` で返す (例外 throw 禁止)。
+  - `RuntimeClasspathManifestTest.kt` で (a) path 構築、(b) sort + self 除外、(c) GAV tiebreak、(d) UTF-8/LF/no trailing newline の 4 ユニットテストを追加し全て緑。
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6_
+  - _Boundary: kolt.build.Builder_
+
+- [ ] 1.3 JVM `kind = "app"` 経路に manifest emit 呼び出しと stale cleanup を組み込む
+  - `BuildCommands.kt` の JVM 経路で jar 生成直後に `kind == "app" && target == "jvm"` の分岐を追加し、`writeRuntimeClasspathManifest` を呼び出す。
+  - 同分岐の else 側 (lib / native) で、`outputRuntimeClasspathPath(config)` に対応する既存ファイルがあれば削除する (kind 変更による stale manifest 防止)。
+  - `JvmAppBuildTest.kt` で emit マトリクス (jvm+app → 出る / jvm+lib → 出ない / native → 出ない / kind を app→lib に変えて rebuild → 削除される) をフィクスチャベースで pin。
+  - schema 違反 (`kind = "app"` で `main` なし等) は既存 parser のエラー表示がそのまま効くため、追加処理なし。1 項目のテストで既存エラーが build 前に出ることを確認。
+  - テストスイートが全緑、fixture で `kolt build` すると manifest が条件通り出現/非出現/削除される。
+  - _Requirements: 1.5, 2.1, 2.7_
+  - _Boundary: kolt.cli.BuildCommands_
+
+- [ ] 1.4 `kolt run` が manifest を読まないことの回帰テスト
+  - `KoltRunManifestIndependenceTest.kt` を追加し、(a) `kolt build` 後に `build/<name>-runtime.classpath` を削除、(b) `kolt run` を起動、(c) 正常終了することを検証する。
+  - テストが緑 (manifest 削除が `kolt run` の経路に影響しないことが CI で保証される)。
+  - _Requirements: 2.8_
+  - _Boundary: kolt.cli.BuildCommands tests_
+
+- [ ] 1.5 (P) ADR 0027 §1 の helper 参照先を訂正
+  - `docs/adr/0027-runtime-classpath-manifest.md` §1 末尾の「Helper `outputRuntimeClasspathPath(config): String` in `kolt/config/Config.kt`」を `kolt/build/Builder.kt` に 1 行修正。
+  - ADR テキストと実装配置が一致し、diff を読めば修正意図が明確な状態。
+  - _Requirements: 2.1_
+  - _Boundary: docs/adr_
+  - _Depends: 1.2_
+
+- [ ] 2. Daemon `kolt.toml` 導入
+- [ ] 2.1 (P) `kolt-jvm-compiler-daemon/kolt.toml` を追加
+  - `target = "jvm"`, `kind = "app"`, `main = "kolt.daemon.main"`, `jvm_target = "21"`, `jdk = "21"` を設定し、`sources = ["src/main/kotlin", "ic/src/main/kotlin"]` で `:ic` ソースを merge する。
+  - 依存は `kotlin-build-tools-api:2.3.20` / `kotlinx-serialization-json:1.7.3` / `kotlin-result:2.3.1` / `ktoml-core:0.7.1` の 4 本のみ (Req 5.3 により `-impl` / fixture classpath は入れない)。
+  - `[kotlin.plugins] serialization = true` を付与。
+  - 当該ディレクトリで `kolt.kexe build` が成功し `build/kolt-jvm-compiler-daemon.jar` + `build/kolt-jvm-compiler-daemon-runtime.classpath` が生成される。`./gradlew :kolt-jvm-compiler-daemon:build` は既存挙動通り成功し続ける。
+  - _Requirements: 1.1, 1.3, 1.4, 5.1, 5.3_
+  - _Boundary: kolt-jvm-compiler-daemon config_
+  - _Depends: 1.3_
+
+- [ ] 2.2 (P) `kolt-native-compiler-daemon/kolt.toml` を追加
+  - `target = "jvm"`, `kind = "app"`, `main = "kolt.nativedaemon.main"`, `jvm_target = "21"`, `jdk = "21"`, `sources = ["src/main/kotlin"]`。
+  - 依存は `kotlinx-serialization-json:1.7.3` / `kotlin-result:2.3.1` のみ。`kotlin-native-compiler-embeddable` は含めない (ADR 0024 §8)。
+  - `[kotlin.plugins] serialization = true` を付与。
+  - 当該ディレクトリで `kolt.kexe build` が成功し jar + manifest が生成される。`./gradlew :kolt-native-compiler-daemon:build` は既存挙動通り成功し続ける。
+  - _Requirements: 1.2, 1.4, 5.1, 5.3_
+  - _Boundary: kolt-native-compiler-daemon config_
+  - _Depends: 1.3_
+
+- [ ] 3. `scripts/assemble-dist.sh` stitcher
+- [ ] 3.1 スクリプト骨格: 3 プロジェクトの直列 `kolt build` と `dist/` 準備
+  - `#!/usr/bin/env bash`、`set -euo pipefail` で新規作成。
+  - 起動時に既存 `dist/` を wipe し、ルート `kolt.toml` から `version` を grep で抜き出し、`dist/kolt-<version>-linux-x64/` を作成するのみ。配下サブディレクトリ (`bin/`, `libexec/`) の作成と内容書き込みは 3.2 / 3.3 の担当。
+  - `${KOLT:-./build/bin/linuxX64/releaseExecutable/kolt.kexe} build` をルート / `kolt-jvm-compiler-daemon/` / `kolt-native-compiler-daemon/` の順で実行。
+  - いずれかの build が非ゼロ終了したら以降のステップを実行せず非ゼロで終了する。
+  - `dist/kolt-<version>-linux-x64/` が準備状態 (空ディレクトリとして存在) で、各プロジェクト配下に `build/<name>.jar` と `build/<name>-runtime.classpath` が揃う。途中 build をわざと失敗させると 3 番目が起動しない。
+  - _Requirements: 3.1, 3.3, 3.5_
+  - _Boundary: scripts/assemble-dist.sh_
+  - _Depends: 2.1, 2.2_
+
+- [ ] 3.2 `kotlin-build-tools-impl` の GAV/SHA pin 集合を決定し、curl で Maven Central から取得
+  - pin 元資材の準備: 実装開始時に `./gradlew :kolt-jvm-compiler-daemon:stageBtaImplJars` を 1 回実行して `kolt-jvm-compiler-daemon/build/bta-impl-jars/` に配置される jar 集合を観測し、ファイル名 (GAV) と `sha256sum` をスクリプト内定数として転記する。pin 後は Gradle 成果物への依存はない。
+  - スクリプト冒頭に GAV 配列と対応する SHA-256 定数を定義する。最低集合は `kotlin-build-tools-impl:2.3.20` + その transitive (daemon の `[dependencies]` で既に `deps/` に入るものは除外)。
+  - `curl -fsSL` で `https://repo1.maven.org/maven2/...` から各 jar を `dist/kolt-<version>-linux-x64/libexec/kolt-bta-impl/` に配置し、`sha256sum` で定数と一致を検証する。不一致は非ゼロ終了。
+  - `libexec/kolt-bta-impl/*.jar` が完全に配置され、sha 検証ログが GAV 毎に "OK" を出す。
+  - _Requirements: 3.2, 3.3_
+  - _Boundary: scripts/assemble-dist.sh_
+
+- [ ] 3.3 Tarball layout 組立て、argfile 生成、tar czf パッケージング
+  - `dist/kolt-<version>-linux-x64/` 配下に `bin/` と `libexec/<daemon>/`、`libexec/<daemon>/deps/`、`libexec/classpath/` を作成。
+  - ルート `kolt.kexe` を `bin/kolt` にコピー (ADR 0018 §1 naming)。
+  - 各 daemon について、self jar を `libexec/<daemon>/<daemon>.jar`、manifest 記載の jar 列を `libexec/<daemon>/deps/` にファイル名保持でコピー。
+  - 各 daemon の argfile を `libexec/classpath/<daemon>.argfile` に生成: `-cp`、`<self>:<deps...>:<impl...>` (separator `:`、linuxX64 前提)、main class FQN (`kolt.daemon.MainKt` / `kolt.nativedaemon.MainKt`)。
+  - `VERSION` ファイルに semver 1 行を書き出す。
+  - `tar czf dist/kolt-<version>-linux-x64.tar.gz -C dist kolt-<version>-linux-x64/` で生成。
+  - 生成された `.tar.gz` を別ディレクトリに展開すると ADR 0018 §1 layout と完全一致し、argfile は `java @argfile` で実行可能な形式になっている。
+  - _Requirements: 3.4, 3.5, 3.6_
+  - _Boundary: scripts/assemble-dist.sh_
+
+- [ ] 4. Self-host smoke CI companion job
+- [ ] 4.1 (P) Companion 用の最小 JVM fixture プロジェクト
+  - `spike/daemon-self-host-smoke/` に最小構成 (`kolt.toml` に `target = "jvm"`, `kind = "app"`, main 1 つ + `[dependencies]` なし or 最小)、`src/main/kotlin/Hello.kt` 等) を配置。
+  - 既存 `kolt.kexe build` でこのディレクトリが build 成功し、`build/<name>.jar` が生成される (動作原理の smoke 用なので、テスト対象は通過)。
+  - _Requirements: 4.4_
+  - _Boundary: spike/daemon-self-host-smoke_
+
+- [ ] 4.2 既存 native self-host job に `kolt.kexe` の upload-artifact step を追加
+  - `.github/workflows/self-host-smoke.yml` の `self-host` job 末尾 (`--version` 検証の後) に `actions/upload-artifact@v4` step を追加し、`./build/bin/linuxX64/debugExecutable/kolt.kexe` を artifact 名 `kolt-kexe` で export する。
+  - 既存の `--version` 検証 step は変更せず合格状態を維持する。
+  - PR CI で native self-host job の完了時に `kolt-kexe` artifact がリストされる。既存の緑判定は崩れない。
+  - _Requirements: 4.6, 5.2_
+  - _Boundary: .github/workflows/self-host-smoke.yml (native job)_
+
+- [ ] 4.3 Companion job (`self-host-post`) を追加し self-host path 全体を検証
+  - `.github/workflows/self-host-smoke.yml` に `self-host-post` job を追加 (`needs: self-host`、ubuntu-latest)。
+  - Steps: checkout → `actions/download-artifact@v4` で `kolt-kexe` 取得 → `chmod +x` → ルート + 2 daemon で `kolt build` 順次実行 → `scripts/assemble-dist.sh` を実行 → 生成 tarball を `/tmp/kolt-install/` 配下に展開 → fixture project (4.1) の dir で展開後の `bin/kolt build` を実行。
+  - いずれの step も `set -euo pipefail` 相当で fail-fast。
+  - PR 毎に `self-host-post` job が動き、fixture の `kolt build` 成功までを緑で通す。途中 step が fail したら job が fail し CI 全体が fail する。
+  - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5_
+  - _Boundary: .github/workflows/self-host-smoke.yml (companion job)_
+  - _Depends: 3.3, 4.1, 4.2_

--- a/docs/adr/0018-distribution-layout-and-self-host-path.md
+++ b/docs/adr/0018-distribution-layout-and-self-host-path.md
@@ -251,9 +251,10 @@ reduces to a single kolt feature:
    form is the same jar plus a declared runtime classpath.
    `DependencyResolution.kt` already builds the list fed into
    `--compiler-jars` today, so the new work is emitting it into a
-   consumable manifest. Schema — lockfile key vs separate file,
-   exact shape — is deferred to a follow-up ADR; §4's
-   `assemble-dist.sh` reads whatever that ADR pins.
+   consumable manifest. Schema pinned by ADR 0027:
+   `build/<name>-runtime.classpath`, plain text, one absolute jar
+   path per line, dependencies only, alphabetical by file name.
+   §4's `assemble-dist.sh` reads that file.
 
 The daemons have **no source-level dependency** on `kolt.kexe` or on
 each other — communication is IPC only (ADR 0016, ADR 0024). Each
@@ -433,6 +434,8 @@ preserved. Trigger conditions that would force this:
   layout).
 - ADR 0025 — library artifact layout (the JVM `kind = "lib"` this
   ADR's §2 consumes directly).
+- ADR 0027 — runtime classpath manifest (pins the §5 schema this
+  ADR deferred).
 - `self-host-smoke.yml` — existing CI workflow for native-side
   self-host; a companion will be needed once daemon self-host
   lands.

--- a/docs/adr/0027-runtime-classpath-manifest.md
+++ b/docs/adr/0027-runtime-classpath-manifest.md
@@ -117,7 +117,7 @@ Rules:
   algorithm shipped in v0.3.0).
 
 Helper `outputRuntimeClasspathPath(config): String` in
-`kolt/config/Config.kt` parallels `outputJarPath(config)` /
+`kolt/build/Builder.kt` parallels `outputJarPath(config)` /
 `outputNativeKlibPath(config)`. Callers do not hand-build the path.
 
 ### §2 Why not in `.kolt.lock`
@@ -215,7 +215,7 @@ add a read-write round trip to `kolt run` for no benefit.
 
 ### Confirmation
 
-- `outputRuntimeClasspathPath(config)` exists in `Config.kt`
+- `outputRuntimeClasspathPath(config)` exists in `Builder.kt`
   alongside the existing artifact-path helpers. Callers compute
   paths through it.
 - A new test file (`JvmAppBuildTest` or similar) pins: JVM `kind =

--- a/docs/adr/0027-runtime-classpath-manifest.md
+++ b/docs/adr/0027-runtime-classpath-manifest.md
@@ -1,0 +1,275 @@
+---
+status: accepted
+date: 2026-04-22
+---
+
+# ADR 0027: Runtime classpath manifest for JVM `kind = "app"` builds
+
+## Summary
+
+- Emit `build/<name>-runtime.classpath` alongside `build/<name>.jar` for
+  JVM `kind = "app"` builds. Plain text, one absolute jar path per line,
+  dependencies only (self jar excluded), sorted alphabetically by file
+  name (§1).
+- Keep `.kolt.lock` as pure resolution state. Runtime jar paths depend
+  on the local `~/.kolt/cache` layout and do not belong in a
+  checked-in lockfile (§2).
+- `scripts/assemble-dist.sh` is the sole in-tree consumer. It reads
+  the self jar plus the manifest, copies both into
+  `libexec/<daemon>/{<name>.jar,deps/*.jar}`, and generates the
+  platform-specific `libexec/classpath/<daemon>.argfile`. kolt does
+  not know the tarball layout (§3).
+- JVM `kind = "app"` is the only emitter. `kind = "lib"` omits the
+  manifest; downstream consumers resolve their own runtime. Native
+  targets have no JVM classpath to describe (§4).
+- `kolt run` continues to assemble classpath in-process from the
+  resolver's return value. The manifest is for **external** JVM
+  launchers only; no second resolver pass, no round-trip through
+  the file (§5).
+
+## Context and Problem Statement
+
+ADR 0018 §5 reduced the daemon self-host gap (#97) to one kolt
+feature: "JVM `kind = "app"` build path with a runtime classpath
+manifest". A dogfood spike on 2026-04-22 confirmed that the `kind =
+"app"` compile and thin-jar steps already work — both
+`kolt-jvm-compiler-daemon` (with `:ic` sources merged in) and
+`kolt-native-compiler-daemon` build end-to-end on the existing
+`kind = "lib"` JVM pipeline (#222). The only observable gap is that
+nothing emits the list of resolved runtime jars that
+`scripts/assemble-dist.sh` needs to stitch the release tarball.
+
+The question this ADR answers: **what file does kolt write so that
+`assemble-dist.sh` can drop jars into `libexec/<daemon>/deps/` and
+emit the `java @argfile` without re-running dependency resolution?**
+
+ADR 0018 §5 deferred the schema choice explicitly — lockfile key vs
+separate file, exact shape. This ADR pins it.
+
+The spike above was recorded as a comment on #97 (2026-04-22); no
+separate spike report file is carried alongside this ADR.
+
+## Decision Drivers
+
+- `assemble-dist.sh` is a thin stitcher (ADR 0018 §4). It must work
+  from kolt's build outputs without knowing the `~/.kolt/cache`
+  layout or re-running Maven resolution.
+- `.kolt.lock` is the resolution contract (ADR 0003). Artifact paths
+  are host-local and portable-lockfile hostile; keeping them separate
+  preserves the lockfile's single purpose.
+- mtime-based build cache (ADR 0007) reuses artifacts under `build/`;
+  a build artifact sitting next to `<name>.jar` lands naturally
+  inside that cache domain.
+- `java @argfile` format is platform-specific (`:` vs `;` separator).
+  kolt emits a platform-neutral input; the final argfile is produced
+  at tarball-assembly time by the consumer that knows the target
+  platform.
+- `kind = "lib"` artifacts are consumed by downstream builds that do
+  their own resolution. A baked-in host path list would be the wrong
+  contract and would encode the publisher's cache location into the
+  jar's neighborhood.
+
+## Decision Outcome
+
+Chosen option: **emit `build/<name>-runtime.classpath` as a separate
+plain-text file**, because it keeps `.kolt.lock` focused on
+resolution state, stays cache-aware via ADR 0007, and leaves the
+platform-dependent argfile concerns with the stitcher that actually
+knows the target platform. Alternatives (lockfile key, pre-assembled
+argfile) are listed at the end.
+
+### §1 Emit format
+
+For every JVM `kind = "app"` build, kolt writes
+`build/<name>-runtime.classpath` with the following shape:
+
+```
+/home/alice/.kolt/cache/com.akuleshov7/ktoml-core-jvm/0.7.1/…/ktoml-core-jvm-0.7.1.jar
+/home/alice/.kolt/cache/com.michael-bull.kotlin-result/kotlin-result-jvm/2.3.1/…/kotlin-result-jvm-2.3.1.jar
+/home/alice/.kolt/cache/org.jetbrains.kotlin/kotlin-build-tools-api/2.3.20/…/kotlin-build-tools-api-2.3.20.jar
+/home/alice/.kolt/cache/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.7.3/…/kotlinx-serialization-json-jvm-1.7.3.jar
+/home/alice/.kolt/cache/org.jetbrains/kotlin-stdlib/2.3.20/…/kotlin-stdlib-2.3.20.jar
+```
+
+Rules:
+
+- **Plain text, UTF-8, LF line endings, no trailing blank line.** No
+  header, no comment syntax. One jar per line.
+- **Absolute paths.** The jars live under `~/.kolt/cache` after
+  resolution; the consumer does not need to walk the cache.
+- **Deps only.** `build/<name>.jar` is NOT listed; its path is a
+  function of `KoltConfig.name` and the consumer computes it
+  directly. Listing self would invite a duplicate when the consumer
+  composes `<self>:<deps>`.
+- **Alphabetical by last path component (file name).** Stable order
+  across rebuilds and across machines; diffs in the manifest
+  correspond to real dependency changes, not resolver internals.
+  On a file-name collision (rare: rename/shading across GAVs),
+  tiebreak by the full `group:artifact:version` string of the
+  resolver entry.
+- **Kotlin stdlib is included.** The JVM resolver treats stdlib as
+  a normal transitive dependency (ADR 0011's skip is native-only,
+  since konanc bundles stdlib in its distribution). The daemon JVM
+  has no ambient stdlib, so listing it is required for launch.
+- **Transitive closure, post-exclusion.** The manifest is the
+  effective runtime classpath: exactly what the resolver selected
+  after BFS, version intervals, and `exclusions` (the Phase 3
+  algorithm shipped in v0.3.0).
+
+Helper `outputRuntimeClasspathPath(config): String` in
+`kolt/config/Config.kt` parallels `outputJarPath(config)` /
+`outputNativeKlibPath(config)`. Callers do not hand-build the path.
+
+### §2 Why not in `.kolt.lock`
+
+`.kolt.lock` records the resolution decision: GAV coordinates,
+resolved version, and integrity metadata that lets another machine
+re-derive the same graph. An absolute path like
+`/home/alice/.kolt/cache/…` is neither portable across machines nor
+stable across a `kolt cache clean`. Storing it in the lockfile would
+muddle two contracts:
+
+- the portable part (GAVs + integrity) belongs in version control;
+- the host-local part (where the jar sits on this machine) is a
+  derived artifact and belongs under `build/`.
+
+Consequence: `.kolt.lock` stays single-purpose. Future lockfile
+schema changes (ADR 0003 successors) do not have to carve out a
+"host-local" subsection.
+
+### §3 `assemble-dist.sh` contract
+
+The stitcher reads two inputs per daemon:
+
+- `<daemon>/build/<daemon>.jar` — the self jar (ADR 0025 §3 shape).
+- `<daemon>/build/<daemon>-runtime.classpath` — this ADR's manifest.
+
+And writes, per platform:
+
+1. `libexec/<daemon>/<daemon>.jar` — copy of the self jar.
+2. `libexec/<daemon>/deps/*.jar` — copy of every path listed in the
+   manifest, preserving the file name.
+3. `libexec/classpath/<daemon>.argfile` — generated with the
+   platform-appropriate separator (`:` on POSIX, `;` on Windows),
+   one `-cp` line, `kolt.daemon.MainKt` or `kolt.nativedaemon.MainKt`
+   on the final line.
+
+kolt itself never references `libexec/` and never writes an argfile.
+The manifest is the handshake; the layout in §1 of ADR 0018 is the
+stitcher's concern alone.
+
+### §4 Kind / target matrix
+
+| Target | Kind | Manifest emitted? |
+|--------|------|-------------------|
+| jvm | app | **yes** |
+| jvm | lib | no — downstream resolves its own runtime |
+| linuxX64 (and other native) | app | no — native binary, no JVM classpath |
+| linuxX64 (and other native) | lib | no — klib directory, not a JVM artifact |
+
+The "no" cases are active — kolt MUST NOT produce
+`build/<name>-runtime.classpath` for them. A regression test in
+`JvmLibraryInvariantsTest` / `NativeStagePlanTest` pins the
+non-emission for lib and native paths.
+
+### §5 Relationship with `kolt run`
+
+JVM `kolt run` today composes the classpath in-process from the
+resolver's return value (see `BuildCommands.kt:runCommand`, where
+`classpath` is handed straight to the `java` subprocess). It does
+**not** read the manifest. The manifest is strictly for external
+launchers (i.e. `assemble-dist.sh` and any future tooling that
+needs to launch the jar without linking kolt's resolver).
+
+This asymmetry is deliberate: an in-process consumer has the
+resolver's typed output and does not need to parse a text file; an
+external consumer has neither. Routing both through the file would
+add a read-write round trip to `kolt run` for no benefit.
+
+### Consequences
+
+**Positive**
+- #97 reduces to implementing this one emit step plus writing
+  `assemble-dist.sh`. No further schema decisions block self-host.
+- `.kolt.lock`, `build/<name>.jar`, and the new manifest each have
+  one purpose. Future schema work touches exactly one of them.
+- Spike-proven that `kind = "app"` JVM compile and thin-jar steps
+  already work (§Context), so the implementation is scoped to
+  "write a file after the jar step".
+
+**Negative**
+- Absolute paths bind the manifest to the build host's cache
+  layout. A manifest rsync'd to another machine with a different
+  `~/.kolt/cache` path is invalid until rebuilt. This is acceptable
+  because `assemble-dist.sh` always runs on the same host as the
+  `kolt build` that produced the manifest.
+- A future change that moves jars into the project tree (e.g. a
+  `vendor/` directory) would invalidate any manifest emitted under
+  the old layout. This is a general property of cache-derived
+  artifacts and is bounded by the mtime cache (ADR 0007) — a
+  cache-location change invalidates the jar artifacts anyway.
+- The manifest duplicates information already present in
+  `.kolt.lock` + `~/.kolt/cache` state. A resolver refactor that
+  re-derives jar paths from lockfile coordinates lives entirely
+  inside kolt; the manifest's contract is stable against it.
+
+### Confirmation
+
+- `outputRuntimeClasspathPath(config)` exists in `Config.kt`
+  alongside the existing artifact-path helpers. Callers compute
+  paths through it.
+- A new test file (`JvmAppBuildTest` or similar) pins: JVM `kind =
+  "app"` builds emit the manifest with the §1 rules; JVM `kind =
+  "lib"` does not; native builds do not.
+- `scripts/assemble-dist.sh` — when it lands — reads the manifest
+  per §3 and is the enforcer of the consumer contract.
+- A regression test pins that `kolt run` (JVM app path) does not
+  open `build/<name>-runtime.classpath`; the §5 asymmetry lives in
+  code, not in docs alone. Easiest form is a test that deletes the
+  manifest after `kolt build` and asserts `kolt run` still
+  succeeds.
+- ADR text and emit code stay in sync via PR review; the manifest
+  shape has no schema registry outside this ADR until a third
+  consumer exists.
+
+## Alternatives considered
+
+1. **`runtime_classpath` array inside `.kolt.lock`.** Rejected.
+   `.kolt.lock` is checked in on many projects; host-local absolute
+   paths belong nowhere in that file. The schema would also need
+   kind-conditional presence (`kind = "lib"` has no runtime
+   classpath to describe), enlarging the lockfile reader surface for
+   no gain over a build artifact.
+2. **Kolt emits a ready-made `@argfile` (`-cp <paths>` plus main
+   class).** Rejected. The argfile uses a platform-specific
+   separator (`:` vs `;`) and also carries JVM tuning flags (`-Xmx`
+   etc.) per ADR 0018 §2. Emitting a single argfile binds the
+   manifest to the build host's OS; baking tuning defaults
+   regresses §2 — operators must be able to tune the installed
+   tarball without rebuilding kolt. The manifest stays pre-argfile
+   so the stitcher, which knows the target platform, finishes
+   the job.
+3. **Kolt emits per-platform argfiles (`*.posix.argfile` +
+   `*.win.argfile`).** Rejected as a variant of alternative 2.
+   Solving the separator question does not solve the tuning-flag
+   bake-in; kolt would still decide JVM flags at build time
+   instead of at tarball-assembly or operator-edit time.
+
+## Related
+
+- #97 — self-host gap; this ADR closes the last schema question
+  listed in its "remaining blocker" section.
+- ADR 0018 §5 — defers the schema pinned here; §3 above implements
+  the contract `assemble-dist.sh` relies on.
+- ADR 0025 §3 — JVM lib artifact shape; this ADR's `kind = "app"`
+  output is the same thin jar plus one companion file.
+- ADR 0003 — TOML config / JSON lockfile boundary; §2 above
+  preserves it.
+- ADR 0007 — mtime-based build cache; the manifest participates as
+  a normal `build/` artifact.
+- ADR 0016 / ADR 0024 — warm JVM compiler daemon / native compiler
+  daemon; the two consumers of `assemble-dist.sh`'s argfile.
+- Dogfood spike 2026-04-22 — recorded inline in Context; both
+  daemons' `kolt build` succeeded on the current `kind = "lib"`
+  JVM pipeline with self-jar output, confirming that the missing
+  piece is exactly this manifest.

--- a/kolt-jvm-compiler-daemon/kolt.lock
+++ b/kolt-jvm-compiler-daemon/kolt.lock
@@ -1,0 +1,87 @@
+{
+  "version": 2,
+  "kotlin": "2.3.20",
+  "jvm_target": "21",
+  "dependencies": {
+    "com.akuleshov7:ktoml-core": {
+      "version": "0.7.1",
+      "sha256": "c22cb661eefc75e30007a1b08d37c4e93a157f7f3a950a478251632c0af6050d"
+    },
+    "com.michael-bull.kotlin-result:kotlin-result": {
+      "version": "2.3.1",
+      "sha256": "96289c225b06d20156a0695432afc104f187ab68c84e9b8bed7af573e5194c83"
+    },
+    "org.apiguardian:apiguardian-api": {
+      "version": "1.1.2",
+      "sha256": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
+      "transitive": true
+    },
+    "org.jetbrains.kotlin:kotlin-build-tools-api": {
+      "version": "2.3.20",
+      "sha256": "22f1ab223854b949099f6b259cef541d5b58a3643df9a49c4577c63c416e843b"
+    },
+    "org.jetbrains.kotlin:kotlin-stdlib": {
+      "version": "2.3.20",
+      "sha256": "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e",
+      "transitive": true
+    },
+    "org.jetbrains.kotlin:kotlin-test": {
+      "version": "2.3.20",
+      "sha256": "d6c9ccf82f67e6cf7fdaf9e0cea419dac4dfa58620a1653d3dba45f544a289ac",
+      "transitive": true
+    },
+    "org.jetbrains.kotlin:kotlin-test-junit5": {
+      "version": "2.3.20",
+      "sha256": "90c554e254623cc49de7ae4c7c932a86287795e45875c47e1937c29c297eff02"
+    },
+    "org.jetbrains.kotlinx:kotlinx-datetime-jvm": {
+      "version": "0.7.1-0.6.x-compat",
+      "sha256": "cf9cdf7b3074044657a1a80bc1bb5280b58545a967ac7fe42b1aa3cf93305714",
+      "transitive": true
+    },
+    "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm": {
+      "version": "1.9.0",
+      "sha256": "1f0afa172110e45a7231ef1b44ae8fd84c1ebaff96f3fc3ad68ef8c48120b59c",
+      "transitive": true
+    },
+    "org.jetbrains.kotlinx:kotlinx-serialization-json": {
+      "version": "1.7.3",
+      "sha256": "b1e9138499ed8d20375edda3f2b1c95f3103a258eff6af9edc5ea07100f2b29c"
+    },
+    "org.jetbrains:annotations": {
+      "version": "13.0",
+      "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
+      "transitive": true
+    },
+    "org.junit.jupiter:junit-jupiter-api": {
+      "version": "5.10.1",
+      "sha256": "60d5c398c32dc7039b99282514ad6064061d8417cf959a1f6bd2038cc907c913",
+      "transitive": true
+    },
+    "org.junit.jupiter:junit-jupiter-engine": {
+      "version": "5.10.1",
+      "sha256": "02930dfe495f93fe70b26550ace3a28f7e1b900c84426c2e4626ce020c7282d6",
+      "transitive": true
+    },
+    "org.junit.platform:junit-platform-commons": {
+      "version": "1.10.1",
+      "sha256": "7d9855ee3f3f71f015eb1479559bf923783243c24fbfbd8b29bed8e8099b5672",
+      "transitive": true
+    },
+    "org.junit.platform:junit-platform-engine": {
+      "version": "1.10.1",
+      "sha256": "baa48e470d6dee7369a0a8820c51da89c1463279eda6e13a304d11f45922c760",
+      "transitive": true
+    },
+    "org.junit.platform:junit-platform-launcher": {
+      "version": "1.10.1",
+      "sha256": "ded414c504e88d02270331071969084e1b2fd9bcf8443f35d44da2c6e3301bc2",
+      "transitive": true
+    },
+    "org.opentest4j:opentest4j": {
+      "version": "1.3.0",
+      "sha256": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+      "transitive": true
+    }
+  }
+}

--- a/kolt-jvm-compiler-daemon/kolt.toml
+++ b/kolt-jvm-compiler-daemon/kolt.toml
@@ -1,0 +1,23 @@
+name = "kolt-jvm-compiler-daemon"
+version = "0.13.0"
+kind = "app"
+
+[kotlin]
+version = "2.3.20"
+
+[kotlin.plugins]
+serialization = true
+
+[build]
+target = "jvm"
+jvm_target = "21"
+jdk = "21"
+main = "kolt.daemon.main"
+sources = ["src/main/kotlin", "ic/src/main/kotlin"]
+test_sources = []
+
+[dependencies]
+"org.jetbrains.kotlin:kotlin-build-tools-api" = "2.3.20"
+"org.jetbrains.kotlinx:kotlinx-serialization-json" = "1.7.3"
+"com.michael-bull.kotlin-result:kotlin-result" = "2.3.1"
+"com.akuleshov7:ktoml-core" = "0.7.1"

--- a/kolt-native-compiler-daemon/kolt.lock
+++ b/kolt-native-compiler-daemon/kolt.lock
@@ -1,0 +1,74 @@
+{
+  "version": 2,
+  "kotlin": "2.3.20",
+  "jvm_target": "21",
+  "dependencies": {
+    "com.michael-bull.kotlin-result:kotlin-result": {
+      "version": "2.3.1",
+      "sha256": "96289c225b06d20156a0695432afc104f187ab68c84e9b8bed7af573e5194c83"
+    },
+    "org.apiguardian:apiguardian-api": {
+      "version": "1.1.2",
+      "sha256": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
+      "transitive": true
+    },
+    "org.jetbrains.kotlin:kotlin-stdlib": {
+      "version": "2.3.20",
+      "sha256": "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e",
+      "transitive": true
+    },
+    "org.jetbrains.kotlin:kotlin-test": {
+      "version": "2.3.20",
+      "sha256": "d6c9ccf82f67e6cf7fdaf9e0cea419dac4dfa58620a1653d3dba45f544a289ac",
+      "transitive": true
+    },
+    "org.jetbrains.kotlin:kotlin-test-junit5": {
+      "version": "2.3.20",
+      "sha256": "90c554e254623cc49de7ae4c7c932a86287795e45875c47e1937c29c297eff02"
+    },
+    "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm": {
+      "version": "1.7.3",
+      "sha256": "f0adde45864144475385cf4aa7e0b7feb27f61fcf9472665ed98cc971b06b1eb",
+      "transitive": true
+    },
+    "org.jetbrains.kotlinx:kotlinx-serialization-json": {
+      "version": "1.7.3",
+      "sha256": "b1e9138499ed8d20375edda3f2b1c95f3103a258eff6af9edc5ea07100f2b29c"
+    },
+    "org.jetbrains:annotations": {
+      "version": "13.0",
+      "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
+      "transitive": true
+    },
+    "org.junit.jupiter:junit-jupiter-api": {
+      "version": "5.10.1",
+      "sha256": "60d5c398c32dc7039b99282514ad6064061d8417cf959a1f6bd2038cc907c913",
+      "transitive": true
+    },
+    "org.junit.jupiter:junit-jupiter-engine": {
+      "version": "5.10.1",
+      "sha256": "02930dfe495f93fe70b26550ace3a28f7e1b900c84426c2e4626ce020c7282d6",
+      "transitive": true
+    },
+    "org.junit.platform:junit-platform-commons": {
+      "version": "1.10.1",
+      "sha256": "7d9855ee3f3f71f015eb1479559bf923783243c24fbfbd8b29bed8e8099b5672",
+      "transitive": true
+    },
+    "org.junit.platform:junit-platform-engine": {
+      "version": "1.10.1",
+      "sha256": "baa48e470d6dee7369a0a8820c51da89c1463279eda6e13a304d11f45922c760",
+      "transitive": true
+    },
+    "org.junit.platform:junit-platform-launcher": {
+      "version": "1.10.1",
+      "sha256": "ded414c504e88d02270331071969084e1b2fd9bcf8443f35d44da2c6e3301bc2",
+      "transitive": true
+    },
+    "org.opentest4j:opentest4j": {
+      "version": "1.3.0",
+      "sha256": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+      "transitive": true
+    }
+  }
+}

--- a/kolt-native-compiler-daemon/kolt.toml
+++ b/kolt-native-compiler-daemon/kolt.toml
@@ -1,0 +1,21 @@
+name = "kolt-native-compiler-daemon"
+version = "0.13.0"
+kind = "app"
+
+[kotlin]
+version = "2.3.20"
+
+[kotlin.plugins]
+serialization = true
+
+[build]
+target = "jvm"
+jvm_target = "21"
+jdk = "21"
+main = "kolt.nativedaemon.main"
+sources = ["src/main/kotlin"]
+test_sources = []
+
+[dependencies]
+"org.jetbrains.kotlinx:kotlinx-serialization-json" = "1.7.3"
+"com.michael-bull.kotlin-result:kotlin-result" = "2.3.1"

--- a/scripts/assemble-dist.sh
+++ b/scripts/assemble-dist.sh
@@ -4,13 +4,15 @@
 #
 # Runs `kolt build` serially in three projects (root, kolt-jvm-compiler-daemon,
 # kolt-native-compiler-daemon), fetches the `kotlin-build-tools-impl`
-# classpath from Maven Central with sha256 pins, and prepares
-# `dist/<tarball-root>/`. Writing the final tarball layout (Task 3.3) is
-# handled by a subsequent task.
+# classpath from Maven Central with sha256 pins, populates the ADR 0018 §1
+# tarball layout under `dist/kolt-<version>-linux-x64/`, and packs it into
+# `dist/kolt-<version>-linux-x64.tar.gz`.
 #
-# Fail-fast: any non-zero build or sha mismatch aborts the remaining steps.
+# Fail-fast: any non-zero build, sha mismatch, or copy failure aborts the
+# remaining steps (`set -euo pipefail`).
 #
-# References: ADR 0018 §1, §4; ADR 0019 §3; daemon-self-host design §Flow 2.
+# References: ADR 0018 §1, §2, §4; ADR 0019 §3; ADR 0027 §1;
+# daemon-self-host design §Flow 2.
 set -euo pipefail
 
 # kotlin-build-tools-impl classpath pin.
@@ -123,6 +125,130 @@ done
 # touch the network.
 fetch_bta_impl
 
-# Task 3.3 will populate $DIST_ROOT/{bin,libexec} and emit the tarball.
+# Daemon metadata: name -> main class FQN. The two daemons share the same
+# JVM kind=app build shape (thin jar + runtime classpath manifest), and
+# differ only in their main class (per `kolt.toml` [build].main) and their
+# resolved deps. Main class FQNs follow Kotlin's file-class convention
+# (`kolt.daemon.main` in kolt.toml -> `kolt.daemon.MainKt` on the JVM).
+DAEMONS=(
+  "kolt-jvm-compiler-daemon:kolt.daemon.MainKt"
+  "kolt-native-compiler-daemon:kolt.nativedaemon.MainKt"
+)
 
-echo "assemble-dist: skeleton ready at $DIST_ROOT"
+# `@KOLT_LIBEXEC@` is a placeholder that `install.sh` (or the CI companion in
+# Task 4.3) rewrites to the absolute `libexec/` path at install time. Writing
+# a placeholder rather than an absolute path keeps the tarball install-location
+# agnostic (ADR 0018 §1 note that the tarball is the unit of relocation);
+# emitting absolute paths here would hard-code `~/.local/share/kolt/<version>/`
+# or equivalent into the release artifact. Post-install substitution is a
+# `sed -i 's|@KOLT_LIBEXEC@|<abs libexec>|g'` pass over each argfile.
+LIBEXEC_PLACEHOLDER="@KOLT_LIBEXEC@"
+
+# copy_manifest_deps — copy every jar listed in the given runtime classpath
+# manifest into `<target_dir>/` preserving its file name. Manifest entries
+# are absolute paths (one per line, ADR 0027 §1); duplicates are flagged as
+# a bug in the resolver rather than silently overwriting.
+copy_manifest_deps() {
+  local manifest="$1"
+  local target_dir="$2"
+  mkdir -p "$target_dir"
+  local jar base
+  while IFS= read -r jar; do
+    [[ -z "$jar" ]] && continue
+    base="$(basename "$jar")"
+    if [[ -e "$target_dir/$base" ]]; then
+      echo "assemble-dist: duplicate dep file name '$base' in $manifest" >&2
+      exit 1
+    fi
+    cp "$jar" "$target_dir/$base"
+  done < "$manifest"
+}
+
+# write_argfile — emit `<libexec>/classpath/<daemon>.argfile` in the
+# `java @argfile` format (ADR 0018 §2): one switch per line, absolute paths,
+# main class on the final line. Classpath ordering is: self jar, then
+# manifest-order deps (alphabetical by file name, ADR 0027 §1), then the
+# kolt-bta-impl jars (alphabetical by file name) via `@KOLT_LIBEXEC@`
+# placeholders resolved at install time.
+write_argfile() {
+  local daemon="$1"
+  local main_class="$2"
+  local manifest="$3"
+  local argfile="$DIST_ROOT/libexec/classpath/${daemon}.argfile"
+
+  local cp_entries=()
+  cp_entries+=("${LIBEXEC_PLACEHOLDER}/${daemon}/${daemon}.jar")
+  local jar base
+  while IFS= read -r jar; do
+    [[ -z "$jar" ]] && continue
+    base="$(basename "$jar")"
+    cp_entries+=("${LIBEXEC_PLACEHOLDER}/${daemon}/deps/${base}")
+  done < "$manifest"
+  # kolt-bta-impl jars in alphabetical order for determinism.
+  local impl_jar
+  while IFS= read -r impl_jar; do
+    base="$(basename "$impl_jar")"
+    cp_entries+=("${LIBEXEC_PLACEHOLDER}/kolt-bta-impl/${base}")
+  done < <(find "$DIST_ROOT/libexec/kolt-bta-impl" -maxdepth 1 -name '*.jar' | sort)
+
+  local cpath
+  # `:` separator is hard-coded; linuxX64 is the only supported target
+  # today. Windows would need `;` and a per-platform branch here.
+  local IFS=':'
+  cpath="${cp_entries[*]}"
+  unset IFS
+
+  {
+    printf '%s\n' '-cp'
+    printf '%s\n' "$cpath"
+    printf '%s\n' "$main_class"
+  } > "$argfile"
+}
+
+# Populate the tarball layout (Task 3.3). Subdirectories are created just
+# in time so a partial rerun after a failure leaves the previous tree in
+# place for debugging (`rm -rf dist` at the top of the script provides the
+# clean-slate idempotency).
+mkdir -p "$DIST_ROOT/bin" "$DIST_ROOT/libexec/classpath"
+
+# `bin/kolt` is the kolt.kexe produced by the root `kolt build` above
+# (self-hosted). `KOLT` (used to drive the three builds) may point at the
+# Gradle-built binary; `./build/kolt.kexe` is always the self-host output.
+ROOT_KEXE="$ROOT_DIR/build/kolt.kexe"
+if [[ ! -x "$ROOT_KEXE" ]]; then
+  echo "assemble-dist: root kolt.kexe not found at $ROOT_KEXE" >&2
+  exit 1
+fi
+cp "$ROOT_KEXE" "$DIST_ROOT/bin/kolt"
+chmod +x "$DIST_ROOT/bin/kolt"
+
+for entry in "${DAEMONS[@]}"; do
+  IFS=':' read -r daemon main_class <<< "$entry"
+  daemon_jar="$ROOT_DIR/$daemon/build/${daemon}.jar"
+  manifest="$ROOT_DIR/$daemon/build/${daemon}-runtime.classpath"
+  if [[ ! -f "$daemon_jar" ]]; then
+    echo "assemble-dist: missing daemon jar: $daemon_jar" >&2
+    exit 1
+  fi
+  if [[ ! -f "$manifest" ]]; then
+    echo "assemble-dist: missing runtime classpath manifest: $manifest" >&2
+    exit 1
+  fi
+  mkdir -p "$DIST_ROOT/libexec/$daemon"
+  cp "$daemon_jar" "$DIST_ROOT/libexec/$daemon/${daemon}.jar"
+  copy_manifest_deps "$manifest" "$DIST_ROOT/libexec/$daemon/deps"
+  write_argfile "$daemon" "$main_class" "$manifest"
+  echo "assemble-dist: populated libexec/$daemon"
+done
+
+# `VERSION` is the bare semver (no newline besides the trailing one `printf`
+# emits; matches ADR 0018 §1 "bare semver, matches git tag").
+printf '%s\n' "$VERSION" > "$DIST_ROOT/VERSION"
+
+# Pack the tarball. `-C dist` cd's into dist/ first so the archive's top
+# level is the versioned directory name (ADR 0018 §1: "extracts to a
+# versioned top-level directory").
+TARBALL="dist/kolt-${VERSION}-linux-x64.tar.gz"
+tar czf "$TARBALL" -C dist "kolt-${VERSION}-linux-x64"
+
+echo "assemble-dist: wrote $TARBALL"

--- a/scripts/assemble-dist.sh
+++ b/scripts/assemble-dist.sh
@@ -3,14 +3,82 @@
 # assemble-dist.sh — release tarball stitcher for kolt.
 #
 # Runs `kolt build` serially in three projects (root, kolt-jvm-compiler-daemon,
-# kolt-native-compiler-daemon) and prepares an empty dist/<tarball-root>/
-# directory. Fetching `kotlin-build-tools-impl` (Task 3.2) and writing the
-# tarball layout (Task 3.3) are handled by subsequent tasks.
+# kolt-native-compiler-daemon), fetches the `kotlin-build-tools-impl`
+# classpath from Maven Central with sha256 pins, and prepares
+# `dist/<tarball-root>/`. Writing the final tarball layout (Task 3.3) is
+# handled by a subsequent task.
 #
-# Fail-fast: any non-zero build aborts the remaining steps.
+# Fail-fast: any non-zero build or sha mismatch aborts the remaining steps.
 #
-# References: ADR 0018 §1, §4; daemon-self-host design §Flow 2.
+# References: ADR 0018 §1, §4; ADR 0019 §3; daemon-self-host design §Flow 2.
 set -euo pipefail
+
+# kotlin-build-tools-impl classpath pin.
+#
+# ADR 0019 §3 requires `-impl` to load via a child URLClassLoader parented by
+# SharedApiClassesClassLoader, so we ship its runtime closure on a separate
+# on-disk classpath (`libexec/kolt-bta-impl/`) rather than bundling into the
+# daemon fat jar or routing through the kolt resolver. The set and sha256s
+# below were observed from `./gradlew :kolt-jvm-compiler-daemon:stageBtaImplJars`
+# against the pinned `kotlin-build-tools-impl:2.3.20` dependency.
+#
+# Exclusions vs the staged set: the daemon's `kolt.toml` [dependencies] declares
+# `org.jetbrains.kotlin:kotlin-build-tools-api = 2.3.20`, whose resolver closure
+# already emits `kotlin-build-tools-api`, `kotlin-stdlib`, and `annotations-13.0`
+# into `libexec/<daemon>/deps/`. Shipping those three a second time here would
+# duplicate jars on the runtime classpath; we keep only what `-impl` brings in
+# addition to the api closure.
+#
+# Format: "group:artifact:version:filename" (:-separated; filename is the
+# exact Maven Central artifact name, including `-jvm` / version variants).
+BTA_IMPL_JARS=(
+  "org.jetbrains.kotlin:kotlin-build-tools-impl:2.3.20:kotlin-build-tools-impl-2.3.20.jar"
+  "org.jetbrains.kotlin:kotlin-build-tools-cri-impl:2.3.20:kotlin-build-tools-cri-impl-2.3.20.jar"
+  "org.jetbrains.kotlin:kotlin-compiler-embeddable:2.3.20:kotlin-compiler-embeddable-2.3.20.jar"
+  "org.jetbrains.kotlin:kotlin-compiler-runner:2.3.20:kotlin-compiler-runner-2.3.20.jar"
+  "org.jetbrains.kotlin:kotlin-daemon-client:2.3.20:kotlin-daemon-client-2.3.20.jar"
+  "org.jetbrains.kotlin:kotlin-daemon-embeddable:2.3.20:kotlin-daemon-embeddable-2.3.20.jar"
+  "org.jetbrains.kotlin:kotlin-reflect:1.6.10:kotlin-reflect-1.6.10.jar"
+  "org.jetbrains.kotlin:kotlin-script-runtime:2.3.20:kotlin-script-runtime-2.3.20.jar"
+  "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0:kotlinx-coroutines-core-jvm-1.8.0.jar"
+)
+
+# SHA-256 digests in `sha256sum -c` input format: "<digest>  <filename>".
+# Paired by filename with BTA_IMPL_JARS; order is not significant.
+BTA_IMPL_SHA256=(
+  "9681bc2164a8bd9f6ddf4c085cf4a836b92d27506667d73bab9f6d855336c910  kotlin-build-tools-impl-2.3.20.jar"
+  "54eced630f28124ccfe2e464e6cacc281e528a8a50a89725721554c9693548fe  kotlin-build-tools-cri-impl-2.3.20.jar"
+  "976f989d0b5f5d80e8e8a8ad4b73da0bfc27fdd965b9fa38362b2be79ecc1337  kotlin-compiler-embeddable-2.3.20.jar"
+  "c069f30a403be70c8152f8aa9f25eccba188eead54263ae02af14421437a2208  kotlin-compiler-runner-2.3.20.jar"
+  "c71a7c1be8fbff04e0af45c9ee8cb7a61d8953bca6b8bf225a5719c725a90b44  kotlin-daemon-client-2.3.20.jar"
+  "8870bab840b8087c96c4ddc06088b4aedf5131c408af3674306304f1f96af3f4  kotlin-daemon-embeddable-2.3.20.jar"
+  "3277ac102ae17aad10a55abec75ff5696c8d109790396434b496e75087854203  kotlin-reflect-1.6.10.jar"
+  "6fcdb7da6e65cf8cc43e5aabab94bdcc48825e7933686f8a1bf694eb88f8e00e  kotlin-script-runtime-2.3.20.jar"
+  "9860906a1937490bf5f3b06d2f0e10ef451e65b95b269f22daf68a3d1f5065c5  kotlinx-coroutines-core-jvm-1.8.0.jar"
+)
+
+MAVEN_CENTRAL_BASE="https://repo1.maven.org/maven2"
+
+# fetch_bta_impl — download the pinned `-impl` classpath into
+# `${DIST_ROOT}/libexec/kolt-bta-impl/` and verify sha256s. Non-zero exit on
+# any curl failure or sha mismatch (set -e carries the sha256sum -c failure).
+fetch_bta_impl() {
+  local target_dir="$DIST_ROOT/libexec/kolt-bta-impl"
+  mkdir -p "$target_dir"
+  local entry group artifact version filename group_path url
+  for entry in "${BTA_IMPL_JARS[@]}"; do
+    IFS=':' read -r group artifact version filename <<< "$entry"
+    group_path="${group//./\/}"
+    url="${MAVEN_CENTRAL_BASE}/${group_path}/${artifact}/${version}/${filename}"
+    echo "assemble-dist: fetching ${group}:${artifact}:${version}"
+    curl -fsSL -o "${target_dir}/${filename}" "$url"
+  done
+  echo "assemble-dist: verifying sha256 for kolt-bta-impl"
+  (
+    cd "$target_dir"
+    printf '%s\n' "${BTA_IMPL_SHA256[@]}" | sha256sum -c -
+  )
+}
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
@@ -50,7 +118,11 @@ for project in "." "kolt-jvm-compiler-daemon" "kolt-native-compiler-daemon"; do
   )
 done
 
-# Task 3.2 will fetch kotlin-build-tools-impl into $DIST_ROOT/libexec/kolt-bta-impl/.
+# Fetch kotlin-build-tools-impl from Maven Central (Task 3.2). Runs after the
+# three `kolt build` invocations so that a broken local build fails before we
+# touch the network.
+fetch_bta_impl
+
 # Task 3.3 will populate $DIST_ROOT/{bin,libexec} and emit the tarball.
 
 echo "assemble-dist: skeleton ready at $DIST_ROOT"

--- a/scripts/assemble-dist.sh
+++ b/scripts/assemble-dist.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# assemble-dist.sh — release tarball stitcher for kolt.
+#
+# Runs `kolt build` serially in three projects (root, kolt-jvm-compiler-daemon,
+# kolt-native-compiler-daemon) and prepares an empty dist/<tarball-root>/
+# directory. Fetching `kotlin-build-tools-impl` (Task 3.2) and writing the
+# tarball layout (Task 3.3) are handled by subsequent tasks.
+#
+# Fail-fast: any non-zero build aborts the remaining steps.
+#
+# References: ADR 0018 §1, §4; daemon-self-host design §Flow 2.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Extract version from root kolt.toml (single `version = "..."` line).
+VERSION="$(grep -E '^version = "' kolt.toml | head -n 1 | sed -E 's/^version = "(.*)"/\1/')"
+if [[ -z "$VERSION" ]]; then
+  echo "assemble-dist: failed to read version from kolt.toml" >&2
+  exit 1
+fi
+
+DIST_ROOT="dist/kolt-${VERSION}-linux-x64"
+
+# Wipe any previous dist/ so reruns are safe (design §release 配管: rerun safe).
+rm -rf dist
+mkdir -p "$DIST_ROOT"
+
+KOLT="${KOLT:-./build/bin/linuxX64/releaseExecutable/kolt.kexe}"
+# Resolve KOLT to an absolute path so the per-project `cd` below does not
+# break relative defaults.
+case "$KOLT" in
+  /*) ;;
+  *) KOLT="$ROOT_DIR/$KOLT" ;;
+esac
+if [[ ! -x "$KOLT" ]]; then
+  echo "assemble-dist: KOLT binary not found or not executable: $KOLT" >&2
+  exit 1
+fi
+
+# Run 3 x kolt build serially. `set -e` plus the subshell `exit` propagate
+# failure so later projects do not run if an earlier one fails.
+for project in "." "kolt-jvm-compiler-daemon" "kolt-native-compiler-daemon"; do
+  echo "assemble-dist: building $project"
+  (
+    cd "$project"
+    "$KOLT" build
+  )
+done
+
+# Task 3.2 will fetch kotlin-build-tools-impl into $DIST_ROOT/libexec/kolt-bta-impl/.
+# Task 3.3 will populate $DIST_ROOT/{bin,libexec} and emit the tarball.
+
+echo "assemble-dist: skeleton ready at $DIST_ROOT"

--- a/spike/daemon-self-host-smoke/kolt.lock
+++ b/spike/daemon-self-host-smoke/kolt.lock
@@ -1,0 +1,61 @@
+{
+  "version": 2,
+  "kotlin": "2.3.20",
+  "jvm_target": "21",
+  "dependencies": {
+    "org.apiguardian:apiguardian-api": {
+      "version": "1.1.2",
+      "sha256": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
+      "transitive": true
+    },
+    "org.jetbrains.kotlin:kotlin-stdlib": {
+      "version": "2.3.20",
+      "sha256": "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e",
+      "transitive": true
+    },
+    "org.jetbrains.kotlin:kotlin-test": {
+      "version": "2.3.20",
+      "sha256": "d6c9ccf82f67e6cf7fdaf9e0cea419dac4dfa58620a1653d3dba45f544a289ac",
+      "transitive": true
+    },
+    "org.jetbrains.kotlin:kotlin-test-junit5": {
+      "version": "2.3.20",
+      "sha256": "90c554e254623cc49de7ae4c7c932a86287795e45875c47e1937c29c297eff02"
+    },
+    "org.jetbrains:annotations": {
+      "version": "13.0",
+      "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
+      "transitive": true
+    },
+    "org.junit.jupiter:junit-jupiter-api": {
+      "version": "5.10.1",
+      "sha256": "60d5c398c32dc7039b99282514ad6064061d8417cf959a1f6bd2038cc907c913",
+      "transitive": true
+    },
+    "org.junit.jupiter:junit-jupiter-engine": {
+      "version": "5.10.1",
+      "sha256": "02930dfe495f93fe70b26550ace3a28f7e1b900c84426c2e4626ce020c7282d6",
+      "transitive": true
+    },
+    "org.junit.platform:junit-platform-commons": {
+      "version": "1.10.1",
+      "sha256": "7d9855ee3f3f71f015eb1479559bf923783243c24fbfbd8b29bed8e8099b5672",
+      "transitive": true
+    },
+    "org.junit.platform:junit-platform-engine": {
+      "version": "1.10.1",
+      "sha256": "baa48e470d6dee7369a0a8820c51da89c1463279eda6e13a304d11f45922c760",
+      "transitive": true
+    },
+    "org.junit.platform:junit-platform-launcher": {
+      "version": "1.10.1",
+      "sha256": "ded414c504e88d02270331071969084e1b2fd9bcf8443f35d44da2c6e3301bc2",
+      "transitive": true
+    },
+    "org.opentest4j:opentest4j": {
+      "version": "1.3.0",
+      "sha256": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+      "transitive": true
+    }
+  }
+}

--- a/spike/daemon-self-host-smoke/kolt.toml
+++ b/spike/daemon-self-host-smoke/kolt.toml
@@ -1,0 +1,14 @@
+name = "smoke"
+version = "0.1.0"
+kind = "app"
+
+[kotlin]
+version = "2.3.20"
+
+[build]
+target = "jvm"
+jvm_target = "21"
+jdk = "21"
+main = "smoke.main"
+sources = ["src/main/kotlin"]
+test_sources = []

--- a/spike/daemon-self-host-smoke/src/main/kotlin/Hello.kt
+++ b/spike/daemon-self-host-smoke/src/main/kotlin/Hello.kt
@@ -1,0 +1,5 @@
+package smoke
+
+fun main() {
+    println("kolt daemon self-host smoke: ok")
+}

--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -14,6 +14,14 @@ internal const val NATIVE_IC_CACHE_DIR = "$BUILD_DIR/.ic-cache"
 
 internal fun outputJarPath(config: KoltConfig): String = "$BUILD_DIR/${config.name}.jar"
 
+// A resolved JVM dependency jar, kept as a pair of (a) absolute cache path and
+// (b) full GAV coordinate for the tiebreak rule in ADR 0027 §1 ("alphabetical
+// by file name, tiebreak by group:artifact:version").
+internal data class ResolvedJar(
+    val cachePath: String,
+    val groupArtifactVersion: String
+)
+
 internal fun outputKexePath(config: KoltConfig): String = "$BUILD_DIR/${config.name}.kexe"
 
 internal fun outputNativeTestKexePath(config: KoltConfig): String = "$BUILD_DIR/${config.name}-test.kexe"

--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -1,8 +1,13 @@
 package kolt.build
 
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
 import kolt.config.CinteropConfig
 import kolt.config.KoltConfig
 import kolt.config.konanTargetGradleName
+import kolt.infra.writeFileAsString
 
 internal const val BUILD_DIR = "build"
 internal const val CLASSES_DIR = "$BUILD_DIR/classes"
@@ -14,6 +19,9 @@ internal const val NATIVE_IC_CACHE_DIR = "$BUILD_DIR/.ic-cache"
 
 internal fun outputJarPath(config: KoltConfig): String = "$BUILD_DIR/${config.name}.jar"
 
+internal fun outputRuntimeClasspathPath(config: KoltConfig): String =
+    "$BUILD_DIR/${config.name}-runtime.classpath"
+
 // A resolved JVM dependency jar, kept as a pair of (a) absolute cache path and
 // (b) full GAV coordinate for the tiebreak rule in ADR 0027 §1 ("alphabetical
 // by file name, tiebreak by group:artifact:version").
@@ -21,6 +29,35 @@ internal data class ResolvedJar(
     val cachePath: String,
     val groupArtifactVersion: String
 )
+
+internal sealed class ManifestWriteError {
+    data class WriteFailed(val path: String, val reason: String) : ManifestWriteError()
+}
+
+// Emits the JVM `kind = "app"` runtime classpath manifest (ADR 0027 §1):
+// UTF-8, LF, no trailing newline; alphabetical by file name, tiebreak by
+// `group:artifact:version`; self jar excluded as a defence-in-depth guard
+// (the resolver's return value already omits it).
+internal fun writeRuntimeClasspathManifest(
+    config: KoltConfig,
+    resolvedJars: List<ResolvedJar>
+): Result<Unit, ManifestWriteError> {
+    val selfJarPath = outputJarPath(config)
+    val sorted = resolvedJars
+        .filter { it.cachePath != selfJarPath }
+        .sortedWith(compareBy({ fileName(it.cachePath) }, { it.groupArtifactVersion }))
+    val content = sorted.joinToString("\n") { it.cachePath }
+    val path = outputRuntimeClasspathPath(config)
+    writeFileAsString(path, content).getOrElse { error ->
+        return Err(ManifestWriteError.WriteFailed(path = error.path, reason = "write failed"))
+    }
+    return Ok(Unit)
+}
+
+private fun fileName(path: String): String {
+    val slash = path.lastIndexOf('/')
+    return if (slash < 0) path else path.substring(slash + 1)
+}
 
 internal fun outputKexePath(config: KoltConfig): String = "$BUILD_DIR/${config.name}.kexe"
 

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -31,6 +31,26 @@ internal data class BuildResult(
     val javaPath: String? = null,
 )
 
+// ADR 0027 §4 kind/target matrix: JVM `kind = "app"` emits
+// `build/<name>-runtime.classpath`; every other combination (JVM lib,
+// native app, native lib) must not. A residual manifest from a previous
+// kind=app build is deleted so `assemble-dist.sh` never picks up a stale
+// classpath after a kind flip (design.md §Components → JVM app tail
+// branch, "stale manifest 削除"). File deletion is best-effort: a failure
+// here is diagnostic noise, not a build breaker, so the helper swallows it.
+internal fun handleRuntimeClasspathManifest(
+    config: KoltConfig,
+    resolvedJars: List<ResolvedJar>,
+): Result<Unit, ManifestWriteError> {
+    val shouldEmit = config.build.target == "jvm" && !config.isLibrary()
+    if (shouldEmit) {
+        return writeRuntimeClasspathManifest(config, resolvedJars)
+    }
+    val manifestPath = outputRuntimeClasspathPath(config)
+    if (fileExists(manifestPath)) deleteFile(manifestPath)
+    return Ok(Unit)
+}
+
 // Kind-gated plan for a native build (ADR 0014 two-stage × ADR 0023 §1).
 // `linkMain == null` ⇒ skip stage 2 (library), stage 1 klib is the artifact.
 // `linkMain != null` ⇒ run stage 2 (app link) with that entry-point FQN.
@@ -170,7 +190,8 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
     // below leaves cached=null for the next run (#50).
     if (fileExists(BUILD_STATE_FILE)) deleteFile(BUILD_STATE_FILE)
     val managedKotlincBin = ensureKotlincBin(config.kotlin.effectiveCompiler, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
-    val classpath = resolveDependencies(config).getOrElse { return Err(it) }.classpath
+    val resolutionOutcome = resolveDependencies(config).getOrElse { return Err(it) }
+    val classpath = resolutionOutcome.classpath
     val pluginJarPathsByAlias = resolveEnabledPluginJarPaths(config, paths, EXIT_BUILD_ERROR).getOrElse { eprintln("error: ${it.message}"); return Err(it.exitCode) }
     val pArgs = pluginJarPathsByAlias.values.map { "-Xplugin=$it" }
     val pluginJarsForDaemon = pluginJarPathsByAlias.mapValues { (_, path) -> listOf(path) }
@@ -236,6 +257,18 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
     val jarCmd = jarCommand(config, jarPath = managedJarBin)
     executeCommand(jarCmd.args).getOrElse { error ->
         eprintln("error: " + formatProcessError(error, "jar packaging"))
+        return Err(EXIT_BUILD_ERROR)
+    }
+
+    // ADR 0027 §1 / §4: JVM kind=app emits the runtime classpath manifest
+    // right after the jar step; every other kind/target combination
+    // (handled by the same helper) scrubs any stale manifest left by a
+    // previous kind=app build. Manifest write failure is treated as a
+    // build failure (ADR 0001: Err propagates, jar artifact is left on
+    // disk mirroring the existing jarCmd failure semantics).
+    handleRuntimeClasspathManifest(config, resolutionOutcome.resolvedJars).getOrElse { err ->
+        val failure = err as ManifestWriteError.WriteFailed
+        eprintln("error: could not write runtime classpath manifest at ${failure.path}: ${failure.reason}")
         return Err(EXIT_BUILD_ERROR)
     }
 
@@ -345,6 +378,14 @@ private fun doNativeBuild(config: KoltConfig, useDaemon: Boolean): Result<BuildR
         eprintln("error: $artifactPath not produced by konanc")
         return Err(EXIT_BUILD_ERROR)
     }
+
+    // ADR 0027 §4 stale cleanup: native builds never emit the manifest,
+    // but a prior `kind = "app" target = "jvm"` build in the same project
+    // directory would have left one behind. Drop it so `assemble-dist.sh`
+    // cannot pick up a mismatched artifact after a retarget. The helper
+    // takes the "cleanup" arm for every non-jvm-app config and only ever
+    // returns Ok, so discarding the Result here is safe by construction.
+    handleRuntimeClasspathManifest(config, emptyList())
 
     val newState = currentState.copy(classesDirMtime = fileMtime(artifactPath))
     writeFileAsString(BUILD_STATE_FILE, serializeBuildState(newState)).getOrElse {

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -96,7 +96,7 @@ internal fun doCheck(useDaemon: Boolean = true): Result<Unit, Int> {
     val paths = resolveKoltPaths().getOrElse { eprintln("error: $it"); return Err(EXIT_BUILD_ERROR) }
     val managedKotlincBin = ensureKotlincBin(config.kotlin.effectiveCompiler, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
 
-    val classpath = resolveDependencies(config).getOrElse { return Err(it) }
+    val classpath = resolveDependencies(config).getOrElse { return Err(it) }.classpath
     val pArgs = resolvePluginArgs(config, paths, EXIT_BUILD_ERROR).getOrElse { eprintln("error: ${it.message}"); return Err(it.exitCode) }
     val cmd = checkCommand(config, classpath, pArgs, kotlincPath = managedKotlincBin)
 
@@ -170,7 +170,7 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
     // below leaves cached=null for the next run (#50).
     if (fileExists(BUILD_STATE_FILE)) deleteFile(BUILD_STATE_FILE)
     val managedKotlincBin = ensureKotlincBin(config.kotlin.effectiveCompiler, paths).getOrElse { eprintln("error: ${it.message}"); return Err(EXIT_BUILD_ERROR) }
-    val classpath = resolveDependencies(config).getOrElse { return Err(it) }
+    val classpath = resolveDependencies(config).getOrElse { return Err(it) }.classpath
     val pluginJarPathsByAlias = resolveEnabledPluginJarPaths(config, paths, EXIT_BUILD_ERROR).getOrElse { eprintln("error: ${it.message}"); return Err(it.exitCode) }
     val pArgs = pluginJarPathsByAlias.values.map { "-Xplugin=$it" }
     val pluginJarsForDaemon = pluginJarPathsByAlias.mapValues { (_, path) -> listOf(path) }

--- a/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
+import kolt.build.ResolvedJar
 import kolt.build.generateKlsClasspath
 import kolt.build.generateWorkspaceJson
 import kolt.build.mergeAllDeps
@@ -16,6 +17,15 @@ private const val WORKSPACE_JSON = "workspace.json"
 private const val KLS_CLASSPATH = "kls-classpath"
 
 internal fun createResolverDeps(): ResolverDeps = defaultResolverDeps()
+
+// Carries both the joined classpath string (null = no deps, existing
+// semantics) and the underlying resolved jar list, so the JVM kind=app tail
+// in BuildCommands can emit the runtime classpath manifest (ADR 0027 §1)
+// without re-walking the resolver graph.
+internal data class JvmResolutionOutcome(
+    val classpath: String?,
+    val resolvedJars: List<ResolvedJar>
+)
 
 internal data class OverlappingDep(
     val groupArtifact: String,
@@ -33,7 +43,7 @@ internal fun findOverlappingDependencies(
         .map { OverlappingDep(it, mainDeps[it], testDeps[it]) }
 }
 
-internal fun resolveDependencies(config: KoltConfig): Result<String?, Int> {
+internal fun resolveDependencies(config: KoltConfig): Result<JvmResolutionOutcome, Int> {
     for (dep in findOverlappingDependencies(config.dependencies, config.testDependencies)) {
         eprintln("warning: '${dep.groupArtifact}' is in both [dependencies] (${dep.mainVersion}) and [test-dependencies] (${dep.testVersion}); using ${dep.mainVersion}")
     }
@@ -43,7 +53,7 @@ internal fun resolveDependencies(config: KoltConfig): Result<String?, Int> {
         if (fileExists(LOCK_FILE)) {
             deleteFile(LOCK_FILE)
         }
-        return Ok(null)
+        return Ok(JvmResolutionOutcome(classpath = null, resolvedJars = emptyList()))
     }
 
     val resolveConfig = config.copy(dependencies = allDeps)
@@ -88,8 +98,13 @@ internal fun resolveDependencies(config: KoltConfig): Result<String?, Int> {
         writeWorkspaceFiles(config, resolveResult.deps)
     }
 
-    val jarPaths = resolveResult.deps.map { it.cachePath }
-    return Ok(buildClasspath(jarPaths).ifEmpty { null })
+    val resolvedJars = resolveResult.deps.map { dep ->
+        ResolvedJar(cachePath = dep.cachePath, groupArtifactVersion = "${dep.groupArtifact}:${dep.version}")
+    }
+    return Ok(JvmResolutionOutcome(
+        classpath = buildClasspath(resolvedJars.map { it.cachePath }).ifEmpty { null },
+        resolvedJars = resolvedJars
+    ))
 }
 
 internal fun resolveNativeDependencies(config: KoltConfig, paths: KoltPaths): Result<List<String>, Int> {

--- a/src/nativeTest/kotlin/kolt/build/RuntimeClasspathManifestTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/RuntimeClasspathManifestTest.kt
@@ -1,0 +1,168 @@
+package kolt.build
+
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.fileExists
+import kolt.infra.readFileAsString
+import kolt.infra.removeDirectoryRecursive
+import kolt.testConfig
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.chdir
+import platform.posix.getcwd
+import platform.posix.mkdir
+import platform.posix.mkdtemp
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+@OptIn(ExperimentalForeignApi::class)
+class RuntimeClasspathManifestTest {
+
+    private var originalCwd: String = ""
+    private var tmpDir: String = ""
+
+    @BeforeTest
+    fun setUp() {
+        originalCwd = memScoped {
+            val buf = allocArray<ByteVar>(PATH_MAX)
+            getcwd(buf, PATH_MAX.toULong())?.toKString() ?: error("getcwd failed")
+        }
+        tmpDir = createTempDir("kolt-runtime-classpath-manifest-")
+        check(chdir(tmpDir) == 0) { "chdir to $tmpDir failed" }
+        // Ensure build dir exists for writeFileAsString.
+        check(mkdir(BUILD_DIR, 0b111111101u) == 0) { "mkdir $BUILD_DIR failed" }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        chdir(originalCwd)
+        if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
+            removeDirectoryRecursive(tmpDir)
+        }
+    }
+
+    @Test
+    fun outputRuntimeClasspathPathUsesBuildDirAndProjectName() {
+        assertEquals(
+            "build/my-app-runtime.classpath",
+            outputRuntimeClasspathPath(testConfig())
+        )
+        assertEquals(
+            "build/hello-world-runtime.classpath",
+            outputRuntimeClasspathPath(testConfig(name = "hello-world"))
+        )
+    }
+
+    @Test
+    fun writeRuntimeClasspathManifestSortsByFileNameAndExcludesSelfJar() {
+        val config = testConfig(name = "demo")
+        val jars = listOf(
+            ResolvedJar(
+                cachePath = "/cache/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.7.3/kotlinx-serialization-json-jvm-1.7.3.jar",
+                groupArtifactVersion = "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3"
+            ),
+            ResolvedJar(
+                cachePath = "/cache/com.akuleshov7/ktoml-core-jvm/0.7.1/ktoml-core-jvm-0.7.1.jar",
+                groupArtifactVersion = "com.akuleshov7:ktoml-core-jvm:0.7.1"
+            ),
+            ResolvedJar(
+                cachePath = "/cache/org.jetbrains/kotlin-stdlib/2.3.20/kotlin-stdlib-2.3.20.jar",
+                groupArtifactVersion = "org.jetbrains:kotlin-stdlib:2.3.20"
+            ),
+            // Self jar: must not appear in the manifest even if provided.
+            ResolvedJar(
+                cachePath = outputJarPath(config),
+                groupArtifactVersion = "self:${config.name}:${config.version}"
+            )
+        )
+
+        writeRuntimeClasspathManifest(config, jars).getOrElse { error("write failed: $it") }
+
+        val content = readFileAsString(outputRuntimeClasspathPath(config))
+            .getOrElse { error("read failed: $it") }
+        val lines = content.split('\n')
+        assertEquals(
+            listOf(
+                "/cache/org.jetbrains/kotlin-stdlib/2.3.20/kotlin-stdlib-2.3.20.jar",
+                "/cache/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.7.3/kotlinx-serialization-json-jvm-1.7.3.jar",
+                "/cache/com.akuleshov7/ktoml-core-jvm/0.7.1/ktoml-core-jvm-0.7.1.jar"
+            ),
+            lines
+        )
+    }
+
+    @Test
+    fun writeRuntimeClasspathManifestTieBreaksByGroupArtifactVersion() {
+        val config = testConfig(name = "tiebreak")
+        // Same file name ("shaded-1.0.0.jar") — tiebreak by GAV lexicographic.
+        val jars = listOf(
+            ResolvedJar(
+                cachePath = "/cache/z.example/shaded/1.0.0/shaded-1.0.0.jar",
+                groupArtifactVersion = "z.example:shaded:1.0.0"
+            ),
+            ResolvedJar(
+                cachePath = "/cache/a.example/shaded/1.0.0/shaded-1.0.0.jar",
+                groupArtifactVersion = "a.example:shaded:1.0.0"
+            )
+        )
+
+        writeRuntimeClasspathManifest(config, jars).getOrElse { error("write failed: $it") }
+
+        val content = readFileAsString(outputRuntimeClasspathPath(config))
+            .getOrElse { error("read failed: $it") }
+        val lines = content.split('\n')
+        assertEquals(
+            listOf(
+                "/cache/a.example/shaded/1.0.0/shaded-1.0.0.jar",
+                "/cache/z.example/shaded/1.0.0/shaded-1.0.0.jar"
+            ),
+            lines
+        )
+    }
+
+    @Test
+    fun writeRuntimeClasspathManifestUsesLfWithoutTrailingNewline() {
+        val config = testConfig(name = "fmt")
+        val jars = listOf(
+            ResolvedJar(
+                cachePath = "/cache/a/a/1/a-1.jar",
+                groupArtifactVersion = "a:a:1"
+            ),
+            ResolvedJar(
+                cachePath = "/cache/b/b/1/b-1.jar",
+                groupArtifactVersion = "b:b:1"
+            )
+        )
+
+        writeRuntimeClasspathManifest(config, jars).getOrElse { error("write failed: $it") }
+
+        val content = readFileAsString(outputRuntimeClasspathPath(config))
+            .getOrElse { error("read failed: $it") }
+        val bytes = content.encodeToByteArray()
+        val expected = "/cache/a/a/1/a-1.jar\n/cache/b/b/1/b-1.jar".encodeToByteArray()
+        assertEquals(expected.size, bytes.size)
+        for (i in expected.indices) {
+            assertEquals(expected[i], bytes[i], "byte mismatch at index $i")
+        }
+        // Explicit invariants: LF-only and no trailing newline.
+        assertFalse(content.contains('\r'), "manifest must not contain CR")
+        assertFalse(content.endsWith('\n'), "manifest must not end with a newline")
+    }
+
+    private fun createTempDir(prefix: String): String {
+        val template = "/tmp/${prefix}XXXXXX"
+        val buf = template.encodeToByteArray().copyOf(template.length + 1)
+        buf.usePinned { pinned ->
+            val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+            return result.toKString()
+        }
+    }
+}

--- a/src/nativeTest/kotlin/kolt/cli/DependencyResolutionTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DependencyResolutionTest.kt
@@ -1,7 +1,25 @@
 package kolt.cli
 
+import com.github.michaelbull.result.getOrElse
+import kolt.testConfig
+import kolt.infra.fileExists
+import kolt.infra.removeDirectoryRecursive
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.chdir
+import platform.posix.getcwd
+import platform.posix.mkdtemp
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class FindOverlappingDependenciesTest {
@@ -65,5 +83,55 @@ class FindOverlappingDependenciesTest {
         val result = findOverlappingDependencies(emptyMap(), emptyMap())
 
         assertTrue(result.isEmpty())
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+class ResolveDependenciesNoDepsTest {
+    private var originalCwd: String = ""
+    private var tmpDir: String = ""
+
+    @BeforeTest
+    fun setUp() {
+        originalCwd = memScoped {
+            val buf = allocArray<ByteVar>(PATH_MAX)
+            getcwd(buf, PATH_MAX.toULong())?.toKString() ?: error("getcwd failed")
+        }
+        tmpDir = createTempDir("kolt-resolve-deps-")
+        check(chdir(tmpDir) == 0) { "chdir to $tmpDir failed" }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        chdir(originalCwd)
+        if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
+            removeDirectoryRecursive(tmpDir)
+        }
+    }
+
+    @Test
+    fun emptyDepsReturnsOutcomeWithNullClasspathAndEmptyJars() {
+        // Use a native target so autoInjectedTestDeps stays empty — the
+        // JVM path auto-injects kotlin-test-junit5 and never reaches the
+        // empty-deps branch. doInstall exercises this branch for native.
+        val config = testConfig(
+            target = "linuxX64",
+            dependencies = emptyMap(),
+            testDependencies = emptyMap()
+        )
+
+        val outcome = resolveDependencies(config).getOrElse { error("resolveDependencies failed: exit=$it") }
+
+        assertNull(outcome.classpath)
+        assertTrue(outcome.resolvedJars.isEmpty())
+    }
+
+    private fun createTempDir(prefix: String): String {
+        val template = "/tmp/${prefix}XXXXXX"
+        val buf = template.encodeToByteArray().copyOf(template.length + 1)
+        buf.usePinned { pinned ->
+            val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+            return result.toKString()
+        }
     }
 }

--- a/src/nativeTest/kotlin/kolt/cli/JvmAppBuildTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/JvmAppBuildTest.kt
@@ -1,0 +1,262 @@
+package kolt.cli
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.build.BUILD_DIR
+import kolt.build.ResolvedJar
+import kolt.build.outputJarPath
+import kolt.build.outputRuntimeClasspathPath
+import kolt.config.ConfigError
+import kolt.config.parseConfig
+import kolt.infra.fileExists
+import kolt.infra.readFileAsString
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kolt.testConfig
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.chdir
+import platform.posix.getcwd
+import platform.posix.mkdir
+import platform.posix.mkdtemp
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration matrix for ADR 0027 §4 / Req 2.1 / 2.7: the JVM `kind = "app"`
+ * build path emits `build/<name>-runtime.classpath`; every other kind/target
+ * combination (JVM lib, native app, native lib) does not — and removes a
+ * stale manifest inherited from a previous `kind = "app"` build.
+ *
+ * The decision point is the pure helper `handleRuntimeClasspathManifest`,
+ * which `doBuild` / `doNativeBuild` invoke once per build after the artifact
+ * step. Exercising the helper directly with temp-dir fixtures captures the
+ * observable effects (file present / absent / removed) without requiring a
+ * live JDK + kotlinc; design.md §Testing Strategy §Integration maps these
+ * cases onto "manifest emit matrix" and "stale manifest cleanup on kind
+ * flip".
+ *
+ * Req 1.5 regression (`kind = "app"` without `main`) is pinned as a parser
+ * smoke: `parseConfig` must reject the malformed `kolt.toml` before any
+ * build machinery runs.
+ */
+@OptIn(ExperimentalForeignApi::class)
+class JvmAppBuildTest {
+
+    private var originalCwd: String = ""
+    private var tmpDir: String = ""
+
+    @BeforeTest
+    fun setUp() {
+        originalCwd = memScoped {
+            val buf = allocArray<ByteVar>(PATH_MAX)
+            getcwd(buf, PATH_MAX.toULong())?.toKString() ?: error("getcwd failed")
+        }
+        tmpDir = createTempDir("kolt-jvm-app-build-")
+        check(chdir(tmpDir) == 0) { "chdir to $tmpDir failed" }
+        check(mkdir(BUILD_DIR, 0b111111101u) == 0) { "mkdir $BUILD_DIR failed" }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        chdir(originalCwd)
+        if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
+            removeDirectoryRecursive(tmpDir)
+        }
+    }
+
+    // Req 2.1 / 2.6 / ADR 0027 §4 row 1: JVM kind=app emits the manifest
+    // with the resolved jar list (excluding self), alphabetical by file
+    // name. Observed via the pure decision helper driven from doBuild.
+    @Test
+    fun jvmAppEmitsManifestWithResolvedJars() {
+        val config = testConfig(name = "myapp", target = "jvm").copy(kind = "app")
+        val jars = listOf(
+            ResolvedJar(
+                cachePath = "/cache/org.jetbrains/kotlin-stdlib/2.3.20/kotlin-stdlib-2.3.20.jar",
+                groupArtifactVersion = "org.jetbrains:kotlin-stdlib:2.3.20"
+            ),
+            ResolvedJar(
+                cachePath = "/cache/com.akuleshov7/ktoml-core-jvm/0.7.1/ktoml-core-jvm-0.7.1.jar",
+                groupArtifactVersion = "com.akuleshov7:ktoml-core-jvm:0.7.1"
+            )
+        )
+
+        handleRuntimeClasspathManifest(config, jars).getOrElse { error("emit failed: $it") }
+
+        val manifestPath = outputRuntimeClasspathPath(config)
+        assertTrue(fileExists(manifestPath), "JVM kind=app must emit $manifestPath")
+        val content = readFileAsString(manifestPath).getOrElse { error("read failed: $it") }
+        // "kotlin-stdlib-2.3.20.jar" sorts before "ktoml-core-jvm-0.7.1.jar"
+        // by file name (lexicographic on the last path component).
+        assertEquals(
+            listOf(
+                "/cache/org.jetbrains/kotlin-stdlib/2.3.20/kotlin-stdlib-2.3.20.jar",
+                "/cache/com.akuleshov7/ktoml-core-jvm/0.7.1/ktoml-core-jvm-0.7.1.jar"
+            ),
+            content.split('\n'),
+            "manifest must list jars sorted by file name"
+        )
+    }
+
+    // Req 2.1 row 1 corner case: an empty resolver outcome still produces
+    // an empty manifest. The stitcher then iterates zero deps — a valid
+    // (if unusual) shape.
+    @Test
+    fun jvmAppWithNoDependenciesEmitsEmptyManifest() {
+        val config = testConfig(name = "noop", target = "jvm").copy(kind = "app")
+
+        handleRuntimeClasspathManifest(config, emptyList()).getOrElse { error("emit failed: $it") }
+
+        val manifestPath = outputRuntimeClasspathPath(config)
+        assertTrue(fileExists(manifestPath), "empty deps still emit a (zero-byte) manifest")
+        val content = readFileAsString(manifestPath).getOrElse { error("read failed: $it") }
+        assertEquals("", content, "no deps → empty content (no trailing newline)")
+    }
+
+    // Req 2.7 / ADR 0027 §4 row 2: JVM kind=lib must not emit the manifest.
+    // If a stale manifest from a previous kind=app build is sitting on
+    // disk, it must be removed so assemble-dist.sh does not pick it up.
+    @Test
+    fun jvmLibDoesNotEmitManifestAndRemovesStaleOne() {
+        val config = testConfig(name = "mylib", target = "jvm")
+            .let { it.copy(kind = "lib", build = it.build.copy(main = null)) }
+        val manifestPath = outputRuntimeClasspathPath(config)
+        // Seed a stale manifest as if a previous kind=app build ran here.
+        writeFileAsString(manifestPath, "/stale/a.jar\n/stale/b.jar")
+            .getError()?.let { error("seed failed: $it") }
+        assertTrue(fileExists(manifestPath), "precondition: seeded stale manifest must exist")
+
+        handleRuntimeClasspathManifest(config, emptyList()).getOrElse { error("cleanup failed: $it") }
+
+        assertFalse(fileExists(manifestPath), "JVM kind=lib must remove a stale manifest")
+    }
+
+    // Req 2.7 / ADR 0027 §4 rows 3 + 4: native targets (app and lib) never
+    // emit the manifest. Any stale file from a prior kind=app JVM build in
+    // the same build/ directory is removed.
+    @Test
+    fun nativeTargetNeverEmitsManifestAndRemovesStaleOne() {
+        val matrix = listOf(
+            testConfig(name = "nativeapp", target = "linuxX64").copy(kind = "app"),
+            testConfig(name = "nativelib", target = "linuxX64")
+                .let { it.copy(kind = "lib", build = it.build.copy(main = null)) },
+        )
+        for (config in matrix) {
+            val manifestPath = outputRuntimeClasspathPath(config)
+            writeFileAsString(manifestPath, "/stale/x.jar")
+                .getError()?.let { error("seed failed for ${config.name}: $it") }
+            assertTrue(fileExists(manifestPath), "precondition: seed must exist for ${config.name}")
+
+            handleRuntimeClasspathManifest(config, emptyList())
+                .getOrElse { error("cleanup failed for ${config.name}: $it") }
+
+            assertFalse(
+                fileExists(manifestPath),
+                "native target (${config.name}/${config.build.target}/${config.kind}) must remove stale manifest"
+            )
+        }
+    }
+
+    // Req 2.7 flip: running kind=app first writes the manifest; switching
+    // kolt.toml to kind=lib and rebuilding removes it. Pin the pair so a
+    // regression in the cleanup arm shows up even when the emit arm keeps
+    // working.
+    @Test
+    fun flippingKindFromAppToLibRemovesTheManifestOnRebuild() {
+        val appConfig = testConfig(name = "flip", target = "jvm").copy(kind = "app")
+        val jars = listOf(
+            ResolvedJar(
+                cachePath = "/cache/org.jetbrains/kotlin-stdlib/2.3.20/kotlin-stdlib-2.3.20.jar",
+                groupArtifactVersion = "org.jetbrains:kotlin-stdlib:2.3.20"
+            )
+        )
+        handleRuntimeClasspathManifest(appConfig, jars).getOrElse { error("emit failed: $it") }
+        val manifestPath = outputRuntimeClasspathPath(appConfig)
+        assertTrue(fileExists(manifestPath), "precondition: first build (app) must emit manifest")
+
+        val libConfig = appConfig.copy(kind = "lib", build = appConfig.build.copy(main = null))
+        handleRuntimeClasspathManifest(libConfig, emptyList())
+            .getOrElse { error("cleanup failed: $it") }
+
+        assertFalse(fileExists(manifestPath), "kind flip app→lib must remove the manifest")
+    }
+
+    // Req 2.3 defence-in-depth: even if the resolver accidentally surfaces
+    // the self jar (`build/<name>.jar`), the emit helper filters it out —
+    // the manifest must never list the project's own artifact.
+    @Test
+    fun selfJarIsExcludedFromEmittedManifest() {
+        val config = testConfig(name = "self-excl", target = "jvm").copy(kind = "app")
+        val jars = listOf(
+            ResolvedJar(
+                cachePath = "/cache/com.example/lib/1.0/lib-1.0.jar",
+                groupArtifactVersion = "com.example:lib:1.0"
+            ),
+            ResolvedJar(
+                cachePath = outputJarPath(config),
+                groupArtifactVersion = "self:${config.name}:${config.version}"
+            ),
+        )
+
+        handleRuntimeClasspathManifest(config, jars).getOrElse { error("emit failed: $it") }
+
+        val manifestPath = outputRuntimeClasspathPath(config)
+        val content = readFileAsString(manifestPath).getOrElse { error("read failed: $it") }
+        assertEquals(
+            listOf("/cache/com.example/lib/1.0/lib-1.0.jar"),
+            content.split('\n'),
+            "self jar must be filtered out of the manifest"
+        )
+    }
+
+    // Req 1.5: a schema-violating kolt.toml (`kind = "app"` without
+    // `[build] main`) is rejected by the parser before any build stage
+    // runs. The existing parser error (`APP_WITHOUT_MAIN_ERROR`) is the
+    // user-facing stop signal; no additional wiring is required from this
+    // task, but this test pins that the parser still refuses the shape
+    // at the config boundary — i.e. `doBuild`'s entry via
+    // `loadProjectConfig` cannot reach the manifest step.
+    @Test
+    fun parserRejectsAppKindWithoutMainBeforeBuildRuns() {
+        val malformed = """
+            name = "broken"
+            version = "0.1.0"
+            kind = "app"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            sources = ["src"]
+        """.trimIndent()
+
+        val error = assertIs<ConfigError.ParseFailed>(
+            assertNotNull(parseConfig(malformed).getError(), "parser must reject app without main")
+        )
+        assertContains(error.message, "[build] main is required for kind = \"app\"")
+    }
+
+    private fun createTempDir(prefix: String): String {
+        val template = "/tmp/${prefix}XXXXXX"
+        val buf = template.encodeToByteArray().copyOf(template.length + 1)
+        buf.usePinned { pinned ->
+            val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+            return result.toKString()
+        }
+    }
+}

--- a/src/nativeTest/kotlin/kolt/cli/KoltRunManifestIndependenceTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/KoltRunManifestIndependenceTest.kt
@@ -1,0 +1,200 @@
+package kolt.cli
+
+import com.github.michaelbull.result.getError
+import kolt.build.BUILD_DIR
+import kolt.build.outputRuntimeClasspathPath
+import kolt.build.runCommand
+import kolt.infra.deleteFile
+import kolt.infra.fileExists
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kolt.testConfig
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.chdir
+import platform.posix.getcwd
+import platform.posix.mkdir
+import platform.posix.mkdtemp
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Req 2.8 / ADR 0027 §5 regression: `kolt run` (JVM app path) must assemble
+ * the runtime classpath in-process from the resolver's return value and
+ * must not read `build/<name>-runtime.classpath`. The manifest is the
+ * hand-off to external launchers (assemble-dist.sh); the in-process
+ * consumer already has the resolver's typed output.
+ *
+ * The observable pin: the pure command builder `runCommand` — the single
+ * hop between `doRun` and the `java` subprocess — returns the same argv
+ * whether the manifest is absent, present with stale content, or present
+ * with mismatching content. Any regression that starts opening the
+ * manifest on the run path would change the output here.
+ *
+ * Exercising `runCommand` directly (instead of end-to-end `doRun`) keeps
+ * the test hermetic: no JDK, no fork, no subprocess. The coverage is
+ * equivalent because `doRun`'s JVM arm hands its `classpath` parameter
+ * straight into `runCommand` (BuildCommands.kt:532) — there is no other
+ * point on the run path where a manifest read could be hiding.
+ */
+@OptIn(ExperimentalForeignApi::class)
+class KoltRunManifestIndependenceTest {
+
+    private var originalCwd: String = ""
+    private var tmpDir: String = ""
+
+    @BeforeTest
+    fun setUp() {
+        originalCwd = memScoped {
+            val buf = allocArray<ByteVar>(PATH_MAX)
+            getcwd(buf, PATH_MAX.toULong())?.toKString() ?: error("getcwd failed")
+        }
+        tmpDir = createTempDir("kolt-run-manifest-indep-")
+        check(chdir(tmpDir) == 0) { "chdir to $tmpDir failed" }
+        check(mkdir(BUILD_DIR, 0b111111101u) == 0) { "mkdir $BUILD_DIR failed" }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        chdir(originalCwd)
+        if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
+            removeDirectoryRecursive(tmpDir)
+        }
+    }
+
+    // Req 2.8 / ADR 0027 §5: with the manifest absent, `runCommand` still
+    // assembles a well-formed `-cp` arg from its in-process `classpath`
+    // parameter. The manifest path is not referenced, not opened, and not
+    // materialised by the call.
+    @Test
+    fun runCommandSucceedsWhenManifestIsAbsent() {
+        val config = testConfig(name = "myapp", target = "jvm").copy(kind = "app")
+        val manifestPath = outputRuntimeClasspathPath(config)
+        assertFalse(
+            fileExists(manifestPath),
+            "precondition: no manifest should exist before runCommand is called",
+        )
+        val resolverClasspath = "/cache/org.jetbrains/kotlin-stdlib/2.3.20/kotlin-stdlib-2.3.20.jar"
+
+        val cmd = runCommand(
+            config,
+            main = "com.example.main",
+            classpath = resolverClasspath,
+        )
+
+        assertEquals(
+            listOf("java", "-cp", "build/classes:$resolverClasspath", "com.example.MainKt"),
+            cmd.args,
+            "runCommand must build -cp from the in-process classpath parameter, not the manifest file",
+        )
+        assertFalse(
+            cmd.args.any { it.contains(manifestPath) },
+            "runCommand argv must not reference the manifest path",
+        )
+        assertFalse(
+            fileExists(manifestPath),
+            "runCommand must not create or materialise the manifest file",
+        )
+    }
+
+    // Req 2.8: `kolt build` emits the manifest, `kolt run` never reads it.
+    // Deleting the manifest after `kolt build` leaves `runCommand` unchanged —
+    // the run path depends only on the in-process `classpath` string.
+    @Test
+    fun runCommandIsUnaffectedByDeletingThePostBuildManifest() {
+        val config = testConfig(name = "myapp", target = "jvm").copy(kind = "app")
+        val manifestPath = outputRuntimeClasspathPath(config)
+        val resolverClasspath =
+            "/cache/org.jetbrains/kotlin-stdlib/2.3.20/kotlin-stdlib-2.3.20.jar:" +
+                "/cache/com.akuleshov7/ktoml-core-jvm/0.7.1/ktoml-core-jvm-0.7.1.jar"
+
+        // Simulate the post-`kolt build` state, then delete the manifest as
+        // step (a) of the Req 2.8 procedure ("after `kolt build` remove
+        // `build/<name>-runtime.classpath`"). `kolt run` must still succeed.
+        writeFileAsString(manifestPath, "/cache/stale-but-never-read.jar")
+            .getError()?.let { error("seed failed: $it") }
+        assertTrue(fileExists(manifestPath), "precondition: seeded manifest must exist")
+
+        val withManifest = runCommand(
+            config,
+            main = "com.example.main",
+            classpath = resolverClasspath,
+        )
+
+        deleteFile(manifestPath)
+        assertFalse(fileExists(manifestPath), "precondition: manifest must be gone after delete")
+
+        val withoutManifest = runCommand(
+            config,
+            main = "com.example.main",
+            classpath = resolverClasspath,
+        )
+
+        assertEquals(
+            withManifest.args,
+            withoutManifest.args,
+            "runCommand output must be byte-for-byte identical regardless of manifest presence",
+        )
+        assertEquals(
+            listOf("java", "-cp", "build/classes:$resolverClasspath", "com.example.MainKt"),
+            withoutManifest.args,
+            "runCommand must assemble -cp from the in-process classpath, not from the (absent) manifest",
+        )
+    }
+
+    // Req 2.8 / ADR 0027 §5 defence-in-depth: if the manifest contains
+    // paths that disagree with the resolver's in-process output, `kolt run`
+    // uses the resolver value. A regression that started reading the
+    // manifest would surface here as the resolver string being replaced
+    // by the manifest's (wrong) contents.
+    @Test
+    fun runCommandIgnoresStaleManifestContentOnDisk() {
+        val config = testConfig(name = "myapp", target = "jvm").copy(kind = "app")
+        val manifestPath = outputRuntimeClasspathPath(config)
+        // Seed a manifest that disagrees with what the resolver returns in
+        // memory. If `runCommand` (or anything on the run path) opened the
+        // manifest, the `-cp` arg would include these stale entries.
+        val staleContent =
+            "/cache/STALE/wrong-1.jar\n" +
+                "/cache/STALE/wrong-2.jar"
+        writeFileAsString(manifestPath, staleContent)
+            .getError()?.let { error("seed failed: $it") }
+        val resolverClasspath =
+            "/cache/org.jetbrains/kotlin-stdlib/2.3.20/kotlin-stdlib-2.3.20.jar"
+
+        val cmd = runCommand(
+            config,
+            main = "com.example.main",
+            classpath = resolverClasspath,
+        )
+
+        assertEquals(
+            listOf("java", "-cp", "build/classes:$resolverClasspath", "com.example.MainKt"),
+            cmd.args,
+            "runCommand must use the resolver's in-process classpath, ignoring stale manifest content",
+        )
+        assertFalse(
+            cmd.args.any { it.contains("STALE") },
+            "runCommand argv must not carry any entry from the stale on-disk manifest",
+        )
+    }
+
+    private fun createTempDir(prefix: String): String {
+        val template = "/tmp/${prefix}XXXXXX"
+        val buf = template.encodeToByteArray().copyOf(template.length + 1)
+        buf.usePinned { pinned ->
+            val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+            return result.toKString()
+        }
+    }
+}


### PR DESCRIPTION
Closes #97.

## 何をしたか

ADR 0018 / 0025 / 0027 で pin 済みの 1 feature — JVM `kind = "app"` の runtime classpath manifest — を実装し、2 daemon の `kolt.toml` / `scripts/assemble-dist.sh` / self-host-post CI companion まで一気通貫で用意した。Kiro spec `daemon-self-host` の全 13 sub-task を 4 phase で landing。Gradle build (`shadowJar` 系) は本 PR 期間中は並走維持。

Phase ごとの粒度で commit を切っているので、レビューは phase 単位でたどれる。

- **Phase 1 (commits 596864c〜8a3cb09)** — `JvmResolutionOutcome` 導入、`Builder.kt` に `outputRuntimeClasspathPath` + `writeRuntimeClasspathManifest` 追加、JVM `kind = "app"` 経路で emit + stale cleanup、`kolt run` が manifest を読まないことの regression test、ADR 0027 §1 の helper 参照先訂正。
- **Phase 2 (f3f92f9 / f3d0a1b)** — `kolt-jvm-compiler-daemon/kolt.toml` (`:ic` を `sources` に merge) と `kolt-native-compiler-daemon/kolt.toml` を新規追加。
- **Phase 3 (0da0d4f〜663cbc9)** — `scripts/assemble-dist.sh` に (骨格 → `kotlin-build-tools-impl` を curl で取得 + SHA-256 pin → tarball layout + argfile + `tar czf`) を順次実装。
- **Phase 4 (a1ef8f4〜2da7307)** — `spike/daemon-self-host-smoke/` fixture、native job に upload-artifact、companion job `self-host-post` 追加。

## レビューで特に見てほしい箇所

**Task 1.2 `writeRuntimeClasspathManifest` の sort + tiebreak** — ADR 0027 §1 は file-name alphabetical が primary、同一 file name の場合に GAV で tiebreak する。`RuntimeClasspathManifestTest` が byte-level で LF / 末尾空行なし / self jar 除外まで pin しているが、sort key の優先順位とファイル書き込み順序が想定通りか (`Builder.kt` の該当箇所 + test 4 本) を確認してほしい。

**Task 1.3 の stale manifest cleanup** — `kolt.toml` の `kind` を `app → lib` に切り替えたときに過去の manifest が残らないよう JVM/native 両経路で削除している。`configMtime` 経由で cache 無効化が走るので結果的に cleanup が必ず効く、という依存関係 (BuildCache.kt) がやや非自明。reviewer verdict ではここが critical 関心だったので再確認ポイント。

**Task 2.x daemon `[dependencies]` の最小化** — Req 5.3 と ADR 0019 §3 の classloader isolation を守るため、daemon の `kolt.toml` には `kotlin-build-tools-impl` / fixture classpath 3 本 / `kotlin-native-compiler-embeddable` を **意図的に書いていない**。runtime resolver にこれらを乗せると isolation が崩れる。現状 daemon manifest に junit-jupiter / kotlin-test 等が transitive closure で混入している — これは `kotlin-build-tools-api` の POM に起因する resolver 挙動で本 PR 外の課題 (follow-up として resolver scope filtering を検討)。Phase 3 assemble-dist.sh はこれらを `libexec/<daemon>/deps/` に出荷する (tarball bloat の注意点)。

**Task 3.2 の SHA-256 pin** — `kotlin-build-tools-impl:2.3.20` とその transitive 9 jar を Maven Central から直接 curl で取得し、script 冒頭に pin した SHA-256 と照合する。pin 値は `./gradlew :kolt-jvm-compiler-daemon:stageBtaImplJars` が配置する jar を実測して転記した。値が Kotlin version 追従で更新が必要になる点は将来の bump タスクで触る。

**Task 3.3 の argfile placeholder 戦略** — argfile の classpath パスを絶対 path で焼き込まず `@KOLT_LIBEXEC@` placeholder を書く。`install.sh` (別トラック、未着地) または Task 4.3 companion job が extract 後に `sed -i` で実 libexec path に置換する、という契約。ADR 0018 §1 の「tarball is the unit of relocation」と整合する設計選択。ただし ADR 0027 §5 により `kolt.kexe` 自体は argfile を読まないので、argfile は現状 `install.sh` と `java @argfile` 経由の直接起動者向け。

**Phase 4 companion job の実 CI 初走** — `self-host-post` は local では YAML parse + 手元 reproduction までしか検証できず、実挙動はこの PR で初観測。失敗したら step 名で切り分けやすいよう fail-fast にしてある。

## スコープ外 (別 issue / 別 PR)

- `install.sh` / `curl | sh` 経路 / GitHub Release への tarball upload (ADR 0018 §4 first release cut 別トラック)
- `shadowJar` / `verifyShadowJar` / `stageBtaImplJars` の除去 — 本 PR では Gradle build を並走維持、段階的撤去は別 issue
- daemon 単体テストの kolt 移行 (`:ic` fixture classpath 3 本 / `BtaImplJarResolver` 経路)
- resolver の test-scope filtering (上記 Phase 2 の transitive 混入問題の根治)
- macOS / Windows 対応 (argfile separator は `:` 固定、linuxX64 only)

## Kiro spec

`.kiro/specs/daemon-self-host/` に requirements / design / research (gap 分析 + synthesis) / tasks を全部コミット済み。レビュー時に参照しやすい形にしてある。