### PR TITLE
ADR 0028: v1.0 release policy and RC window

### DIFF
--- a/docs/adr/0028-v1-release-policy.md
+++ b/docs/adr/0028-v1-release-policy.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-04-24
 ---
 

--- a/docs/adr/0028-v1-release-policy.md
+++ b/docs/adr/0028-v1-release-policy.md
@@ -68,8 +68,9 @@ informal decision that currently lives only in conversation.
   full criterion.
 - **Each new RC resets the full 14 days from its own publication
   timestamp.** A bug found on day 10 of `rc.1` ships as `rc.2` and
-  `rc.2` starts a fresh 14-day window. No partial carry-over,
-  regardless of how narrow the fix is.
+  `rc.2` starts a fresh 14-day window. Publishing `rc.(N+1)`
+  terminates `rc.N`'s clock; only the newest RC is live. No partial
+  carry-over, regardless of how narrow the fix is.
 - **Milestone re-opens invalidate the current RC.** If a new milestone
   issue is opened during an RC window, that RC is abandoned and no
   release is cut from it. The next publication is `rc.(N+1)` after
@@ -95,9 +96,10 @@ informal decision that currently lives only in conversation.
 ### §3 Post-v1 compatibility commitments
 
 - **kolt.toml schema.** Additive fields allowed in any minor; removed
-  or semantically-changed fields require a deprecation window of at
-  least one minor release, during which the old shape continues to
-  work and a stderr warning names the replacement.
+  or semantically-changed fields are minor after a deprecation
+  window of at least one released minor, during which the old shape
+  continues to work and a stderr warning names the replacement.
+  Never patch.
 - **Lockfile format** (`kolt.lock`). A new format is written on the
   next regenerate; the old format is read for one minor then rejected
   in the following minor. Users whose lockfiles have not regenerated
@@ -140,14 +142,16 @@ informal decision that currently lives only in conversation.
 - **Yanked tarballs stay reachable** at their original URLs so
   existing installs can still re-download. Yank is advisory, not
   destructive.
