### PR TITLE
Foundation for main/test closure separation (Lockfile v3 + Origin + auto-inject skip)

### DIFF
--- a/.kiro/specs/main-test-closure-separation/design.md
+++ b/.kiro/specs/main-test-closure-separation/design.md
@@ -1,0 +1,487 @@
+# Design Document
+
+## Overview
+
+kolt JVM resolver が現在 `[dependencies]` / `[test-dependencies]` / 自動注入 `kotlin-test-junit5` を単一 closure に畳み込んでいるのを、main closure と test closure を別集合として解決するよう変更する。`ResolvedDep` に `Origin` を追加して 1 回の fixpoint で両 closure を同時に算出し、caller (build / run / test / manifest / workspace.json) は origin で filter する形に揃える。`.kolt.lock` は per-entry `test: Boolean` flag を v3 schema で保持する。
+
+**Purpose**: JVM `kind = "app"` の runtime classpath manifest (ADR 0027 §1) と `.kolt.lock` から test 専用依存を締め出し、配布成果物 (daemon self-host、`scripts/assemble-dist.sh`) を正しい shape に戻す。
+
+**Users**: JVM `kind = "app"` を配布する開発者 (kolt 自身の daemon self-host、および `[test-dependencies]` を使う user プロジェクト全般)、IDE (workspace.json 経由)、`.kolt.lock` を手で読むレビュアー。
+
+**Impact**: resolver 返り値の shape (+`Origin`)、lockfile schema (v2 → v3、`test: Boolean` 列追加)、`JvmResolutionOutcome` のフィールド構成、build/run/test 経路の classpath 構築コードが変わる。ADR 0027 §1 と ADR 0003 の schema 表に v3 行を追記する。
+
+### Goals
+- `.kolt.lock` / `build/<name>-runtime.classpath` / `kolt run` の classpath から test 起源の依存を除去する。
+- `kolt test` の classpath は main closure と test closure の和を従来通り渡す。
+- 変更後も resolver kernel の "direct wins / main wins on overlap / strict / rejects" の既存不変条件を保つ。
+- daemon self-host (`kolt-jvm-compiler-daemon`) の成果物 tarball が junit 系の jar を含まなくなる。
+
+### Non-Goals
+- POM `<scope>test</scope>` フィルタ機構 (`Resolution.isIncludedScope`、既存実装済) に手を入れない。
+- `provided` / `system` / `import` / `runtime` scope の細分対応は実装しない。将来導入時は schema v4 bump で対応。
+- Gradle Module Metadata の `usage=test` variant 区別は別 issue。
+- Kotlin/Native resolver (`resolveNative`) の動作は変えない (現状で `config.dependencies` のみ使用しており本問題の影響を受けない)。
+- 旧 lockfile (v1 / v2) の自動 migration は行わない。v1/v2 は unsupported として reject し、ユーザーに再解決を促す (pre-v1 方針)。
+
+## Boundary Commitments
+
+### This Spec Owns
+- `kolt.resolve.Resolution.fixpointResolve` の 2-seed API (`mainSeeds` / `testSeeds`) と、kernel 内での origin 伝播ルール。
+- `kolt.resolve.Resolver.ResolvedDep` / `kolt.resolve.Lockfile.LockEntry` の `test: Boolean` フィールド追加と、v3 schema の parse / serialize。
+- `kolt.cli.DependencyResolution.resolveDependencies` の 2 closure 返却と `JvmResolutionOutcome` の shape 変更。
+- `kolt.build.Builder.writeRuntimeClasspathManifest` / `kolt.cli.BuildCommands` (doBuild / doRun / doTest) / `kolt.build.Workspace` の origin-aware 経路更新。
+- ADR 0027 §1 と ADR 0003 §2 の文言補足。
+- `kolt.build.TestDeps.autoInjectedTestDeps` の適用条件 (test_sources 空かつ test-dependencies 空時は skip)。
+
+### Out of Boundary
+- POM scope filter (`isIncludedScope`) の拡張 (既存実装で AC 達成済)。
+- `kolt run` / `kolt test` の実行経路そのもの (classpath 入力のみ変わる、コマンド組み立て本体は触らない)。
+- `PluginJarFetcher` / `BtaImplFetcher` の解決経路 (本 lockfile とは別管理、origin 概念と無関係)。
+- `scripts/assemble-dist.sh` の改修 (passive consumer、manifest が変われば自動追従)。
+- v1 → v3 / v2 → v3 の migration 実装。
+
+### Allowed Dependencies
+- `kotlin-result` の `Result<V, E>` (ADR 0001)。
+- `kotlinx.serialization` (lockfile JSON、ADR 0003)。
+- 既存 `kolt.resolve` kernel (strict / rejects / exclusions / version intervals の相互作用)。
+- 既存 ADR 0027 §1 / §4 / §5 (manifest 契約)、ADR 0003 §2 (schema evolution パターン)。
+
+### Revalidation Triggers
+- `ResolvedDep` の新 `origin` フィールドを消費する caller が増えた場合 (現状 cli / build / workspace)。
+- `.kolt.lock` schema を v4 に進める変更 (origin 表現を `test: Boolean` から enum に変える等)。
+- `scripts/assemble-dist.sh` が manifest 以外の情報を読みたくなった場合 (例えば lockfile を直読みしたい)。
+- `kolt.toml` に `[runtime-dependencies]` 等の新セクションを追加する場合 (本 spec の 2-origin 前提が 3 以上に拡張される)。
+
+## Architecture
+
+### Existing Architecture Analysis
+
+- 依存方向は `cli → build → resolve / infra`、`kolt.resolve` は純粋 (ADR 0004)。本 spec は resolver kernel に origin 概念を 1 段加えるが、I/O は従来通り caller 側 (`kolt.cli.DependencyResolution` が adapter 経由で network/cache を渡す) に閉じる。
+- 既存の `LockEntry.transitive: Boolean = false` が v1 → v2 で `@SerialName` + default 付きで追加されたパターンを踏襲して `test: Boolean = false` を追加する。`parseLockfile` の `version !in 1..2` 判定を `!in 1..3` に置き換えるのではなく、pre-v1 方針に従って `1..3` にせず **v3 のみ受理** する (v1/v2 は unsupported で reject)。
+- 既存 `JvmResolutionOutcome(classpath, resolvedJars)` は「全依存の classpath」と「manifest 用 jar 一覧」を抱えていたが、本 spec 以降は「origin 付き jar 一覧」に集約し、classpath 文字列は caller が用途ごとに組み立てる。
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+  KoltToml[kolt.toml]
+  Config[KoltConfig]
+  TestDeps[TestDeps.autoInjectedTestDeps]
+  DepRes[DependencyResolution.resolveDependencies]
+  Kernel[Resolution.fixpointResolve main, test]
+  Transitive[TransitiveResolver.resolveTransitive]
+  ResolvedDeps[List ResolvedDep with origin]
+  Lockfile[.kolt.lock v3]
+  Outcome[JvmResolutionOutcome]
+  Manifest[writeRuntimeClasspathManifest main only]
+  RunCmd[doRun main classpath]
+  TestCmd[doTest main union test classpath]
+  Workspace[Workspace.generateWorkspaceJson split]
+
+  KoltToml --> Config
+  Config --> TestDeps
+  Config --> DepRes
+  TestDeps --> DepRes
+  DepRes --> Transitive
+  Transitive --> Kernel
+  Kernel --> ResolvedDeps
+  ResolvedDeps --> Lockfile
+  ResolvedDeps --> Outcome
+  Outcome --> Manifest
+  Outcome --> RunCmd
+  Outcome --> TestCmd
+  Outcome --> Workspace
+```
+
+**Key decisions**:
+- Kernel は main / test 両 seed を同時に BFS する (Option C)。external I/O (download / sha256) は 1 回。
+- `ResolvedDep.origin: Origin` (MAIN / TEST) で伝播し、caller は filter のみ担当 (3c)。
+- main / test 両 seed に同一 GA が現れた場合、main 版が採用され test 版は破棄 (main wins on overlap、R1 AC2、kernel 不変条件)。
+- 結果として **main closure と test closure は GA 上で disjoint**。caller 側の重複除去ロジックは不要。
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|-----|-----|-----|
+| Resolver kernel | Kotlin/Native (`kolt.resolve`) | 2-seed fixpoint + origin 付き解決 | ADR 0001 `Result<V, E>` 準拠、純粋 (ADR 0004) |
+| Lockfile | `kotlinx-serialization-json` 1.7.3 | v3 schema の read/write | `@SerialName` + default で v2 → v3 進化、v1/v2 は reject (ADR 0003) |
+| CLI orchestration | `kolt.cli`, `kolt.build` | `JvmResolutionOutcome` 再構成、doBuild/doRun/doTest/manifest の caller 側 filter | `BuildCommands.kt` L139-349 / L604-/L661-741 が touch 対象 |
+| IDE 出力 | workspace.json / kls-classpath | main / test module の dep 可視範囲を origin で分離 | `Workspace.kt` L13-109 (副次的修正、6a) |
+
+## File Structure Plan
+
+### Modified Files
+
+#### `kolt.resolve` — 解決 kernel と lockfile
+- `src/nativeMain/kotlin/kolt/resolve/Resolution.kt` — `fixpointResolve` に `testSeeds: Map<String, String> = emptyMap()` 引数を追加。BFS state に per-GA origin bitmap を持たせる。`pomChildLookup` はそのまま流用。
+- `src/nativeMain/kotlin/kolt/resolve/Resolver.kt` — `ResolvedDep` に `origin: Origin` 追加、`Origin` enum (MAIN, TEST) 新設。`resolve()` で Native ブランチは従来通り main-only で呼び、JVM ブランチは `config.dependencies` と test seeds を両方渡す。
+- `src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt` — `resolveTransitive` が test seeds を受け取り kernel へ中継、`materialize` で origin を `ResolvedDep` に転写。overlap は kernel で main に寄せ済みなので materialize 側は単純 1 回ループ。
+- `src/nativeMain/kotlin/kolt/resolve/Lockfile.kt` — `LockEntry(version, sha256, transitive = false, test = false)` に `test` を追加。`LockEntryJson` に `@SerialName("test") val test: Boolean = false`。`parseLockfile` は `version != 3` を unsupported として reject。serializer は `version = 3` を出す。
+
+#### `kolt.build` — 自動注入と manifest
+- `src/nativeMain/kotlin/kolt/build/TestDeps.kt` — `autoInjectedTestDeps(config)` を `config.build.testSources.isEmpty() && config.testDependencies.isEmpty()` なら空を返すよう条件追加。`mergeAllDeps` は本 spec 後は使用されないため削除。
+- `src/nativeMain/kotlin/kolt/build/Builder.kt` — `writeRuntimeClasspathManifest(config, resolvedJars)` に送る `resolvedJars` は caller 側で main filter 済み。本関数内部は変更なし。
+- `src/nativeMain/kotlin/kolt/build/Workspace.kt` — `generateWorkspaceJson` の引数を `mainDeps: List<ResolvedDep>` と `testDeps: List<ResolvedDep>` の 2 つに分け、`buildMainModule` は main のみ、`buildTestModule` は main + test を列挙。`generateKlsClasspath` は main + test を受け取り従来通り `:` 結合 (IDE 側は統合 classpath を期待)。
+
+#### `kolt.cli` — 呼び出し経路と test 経路
+- `src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt` — `resolveDependencies(config)` を 1 回の resolver 呼び出しで main / test 両 seed を渡すよう変更。`JvmResolutionOutcome` を `(mainClasspath, mainJars, allJars)` の 3 フィールドに再定義。`findOverlappingDependencies` の警告位置は据え置き。`writeWorkspaceFiles` は main と test の `ResolvedDep` を分離して `Workspace` に渡す。
+- `src/nativeMain/kotlin/kolt/cli/BuildCommands.kt` — `doBuild` の返す `BuildResult` に `classpath` が残るが意味を main-only に変える (L139, L243, L341, L349)。`doRun` (L604-) は `classpath` をそのまま `java` subproc へ (変更なし、意味だけ main に狭まる)。`doTest` (L661-741) の classpath 組立てを `mainJars + testJars` の和で再構築 (L709 compile + L723 run 両方)。`handleRuntimeClasspathManifest` (L41-52, L329) の入力を `mainJars` に変える。
+- `src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt` — `doTree` / `doInstall` の `mergeAllDeps` 利用箇所 (L254, L334) を main / test 別解決に置換、tree 表示は従来の「main → test」セクション分けを維持。
+
+#### Documentation
+- `docs/adr/0027-runtime-classpath-manifest.md` — §1 の "transitive closure, post-exclusion" を「main closure の transitive closure, post-exclusion」に狭める補足を追加。§4 kind 表にも main-only 注記。
+- `docs/adr/0003-toml-config-json-lockfile.md` — §2 の "Schema evolution (v1 → v2)" 節に v2 → v3 の行を追記、v1/v2 は unsupported で reject する旨を明示。
+
+#### Regenerated artifacts
+- `kolt-jvm-compiler-daemon/kolt.lock` — v3 で再生成 (regenerate は実装後の 1 コマンド、tracked 状態維持)。
+- `spike/daemon-self-host-smoke/kolt.lock` — 同上。
+
+### Created Files
+新規ファイルなし (既存モジュール内に origin enum と 2-seed API を追加するのみ)。
+
+## System Flows
+
+### 解決 → 消費者の origin 経由データフロー
+
+```mermaid
+sequenceDiagram
+  participant User as kolt CLI
+  participant DR as DependencyResolution
+  participant TR as TransitiveResolver
+  participant K as fixpointResolve
+  participant LF as Lockfile
+  participant BC as BuildCommands
+  participant MF as RuntimeClasspathManifest
+  participant WS as Workspace
+
+  User->>DR: resolveDependencies(config)
+  DR->>TR: resolveTransitive(main, test, deps, cache)
+  TR->>K: fixpointResolve(mainSeeds, testSeeds, lookup)
+  K-->>TR: nodes with origin
+  TR-->>DR: ResolvedDep list (origin tagged)
+  DR->>LF: writeLockfile v3
+  DR-->>User: JvmResolutionOutcome(mainClasspath, mainJars, allJars)
+  User->>BC: doBuild / doRun / doTest
+  BC->>MF: mainJars only (kind=app only)
+  BC->>WS: (mainDeps, testDeps) split
+```
+
+**Key decisions**:
+- kernel は 1 パス / materialize 1 回 (Option C)。overlap 解消は kernel 内で完結。
+- manifest と `kolt run` は `mainClasspath` / `mainJars` を使う。`doTest` は `allJars` を joinTo で string 化して compile / run に渡す。
+- workspace.json への入力だけ `(mainDeps, testDeps)` で渡し、IDE の main / test module の可視範囲を正しく絞る (副次修正、6a)。
+
+## Requirements Traceability
+
+| Req | Summary | Components | Interfaces | Flows |
+|-----|-----|-----|-----|-----|
+| 1.1 | main / test closure を別集合で算出 | `Resolution.fixpointResolve`, `TransitiveResolver.resolveTransitive` | 2-seed API | Sequence (kernel) |
+| 1.2 | main wins on overlap | `Resolution.fixpointResolve` | kernel state: `(version, direct, origin)` | kernel BFS 内処理 |
+| 1.3 | 衝突警告 | `DependencyResolution.findOverlappingDependencies` | 既存 | 変更なし |
+| 1.4 | test_sources/test-deps 空時 auto-inject skip | `TestDeps.autoInjectedTestDeps` | 条件追加 | 前段 filter |
+| 1.5 | Native は対象外 | `Resolver.resolve` Native branch | 2-seed signature は default empty で通過 | 既存動作 |
+| 2.1 | test-only エントリが `test: true` | `Lockfile.LockEntry`, `buildLockfileFromResolved` | `test: Boolean` 追加 | 永続化 |
+| 2.2 | main エントリが `test: false` | 同上 | 同上 | 同上 |
+| 2.3 | parse/serialize roundtrip で origin 保持 | `parseLockfile`, `serializeLockfile` | v3 schema | I/O |
+| 2.4 | 旧 schema reject | `parseLockfile` | `version != 3` → `UnsupportedVersion` | エラーパス |
+| 2.5 | 辞書順出力、origin は per-entry | `serializeLockfile` | `sortedBy { it.key }` 維持 | 永続化 |
+| 3.1 | manifest は main closure のみ ADR 0027 ルール | `BuildCommands.handleRuntimeClasspathManifest`, `Builder.writeRuntimeClasspathManifest` | `mainJars` を渡す | build tail |
+| 3.2 | test-only を manifest に含めない | 同上 | 同上 | 同上 |
+| 3.3 | lib/native は manifest 出さない | 既存 `handleRuntimeClasspathManifest` ガード | 変更なし | 既存 |
+| 3.4 | ADR 0027 §1 文言補足 | `docs/adr/0027-*.md` | doc change | — |
+| 4.1 | test classpath = main ∪ test | `BuildCommands.doTest` | `allJars` を compile/run に渡す | build tail |
+| 4.2 | 重複 GA は main 版 1 回のみ | kernel の disjoint 保証 | 既存不変条件 | 前段 kernel |
+| 4.3 | test_sources 空時 no-op | 既存 `doTest` 早期 return | 変更なし | 既存 |
+| 5.1 | run classpath は main のみ | `BuildCommands.doBuild`, `doRun` | `mainClasspath` を java へ | build tail |
+| 5.2 | manifest read-back 無し | 既存経路維持 | 変更なし (ADR 0027 §5) | 既存 |
+| 6.1 | daemon manifest に junit 系なし | 上記 + daemon kolt.toml の解決結果 | 統合検証 | build tail |
+| 6.2 | assemble-dist.sh 側で jar copy されない | passive consumer | manifest が狭まる副次効果 | 配布 |
+| 6.3 | daemon / spike lockfile 再生成 | 作業: `kolt deps install` | v3 schema で書き戻し | 実装後 |
+
+## Components and Interfaces
+
+### Summary
+
+| Component | Domain | Intent | Req Coverage | Key Dependencies | Contracts |
+|-----------|--------|--------|--------------|------------------|-----------|
+| fixpointResolve | resolve kernel | main/test 2-seed の同時 BFS | 1.1, 1.2, 4.2 | pomChildLookup (P0) | Service |
+| ResolvedDep + Origin | resolve data | 解決結果に origin を付ける | 1.1, 2.1, 2.2 | 上流 kernel (P0) | State |
+| Lockfile v3 | persistence | `test: Boolean` を per-entry 記録 | 2.1–2.5 | kotlinx.serialization (P0) | State |
+| TestDeps.autoInjectedTestDeps | build前処理 | 空条件で auto-inject skip | 1.4 | KoltConfig (P0) | Service |
+| DependencyResolution.resolveDependencies | cli orchestration | 2-seed を resolver に渡し `JvmResolutionOutcome` を返す | 1.1, 1.3, 3.1, 4.1, 5.1 | TransitiveResolver (P0), Lockfile (P0) | Service |
+| writeRuntimeClasspathManifest | build tail | caller から渡された main jar を ADR 0027 §1 で書き出す | 3.1–3.3 | Builder 既存 | Batch |
+| BuildCommands.doBuild/doRun/doTest | cli | main vs all classpath を用途別に組む | 3.1, 4.1, 5.1 | `JvmResolutionOutcome` (P0) | Service |
+| Workspace.generateWorkspaceJson | IDE 出力 | main / test module の dep 可視範囲を split | 副次 (6a) | ResolvedDep 列 (P1) | Batch |
+
+### kolt.resolve — Kernel
+
+#### fixpointResolve (2-seed)
+
+| Field | Detail |
+|-------|--------|
+| Intent | main seeds と test seeds を 1 パスで解決し origin 付き `DependencyNode` を返す |
+| Requirements | 1.1, 1.2, 1.5, 4.2 |
+
+**Responsibilities & Constraints**
+- main seed と test seed の両方から BFS を同時に進め、各 GA の最終 version と origin (MAIN / TEST) を確定する。
+- 同一 GA が main / test 両方から到達した場合は **main を勝者**とする (R1 AC2)。test-only GA のみ `origin = TEST`。
+- strict / rejects / exclusions / 版数比較の既存不変条件は変更なし。
+- Native から呼ばれるときは `testSeeds = emptyMap()` default で通過し、origin は全 MAIN。
+
+**Dependencies**
+- Inbound: `TransitiveResolver.resolveTransitive` (P0)
+- Outbound: `pomChildLookup` (P0)
+- External: なし
+
+**Contracts**: [x] Service  [ ] API  [ ] Event  [ ] Batch  [ ] State
+
+##### Service Interface
+
+```kotlin
+fun fixpointResolve(
+  mainSeeds: Map<String, String>,
+  testSeeds: Map<String, String> = emptyMap(),
+  childLookup: (groupArtifact: String, version: String) -> Result<List<Child>, ResolveError>,
+): Result<List<DependencyNode>, ResolveError>
+
+data class DependencyNode(
+  val groupArtifact: String,
+  val version: String,
+  val direct: Boolean,
+  val origin: Origin,
+)
+
+enum class Origin { MAIN, TEST }
+```
+
+- Preconditions: main/test seeds の各 `(GA, version)` は `parseCoordinate` で valid。
+- Postconditions: 返却 list の GA は unique (main ∪ test 和集合だが disjoint 後)。`origin == MAIN` は「main seed から到達可能な版」、`TEST` は「test seed のみから到達した版」。
+- Invariants: 同一 GA が main と test から同時に seed された場合、返却 list には main 版のみが残る (test 版は破棄)。
+
+**Implementation Notes**
+- BFS state の既存 `Map<String, Pair<String, Boolean>>` を `Map<String, Triple<String, Boolean, OriginSet>>` 相当に拡張する (data class で表現)。`OriginSet` は `(fromMain: Boolean, fromTest: Boolean)` の 2-bit bitmap。materialize 直前に `fromMain` が true なら `Origin.MAIN`、false かつ `fromTest` true なら `Origin.TEST`。
+- queue entry にも origin bitmap を持たせ、child 展開時に親 origin を継承する。
+- 既存 BFS の "direct wins" チェックはそのまま、main seed は direct=true、test seed も direct=true (どちらも user 宣言または kolt 自動注入の意図で入ってくる direct 扱い)。
+- Risks: 既存 strict / rejects 経路との相互作用は test 側の強制版数に影響する可能性あり。テストで kernel の ResolutionTest.kt に origin 軸ケースを追加する。
+
+### kolt.resolve — Data / Persistence
+
+#### ResolvedDep + Origin
+
+```kotlin
+data class ResolvedDep(
+  val groupArtifact: String,
+  val version: String,
+  val sha256: String,
+  val cachePath: String,
+  val transitive: Boolean = false,
+  val origin: Origin = Origin.MAIN,
+)
+```
+
+- `origin = MAIN` が default (Native の call 経路と後方互換のための安全値)。
+- JVM resolver は kernel の結果に応じて MAIN / TEST を書き込む。
+
+#### Lockfile v3 schema
+
+```kotlin
+data class LockEntry(
+  val version: String,
+  val sha256: String,
+  val transitive: Boolean = false,
+  val test: Boolean = false,
+)
+
+data class Lockfile(
+  val version: Int,           // 3
+  val kotlin: String,
+  val jvmTarget: String,
+  val dependencies: Map<String, LockEntry>,
+)
+```
+
+- `parseLockfile`: `parsed.version != 3` → `LockfileError.UnsupportedVersion(parsed.version)`。v1 / v2 を受けた場合もこれで reject される (pre-v1、5a)。
+- `serializeLockfile`: `version = 3` 固定、エントリは `group:artifact` 辞書順、各エントリに `test` フィールドを含める。default false のエントリは JSON 省略可 (kotlinx.serialization の `encodeDefaults = false` で小さく保つか、explicit に書くかは実装判断。既存 `transitive` と同じ方針に揃える)。
+
+**Example** (daemon 再生成後の想定):
+
+```json
+{
+  "version": 3,
+  "kotlin": "2.3.20",
+  "jvm_target": "21",
+  "dependencies": {
+    "org.jetbrains.kotlin:kotlin-build-tools-api": {
+      "version": "2.3.20",
+      "sha256": "..."
+    },
+    "org.jetbrains.kotlin:kotlin-test-junit5": {
+      "version": "2.3.20",
+      "sha256": "...",
+      "test": true
+    }
+  }
+}
+```
+
+### kolt.build — 前処理
+
+#### TestDeps.autoInjectedTestDeps
+
+```kotlin
+fun autoInjectedTestDeps(config: KoltConfig): Map<String, String> =
+  if (
+    config.build.target != "jvm" ||
+    (config.build.testSources.isEmpty() && config.testDependencies.isEmpty())
+  ) emptyMap()
+  else mapOf("org.jetbrains.kotlin:kotlin-test-junit5" to config.kotlin.version)
+```
+
+- `mergeAllDeps` は本 spec 後に呼び出し元がなくなるので削除。test tree 表示など現行 `mergeAllDeps` 利用箇所は「main / test を別 lookup して表示」に振替。
+
+### kolt.cli — Orchestration
+
+#### JvmResolutionOutcome (新 shape)
+
+```kotlin
+internal data class JvmResolutionOutcome(
+  val mainClasspath: String?,    // 依存ゼロなら null (既存セマンティクス維持)
+  val mainJars: List<ResolvedJar>,
+  val allJars: List<ResolvedJar>,  // main + test (disjoint、test 部分のみ mainJars と異なる)
+)
+```
+
+- `mainClasspath` は `mainJars.map { cachePath }.joinToString(":")` の再現。`allJars` から `allClasspath` を caller が必要時に組む。
+- 依存ゼロの既存挙動 (classpath = null、lockfile 削除) は `mainJars.isEmpty() && allJars.isEmpty()` で判定。
+
+#### DependencyResolution.resolveDependencies
+
+**Responsibilities & Constraints**
+- `config.dependencies` を main seeds、`autoInjectedTestDeps(config) + config.testDependencies` を test seeds として `resolve()` を 1 回呼ぶ。
+- 返却 `ResolvedDep` list を origin で分割し `JvmResolutionOutcome` に詰める。
+- Lockfile 書き出しは全エントリを `test` flag 付きで永続化。
+- `writeWorkspaceFiles` には `(mainJars, testJars)` を渡す。
+
+#### BuildCommands.doBuild / doRun / doTest / handleRuntimeClasspathManifest
+
+**Responsibilities & Constraints**
+- `doBuild` の `BuildResult.classpath` は main-only を保持 (既存の kotlinc compile 入力は main のみで正しい)。
+- `doRun(config, classpath, ...)` はそのまま受けた classpath (= main) を `java` に渡す。意味の変化のみ、コード shape 変化なし。
+- `doTest` は `doBuild` から直接 `allJars` を再取得できないので、`JvmResolutionOutcome` を `BuildResult` に持ち回るか、doTest 内で再解決を避ける経路にする (既存の `val (_, classpath, javaPath) = doBuild(...)` パターンの返り型を拡張)。
+- `handleRuntimeClasspathManifest` には `mainJars` を渡す。`writeRuntimeClasspathManifest` 関数本体は変更なし (filter は caller)。
+
+#### DependencyCommands.doTree / doInstall
+
+- `mergeAllDeps` を使っていた (`DependencyCommands.kt:254, 334`) 箇所は `autoInjectedTestDeps(config) + config.testDependencies` を test 側、`config.dependencies` を main 側として別 tree で描画 (既存の「test dependencies:」セクション分けを維持)。
+- `doInstall` は `resolveDependencies` 経由で統合。
+
+### kolt.build — Workspace
+
+#### generateWorkspaceJson (split)
+
+```kotlin
+fun generateWorkspaceJson(
+  config: KoltConfig,
+  mainDeps: List<ResolvedDep>,
+  testDeps: List<ResolvedDep>,
+): String
+```
+
+- `buildMainModule`: `mainDeps` のみを library 列挙。
+- `buildTestModule`: `mainDeps + testDeps` を列挙 (test ソースは main も見るため)。
+- `libraries` top-level: `mainDeps + testDeps` を列挙 (IDE が全 library を認識するため)。
+- `generateKlsClasspath(resolvedDeps)`: 引数は `mainDeps + testDeps` を caller 側で結合して渡す。
+
+## Data Models
+
+### Logical Data Model
+
+**Lockfile schema v3**:
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| version | Int | 3 | v1/v2 は unsupported |
+| kotlin | String | — | 既存 |
+| jvm_target | String | — | 既存 |
+| dependencies | Map<String, LockEntry> | — | key は `group:artifact`、辞書順 |
+| LockEntry.version | String | — | 既存 |
+| LockEntry.sha256 | String | — | 既存 |
+| LockEntry.transitive | Boolean | false | 既存 |
+| LockEntry.test | Boolean | false | 新規 |
+
+**Kernel state** (内部):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| versions | Map<GA, VersionedEntry> | VersionedEntry = (version: String, direct: Boolean, origin: OriginSet) |
+| OriginSet | data class | (fromMain: Boolean, fromTest: Boolean)、最終 materialize 時に `Origin.MAIN` / `Origin.TEST` に畳む |
+
+### Consistency & Integrity
+- resolver は `.kolt.lock` に書いた状態と sha256 一致を維持 (既存動作)。
+- `test` flag の truth は resolver 内 origin の決定で一意 (`fromMain = true` → test=false、それ以外 → test=true)。caller は flag を信頼して filter する。
+
+## Error Handling
+
+### Error Categories and Responses
+
+**旧 schema 検出** (R2 AC4): `parseLockfile` が `LockfileError.UnsupportedVersion(v)` を返す → CLI は stderr に
+```
+warning: unsupported lock file version <v>; run `kolt deps install` to regenerate
+```
+を出し、lockfile を無視して再解決する (既存 `resolveDependencies` の `parseLockfile` 失敗時 fallback 経路と同じ処理)。
+
+**衝突警告** (R1 AC3): `findOverlappingDependencies` が main/test に同 GA 異 version を検出 → 既存の stderr 警告を維持。main 側 version が採用される旨のメッセージ変更なし。
+
+**Resolver error** (既存): `ResolveError.*` は origin 軸で新規カテゴリを追加しない。strict/rejects/downloadFailed などは既存パスでそのまま。
+
+### Monitoring
+- 追加のメトリクスなし。lockfile schema version は `.kolt.lock` 内 `"version": 3` で直接確認可能。
+
+## Testing Strategy
+
+### Unit Tests (resolver kernel)
+- `ResolutionTest.kt`: main/test 両 seed で origin 付き結果が得られる (1.1)。
+- `ResolutionTest.kt`: main / test 両方に同一 GA が出たとき main 版が勝つ (1.2, 4.2)。
+- `ResolutionTest.kt`: test seed のみから到達した GA は origin=TEST (1.1)。
+- `ResolutionTest.kt`: 既存 strict / rejects / exclusions テストが 2-seed API でも回帰しない (kernel 不変条件)。
+
+### Unit Tests (lockfile)
+- `LockfileTest.kt`: v3 の parse / serialize roundtrip で `test: true` / `false` が保持される (2.1, 2.2, 2.3)。
+- `LockfileTest.kt`: v2 / v1 lockfile 入力に対し `LockfileError.UnsupportedVersion` が返る (2.4)。
+- `LockfileTest.kt`: 辞書順ソートと per-entry origin (2.5)。
+
+### Unit Tests (build)
+- `TestDepsTest.kt`: `test_sources` 空かつ `test-dependencies` 空で `autoInjectedTestDeps` が空 (1.4)。他条件での既存挙動維持。
+- `RuntimeClasspathManifestTest.kt`: `mainJars` のみ manifest に出る、test-only jar は除外される (3.1, 3.2)。JVM lib / Native では emit されない (3.3、既存継続)。
+- `WorkspaceTest.kt`: main module に testJars が現れない、test module に main と test の両方が現れる (副次 6a)。
+
+### Integration Tests
+- `JvmAppBuildTest.kt` (既存相当): JVM app build で `.kolt.lock` が v3 で出る、`build/<name>-runtime.classpath` に `kotlin-test-junit5` / `junit-jupiter-*` / `opentest4j` が含まれない (3.1, 3.2, 6.1)。
+- `DependencyResolutionTest.kt`: `findOverlappingDependencies` 既存警告が新 API でも保たれる (1.3)。
+- daemon self-host 経路 (existing CI `self-host-post` job): `kolt-jvm-compiler-daemon` を `kolt` 自身で build → manifest 内容を grep して junit 系ゼロを確認 (6.1, 6.2)。
+
+### E2E / Manual Verification
+- `kolt-jvm-compiler-daemon/kolt.lock` を実装後に `kolt deps install` で regenerate し、diff で v3 schema と `test: true` フィールドを確認 (6.3)。
+- `spike/daemon-self-host-smoke/kolt.lock` 同上。
+- `scripts/assemble-dist.sh` をローカルで走らせて `libexec/kolt-jvm-compiler-daemon/deps/` に junit 系 jar が入っていないことを確認 (6.2)。
+
+### 回帰対象
+- 既存 `TransitiveResolverTest.scopeFilteringSkipsTestAndProvided` は POM scope filter の責務なので維持、挙動変化なし。
+- `LockfileTest.kt` の v1 / v2 parse ケースは `UnsupportedVersion` を期待するケースに書き換え (5a)。
+- `DependencyResolutionTest.kt` / `RunLibraryRejectionTest.kt` / `BuildLibraryTest.kt` 等で `JvmResolutionOutcome` の shape を参照しているテストは新フィールドに追従。
+
+## Migration Strategy
+
+ADR 0003 / CLAUDE.md の pre-v1 方針に従い、**lockfile migration shim は実装しない**。
+
+1. 実装 merge と同時に `kolt-jvm-compiler-daemon/kolt.lock` と `spike/daemon-self-host-smoke/kolt.lock` を v3 で regenerate し同 PR でコミット。
+2. リリースノートに「`.kolt.lock` は v3 に進みました。既存プロジェクトは `kolt deps install` で再生成してください。」を書く。
+3. v1 / v2 を検出した kolt は `warning: unsupported lock file version N` を stderr に出し、lockfile を無視して再解決する。再解決結果は v3 で書き戻され、以降は通常動作。
+
+## Supporting References
+
+- 背景調査 (現行コード位置、選択肢比較、効果推定) は `research.md` を参照。
+- ADR 0027 §1 / §4 / §5: runtime manifest の契約。本 spec で §1 / §4 を補足する。
+- ADR 0003 §2: lockfile schema evolution 手順。v2 → v3 もこのパターンに従う。
+- ADR 0025 §3: JVM lib artifact shape (本 spec からは読むだけ、変更なし)。
+- Issue #229: original 問題記述 (本 spec 作成時に資料の診断を訂正して再投稿済み)。

--- a/.kiro/specs/main-test-closure-separation/requirements.md
+++ b/.kiro/specs/main-test-closure-separation/requirements.md
@@ -1,0 +1,79 @@
+# Requirements Document
+
+## Introduction
+
+kolt の JVM 依存 resolver は `[dependencies]` と `[test-dependencies]`、および JVM で自動注入される `kotlin-test-junit5` を単一の closure に畳み込んで resolve する。結果、test 由来の依存 (junit-jupiter 系 / junit-platform 系 / opentest4j / apiguardian-api 等) が `.kolt.lock` と `build/<name>-runtime.classpath` (ADR 0027 §1) に main 依存として記録され、JVM `kind = "app"` の配布成果物 (`scripts/assemble-dist.sh` が `libexec/<daemon>/deps/` に copy する jar 群) が bloat する。同じ挙動は user プロジェクトが `[test-dependencies]` を宣言した時点で再現する。
+
+本 spec は main 依存 closure と test 依存 closure を resolver 出力の段階で分離し、runtime classpath manifest と JVM 実行時 classpath は main closure のみを含み、`kolt test` の classpath は従来通り main ∪ test を含むという契約を確立する。併せて `.kolt.lock` は origin (main / test) を区別できる表現を持ち、ADR 0027 §1 の "transitive closure, post-exclusion" 文言は非test closure に限定する旨を補足する。
+
+## Boundary Context
+
+- **In scope**: JVM target (`kind = "app"` / `kind = "lib"`) の resolver 出力 / lockfile / runtime classpath manifest / `kolt run` / `kolt test` classpath。`kolt.build.TestDeps`、`kolt.cli.DependencyResolution`、`kolt.resolve.Lockfile` (schema)、`kolt.build.Builder.writeRuntimeClasspathManifest`、ADR 0027 §1。
+- **Out of scope**: POM `<scope>test</scope>` フィルタ (`Resolution.isIncludedScope` で実装済、`TransitiveResolverTest.scopeFilteringSkipsTestAndProvided` に回帰テストあり)、`provided` / `system` / `import` scope の細分対応、Gradle Module Metadata の `usage=test` variant 区別 (別 issue)、Kotlin/Native target の依存解決 (現行で `config.dependencies` のみを解決し、本問題の影響を受けない)。
+- **Adjacent expectations**: `scripts/assemble-dist.sh` は runtime manifest のエントリをそのまま `libexec/<daemon>/deps/` に copy する passive consumer であり、本 spec が manifest を非test closure に絞る副作用として tarball が縮む。ADR 0027 §1 の文言は実装に合わせて更新する。pre-v1 の "no backward compatibility" 方針 (CLAUDE.md) に従い、lockfile schema は clean break で bump し移行 shim は設けない。
+
+## Requirements
+
+### Requirement 1: Main / Test closure を resolver 出力で分離する
+
+**Objective:** kolt を使う JVM 開発者として、resolver の解決結果で main 由来依存と test 由来依存が別物として扱われることを望む。runtime classpath には test 依存が載らず、test 実行時には必要な test 依存が揃うという配布成果物と開発ワークフロー双方の期待が成り立つからである。
+
+#### Acceptance Criteria
+
+1. When JVM target で `kolt build` / `kolt run` / `kolt test` / `kolt deps install` のいずれかを実行した時、the resolver shall `config.dependencies` を root とする main closure と `config.testDependencies` + 自動注入された `kotlin-test-junit5` を root とする test closure をそれぞれ別集合として算出する。
+2. When 同一の `group:artifact` が main closure と test closure の両方に現れた時、the resolver shall main closure の version を採用し、test closure 側の同じエントリは main closure のものとして扱う (現行の "main wins on overlap" 挙動の保持)。
+3. If `[dependencies]` と `[test-dependencies]` に同じ `group:artifact` が異なる version で宣言された時、then the kolt CLI shall 現行どおり警告を stderr に出力し main version を採用する。
+4. When JVM target で `config.build.testSources` が空かつ `config.testDependencies` が空だった時、the resolver shall test closure を空集合として算出し (`kotlin-test-junit5` の自動注入を skip する)、main closure の結果には影響を与えない。
+5. The resolver shall Kotlin/Native target では main closure のみを解決し、本分離契約の対象外として現行動作を維持する。
+
+### Requirement 2: Lockfile が main / test origin を区別できる
+
+**Objective:** `.kolt.lock` を参照するツールと人間として、各エントリが main 由来か test 由来かを `.kolt.lock` 単体から判別できる表現を望む。配布成果物のレビュー、ローカル監査、CI の差分チェックが一ファイルで成り立つからである。
+
+#### Acceptance Criteria
+
+1. When resolver が test closure のみに属するエントリを lockfile に書き出す時、the lockfile writer shall そのエントリが test 由来である事実を `.kolt.lock` 上で識別可能な形で記録する。
+2. When resolver が main closure に属するエントリ (main のみ、あるいは main と test の両方で同じ version) を lockfile に書き出す時、the lockfile writer shall そのエントリが main 由来である事実を `.kolt.lock` 上で識別可能な形で記録する。
+3. When `.kolt.lock` を再読込した時、the lockfile parser shall 各エントリの origin (main / test) を復元でき、再書き出ししても origin 情報が失われない。
+4. If kolt が本 spec 以前の schema version で書かれた `.kolt.lock` を読んだ時、then the kolt CLI shall clean break 方針 (pre-v1) に従って unsupported version を stderr に報告し、ユーザーに `kolt deps install` による再生成を促す。
+5. The lockfile serializer shall 全エントリを `group:artifact` の辞書順で出力し、origin 情報は per-entry で保持する (main / test を別セクションに分割しない)。
+
+### Requirement 3: Runtime classpath manifest は main closure のみを含む
+
+**Objective:** JVM `kind = "app"` 成果物を配布する開発者として、`build/<name>-runtime.classpath` が実行時に必要な main closure だけを列挙することを望む。`scripts/assemble-dist.sh` が tarball に入れる jar から test 専用依存が除外され、配布物が意図通りの構成になるからである。
+
+#### Acceptance Criteria
+
+1. When JVM target `kind = "app"` の build が成功した時、the Builder shall `build/<name>-runtime.classpath` に main closure のエントリのみを ADR 0027 §1 のルール (ファイル名の辞書順、同名時は GAV で tiebreak、絶対パス、UTF-8 LF、末尾改行なし) で書き出す。
+2. When `kotlin-test-junit5` や `[test-dependencies]` 由来のエントリが test closure にのみ存在した時、the Builder shall それらを `build/<name>-runtime.classpath` に含めない。
+3. The Builder shall JVM `kind = "lib"` / Kotlin/Native target では現行通り `build/<name>-runtime.classpath` を emit しない。
+4. The ADR 0027 §1 shall "transitive closure, post-exclusion" の定義を main closure (非test closure) に限定する旨の補足文言を含む。
+
+### Requirement 4: `kolt test` の classpath は main ∪ test を維持する
+
+**Objective:** `kolt test` を使う開発者として、test コンパイルと test 実行に必要な依存 (`kotlin-test-junit5` + `[test-dependencies]` + その transitive + main 依存) が従来どおりすべて揃うことを望む。既存の test ワークフローが本分離によって退行しない保証が要るからである。
+
+#### Acceptance Criteria
+
+1. When JVM target で `kolt test` を実行した時、the kolt CLI shall main closure と test closure の和集合を test コンパイル / 実行用 classpath に渡す。
+2. When 同じ `group:artifact` が main と test の両方に解決された時、the kolt CLI shall main closure の version で一度だけ classpath に載せ、重複エントリを生まない。
+3. When `config.build.testSources` が空だった時、the kolt CLI shall 現行挙動どおり `kolt test` を no-op として扱い、test closure の解決・配置を skip する。
+
+### Requirement 5: `kolt run` / JVM in-process 実行は main closure のみを使う
+
+**Objective:** `kolt run` や JVM `kind = "app"` を直接実行する立場として、development 時起動と配布成果物起動が同じ main closure だけで成り立つことを望む。両者で挙動が一致し、test 依存が production 実行経路に紛れ込まないからである。
+
+#### Acceptance Criteria
+
+1. When JVM target `kind = "app"` で `kolt run` を実行した時、the kolt CLI shall main closure のみを `java` サブプロセスの classpath として渡し、test 由来依存を含めない。
+2. The kolt CLI shall `kolt run` 時に `build/<name>-runtime.classpath` manifest を read-back せず、ADR 0027 §5 の asymmetry を保持する。
+
+### Requirement 6: 配布成果物と daemon self-host の再検証
+
+**Objective:** kolt 自身の保守担当として、`kolt-jvm-compiler-daemon` と `kolt-native-compiler-daemon` が本分離契約の下で正しく起動する配布成果物を生成することを望む。v1.0 milestone で self-host を崩さないことが前提だからである。
+
+#### Acceptance Criteria
+
+1. When `kolt-jvm-compiler-daemon` に対して `kolt build` が成功した時、the daemon runtime classpath manifest shall `org.junit.jupiter:*` / `org.junit.platform:*` / `org.opentest4j:opentest4j` / `org.apiguardian:apiguardian-api` / `org.jetbrains.kotlin:kotlin-test` / `org.jetbrains.kotlin:kotlin-test-junit5` のいずれをも含まない。
+2. When `scripts/assemble-dist.sh` が本契約下で生成された manifest を読んだ時、the assemble-dist.sh shall `libexec/kolt-jvm-compiler-daemon/deps/` に test 由来の jar を copy しない。
+3. When `kolt-jvm-compiler-daemon/kolt.lock` と `spike/daemon-self-host-smoke/kolt.lock` が本契約下で再生成された時、the lockfiles shall 新 schema で書き出され、tracked 状態を維持する。

--- a/.kiro/specs/main-test-closure-separation/research.md
+++ b/.kiro/specs/main-test-closure-separation/research.md
@@ -1,0 +1,191 @@
+# Gap Analysis: main-test-closure-separation
+
+## 1. Current State Investigation
+
+### Domain-related assets
+
+- **`kolt.build.TestDeps`** (`src/nativeMain/kotlin/kolt/build/TestDeps.kt`)
+  - `autoInjectedTestDeps(config)` — JVM 時に無条件で `kotlin-test-junit5` を返す。`test_sources` / `[test-dependencies]` の有無を見ない。
+  - `mergeAllDeps(config)` — `auto < main < test` 優先順で単一 `Map<String, String>` に畳み込み。
+- **`kolt.cli.DependencyResolution`** (`src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt`)
+  - `resolveDependencies(config)` — `mergeAllDeps` の結果を `config.copy(dependencies = allDeps)` として resolver に渡す (L53, L61)。
+  - `findOverlappingDependencies` — main/test 版数ズレの警告 (L36-44, 既存動作、保持要)。
+  - `JvmResolutionOutcome(classpath, resolvedJars)` — 単一 classpath と `ResolvedJar` リストを返す (L25-28)。
+- **`kolt.resolve.Resolver`**
+  - `resolve(config, existingLock, cacheBase, deps)` — Native / JVM で分岐 (L111-118)。
+  - `ResolvedDep(groupArtifact, version, sha256, cachePath, transitive)` — origin 属性なし (L72-77)。
+  - `ResolveResult(deps, lockChanged)` (L80)。
+- **`kolt.resolve.TransitiveResolver`**
+  - `resolveTransitive(config, existingLock, cacheBase, deps)` — `resolveGraph(config.dependencies, pomLookup)` 経由 (L11-41)。
+  - `materialize()` — 解決済 node を `ResolvedDep` に詰めて download / sha256 確認 (L160-236)。
+- **`kolt.resolve.Resolution`**
+  - `fixpointResolve(directDeps, childLookup)` — 単一 directDeps Map を受ける BFS fixpoint (L52-74)。
+  - `pomChildLookup` — test scope フィルタは既に `isIncludedScope` で適用済 (L248-251、AC 的に動作済)。
+- **`kolt.resolve.Lockfile`**
+  - `LockEntry(version, sha256, transitive = false)` (L17)。
+  - `Lockfile(version, kotlin, jvmTarget, dependencies: Map<String, LockEntry>)` (L20-25)。
+  - `parseLockfile` は `version !in 1..2` を拒否 (L56)。`transitive` は v1 でも `@SerialName` default で互換。
+- **`kolt.build.Builder`**
+  - `writeRuntimeClasspathManifest(config, resolvedJars)` — 全 `ResolvedJar` を ADR 0027 §1 ルールで書き出し (L38-53)。
+  - 呼び出しは `BuildCommands.handleRuntimeClasspathManifest` (`BuildCommands.kt` L41-52) で JVM `kind = "app"` にのみ発火。
+- **`kolt.cli.BuildCommands`**
+  - `doBuild` — `resolveDependencies` → `BuildResult(config, classpath, javaPath)` (L139-349、manifest 発火は L329)。
+  - `doRun(config, classpath, ...)` — build で得た classpath を `java` subproc に渡す (L604-)。
+  - `doTest(config, ...)` — `doBuild` を L672 で再利用し、返ってきた単一 `classpath` で test コンパイル (L709) と test run (L723) の両方を駆動 (L661-741)。
+- **`kolt.build.Workspace`**
+  - `generateWorkspaceJson(config, resolvedDeps)` — main module と test module の両方に全 `resolvedDeps` を流し込んでいる (L32-109)。本 spec 下では main module を main closure のみ、test module を main ∪ test にするのが自然。
+  - `generateKlsClasspath` は単純に `resolvedDeps.joinToString(":")`。
+- **ADR 0027 §1 / §4 / §5** — `docs/adr/0027-runtime-classpath-manifest.md`。manifest は "transitive closure, post-exclusion"、JVM `kind = "app"` のみ emit、`kolt run` は manifest を read-back しない asymmetry。
+- **ADR 0003 §2 / §5** — `docs/adr/0003-toml-config-json-lockfile.md`。lockfile schema 進化は `@SerialName` + nullable/default + version ディスクリミネータ、v1 → v2 bump の前例あり。
+- **ADR 0025 §3** — JVM lib artifact shape (本 spec からは読むだけ、書き換え不要)。
+
+### Conventions / 依存方向
+
+- `cli → build → resolve / infra` の一方向 (steering `structure.md`)。resolver API を変える場合、cli / build の呼び出し側はすべて追従対象。
+- `kotlin-result 2.x` の value class 制約 (`getOrElse` / `isErr`、`is Ok` 禁止、auto memory)。
+- Pre-v1 の "no backward compatibility"。lockfile schema は clean break で v3 に上げてよい。
+
+### 既存テスト (回帰 contract を pin しているもの)
+
+- `src/nativeTest/kotlin/kolt/build/TestDepsTest.kt` — `mergeAllDeps` / `autoInjectedTestDeps` の現行契約。
+- `src/nativeTest/kotlin/kolt/resolve/LockfileTest.kt` — v1 / v2 parse / serialize、version 受理範囲。
+- `src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt` — scope フィルタ (`scopeFilteringSkipsTestAndProvided` 他)、transitive、exclusions。
+- `src/nativeTest/kotlin/kolt/cli/DependencyResolutionTest.kt` — `findOverlappingDependencies`、`resolveDependencies` no-deps。
+- `src/nativeTest/kotlin/kolt/build/RuntimeClasspathManifestTest.kt` — manifest 書き出し (ADR 0027 §1 ルール)。
+- `src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt` — workspace.json 構造。
+- `src/nativeTest/kotlin/kolt/cli/JvmAppBuildTest.kt` / `RunLibraryRejectionTest.kt` / `BuildLibraryTest.kt` / `DoInitTest.kt` — kind=app / lib の end-to-end 挙動。
+
+### Integration surfaces
+
+- **IDE (workspace.json / kls-classpath)**: main / test で dep 可視範囲を分けるのが本来の IDE 契約。現行は両 module に同じ list が入っており、本 spec でむしろ IDE 側の挙動も改善する。
+- **`scripts/assemble-dist.sh`**: `build/<daemon>-runtime.classpath` を入力として `libexec/<daemon>/deps/*.jar` を生成する passive consumer。manifest 側が main closure のみになれば自動追従。
+- **`.kolt.lock`**: 手で読む開発者、レビュアー、CI 差分チェック。v3 bump は stderr + `kolt deps install` による再生成を要求するだけで済む (pre-v1 方針)。
+
+---
+
+## 2. Requirements Feasibility Analysis
+
+### Technical needs per requirement
+
+| Req | 技術ニーズ | 既存 asset | 状態 |
+|-----|--------|--------|--------|
+| **R1** main / test closure 分離 | resolver へ 2 入力を渡す API、または 1 入力で origin タグ付き出力 | `resolveDependencies`, `resolveTransitive`, `fixpointResolve` すべて単一 Map 前提 | **Missing** (API signature 拡張) |
+| **R1 AC4** test_sources 空 skip | `autoInjectedTestDeps` 内の条件分岐 | 現行は無条件 inject | **Missing** (条件追加) |
+| **R1 AC5** Native 対象外 | `resolveNative` が既に `config.dependencies` のみ使用 | `NativeResolver.kt` 既存 | **Partial** (既に別経路、API 変更に追従するだけ) |
+| **R2** Lockfile origin フィールド | `LockEntry`, `LockEntryJson`, `parseLockfile`, `serializeLockfile`、schema version | `transitive` 追加の前例 (v1→v2) | **Missing** (v3 schema + parser 拡張) |
+| **R2 AC4** 旧 schema 拒否 | `parseLockfile` の `version !in 1..2` 判定 | 既存 | **Partial** (範囲拡張 + メッセージ文言追加) |
+| **R3** runtime manifest main-only | `writeRuntimeClasspathManifest` の入力フィルタ、`JvmResolutionOutcome.resolvedJars` の意味付け | manifest ルール (alphabetical, GAV tiebreak) は既存 | **Missing** (main closure のみ渡す経路) |
+| **R3 AC4** ADR 0027 §1 文言補足 | `docs/adr/0027-runtime-classpath-manifest.md` | 既存 ADR | **Missing** (文言追加) |
+| **R4** test classpath = main ∪ test | `doTest` で classpath を構成 | 現行は単一 merged classpath を使い回し | **Partial** (union merge logic 追加) |
+| **R4 AC3** test_sources 空時 no-op | 既存 `doTest` の early return 経路 | `BuildCommands.kt:677-680` | **Existing** (維持のみ) |
+| **R5** kolt run main-only | `JvmResolutionOutcome.classpath` の意味を main-only に再定義 | 現行は merged | **Partial** (build 経路で main-only を返す) |
+| **R5 AC2** manifest read-back しない asymmetry | ADR 0027 §5 確立済、既存コードで守られている | 既存 | **Existing** (保持のみ) |
+| **R6** daemon self-host 再検証 | `kolt-jvm-compiler-daemon/kolt.lock` / `spike/daemon-self-host-smoke/kolt.lock` の regen、`assemble-dist.sh` smoke | 既存 self-host-post CI | **Operational** (実装後に再生成) |
+
+### Complexity signals
+
+- **Algorithmic**: 2 closure 計算と overlap dedup (R1 AC2)。既存 `fixpointResolve` は直接 dep のみ "main wins" を保証しているので、2 入力版では「main 選択が test 選択より優先」ルールの表現を要設計。
+- **Schema evolution**: lockfile v3 bump。前例 (v1 → v2) で確立されたパターンをそのまま踏襲可能。
+- **Integration**: cli → build → resolve への signature change が下流 (manifest / run / test / workspace) すべてに伝搬。touch 箇所多いが、各々の変更は局所的。
+
+### Research Needed (design 時に詰める項目)
+
+- **R-1**: `fixpointResolve` を 2 入力 API に拡張するか、結果に `origin` タグを持たせる単一 API か。前者は BFS 実装を 2 度走らせるか、同時に走らせるか選択。後者は main-seeded entry のキャッシュが test-seeded entry に影響しないよう state の分離を要設計。
+- **R-2**: `LockEntry` に `origin: String` を直書きするか、`test: Boolean = false` フラグで書くか (既存 `transitive: Boolean` と対称)。ADR 0003 の「`@SerialName` + default で互換」とどちらが整合するか。
+- **R-3**: `kolt test` 実行時 classpath の merge ルール (R1 AC2 の "main wins on overlap" を test classpath 構築側でも守る)。重複 jar path の除去キーは GA か `cachePath` か。
+- **R-4**: `JvmResolutionOutcome` を `mainClasspath` / `testClasspath` / `mainJars` / `testJars` の 4 フィールドに拡張するか、`ResolvedDep.origin` を外出しにして単一 list で返すか。
+- **R-5**: v2 lockfile を検出したとき、unsupported version エラー (R2 AC4) か、main-origin として silently 読めるか。後者は clean break 原則に反するが、CI 互換で議論余地あり。
+
+---
+
+## 3. Implementation Approach Options
+
+### Option A: `ResolvedDep.origin` タグ付きの単一 resolver パス
+
+- **概要**: `ResolvedDep` に `origin: Origin` (MAIN / TEST) を追加し、resolver は `config.dependencies` と `config.testDependencies` + `autoInjectedTestDeps` を同じパスで走らせつつ、main seed から到達した node は MAIN、test seed のみから到達した node は TEST とタグ付けして返す。`materialize` は一度だけ走る。呼び出し側は origin で filter する。
+- **整合**: `kolt.resolve` 内の fixpoint state に "seeded by" 情報を足す必要あり。既存の "direct wins" 扱い (`second: Boolean` in `Resolution.versions`) の隣に `originFlags: Set<Origin>` を持たせる形。
+- **Trade-offs**:
+  - ✅ resolver 一回で済むので wire / cache / 404 フォールバックの再実装不要。
+  - ✅ overlap 解決が kernel 内部で完結し、呼び出し側は単純な filter のみ。
+  - ❌ `fixpointResolve` の state モデルに origin 概念を染み込ませるため、kernel の認知負荷が上がる。
+  - ❌ kernel の既存テスト (ResolutionTest.kt) に origin 軸を足すので test 追加が多い。
+
+### Option B: 2 度の resolver 呼び出し (main 一回 / test 一回) を caller で orchestrate
+
+- **概要**: `resolveDependencies` が `resolve(config.copy(dependencies = mainDeps), ...)` と `resolve(config.copy(dependencies = testDeps ∪ autoInject), ...)` を続けて呼ぶ。test pass では main 結果を先に populate して "main wins on overlap" を確保 (もしくは test 結果から main GA を除外)。lockfile 書き出し時に origin タグを付与。
+- **整合**: resolver 本体は無変更。`Resolver.resolve` / `fixpointResolve` / `ResolvedDep` のシグネチャそのまま。
+- **Trade-offs**:
+  - ✅ kernel を触らないので既存テストの影響が最小。
+  - ✅ Native は今まで通り 1 回呼びで済む (test は JVM 限定なので関係なし)。
+  - ❌ cache / 404 フォールバック / sha256 確認が重複呼び出しで 2 倍走る。パフォーマンスは cache hit が前提なので実害は小さいが、lock 一致性 (test pass 中に main の同一 jar を再 download しない) を caller 側で保証する必要。
+  - ❌ overlap の解決ロジックが caller 側に出るので `resolveDependencies` が太る。`findOverlappingDependencies` の警告と位置関係を再設計。
+
+### Option C: Hybrid — kernel は 2-seed を受ける、materialize は一度
+
+- **概要**: `fixpointResolve` に `mainSeeds: Map` と `testSeeds: Map` の 2 入力を追加、BFS は両 seed から開始するが `versions` に origin bitmap を保持し、conflict は "main wins"。`materialize` は 1 回のみ走り、`ResolvedDep.origin` を返す。呼び出し側は `origin` で filter。
+- **整合**: kernel API は軽く拡張するが、external state (cache / download) は一度だけ動く。B の重複 I/O を回避し、A の kernel 染み込みを局所化。
+- **Trade-offs**:
+  - ✅ 外部 I/O (download / sha256) が 1 回。
+  - ✅ overlap ルールが kernel 内で表現され、caller は filter だけ。
+  - ✅ 既存 `fixpointResolve` の signature に `testSeeds: Map<String, String> = emptyMap()` を default 付きで足せば Native 呼び出し箇所は変更不要。
+  - ❌ kernel に origin bitmap が入り、A よりは局所的だが B よりは複雑。既存 ResolutionTest.kt に origin 軸のテストを足す。
+  - ❌ design で state モデル (Pair<String, Boolean> → Triple<String, Boolean, OriginSet> 相当) の shape を確定する必要あり。
+
+### Non-trivial sub-decisions (いずれの Option でも共通)
+
+- **`autoInjectedTestDeps` の skip 条件 (R1 AC4)**: `config.build.testSources.isEmpty() && config.testDependencies.isEmpty()` を単純 AND で判定、inject を emptyMap に。config の読み方は既存。
+- **Lockfile v3 schema (R2)**: `LockEntry.origin: String = "main"` を追加し、`LockEntryJson` にも default 付きで `@SerialName("origin")` 追加。`parseLockfile` の version 許容を `1..3` に。v1 / v2 は今まで通り `origin = "main"` で補完するか、clean break で reject するかは R-5 で決める。
+- **`writeRuntimeClasspathManifest` (R3)**: 呼び出し元 `handleRuntimeClasspathManifest` で `resolvedJars.filter { it.origin == MAIN }` を適用、manifest 生成自体は既存ロジック。
+- **`doTest` classpath (R4)**: `doBuild` 経路が返す `mainClasspath` を受け取り、test closure 由来 jar を後段で append、`:` 結合。dedup キーは GA (main wins)。
+- **Workspace / kls-classpath (IDE 副次効果)**: main module は main closure、test module は main ∪ test。今まで test module の可視範囲が正しくなかったが、本 spec でむしろ契約を修正する形になる (別 issue 化するか、同 PR で一緒に直すかは design で判断)。
+
+---
+
+## 4. Out-of-Scope for Gap Analysis
+
+(design で詰める前提の領域を記録)
+
+- `fixpointResolve` の state モデル詳細 (Origin bitmap の data class shape、overlap の具体的分岐)。
+- `Workspace.kt` の main / test 分離を本 PR スコープに含めるか分離するかの判断。
+- `.kolt.lock` schema v3 の正確なフィールド名 (`origin` vs `test`) の bikeshed。
+
+## Research Needed (carry forward to design)
+
+- R-1 / R-3 / R-4 (resolver API + test classpath merge 形)。
+- R-2 (LockEntry の origin 表現: `origin` 列 vs `test: Boolean` 列)。
+- R-5 (旧 schema lockfile の挙動: reject か silent upgrade か)。
+
+---
+
+## 5. Implementation Complexity & Risk
+
+### Effort: **M (3–7 日)**
+理由: resolver signature の局所拡張 + lockfile v3 schema bump + 呼び出し側 5 経路 (build/run/test/manifest/workspace) の追従 + テスト 40–50 本の更新。既存の "direct wins" 機構・schema evolution 前例・manifest 経路はすべて揃っており、ゼロから作る部分はない。
+
+### Risk: **Medium**
+理由: `kolt.resolve` kernel (reliability floor、steering `structure.md` に「Gradle/Maven spec 相当の信頼性」と明記) に触る変更があるため、既存の fixpoint / overlap / strict / rejects ロジックに origin 概念を乗せる際に意図せぬ回帰を入れるリスクがある。Native 経路との分岐 (signature 変更時の call site 追従漏れ) も Medium。逆に lockfile schema bump と manifest filter は前例・パターンが確立していて Low。
+
+---
+
+## Recommendations for Design Phase
+
+### 推奨アプローチ: **Option C (Hybrid: kernel は 2-seed、materialize 一回)**
+
+- `fixpointResolve` / `resolveGraph` / `resolveTransitive` に `testSeeds: Map<String, String>` を default `emptyMap()` で追加することで Native 呼び出し側 (`resolveNative`) は変更不要にできる。
+- kernel 内で origin を追跡するコストを払う代わりに、外部 I/O (download, sha256, cache hit check) は 1 回に保つ。Option B の重複 I/O コストが cache hit 前提でも気持ち悪く、Option A の "kernel 全域に origin" より局所化できる。
+- `ResolvedDep.origin: Origin` (enum MAIN / TEST) を新設、`LockEntryJson` に `origin: String = "main"` を @SerialName 付きで追加、`Lockfile.version` を 3 に bump。旧 v1 / v2 は `parseLockfile` が unsupported version を返し、ユーザーは `kolt deps install` で再生成 (pre-v1 方針)。
+
+### Key decisions to lock in design
+
+1. **Resolver signature**: `fixpointResolve(mainSeeds, testSeeds = emptyMap(), childLookup)` のどちらか。(R-1)
+2. **Origin 表現**: `ResolvedDep` / `LockEntry` に `origin` を持たせるか、`test: Boolean` にするか。(R-2)
+3. **test classpath merge の責務分界**: `doTest` 内 or `DependencyResolution` の返り値で main+test を返す。(R-3)
+4. **`JvmResolutionOutcome` の再設計**: single `classpath` / `resolvedJars` から、`main*` / `test*` を別フィールドとして返す、あるいは `resolvedJars` 一本で origin から filter させる。(R-4)
+5. **旧 lockfile 互換**: v1 / v2 は reject (clean break) で確定させるか、silent migrate で origin=main 補完するか。(R-5)
+6. **Workspace.kt の main/test 修正を同一 PR に含めるか**: IDE 契約の副次効果を design で切り出すか。
+
+### Carry to design: 研究アイテム
+
+- `fixpointResolve` の BFS state (`Map<String, Pair<String, Boolean>>`) を origin-aware に拡張する具体的 shape。
+- v3 schema の例 JSON (`origin: "main" | "test"`) と、LockfileTest.kt に追加する parse / roundtrip ケース。
+- Option C における test seed からの conflict resolution (main が先 vs test が先で挙動が変わらないことの不変条件)。

--- a/.kiro/specs/main-test-closure-separation/spec.json
+++ b/.kiro/specs/main-test-closure-separation/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "main-test-closure-separation",
+  "created_at": "2026-04-24T00:40:29Z",
+  "updated_at": "2026-04-24T01:39:23Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/main-test-closure-separation/tasks.md
+++ b/.kiro/specs/main-test-closure-separation/tasks.md
@@ -2,7 +2,7 @@
 
 ## 1. Foundation: data types, schema, 自動注入条件
 
-- [ ] 1.1 (P) Lockfile schema を v3 に bump し `test: Boolean` フラグを追加
+- [x] 1.1 (P) Lockfile schema を v3 に bump し `test: Boolean` フラグを追加
   - `LockEntry` に `test: Boolean = false` を追加 (既存 `transitive: Boolean = false` と同形)
   - `LockEntryJson` に `@SerialName("test") val test: Boolean = false` を追加
   - `parseLockfile` を `version != 3` で `LockfileError.UnsupportedVersion` を返すよう変更 (v1 / v2 は reject)
@@ -12,7 +12,7 @@
   - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5_
   - _Boundary: kolt.resolve.Lockfile_
 
-- [ ] 1.2 (P) `Origin` enum と resolver data class の origin フィールド
+- [x] 1.2 (P) `Origin` enum と resolver data class の origin フィールド
   - `kolt.resolve` に `enum class Origin { MAIN, TEST }` を新設
   - `ResolvedDep` に `origin: Origin = Origin.MAIN` を追加 (default は Native 経路 / 既存呼び出し互換用)
   - `DependencyNode` にも `origin: Origin` を追加
@@ -21,7 +21,7 @@
   - _Requirements: 1.1, 2.1, 2.2_
   - _Boundary: kolt.resolve.Resolver, kolt.resolve.Resolution_
 
-- [ ] 1.3 (P) `autoInjectedTestDeps` を test ソース / test 依存が空のとき skip
+- [x] 1.3 (P) `autoInjectedTestDeps` を test ソース / test 依存が空のとき skip
   - `target == "jvm"` かつ (`testSources.isNotEmpty()` または `testDependencies.isNotEmpty()`) の時のみ `kotlin-test-junit5` を返すよう条件追加
   - `TestDepsTest.kt` に (a) `testSources = []` / `testDependencies = {}` 時に空 Map を返す、(b) 従来条件では継続 inject する、2 ケースを追加
   - 完了条件: `TestDepsTest.kt` の新旧ケースが pass、`autoInjectedTestDeps(config)` の呼び出しで daemon 相当の config (`test_sources = []`) に空 Map が返る

--- a/.kiro/specs/main-test-closure-separation/tasks.md
+++ b/.kiro/specs/main-test-closure-separation/tasks.md
@@ -1,0 +1,135 @@
+# Implementation Plan
+
+## 1. Foundation: data types, schema, 自動注入条件
+
+- [ ] 1.1 (P) Lockfile schema を v3 に bump し `test: Boolean` フラグを追加
+  - `LockEntry` に `test: Boolean = false` を追加 (既存 `transitive: Boolean = false` と同形)
+  - `LockEntryJson` に `@SerialName("test") val test: Boolean = false` を追加
+  - `parseLockfile` を `version != 3` で `LockfileError.UnsupportedVersion` を返すよう変更 (v1 / v2 は reject)
+  - `serializeLockfile` は `version = 3` を出力し、辞書順 + per-entry `test` フィールドを含める
+  - `LockfileTest.kt` に v3 roundtrip テスト (`test: true` / `test: false` / 欠如 default) と v1 / v2 が `UnsupportedVersion` を返す回帰テストを追加
+  - 完了条件: `LockfileTest.kt` の新旧テスト群が pass し、`.kolt.lock` 文字列に `"version": 3` と per-entry `"test": true` を持つサンプルがテストから確認できる
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5_
+  - _Boundary: kolt.resolve.Lockfile_
+
+- [ ] 1.2 (P) `Origin` enum と resolver data class の origin フィールド
+  - `kolt.resolve` に `enum class Origin { MAIN, TEST }` を新設
+  - `ResolvedDep` に `origin: Origin = Origin.MAIN` を追加 (default は Native 経路 / 既存呼び出し互換用)
+  - `DependencyNode` にも `origin: Origin` を追加
+  - `ResolverTest.kt` 相当で `ResolvedDep(..., origin = Origin.TEST)` の copy/equals が期待通りであることを確認
+  - 完了条件: `ResolvedDep` / `DependencyNode` が `origin` フィールドを持ち、既存 resolver テスト全量が回帰しない
+  - _Requirements: 1.1, 2.1, 2.2_
+  - _Boundary: kolt.resolve.Resolver, kolt.resolve.Resolution_
+
+- [ ] 1.3 (P) `autoInjectedTestDeps` を test ソース / test 依存が空のとき skip
+  - `target == "jvm"` かつ (`testSources.isNotEmpty()` または `testDependencies.isNotEmpty()`) の時のみ `kotlin-test-junit5` を返すよう条件追加
+  - `TestDepsTest.kt` に (a) `testSources = []` / `testDependencies = {}` 時に空 Map を返す、(b) 従来条件では継続 inject する、2 ケースを追加
+  - 完了条件: `TestDepsTest.kt` の新旧ケースが pass、`autoInjectedTestDeps(config)` の呼び出しで daemon 相当の config (`test_sources = []`) に空 Map が返る
+  - _Requirements: 1.4_
+  - _Boundary: kolt.build.TestDeps_
+
+## 2. Core: 2-seed resolver と caller orchestration
+
+- [ ] 2.1 `fixpointResolve` を 2-seed API に拡張し kernel で main wins on overlap を保証
+  - signature を `fixpointResolve(mainSeeds, testSeeds = emptyMap(), childLookup)` に拡張
+  - BFS queue entry と versions state に `OriginSet(fromMain, fromTest)` を保持し、child 展開時に親の origin を OR 継承
+  - main / test 両方から到達した GA は materialize 時に `Origin.MAIN` に畳む (main wins)、test-only 到達は `Origin.TEST` で返す
+  - 既存 strict / rejects / exclusions / 版数比較の不変条件が壊れていないことを確認
+  - `ResolutionTest.kt` に:
+    - 両 seed で origin 付き結果を返すケース
+    - 同一 GA が main/test 両方から seed された時 main 版が勝ち origin=MAIN
+    - test seed のみから到達した GA は origin=TEST
+    - 既存 strict / rejects / exclusions テストを 2-seed API で呼んでも回帰しない
+  - 完了条件: `ResolutionTest.kt` の新旧テストが全量 pass、Native 呼び出し経路 (`testSeeds` default) で既存挙動
+  - _Requirements: 1.1, 1.2, 1.5, 4.2_
+  - _Boundary: kolt.resolve.Resolution_
+  - _Depends: 1.2_
+
+- [ ] 2.2 `resolveTransitive` に test seeds を透過し materialize で origin を `ResolvedDep` に転写
+  - `resolveTransitive(config, existingLock, cacheBase, deps, testSeeds = emptyMap())` に拡張
+  - kernel から受けた `DependencyNode.origin` を `materialize` ループで `ResolvedDep.origin` に転写
+  - `TransitiveResolverTest.kt` に test seeds 入力 → 返却 `ResolvedDep` の origin が MAIN / TEST で分かれることを確認するケースを追加
+  - 既存 `scopeFilteringSkipsTestAndProvided` 等の scope フィルタ回帰テストが通ること
+  - 完了条件: `TransitiveResolverTest.kt` の既存+新規テストが pass、test-only 依存が `ResolvedDep.origin == Origin.TEST` で返る
+  - _Requirements: 1.1_
+  - _Boundary: kolt.resolve.TransitiveResolver_
+
+- [ ] 2.3 `DependencyResolution.resolveDependencies` を 2-seed 呼び出し化し `JvmResolutionOutcome` を再設計
+  - `JvmResolutionOutcome` を `(mainClasspath: String?, mainJars: List<ResolvedJar>, allJars: List<ResolvedJar>)` に差し替え
+  - `config.dependencies` を main seeds、`autoInjectedTestDeps(config) + config.testDependencies` を test seeds として `resolve()` を 1 回呼ぶ
+  - 戻り `ResolvedDep` list を origin で分け、`mainJars` / `allJars` を計算 (`allJars = mainJars + testJars`、disjoint 保証済み)
+  - 既存 `findOverlappingDependencies` 警告は従前の位置で維持
+  - Lockfile 書き出しは全エントリに `test` flag を付けて v3 で永続化
+  - `mergeAllDeps` の定義と呼び出し箇所を削除
+  - `DependencyResolutionTest.kt` に (a) main / test が origin 通り分離される、(b) `JvmResolutionOutcome.mainClasspath` / `mainJars` / `allJars` が期待通りに出るケースを追加
+  - 完了条件: `DependencyResolutionTest.kt` の新旧テストが pass、lockfile サンプルが `"version": 3` と `"test": true` を含む
+  - _Requirements: 1.1, 1.3, 2.1, 2.2, 2.3, 2.5_
+  - _Boundary: kolt.cli.DependencyResolution_
+  - _Depends: 1.1, 1.3, 2.2_
+
+## 3. Integration: caller 側の origin filter と出力経路
+
+- [ ] 3.1 (P) `BuildCommands` の build / run / test 経路を新 `JvmResolutionOutcome` に追従
+  - `doBuild` の返り (`BuildResult`) を拡張し `mainJars` と `allJars` を後段に持ち回る経路を確保
+  - `doRun` は既存 `classpath` (main-only) をそのまま `java` subproc に渡す (意味のみ狭まる)
+  - `doTest` は compile (L709 相当) と run (L723 相当) の両方で `allJars` から classpath を組み立てる (disjoint 前提で単純結合)
+  - `doTest` の early-return 経路 (`existingTestSources` 空時の no-op) が本変更後も維持されていることを確認
+  - `handleRuntimeClasspathManifest` 呼び出しの入力を `mainJars` に差し替え (JVM `kind = "app"` のみ発火、lib/native は従前のガード維持)
+  - `BuildCommandsTest.kt` / `JvmAppBuildTest.kt` に以下を追加/更新:
+    - JVM app build 後の `build/<name>-runtime.classpath` に test-only jar (junit 系 / opentest4j / apiguardian) が含まれない
+    - JVM lib / Native build は `*-runtime.classpath` を emit しない既存ガードが回帰しない
+    - `kolt test` compile/run classpath に main deps と test deps 両方が載り、重複 GA は main 版 1 個のみ
+    - `test_sources = []` の JVM app で `kolt test` が no-op (classpath 生成も走らない)
+  - 完了条件: manifest ファイルに test 由来の絶対パスが存在しないことを test で pin でき、`kolt run` の classpath 組立てが main-only に縮む
+  - _Requirements: 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 5.1, 5.2_
+  - _Boundary: kolt.cli.BuildCommands, kolt.build.Builder_
+  - _Depends: 2.3_
+
+- [ ] 3.2 (P) `Workspace.generateWorkspaceJson` を main / test 分離入力に切り替え
+  - `generateWorkspaceJson(config, mainDeps, testDeps)` に signature 変更
+  - `buildMainModule` は `mainDeps` のみを library 列挙
+  - `buildTestModule` は `mainDeps + testDeps` を列挙 (test コードは main も見る)
+  - top-level `libraries` は `mainDeps + testDeps` を列挙
+  - `generateKlsClasspath` は caller が結合して渡す
+  - `WorkspaceTest.kt` に (a) main module dep list に testJars が含まれない、(b) test module dep list に main + test の両方が含まれる、(c) top-level libraries 漏れなし、の 3 ケースを追加
+  - `DependencyResolution.writeWorkspaceFiles` 側で `(mainJars, testJars)` を渡すよう更新
+  - 完了条件: `WorkspaceTest.kt` の新旧テストが pass、生成された workspace.json の JSON で main / test module の dep 配列が期待通り
+  - _Requirements: 2.1, 2.2_
+  - _Boundary: kolt.build.Workspace, kolt.cli.DependencyResolution_
+  - _Depends: 2.3_
+
+- [ ] 3.3 (P) `DependencyCommands.doTree` / `doInstall` を origin 別に組み直す
+  - `doTree` (L254, L334 付近) の `mergeAllDeps` 呼び出しを main seeds (`config.dependencies`) と test seeds (`autoInjectedTestDeps + config.testDependencies`) の別 tree 表示に置換 (既存「test dependencies:」セクション出力は維持)
+  - `doInstall` は `resolveDependencies` 経由で統一 (直接 resolver 呼び出しの箇所があれば新 `JvmResolutionOutcome` に追従)
+  - 既存の deps tree 整形出力 (`formatDependencyTree`) はそのまま使用
+  - `DependencyCommandsTest.kt` (既存に合わせて) に (a) `[dependencies]` / `[test-dependencies]` 両方宣言時に 2 section 出力、(b) auto-inject skip 条件下では test section が空、の回帰テストを追加
+  - 完了条件: `kolt deps tree` / `kolt deps install` が手動スモークで期待通り動き、`DependencyCommandsTest.kt` の test が pass
+  - _Requirements: 1.4_
+  - _Boundary: kolt.cli.DependencyCommands_
+  - _Depends: 2.3_
+
+## 4. Validation: ADR / 成果物の更新とスモーク
+
+- [ ] 4.1 (P) ADR 0027 §1 と ADR 0003 §2 の文言を新契約に揃える
+  - ADR 0027 §1 の "transitive closure, post-exclusion" を「main closure (非test closure) の transitive closure, post-exclusion」に限定する文言を追加
+  - ADR 0027 §4 の kind マトリクス脚注に「emit 対象は main closure のみ」の補足
+  - ADR 0003 §2 の schema evolution 節に v2 → v3 (`LockEntry.test: Boolean` 追加、v1/v2 は unsupported で reject) の行を追記
+  - 完了条件: `docs/adr/0027-*.md` / `docs/adr/0003-*.md` の diff が上記文言追加のみを含み、markdown として整形されている
+  - _Requirements: 3.4_
+  - _Boundary: docs/adr_
+
+- [ ] 4.2 Daemon と spike の lockfile を v3 で再生成
+  - `kolt-jvm-compiler-daemon/kolt.lock` を `kolt deps install` 相当で再生成し tracked 状態でコミット
+  - `spike/daemon-self-host-smoke/kolt.lock` を同様に再生成
+  - 生成された lockfile の `"version": 3` と test-origin エントリの `"test": true` を目視確認
+  - 完了条件: 両 lockfile が v3 schema で、`kotlin-test-junit5` / junit-jupiter 系が `"test": true` で記録されるか、そもそも 出現しない (daemon は test_sources 空なので auto-inject skip 後は記録ゼロが期待値)
+  - _Requirements: 2.1, 6.3_
+  - _Depends: 3.1, 3.2, 3.3_
+
+- [ ] 4.3 Daemon self-host runtime manifest に test deps が混入しないことを smoke で確認
+  - `./gradlew build` 経由で `kolt.kexe` を生成 → `kolt.kexe build` を `kolt-jvm-compiler-daemon/` に対して走らせ、`build/kolt-jvm-compiler-daemon-runtime.classpath` を grep
+  - 出力に `org.junit.jupiter` / `org.junit.platform` / `org.opentest4j` / `org.apiguardian` / `kotlin-test` / `kotlin-test-junit5` のいずれも含まれないことを CI の `self-host-post` 経路または相当のテストで pin
+  - `JvmAppBuildTest.kt` か追加 smoke test に「auto-inject が skip され test_sources 空の JVM app では manifest が test 由来 jar を含まない」ケースを入れる
+  - 完了条件: grep 結果が空であることが CI で検証される、もしくは相当のテストが green
+  - _Requirements: 6.1, 6.2_
+  - _Depends: 4.2_

--- a/src/nativeMain/kotlin/kolt/build/TestDeps.kt
+++ b/src/nativeMain/kotlin/kolt/build/TestDeps.kt
@@ -4,6 +4,7 @@ import kolt.config.KoltConfig
 
 fun autoInjectedTestDeps(config: KoltConfig): Map<String, String> {
   if (config.build.target != "jvm") return emptyMap()
+  if (config.build.testSources.isEmpty() && config.testDependencies.isEmpty()) return emptyMap()
   return mapOf("org.jetbrains.kotlin:kotlin-test-junit5" to config.kotlin.version)
 }
 

--- a/src/nativeMain/kotlin/kolt/resolve/Lockfile.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Lockfile.kt
@@ -14,9 +14,13 @@ sealed class LockfileError {
   data class UnsupportedVersion(val version: Int) : LockfileError()
 }
 
-data class LockEntry(val version: String, val sha256: String, val transitive: Boolean = false)
+data class LockEntry(
+  val version: String,
+  val sha256: String,
+  val transitive: Boolean = false,
+  val test: Boolean = false,
+)
 
-// V1 lockfiles (without `transitive` field) are accepted with transitive defaulting to false.
 data class Lockfile(
   val version: Int,
   val kotlin: String,
@@ -29,6 +33,7 @@ private data class LockEntryJson(
   val version: String,
   val sha256: String,
   val transitive: Boolean = false,
+  @SerialName("test") val test: Boolean = false,
 )
 
 @Serializable
@@ -53,7 +58,7 @@ fun parseLockfile(jsonString: String): Result<Lockfile, LockfileError> {
     } catch (e: IllegalArgumentException) {
       return Err(LockfileError.ParseFailed("failed to parse kolt.lock: ${e.message}"))
     }
-  if (parsed.version !in 1..2) {
+  if (parsed.version != 3) {
     return Err(LockfileError.UnsupportedVersion(parsed.version))
   }
   return Ok(
@@ -62,7 +67,9 @@ fun parseLockfile(jsonString: String): Result<Lockfile, LockfileError> {
       kotlin = parsed.kotlin,
       jvmTarget = parsed.jvmTarget,
       dependencies =
-        parsed.dependencies.mapValues { (_, v) -> LockEntry(v.version, v.sha256, v.transitive) },
+        parsed.dependencies.mapValues { (_, v) ->
+          LockEntry(v.version, v.sha256, v.transitive, v.test)
+        },
     )
   )
 }
@@ -71,7 +78,7 @@ fun serializeLockfile(lockfile: Lockfile): String {
   val sorted =
     lockfile.dependencies.entries
       .sortedBy { it.key }
-      .associate { (k, v) -> k to LockEntryJson(v.version, v.sha256, v.transitive) }
+      .associate { (k, v) -> k to LockEntryJson(v.version, v.sha256, v.transitive, v.test) }
   val json =
     LockfileJson(
       version = lockfile.version,

--- a/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
@@ -5,7 +5,12 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 
-data class DependencyNode(val groupArtifact: String, val version: String, val direct: Boolean)
+data class DependencyNode(
+  val groupArtifact: String,
+  val version: String,
+  val direct: Boolean,
+  val origin: Origin = Origin.MAIN,
+)
 
 /**
  * A child as seen by the resolution kernel. Populated by resolver-specific lookup adapters

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -69,12 +69,18 @@ fun formatResolveError(error: ResolveError): String =
       "error: resolved ${error.groupArtifact}:${error.version} is rejected by constraint '${error.rejectPattern}'"
   }
 
+enum class Origin {
+  MAIN,
+  TEST,
+}
+
 data class ResolvedDep(
   val groupArtifact: String,
   val version: String,
   val sha256: String,
   val cachePath: String,
   val transitive: Boolean = false,
+  val origin: Origin = Origin.MAIN,
 )
 
 data class ResolveResult(val deps: List<ResolvedDep>, val lockChanged: Boolean)
@@ -119,7 +125,7 @@ fun resolve(
 
 fun buildLockfileFromResolved(config: KoltConfig, deps: List<ResolvedDep>): Lockfile {
   return Lockfile(
-    version = 2,
+    version = 3,
     kotlin = config.kotlin.version,
     jvmTarget = config.build.jvmTarget,
     dependencies =

--- a/src/nativeTest/kotlin/kolt/build/TestDepsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/TestDepsTest.kt
@@ -91,6 +91,34 @@ class TestDepsTest {
   }
 
   @Test
+  fun jvmTargetSkipsInjectionWhenTestSourcesAndTestDepsEmpty() {
+    val config = testConfig(testSources = emptyList(), testDependencies = emptyMap())
+    val injected = autoInjectedTestDeps(config)
+
+    assertEquals(emptyMap(), injected)
+  }
+
+  @Test
+  fun jvmTargetInjectsWhenOnlyTestDependenciesDeclared() {
+    val config =
+      testConfig(
+        testSources = emptyList(),
+        testDependencies = mapOf("io.kotest:kotest-runner-junit5" to "5.8.0"),
+      )
+    val injected = autoInjectedTestDeps(config)
+
+    assertEquals(mapOf("org.jetbrains.kotlin:kotlin-test-junit5" to "2.1.0"), injected)
+  }
+
+  @Test
+  fun jvmTargetInjectsWhenOnlyTestSourcesPresent() {
+    val config = testConfig(testSources = listOf("test"), testDependencies = emptyMap())
+    val injected = autoInjectedTestDeps(config)
+
+    assertEquals(mapOf("org.jetbrains.kotlin:kotlin-test-junit5" to "2.1.0"), injected)
+  }
+
+  @Test
   fun mergeAllDepsNativeTargetHasNoAutoInjected() {
     val config =
       KoltConfig(

--- a/src/nativeTest/kotlin/kolt/resolve/LockfileTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/LockfileTest.kt
@@ -11,11 +11,11 @@ import kotlin.test.assertTrue
 class LockfileTest {
 
   @Test
-  fun parseValidLockfile() {
+  fun parseValidV3Lockfile() {
     val json =
       """
             {
-                "version": 1,
+                "version": 3,
                 "kotlin": "2.1.0",
                 "jvm_target": "17",
                 "dependencies": {
@@ -28,7 +28,7 @@ class LockfileTest {
         """
         .trimIndent()
     val lockfile = assertNotNull(parseLockfile(json).get())
-    assertEquals(1, lockfile.version)
+    assertEquals(3, lockfile.version)
     assertEquals("2.1.0", lockfile.kotlin)
     assertEquals("17", lockfile.jvmTarget)
     assertEquals(1, lockfile.dependencies.size)
@@ -36,6 +36,8 @@ class LockfileTest {
       assertNotNull(lockfile.dependencies["org.jetbrains.kotlinx:kotlinx-coroutines-core"])
     assertEquals("1.9.0", entry.version)
     assertEquals("abc123def456", entry.sha256)
+    assertEquals(false, entry.transitive)
+    assertEquals(false, entry.test)
   }
 
   @Test
@@ -43,7 +45,7 @@ class LockfileTest {
     val json =
       """
             {
-                "version": 1,
+                "version": 3,
                 "kotlin": "2.1.0",
                 "jvm_target": "17",
                 "dependencies": {}
@@ -55,7 +57,45 @@ class LockfileTest {
   }
 
   @Test
-  fun parseUnsupportedVersionReturnsErr() {
+  fun parseV1LockfileReturnsUnsupportedVersion() {
+    val json =
+      """
+            {
+                "version": 1,
+                "kotlin": "2.1.0",
+                "jvm_target": "17",
+                "dependencies": {}
+            }
+        """
+        .trimIndent()
+    val err = assertIs<LockfileError.UnsupportedVersion>(parseLockfile(json).getError())
+    assertEquals(1, err.version)
+  }
+
+  @Test
+  fun parseV2LockfileReturnsUnsupportedVersion() {
+    val json =
+      """
+            {
+                "version": 2,
+                "kotlin": "2.1.0",
+                "jvm_target": "17",
+                "dependencies": {
+                    "org.jetbrains.kotlin:kotlin-stdlib": {
+                        "version": "2.1.0",
+                        "sha256": "def456",
+                        "transitive": true
+                    }
+                }
+            }
+        """
+        .trimIndent()
+    val err = assertIs<LockfileError.UnsupportedVersion>(parseLockfile(json).getError())
+    assertEquals(2, err.version)
+  }
+
+  @Test
+  fun parseFutureVersionReturnsUnsupportedVersion() {
     val json =
       """
             {
@@ -75,10 +115,65 @@ class LockfileTest {
   }
 
   @Test
-  fun serializeLockfileSortsDependencies() {
+  fun parseV3EntryWithTestTrueAndTransitiveTrue() {
+    val json =
+      """
+            {
+                "version": 3,
+                "kotlin": "2.1.0",
+                "jvm_target": "17",
+                "dependencies": {
+                    "org.jetbrains.kotlin:kotlin-test-junit5": {
+                        "version": "2.1.0",
+                        "sha256": "aaa",
+                        "transitive": false,
+                        "test": true
+                    },
+                    "org.junit.jupiter:junit-jupiter-api": {
+                        "version": "5.10.0",
+                        "sha256": "bbb",
+                        "transitive": true,
+                        "test": true
+                    }
+                }
+            }
+        """
+        .trimIndent()
+    val lockfile = assertNotNull(parseLockfile(json).get())
+    val direct = assertNotNull(lockfile.dependencies["org.jetbrains.kotlin:kotlin-test-junit5"])
+    assertEquals(true, direct.test)
+    assertEquals(false, direct.transitive)
+    val transitive = assertNotNull(lockfile.dependencies["org.junit.jupiter:junit-jupiter-api"])
+    assertEquals(true, transitive.test)
+    assertEquals(true, transitive.transitive)
+  }
+
+  @Test
+  fun parseV3EntryWithTestFieldAbsentDefaultsToFalse() {
+    val json =
+      """
+            {
+                "version": 3,
+                "kotlin": "2.1.0",
+                "jvm_target": "17",
+                "dependencies": {
+                    "com.example:lib": {
+                        "version": "1.0.0",
+                        "sha256": "hash"
+                    }
+                }
+            }
+        """
+        .trimIndent()
+    val lockfile = assertNotNull(parseLockfile(json).get())
+    assertEquals(false, lockfile.dependencies["com.example:lib"]!!.test)
+  }
+
+  @Test
+  fun serializeSortsDependenciesAlphabetically() {
     val lockfile =
       Lockfile(
-        version = 1,
+        version = 3,
         kotlin = "2.1.0",
         jvmTarget = "17",
         dependencies =
@@ -89,118 +184,54 @@ class LockfileTest {
       )
     val serialized = serializeLockfile(lockfile)
     val reparsed = assertNotNull(parseLockfile(serialized).get())
-    assertEquals(lockfile.version, reparsed.version)
-    assertEquals(lockfile.kotlin, reparsed.kotlin)
-    assertEquals(lockfile.jvmTarget, reparsed.jvmTarget)
-    assertEquals(lockfile.dependencies, reparsed.dependencies)
+    assertEquals(lockfile, reparsed)
 
-    // Verify dependency keys are sorted alphabetically
     val comIndex = serialized.indexOf("com.squareup:okhttp")
     val orgIndex = serialized.indexOf("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     assertTrue(comIndex < orgIndex, "dependencies should be sorted alphabetically")
   }
 
   @Test
-  fun serializeAndParseRoundTrip() {
+  fun serializeV3RoundTripPreservesTestFlag() {
     val lockfile =
       Lockfile(
-        version = 1,
-        kotlin = "2.1.0",
-        jvmTarget = "17",
-        dependencies = mapOf("junit:junit" to LockEntry("4.13.2", "ccc333")),
-      )
-    val serialized = serializeLockfile(lockfile)
-    val reparsed = assertNotNull(parseLockfile(serialized).get())
-    assertEquals(lockfile, reparsed)
-  }
-
-  @Test
-  fun parseV2LockfileWithTransitiveField() {
-    val json =
-      """
-            {
-                "version": 2,
-                "kotlin": "2.1.0",
-                "jvm_target": "17",
-                "dependencies": {
-                    "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
-                        "version": "1.9.0",
-                        "sha256": "abc123",
-                        "transitive": false
-                    },
-                    "org.jetbrains.kotlin:kotlin-stdlib": {
-                        "version": "2.1.0",
-                        "sha256": "def456",
-                        "transitive": true
-                    }
-                }
-            }
-        """
-        .trimIndent()
-    val lockfile = assertNotNull(parseLockfile(json).get())
-    assertEquals(2, lockfile.version)
-    assertEquals(
-      false,
-      lockfile.dependencies["org.jetbrains.kotlinx:kotlinx-coroutines-core"]!!.transitive,
-    )
-    assertEquals(true, lockfile.dependencies["org.jetbrains.kotlin:kotlin-stdlib"]!!.transitive)
-  }
-
-  @Test
-  fun parseV1LockfileDefaultsTransitiveToFalse() {
-    val json =
-      """
-            {
-                "version": 1,
-                "kotlin": "2.1.0",
-                "jvm_target": "17",
-                "dependencies": {
-                    "junit:junit": {
-                        "version": "4.13.2",
-                        "sha256": "ccc333"
-                    }
-                }
-            }
-        """
-        .trimIndent()
-    val lockfile = assertNotNull(parseLockfile(json).get())
-    assertEquals(false, lockfile.dependencies["junit:junit"]!!.transitive)
-  }
-
-  @Test
-  fun serializeV2LockfileIncludesTransitiveField() {
-    val lockfile =
-      Lockfile(
-        version = 2,
+        version = 3,
         kotlin = "2.1.0",
         jvmTarget = "17",
         dependencies =
           mapOf(
-            "org.example:lib" to LockEntry("1.0.0", "aaa111", transitive = false),
-            "org.example:transitive-lib" to LockEntry("2.0.0", "bbb222", transitive = true),
-          ),
-      )
-    val serialized = serializeLockfile(lockfile)
-    val reparsed = assertNotNull(parseLockfile(serialized).get())
-    assertEquals(false, reparsed.dependencies["org.example:lib"]!!.transitive)
-    assertEquals(true, reparsed.dependencies["org.example:transitive-lib"]!!.transitive)
-  }
-
-  @Test
-  fun serializeV2RoundTrip() {
-    val lockfile =
-      Lockfile(
-        version = 2,
-        kotlin = "2.1.0",
-        jvmTarget = "17",
-        dependencies =
-          mapOf(
-            "a:b" to LockEntry("1.0", "hash1", transitive = false),
-            "c:d" to LockEntry("2.0", "hash2", transitive = true),
+            "org.example:main-lib" to LockEntry("1.0.0", "hash1", transitive = false, test = false),
+            "org.example:main-transitive" to
+              LockEntry("2.0.0", "hash2", transitive = true, test = false),
+            "org.example:test-lib" to LockEntry("3.0.0", "hash3", transitive = false, test = true),
+            "org.example:test-transitive" to
+              LockEntry("4.0.0", "hash4", transitive = true, test = true),
           ),
       )
     val serialized = serializeLockfile(lockfile)
     val reparsed = assertNotNull(parseLockfile(serialized).get())
     assertEquals(lockfile, reparsed)
+    assertEquals(3, reparsed.version)
+    assertEquals(false, reparsed.dependencies["org.example:main-lib"]!!.test)
+    assertEquals(true, reparsed.dependencies["org.example:test-lib"]!!.test)
+    assertEquals(true, reparsed.dependencies["org.example:test-transitive"]!!.test)
+  }
+
+  @Test
+  fun serializedV3OutputContainsVersionAndTestTrueField() {
+    val lockfile =
+      Lockfile(
+        version = 3,
+        kotlin = "2.1.0",
+        jvmTarget = "17",
+        dependencies =
+          mapOf(
+            "org.jetbrains.kotlin:kotlin-test-junit5" to
+              LockEntry("2.1.0", "hash", transitive = false, test = true)
+          ),
+      )
+    val serialized = serializeLockfile(lockfile)
+    assertTrue(serialized.contains("\"version\": 3"), "must emit schema version 3")
+    assertTrue(serialized.contains("\"test\": true"), "must emit per-entry test flag when true")
   }
 }

--- a/src/nativeTest/kotlin/kolt/resolve/ResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolverTest.kt
@@ -250,6 +250,49 @@ class ResolverTest {
   }
 
   @Test
+  fun resolvedDepOriginDefaultsToMain() {
+    val dep = ResolvedDep("com.example:lib", "1.0.0", "hash", "/cache/lib.jar")
+    assertEquals(Origin.MAIN, dep.origin)
+  }
+
+  @Test
+  fun resolvedDepCopyToTestOriginChangesOnlyOrigin() {
+    val main = ResolvedDep("com.example:lib", "1.0.0", "hash", "/cache/lib.jar")
+    val test = main.copy(origin = Origin.TEST)
+    assertEquals(Origin.TEST, test.origin)
+    assertEquals(main.groupArtifact, test.groupArtifact)
+    assertEquals(main.version, test.version)
+    assertEquals(main.sha256, test.sha256)
+    assertEquals(main.cachePath, test.cachePath)
+    assertEquals(main.transitive, test.transitive)
+    assertTrue(main != test, "origin is part of equality")
+  }
+
+  @Test
+  fun resolvedDepEqualityRespectsOrigin() {
+    val a = ResolvedDep("com.example:lib", "1.0.0", "hash", "/cache/lib.jar", origin = Origin.TEST)
+    val b = ResolvedDep("com.example:lib", "1.0.0", "hash", "/cache/lib.jar", origin = Origin.TEST)
+    assertEquals(a, b)
+  }
+
+  @Test
+  fun dependencyNodeOriginDefaultsToMain() {
+    val node = DependencyNode("com.example:lib", "1.0.0", direct = true)
+    assertEquals(Origin.MAIN, node.origin)
+  }
+
+  @Test
+  fun dependencyNodeCopyToTestOriginChangesOnlyOrigin() {
+    val main = DependencyNode("com.example:lib", "1.0.0", direct = true)
+    val test = main.copy(origin = Origin.TEST)
+    assertEquals(Origin.TEST, test.origin)
+    assertEquals(main.groupArtifact, test.groupArtifact)
+    assertEquals(main.version, test.version)
+    assertEquals(main.direct, test.direct)
+    assertTrue(main != test)
+  }
+
+  @Test
   fun buildLockfileFromResolvedDeps() {
     val base = testConfig()
     val config =
@@ -263,7 +306,7 @@ class ResolverTest {
         ResolvedDep("org.example:other", "2.0.0", "def456", "/cache/other.jar", transitive = true),
       )
     val lockfile = buildLockfileFromResolved(config, deps)
-    assertEquals(2, lockfile.version)
+    assertEquals(3, lockfile.version)
     assertEquals("2.1.0", lockfile.kotlin)
     assertEquals("17", lockfile.jvmTarget)
     assertEquals(2, lockfile.dependencies.size)


### PR DESCRIPTION
Refs #229. Lands the Kiro spec and foundation (Task 1.1–1.3 of `.kiro/specs/main-test-closure-separation/tasks.md`). No behavior change visible to callers yet — the 2-seed resolver (Task 2.1+) rides on top of these data types.

## What changed

- `Lockfile.kt` — v2 → v3. `LockEntry` gains `test: Boolean = false`; `parseLockfile` rejects anything that isn't version 3 (v1/v2 treated as unsupported per pre-v1 clean-break policy, not migrated). `buildLockfileFromResolved` emits v3.
- `Resolver.kt` / `Resolution.kt` — add `enum class Origin { MAIN, TEST }` and plumb `origin: Origin = Origin.MAIN` onto `ResolvedDep` and `DependencyNode`. Default `MAIN` so existing Native-resolver callsites and the `DependencyNode(ga, v, direct)` construction in `fixpointResolve` keep compiling unchanged.
- `TestDeps.kt` — `autoInjectedTestDeps` now skips injecting `kotlin-test-junit5` when `build.testSources` and `testDependencies` are both empty. Daemon-style JVM apps with no test surface stop pulling junit into the closure.

## Review focus

- `Lockfile.kt` parse/serialize: confirm the `version != 3` rejection and that `test` defaults to `false` on round-trip (see the `parseV3EntryWithTestFieldAbsentDefaultsToFalse` test).
- `buildLockfileFromResolved` emits v3 but doesn't yet write `test` from `ResolvedDep.origin` — that wiring is Task 2.3 scope and intentionally deferred.
- `Origin` default is `MAIN` everywhere, including `DependencyNode`'s `map { (ga, vd) -> DependencyNode(ga, vd.first, vd.second) }` site in `Resolution.kt` — no kernel-state change in this PR. 2-seed BFS comes in Task 2.1.
- Whether the `autoInjectedTestDeps` skip condition belongs here vs. the caller (`DependencyResolution`). Design §TestDeps places it here so `doTree` / `doInstall` / resolver all agree on a single truth.

## Tests

`./gradlew linuxX64Test` green. New coverage: v3 roundtrip + v1/v2/v99 reject in `LockfileTest.kt`, `Origin` default/copy/equality in `ResolverTest.kt`, skip + both positive cases in `TestDepsTest.kt`.