### PR TITLE
Surface corrupted libexec on bundled BTA-impl miss (#234)

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonPreconditions.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltPaths
+import kolt.infra.isDirectory
 import kolt.infra.listJarFiles
 import kolt.resolve.compareVersions
 import kolt.resolve.defaultResolverDeps
@@ -79,6 +80,8 @@ internal fun resolveDaemonPreconditions(
   fetchBtaImplJars: (String, String) -> Result<List<String>, BtaImplFetchError> = { v, base ->
     ensureBtaImplJars(v, base, defaultResolverDeps())
   },
+  isDirectory: (String) -> Boolean = ::isDirectory,
+  warningSink: (String) -> Unit = {},
 ): Result<DaemonSetup, DaemonPreconditionError> {
   // Floor check first: cheaper than any disk probe and short-circuits
   // every variant the daemon cannot serve. Equal to or above 2.3.0
@@ -141,7 +144,25 @@ internal fun resolveDaemonPreconditions(
     if (kotlincVersion == bundledKotlinVersion) {
       when (val res = resolveBundledBtaImplJars()) {
         is BtaImplJarsResolution.Resolved -> res.jars
-        is BtaImplJarsResolution.NotFound -> null
+        is BtaImplJarsResolution.NotFound -> {
+          // When the probed libexec kolt-bta-impl dir's parent is a
+          // directory, the selfExe is sitting in an installed layout
+          // (`<prefix>/bin/kolt` + `<prefix>/libexec/`) whose -impl
+          // subdir is empty or missing. That is an install integrity
+          // regression — warn before silently falling through to the
+          // Maven fetcher. Dev binaries (no libexec sibling) stay
+          // silent because the heuristic fails.
+          parentDir(res.probedDir)?.let { parent ->
+            if (isDirectory(parent)) {
+              warningSink(
+                "warning: installed kolt libexec is missing ${res.probedDir} " +
+                  "— fetching kotlin-build-tools-impl from Maven Central instead. " +
+                  "Reinstall kolt to restore the bundled fast path."
+              )
+            }
+          }
+          null
+        }
       }
     } else null
 

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -870,15 +870,21 @@ internal fun resolveCompilerBackend(
   absProjectPath: String,
   bundledKotlinVersion: String = BUNDLED_DAEMON_KOTLIN_VERSION,
   pluginJars: Map<String, List<String>> = emptyMap(),
-  preconditionResolver:
-    (KoltPaths, String, String, String) -> Result<DaemonSetup, DaemonPreconditionError> =
-    { p, kotlincVersion, cwd, bundled ->
-      resolveDaemonPreconditions(p, kotlincVersion, cwd, bundled)
-    },
   daemonDirCreator: (String) -> Result<Unit, MkdirFailed> = ::ensureDirectoryRecursive,
   daemonBackendFactory: (DaemonSetup, Map<String, List<String>>) -> CompilerBackend =
     ::createDaemonBackend,
   warningSink: (String) -> Unit = ::eprintln,
+  preconditionResolver:
+    (KoltPaths, String, String, String) -> Result<DaemonSetup, DaemonPreconditionError> =
+    { p, kotlincVersion, cwd, bundled ->
+      resolveDaemonPreconditions(
+        paths = p,
+        kotlincVersion = kotlincVersion,
+        absProjectPath = cwd,
+        bundledKotlinVersion = bundled,
+        warningSink = warningSink,
+      )
+    },
 ): CompilerBackend {
   if (!useDaemon) return subprocessBackend
 

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
@@ -337,6 +337,7 @@ class DaemonPreconditionsTest {
     // would degrade to subprocess.
     val fetched = listOf("/cache/impl-bundled.jar")
     var fetchedVersion: String? = null
+    val warnings = mutableListOf<String>()
     val result =
       resolveDaemonPreconditions(
         paths = paths,
@@ -353,11 +354,56 @@ class DaemonPreconditionsTest {
           fetchedVersion = v
           Ok(fetched)
         },
+        isDirectory = { false },
+        warningSink = { warnings += it },
       )
 
     val setup = assertNotNull(result.get())
     assertEquals(fetched, setup.btaImplJars)
     assertEquals(bundledVersion, fetchedVersion)
+    assertEquals(
+      emptyList<String>(),
+      warnings,
+      "dev binary (no libexec sibling) should stay silent on bundled fall-through",
+    )
+  }
+
+  @Test
+  fun bundledBtaImplLibexecMissInInstalledLayoutWarnsBeforeFetching() {
+    // When the probed libexec/kolt-bta-impl's parent dir (the install
+    // layout's `libexec/`) exists, the miss points at a corrupted install
+    // rather than a dev binary. #234: emit a diagnostic so the silent
+    // Maven Central fetch does not mask the regression.
+    val fetched = listOf("/cache/impl-bundled.jar")
+    val warnings = mutableListOf<String>()
+    val result =
+      resolveDaemonPreconditions(
+        paths = paths,
+        kotlincVersion = bundledVersion,
+        absProjectPath = absProject,
+        bundledKotlinVersion = bundledVersion,
+        ensureJavaBin = { Ok("/fake/java") },
+        resolveDaemonJar = { okJar },
+        listCompilerJars = { fakeJars },
+        resolveBundledBtaImplJars = {
+          BtaImplJarsResolution.NotFound("/fake/libexec/kolt-bta-impl")
+        },
+        fetchBtaImplJars = { _, _ -> Ok(fetched) },
+        isDirectory = { path -> path == "/fake/libexec" },
+        warningSink = { warnings += it },
+      )
+
+    assertNotNull(result.get())
+    assertEquals(1, warnings.size, "expected one install-corruption warning: $warnings")
+    val warning = warnings.single()
+    assertTrue(
+      warning.contains("/fake/libexec/kolt-bta-impl"),
+      "warning should name the missing probed dir: $warning",
+    )
+    assertTrue(
+      warning.contains("Reinstall kolt") || warning.contains("Maven Central"),
+      "warning should guide the operator toward a fix: $warning",
+    )
   }
 
   @Test


### PR DESCRIPTION
Closes #234.

After #231 `DaemonPreconditions` silently fell through to the Maven Central fetcher on any bundled-version libexec miss, which hid the install-integrity signal for a corrupted installed kolt. ADR 0018 §1 treats the tarball as the atomic unit of relocation — a silent fetch undermines that invariant when the user sees it.

Split the dev-binary case (no libexec sibling, stay silent) from the installed-layout case (`<prefix>/libexec/` exists, `kolt-bta-impl/` is missing — warn and still fetch) via an injected `isDirectory` probe against the parent of the probed dir.

## Reviewer focus

- Heuristic: `isDirectory(parentDir(probedDir))` distinguishes installed layout from dev binary. For dev binaries the probedDir's parent is `<something>/libexec` which does not exist (dev binaries are not in a tarball install), so the warning stays silent. For installed layouts, the parent `libexec/` exists by construction. Edge cases worth considering: a user who has manually created `libexec/` without populating `kolt-bta-impl/` would trigger a false-positive warning. That is arguably correct — the layout looks broken.
- `resolveCompilerBackend` now threads `warningSink` through its default `preconditionResolver` lambda. The parameter list was reordered so the lambda can close over `warningSink`; all callers use named arguments so this is source-compatible.
- Test coverage adds both the silent-dev-binary case and the warning-on-installed-layout case. Existing tests are unaffected because `isDirectory` defaults to the real `infra.isDirectory` and their probed paths don't exist on disk.