-- **Yank manifest.** The repo ships a top-level `YANKED` text file
-  (one `<version>    <replacement-version>    <reason>` tab-separated
-  line per yanked release). `install.sh` (#230) reads the manifest
-  from the HEAD of `main` at install time and refuses a yanked
-  version unless the user sets `KOLT_ALLOW_YANKED=1`. The manifest is
-  edited by the same PR that publishes the replacement; CI fails the
-  release workflow if a yanked version is about to be tagged without
-  its replacement landing first.
+- **Yank manifest.** The repo ships a top-level `YANKED` text file.
+  Each non-empty line is exactly three tab-separated fields —
+  `<version>\t<replacement-version>\t<reason>`; comments and blank
+  lines are not allowed (parser failure is a release-workflow error).
+  Order is newest yank last. `install.sh` (see #230) reads the
+  manifest from the HEAD of `main` at install time and refuses a
+  yanked version unless the user sets `KOLT_ALLOW_YANKED=1`. The
+  manifest is edited by the same PR that publishes the replacement;
+  CI fails the release workflow if a yanked version is about to be
+  tagged without its replacement landing first.
 
 ### Consequences
 
@@ -163,8 +167,9 @@ informal decision that currently lives only in conversation.
   milestone-clear; a bug on day 10 costs another 14 days. No workaround.
 - Every deprecation becomes a two-release commitment: a runtime
   warning in `1.N.0` and the removal code in `1.(N+1).0`. Wire-
-  protocol and on-disk-layout deprecations carry detection code that
-  survives the window and then gets deleted.
+  protocol and on-disk-layout deprecations carry detection code
+  (legacy `protocolVersion` branches, legacy `~/.kolt/` path probes)
+  that survives the window and then gets deleted.
 - Windows users get no v1 story.
 - `kolt init` / `kolt new` have a chicken-and-egg question — what
   kolt version does a generated `kolt.toml` pin — that this ADR does
@@ -177,8 +182,9 @@ informal decision that currently lives only in conversation.
   separate `v1.0` label on issues.
 - Release workflow (#230) enforces SemVer tag format via a pre-publish
   regex; a tag not matching
-  `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-rc\.[1-9]\d*)?$`
-  fails the job.
+  `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(rc|beta)\.[1-9]\d*)?$`
+  fails the job. The `-beta.N` arm is reserved for post-v1 experiments
+  per §2; pre-v1 tags never carry a pre-release suffix.
 - RC publication timestamp and any `regression-v1` tagged issues
   against that RC are the only inputs to "is this RC clean?". Tracked
   by maintainer memo, not automation. An RC with a `regression-v1`

--- a/docs/adr/0028-v1-release-policy.md
+++ b/docs/adr/0028-v1-release-policy.md
@@ -1,0 +1,199 @@
+---
+status: proposed
+date: 2026-04-24
+---
+
+# ADR 0028: v1.0 release policy and RC window
+
+## Summary
+
+- v1.0 cut-over is gated by the `v1.0` GitHub milestone reaching zero
+  open issues, followed by one or more `1.0.0-rc.N` pre-releases whose
+  observation periods pass clean (§1).
+- Version scheme is SemVer: current `0.x` line remains breaking-change
+  at will, `1.0.0-rc.N` freezes the breaking-change surface, `1.0.0`
+  commits to it (§2).
+- Post-v1, breaking changes require a deprecation window of at least
+  one minor release, with a release-notes call-out and a runtime warning
+  when the deprecated path is hit (§3).
+- v1.0 ships linuxX64 and macOS (`macosX64` / `macosArm64`) and
+  linuxArm64. Windows is out of scope for v1.0 and has no tracked issue;
+  a future ADR revisits after v1 lands (§4).
+- Yank policy: a shipped tag may be marked yanked on the GitHub Release
+  page, but the tarball stays reachable so existing installs do not
+  brick. Replacement is a new patch release, never an in-place retag
+  (§5).
+
+## Context and Problem Statement
+
+kolt has a `v1.0` milestone on GitHub that tracks the open issues which
+must close before v1.0 ships. The CLAUDE.md project memory already
+records "no backward compatibility until v1.0"; past that line, the
+project takes on the usual stable-release obligations. Three questions
+have been decided informally but are not written down:
+
+1. **What is the gate between milestone-clear and the v1.0 tag?** Simply
+   cutting `1.0.0` the moment the milestone empties leaves no
+   observation window for regressions. Existing practice is to run an
+   RC period first, but the duration, success criteria, and how RCs
+   are published are not recorded.
+2. **What does kolt commit to after v1.0?** SemVer is the obvious
+   choice, but the deprecation window length, the yank policy, and
+   whether patch releases can accept new `kolt.toml` schema fields
+   need an explicit line.
+3. **Which platforms does v1.0 support?** macOS and linuxArm64 have
+   issues (#82, #83); Windows is mentioned as out-of-scope in #84 but
+   nowhere authoritative. A reader looking for "does kolt 1.0 run on
+   Windows?" cannot answer from the repo today.
+
+ADR 0018 §4 covers release tarball packaging but is silent on when
+tarballs turn from "0.x continuous" into "release-candidate" into
+"stable".
+
+## Decision Drivers
+
+- **Concrete cut criteria.** A maintainer should be able to decide
+  "now is or is not the time to tag v1.0" from this ADR without asking.
+- **User visibility.** Whatever is committed to must be visible from
+  the GitHub Release page or the README, not buried in ADRs only
+  contributors read.
+- **Observation period that reflects real use.** An RC whose only
+  exercise is CI self-host-smoke is not a signal; real users must
+  install it.
+- **Reversibility.** A policy bug found post-v1 (e.g. yank mechanics)
+  must be fixable without a v2.0 cut.
+
+## Decision Outcome
+
+Chosen: the five-bullet Summary above, because each bullet closes an
+informal decision that currently lives only in conversation.
+
+### §1 Gate to v1.0
+
+- The `v1.0` GitHub milestone must reach zero open issues. Opening a new
+  issue into the milestone after the gate re-opens it.
+- After milestone-clear, the next release published is
+  `1.0.0-rc.1`, not `1.0.0`. The RC tag fires the same
+  `.github/workflows/release.yml` path as a stable tag (once #230 lands)
+  and produces `kolt-1.0.0-rc.1-<os>-<arch>.tar.gz` on the GitHub
+  Release page, marked as a pre-release.
+- Observation period for each RC: minimum 14 days of real-user
+  exposure with no bug report tagged `regression-v1`. A new RC (`-rc.2`,
+  etc.) resets the window only for the fix surface; an uneventful RC
+  that expires is promoted to `1.0.0` by re-tagging on the same commit
+  (i.e. `1.0.0` and `1.0.0-rc.N` point at the same SHA).
+- At least one RC is required. There is no upper bound; ship RCs until
+  an observation window closes clean.
+
+### §2 Version scheme
+
+- Pre-v1: the `0.x.y` line. Breaking changes land at will, with
+  release-note guidance per CLAUDE.md ("expect users to run
+  `rm -rf ~/.kolt/daemon/`" and similar). No deprecation window is
+  required in `0.x`.
+- RC line: `1.0.0-rc.N`, `N` starts at 1 and increments per RC. RCs are
+  always pre-releases on GitHub, never tagged `latest`.
+- Stable: `1.0.0`, then `1.0.y` for bug-fix-only patches and `1.x.0`
+  for additive features. `x` increments may relax compatibility where
+  §3 permits.
+- Pre-release tail is reserved for experiments (e.g. `1.1.0-beta.1`)
+  and does not fire the release workflow's `latest` tag.
+
+### §3 Post-v1 compatibility commitments
+
+- **kolt.toml schema.** Additive fields are allowed in any minor; removed
+  or semantically-changed fields require a deprecation window of at
+  least one minor release, during which the old shape continues to work
+  and a stderr warning names the replacement.
+- **CLI surface.** Same rule as kolt.toml. Adding a new command or flag
+  is minor; removing or re-meaning an existing command or flag is
+  minor after a deprecation window, never patch.
+- **On-disk layout** (`~/.kolt/`). Reorganisations require either a
+  one-time migration performed on first run or a deprecation window;
+  which path is taken is decided per-case in the ADR proposing the
+  move.
+- **Wire protocol.** The daemon protocol carries its own versioning
+  (existing `protocolVersion` field in the frame header, ADR 0016).
+  A protocol bump is allowed at a minor boundary if the native client
+  negotiates down. A hard break requires a major.
+- **Deprecation warnings** are emitted once per kolt invocation, gated
+  behind `KOLT_HIDE_DEPRECATION_WARNINGS=1` for CI / scripted use.
+
+### §4 Platform scope at v1.0
+
+- Supported targets in the first v1.0 cut: `linuxX64`, `linuxArm64`,
+  `macosX64`, `macosArm64`. These are the targets #82 and #83 unblock
+  plus the existing `linuxX64`.
+- Windows is **out of scope** for v1.0 and has no tracking issue. A
+  future ADR revisits after v1 ships; the decision is not "never",
+  it is "not required to call kolt stable on Linux and macOS".
+- Target addition post-v1.0 is a minor-release event. Removing a
+  supported target is a major.
+
+### §5 Yank policy
+
+- A shipped tag is never retagged on a different SHA. If a release is
+  found broken after publication, the fix ships as a new patch and the
+  bad release is marked yanked on its GitHub Release page with a
+  pointer to the replacement.
+- A yanked tarball stays reachable at its original URL so existing
+  installs can still re-download. The yank is advisory, not
+  destructive.
+- `install.sh` (see ADR 0018 §4, #230) pins the latest non-yanked
+  release by default. A user can explicitly install a yanked version
+  with `KOLT_VERSION=<yanked>` and accepts the breakage.
+
+### Consequences
+
+**Positive**
+- A reader can answer "what does kolt commit to post-v1?" from one
+  document.
+- The milestone acts as the single checklist; no parallel "v1 readiness"
+  bookkeeping is required.
+- Breaking changes post-v1 are visible to the user through a stderr
+  warning before the removal release lands.
+
+**Negative**
+- 14-day RC observation windows delay v1.0 by at least two weeks past
+  milestone-clear; no workaround.
+- Windows users get no v1 story. The trade-off accepts the scope
+  reduction to ship v1 on a predictable schedule.
+
+### Confirmation
+
+- The `v1.0` milestone on GitHub is the source of truth for the gate.
+  A new `v1.0` label on issues is redundant and not created.
+- Release workflow (#230) enforces SemVer tag format via a pre-publish
+  regex; a tag not matching `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-rc\.[1-9]\d*)?$`
+  fails the job.
+- RC observation period is tracked by maintainer memo, not automation.
+  An RC that ships with an open `regression-v1` issue older than its
+  cut time is by definition not clean and blocks the next RC or the
+  v1.0 cut.
+
+## Alternatives considered
+
+1. **Cut `1.0.0` the moment the milestone empties.** Rejected. Even a
+   perfect milestone cannot catch integration bugs that only surface
+   under real install-and-use flows; the RC window is a cheap safety
+   margin against "we forgot to test X on a fresh machine" regressions.
+2. **Indefinite beta (no v1.0 promise).** Rejected. "Pre-v1" is
+   already the status quo and the memory already records the cost
+   ("no back-compat until v1.0"). Staying pre-v1 indefinitely would
+   keep kolt unrecommendable for real projects, which is the entire
+   point of cutting v1.0.
+3. **CalVer (`YYYY.MM.N`).** Rejected. kolt's users consume its
+   breakage budget, not its release cadence; SemVer communicates the
+   breakage budget, CalVer does not.
+4. **Drop the 14-day RC floor and ship as soon as an RC is "looks
+   fine".** Rejected. Without an explicit floor the observation
+   period collapses to whoever is most eager to ship; a hard minimum
+   is the cheapest guard against this.
+
+## Related
+
+- #230 — `install.sh` + release workflow that RCs consume (ADR 0018 §4).
+- #84 — multi-platform binary distribution, unblocks §4.
+- ADR 0018 §4 — release tarball packaging (this ADR sits on top of it).
+- CLAUDE.md — "no backward compatibility until v1.0" is the contract
+  this ADR takes over once v1.0 ships.

--- a/docs/adr/0028-v1-release-policy.md
+++ b/docs/adr/0028-v1-release-policy.md
@@ -7,48 +7,32 @@ date: 2026-04-24
 
 ## Summary
 
-- v1.0 cut-over is gated by the `v1.0` GitHub milestone reaching zero
-  open issues, followed by one or more `1.0.0-rc.N` pre-releases whose
-  observation periods pass clean (§1).
-- Version scheme is SemVer: current `0.x` line remains breaking-change
-  at will, `1.0.0-rc.N` freezes the breaking-change surface, `1.0.0`
-  commits to it (§2).
-- Post-v1, breaking changes require a deprecation window of at least
-  one minor release, with a release-notes call-out and a runtime warning
-  when the deprecated path is hit (§3).
-- v1.0 ships linuxX64 and macOS (`macosX64` / `macosArm64`) and
-  linuxArm64. Windows is out of scope for v1.0 and has no tracked issue;
-  a future ADR revisits after v1 lands (§4).
-- Yank policy: a shipped tag may be marked yanked on the GitHub Release
-  page, but the tarball stays reachable so existing installs do not
-  brick. Replacement is a new patch release, never an in-place retag
-  (§5).
+- v1.0 is gated by the `v1.0` GitHub milestone reaching zero open
+  issues, then one or more `1.0.0-rc.N` pre-releases each observed for
+  at least 14 calendar days with no `regression-v1`-tagged issue
+  opened against them (§1).
+- SemVer; the 0.x line breaks at will until `rc.1` freezes the surface
+  (§2).
+- Post-v1 breaking changes require a deprecation window of at least
+  one minor release with a release-note call-out and a stderr warning
+  on hit (§3).
+- v1.0 ships `linuxX64`, `linuxArm64`, `macosX64`, `macosArm64`. All
+  four are required; a linuxX64-only v1.0 is not a valid cut. Windows
+  is out of scope, with no tracking issue, revisited post-v1 (§4).
+- Yank policy: shipped tags are immutable and their tarballs stay
+  reachable; yank status is declared in a `YANKED` manifest that
+  `install.sh` consults (§5).
 
 ## Context and Problem Statement
 
-kolt has a `v1.0` milestone on GitHub that tracks the open issues which
-must close before v1.0 ships. The CLAUDE.md project memory already
-records "no backward compatibility until v1.0"; past that line, the
-project takes on the usual stable-release obligations. Three questions
-have been decided informally but are not written down:
-
-1. **What is the gate between milestone-clear and the v1.0 tag?** Simply
-   cutting `1.0.0` the moment the milestone empties leaves no
-   observation window for regressions. Existing practice is to run an
-   RC period first, but the duration, success criteria, and how RCs
-   are published are not recorded.
-2. **What does kolt commit to after v1.0?** SemVer is the obvious
-   choice, but the deprecation window length, the yank policy, and
-   whether patch releases can accept new `kolt.toml` schema fields
-   need an explicit line.
-3. **Which platforms does v1.0 support?** macOS and linuxArm64 have
-   issues (#82, #83); Windows is mentioned as out-of-scope in #84 but
-   nowhere authoritative. A reader looking for "does kolt 1.0 run on
-   Windows?" cannot answer from the repo today.
-
-ADR 0018 §4 covers release tarball packaging but is silent on when
-tarballs turn from "0.x continuous" into "release-candidate" into
-"stable".
+kolt has a `v1.0` GitHub milestone that tracks the issues blocking v1.0.
+CLAUDE.md records "no backward compatibility until v1.0"; past that
+line, the project takes on stable-release obligations. Three informal
+decisions are not written down: the gate between milestone-clear and
+`v1.0`, the post-v1 compatibility commitments, and the target matrix
+for v1.0. ADR 0018 §4 covers release tarball packaging but is silent
+on when tarballs turn from "0.x continuous" into "release-candidate"
+into "stable".
 
 ## Decision Drivers
 
@@ -70,106 +54,138 @@ informal decision that currently lives only in conversation.
 
 ### §1 Gate to v1.0
 
-- The `v1.0` GitHub milestone must reach zero open issues. Opening a new
-  issue into the milestone after the gate re-opens it.
-- After milestone-clear, the next release published is
-  `1.0.0-rc.1`, not `1.0.0`. The RC tag fires the same
-  `.github/workflows/release.yml` path as a stable tag (once #230 lands)
-  and produces `kolt-1.0.0-rc.1-<os>-<arch>.tar.gz` on the GitHub
-  Release page, marked as a pre-release.
-- Observation period for each RC: minimum 14 days of real-user
-  exposure with no bug report tagged `regression-v1`. A new RC (`-rc.2`,
-  etc.) resets the window only for the fix surface; an uneventful RC
-  that expires is promoted to `1.0.0` by re-tagging on the same commit
-  (i.e. `1.0.0` and `1.0.0-rc.N` point at the same SHA).
-- At least one RC is required. There is no upper bound; ship RCs until
-  an observation window closes clean.
+- The `v1.0` GitHub milestone must reach zero open issues. A new issue
+  added to the milestone after it cleared re-opens the gate.
+- After milestone-clear, the next release is `1.0.0-rc.1`, not
+  `1.0.0`. The RC tag fires the release workflow (#230) and publishes
+  `kolt-1.0.0-rc.1-<os>-<arch>.tar.gz` on GitHub Releases marked
+  pre-release.
+- Observation window: **14 calendar days measured from the RC's
+  publication timestamp**. The window passes clean when no issue
+  tagged `regression-v1` has been opened against that RC during those
+  14 days. There is no separate "real user install confirmed" test —
+  the time floor plus the absence of a `regression-v1` issue is the
+  full criterion.
+- **Each new RC resets the full 14 days from its own publication
+  timestamp.** A bug found on day 10 of `rc.1` ships as `rc.2` and
+  `rc.2` starts a fresh 14-day window. No partial carry-over,
+  regardless of how narrow the fix is.
+- **Milestone re-opens invalidate the current RC.** If a new milestone
+  issue is opened during an RC window, that RC is abandoned and no
+  release is cut from it. The next publication is `rc.(N+1)` after
+  the milestone is cleared again.
+- **RC → v1.0 promotion.** When an RC passes clean, a new `v1.0.0`
+  tag is created at the same SHA as the final RC. The RC tag stays in
+  place; no tag is moved. The release workflow treats the new tag as
+  a stable publication and marks it `latest`.
+- At least one RC is required; no upper bound.
 
 ### §2 Version scheme
 
-- Pre-v1: the `0.x.y` line. Breaking changes land at will, with
-  release-note guidance per CLAUDE.md ("expect users to run
-  `rm -rf ~/.kolt/daemon/`" and similar). No deprecation window is
-  required in `0.x`.
-- RC line: `1.0.0-rc.N`, `N` starts at 1 and increments per RC. RCs are
-  always pre-releases on GitHub, never tagged `latest`.
-- Stable: `1.0.0`, then `1.0.y` for bug-fix-only patches and `1.x.0`
-  for additive features. `x` increments may relax compatibility where
-  §3 permits.
-- Pre-release tail is reserved for experiments (e.g. `1.1.0-beta.1`)
-  and does not fire the release workflow's `latest` tag.
+- Pre-v1: the `0.x.y` line. Breaking changes land at will, release-note
+  guidance per CLAUDE.md (e.g. "run `rm -rf ~/.kolt/daemon/`"). No
+  deprecation window is required in 0.x.
+- RC: `1.0.0-rc.N`, `N` starts at 1. RCs are GitHub pre-releases, never
+  tagged `latest`.
+- Stable: `1.0.y` for bug-fix-only patches, `1.x.0` for additive
+  features (and compatibility relaxation per §3).
+- Pre-release tail (`1.1.0-beta.1` etc.) is reserved for post-v1
+  experiments and does not fire `latest`.
 
 ### §3 Post-v1 compatibility commitments
 
-- **kolt.toml schema.** Additive fields are allowed in any minor; removed
+- **kolt.toml schema.** Additive fields allowed in any minor; removed
   or semantically-changed fields require a deprecation window of at
-  least one minor release, during which the old shape continues to work
-  and a stderr warning names the replacement.
-- **CLI surface.** Same rule as kolt.toml. Adding a new command or flag
-  is minor; removing or re-meaning an existing command or flag is
-  minor after a deprecation window, never patch.
-- **On-disk layout** (`~/.kolt/`). Reorganisations require either a
-  one-time migration performed on first run or a deprecation window;
-  which path is taken is decided per-case in the ADR proposing the
-  move.
-- **Wire protocol.** The daemon protocol carries its own versioning
-  (existing `protocolVersion` field in the frame header, ADR 0016).
-  A protocol bump is allowed at a minor boundary if the native client
-  negotiates down. A hard break requires a major.
-- **Deprecation warnings** are emitted once per kolt invocation, gated
-  behind `KOLT_HIDE_DEPRECATION_WARNINGS=1` for CI / scripted use.
+  least one minor release, during which the old shape continues to
+  work and a stderr warning names the replacement.
+- **Lockfile format** (`kolt.lock`). A new format is written on the
+  next regenerate; the old format is read for one minor then rejected
+  in the following minor. Users whose lockfiles have not regenerated
+  in a year see a clear "please run `kolt update`" error, not silent
+  corruption.
+- **CLI surface.** Same rule as kolt.toml. Adding a command or flag is
+  minor; removing or re-meaning an existing command or flag is minor
+  after a deprecation window, never patch.
+- **On-disk layout** (`~/.kolt/` and `build/`, including library
+  artifact layout per ADR 0025). Reorganisations require either a
+  one-time migration on first run or a deprecation window; the
+  proposing ADR picks which.
+- **Wire protocol.** The daemon protocol carries its own version
+  (existing `protocolVersion` in the frame header, ADR 0016). A bump
+  is allowed at a minor boundary if the native client negotiates down.
+  A hard break requires a major.
+- **Deprecation warnings** are emitted once per kolt invocation and
+  silenced by `KOLT_DEPRECATION_WARNINGS=off` (positive form; `on`
+  is the default).
 
 ### §4 Platform scope at v1.0
 
-- Supported targets in the first v1.0 cut: `linuxX64`, `linuxArm64`,
-  `macosX64`, `macosArm64`. These are the targets #82 and #83 unblock
-  plus the existing `linuxX64`.
-- Windows is **out of scope** for v1.0 and has no tracking issue. A
-  future ADR revisits after v1 ships; the decision is not "never",
-  it is "not required to call kolt stable on Linux and macOS".
+- **All four of `linuxX64`, `linuxArm64`, `macosX64`, `macosArm64`
+  must ship together.** A `linuxX64`-only v1.0 is not a valid cut;
+  if #82 or #83 slip, v1.0 slips. The `v1.0` milestone already holds
+  both issues, so this follows from §1 transitively, but the all-four
+  rule is called out to prevent a "ship what we have, chase the rest
+  as 1.1.0" shortcut.
+- **Windows is out of scope** for v1.0 and has no tracking issue.
+  Windows issues filed pre-v1 are closed with a pointer to this
+  section. The decision is not "never", it is "not required to call
+  kolt stable on Linux and macOS"; a future ADR revisits post-v1.
 - Target addition post-v1.0 is a minor-release event. Removing a
   supported target is a major.
 
 ### §5 Yank policy
 
-- A shipped tag is never retagged on a different SHA. If a release is
-  found broken after publication, the fix ships as a new patch and the
-  bad release is marked yanked on its GitHub Release page with a
-  pointer to the replacement.
-- A yanked tarball stays reachable at its original URL so existing
-  installs can still re-download. The yank is advisory, not
+- **Shipped tags are immutable.** A tag's SHA is never moved. If a
+  release is broken, the fix ships as a new patch.
+- **Yanked tarballs stay reachable** at their original URLs so
+  existing installs can still re-download. Yank is advisory, not
   destructive.
-- `install.sh` (see ADR 0018 §4, #230) pins the latest non-yanked
-  release by default. A user can explicitly install a yanked version
-  with `KOLT_VERSION=<yanked>` and accepts the breakage.
+- **Yank manifest.** The repo ships a top-level `YANKED` text file
+  (one `<version>    <replacement-version>    <reason>` tab-separated
+  line per yanked release). `install.sh` (#230) reads the manifest
+  from the HEAD of `main` at install time and refuses a yanked
+  version unless the user sets `KOLT_ALLOW_YANKED=1`. The manifest is
+  edited by the same PR that publishes the replacement; CI fails the
+  release workflow if a yanked version is about to be tagged without
+  its replacement landing first.
 
 ### Consequences
 
 **Positive**
-- A reader can answer "what does kolt commit to post-v1?" from one
-  document.
-- The milestone acts as the single checklist; no parallel "v1 readiness"
-  bookkeeping is required.
-- Breaking changes post-v1 are visible to the user through a stderr
-  warning before the removal release lands.
+- "What does kolt commit to post-v1?" has one authoritative answer.
+- The milestone is the single checklist; no parallel v1-readiness
+  bookkeeping.
+- Breaking changes are visible to the user via stderr warning before
+  the removal release.
 
 **Negative**
-- 14-day RC observation windows delay v1.0 by at least two weeks past
-  milestone-clear; no workaround.
-- Windows users get no v1 story. The trade-off accepts the scope
-  reduction to ship v1 on a predictable schedule.
+- The 14-day RC floor delays v1.0 by at least two weeks past
+  milestone-clear; a bug on day 10 costs another 14 days. No workaround.
+- Every deprecation becomes a two-release commitment: a runtime
+  warning in `1.N.0` and the removal code in `1.(N+1).0`. Wire-
+  protocol and on-disk-layout deprecations carry detection code that
+  survives the window and then gets deleted.
+- Windows users get no v1 story.
+- `kolt init` / `kolt new` have a chicken-and-egg question — what
+  kolt version does a generated `kolt.toml` pin — that this ADR does
+  not answer. Tracked as a follow-up under the `kolt new` feature
+  (#28).
 
 ### Confirmation
 
-- The `v1.0` milestone on GitHub is the source of truth for the gate.
-  A new `v1.0` label on issues is redundant and not created.
+- `v1.0` milestone on GitHub is the source of truth for the gate. No
+  separate `v1.0` label on issues.
 - Release workflow (#230) enforces SemVer tag format via a pre-publish
-  regex; a tag not matching `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-rc\.[1-9]\d*)?$`
+  regex; a tag not matching
+  `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-rc\.[1-9]\d*)?$`
   fails the job.
-- RC observation period is tracked by maintainer memo, not automation.
-  An RC that ships with an open `regression-v1` issue older than its
-  cut time is by definition not clean and blocks the next RC or the
-  v1.0 cut.
+- RC publication timestamp and any `regression-v1` tagged issues
+  against that RC are the only inputs to "is this RC clean?". Tracked
+  by maintainer memo, not automation. An RC with a `regression-v1`
+  issue opened after its publication timestamp is not clean and
+  blocks promotion.
+- Yank status is enforced by the `YANKED` manifest in repo HEAD;
+  `install.sh` parsing it is in scope for #230.
 
 ## Alternatives considered
 
@@ -177,11 +193,10 @@ informal decision that currently lives only in conversation.
    perfect milestone cannot catch integration bugs that only surface
    under real install-and-use flows; the RC window is a cheap safety
    margin against "we forgot to test X on a fresh machine" regressions.
-2. **Indefinite beta (no v1.0 promise).** Rejected. "Pre-v1" is
-   already the status quo and the memory already records the cost
-   ("no back-compat until v1.0"). Staying pre-v1 indefinitely would
-   keep kolt unrecommendable for real projects, which is the entire
-   point of cutting v1.0.
+2. **Indefinite beta (no v1.0 promise).** Rejected. Pre-v1 is the
+   status quo and the no-back-compat cost is already recorded; keeping
+   it indefinitely would leave kolt unrecommendable for real projects,
+   which is the entire point of cutting v1.0.
 3. **CalVer (`YYYY.MM.N`).** Rejected. kolt's users consume its
    breakage budget, not its release cadence; SemVer communicates the
    breakage budget, CalVer does not.
@@ -195,5 +210,6 @@ informal decision that currently lives only in conversation.
 - #230 — `install.sh` + release workflow that RCs consume (ADR 0018 §4).
 - #84 — multi-platform binary distribution, unblocks §4.
 - ADR 0018 §4 — release tarball packaging (this ADR sits on top of it).
-- CLAUDE.md — "no backward compatibility until v1.0" is the contract
-  this ADR takes over once v1.0 ships.
+- CLAUDE.md — the "no back-compat until v1.0" rule is the
+  contributor-facing side; this ADR is the user-facing counterpart
+  that activates when v1.0 ships.


### PR DESCRIPTION
Codify the informal v1.0 cut policy so "when does kolt 1.0 ship, and what does it commit to?" has one authoritative answer.

- v1.0 cut is gated by the `v1.0` milestone reaching zero open issues, followed by at least one `1.0.0-rc.N` pre-release with a 14-day observation window.
- SemVer; pre-v1 continues breaking at will, RC freezes the surface, v1.0 commits to it.
- Post-v1 breaking changes require a one-minor deprecation window with a stderr warning.
- linuxX64 + linuxArm64 + macOS for v1.0. Windows is out of scope and has no tracking issue; a future ADR revisits.
- Yank policy: never retag, always ship a new patch, mark the old Release page as yanked.

## Reviewer focus

- The 14-day RC floor is a guess more than a measurement. If the team's appetite is shorter (7 days) or longer (30 days), speak up now — this is the one knob that directly controls v1 slip.
- Windows-out-of-scope has live implications: no issue tracks it today and the ADR commits to "not required to call kolt stable". If anyone wants Windows in v1, say so before this lands.
- Platform list in §4 includes linuxArm64 + macOS, which depend on #82/#83 landing. The milestone already holds both; flagging for visibility.
- The deprecation window in §3 covers kolt.toml schema, CLI surface, on-disk layout, and wire protocol. Check each domain for missing cases (e.g. daemon IPC payload, lockfile format).