### PR TITLE
Core 2-seed resolver and origin-split JVM outcome (#229)

### DIFF
--- a/.kiro/specs/main-test-closure-separation/tasks.md
+++ b/.kiro/specs/main-test-closure-separation/tasks.md
@@ -30,7 +30,7 @@
 
 ## 2. Core: 2-seed resolver と caller orchestration
 
-- [ ] 2.1 `fixpointResolve` を 2-seed API に拡張し kernel で main wins on overlap を保証
+- [x] 2.1 `fixpointResolve` を 2-seed API に拡張し kernel で main wins on overlap を保証
   - signature を `fixpointResolve(mainSeeds, testSeeds = emptyMap(), childLookup)` に拡張
   - BFS queue entry と versions state に `OriginSet(fromMain, fromTest)` を保持し、child 展開時に親の origin を OR 継承
   - main / test 両方から到達した GA は materialize 時に `Origin.MAIN` に畳む (main wins)、test-only 到達は `Origin.TEST` で返す
@@ -45,7 +45,7 @@
   - _Boundary: kolt.resolve.Resolution_
   - _Depends: 1.2_
 
-- [ ] 2.2 `resolveTransitive` に test seeds を透過し materialize で origin を `ResolvedDep` に転写
+- [x] 2.2 `resolveTransitive` に test seeds を透過し materialize で origin を `ResolvedDep` に転写
   - `resolveTransitive(config, existingLock, cacheBase, deps, testSeeds = emptyMap())` に拡張
   - kernel から受けた `DependencyNode.origin` を `materialize` ループで `ResolvedDep.origin` に転写
   - `TransitiveResolverTest.kt` に test seeds 入力 → 返却 `ResolvedDep` の origin が MAIN / TEST で分かれることを確認するケースを追加
@@ -54,7 +54,7 @@
   - _Requirements: 1.1_
   - _Boundary: kolt.resolve.TransitiveResolver_
 
-- [ ] 2.3 `DependencyResolution.resolveDependencies` を 2-seed 呼び出し化し `JvmResolutionOutcome` を再設計
+- [x] 2.3 `DependencyResolution.resolveDependencies` を 2-seed 呼び出し化し `JvmResolutionOutcome` を再設計
   - `JvmResolutionOutcome` を `(mainClasspath: String?, mainJars: List<ResolvedJar>, allJars: List<ResolvedJar>)` に差し替え
   - `config.dependencies` を main seeds、`autoInjectedTestDeps(config) + config.testDependencies` を test seeds として `resolve()` を 1 回呼ぶ
   - 戻り `ResolvedDep` list を origin で分け、`mainJars` / `allJars` を計算 (`allJars = mainJars + testJars`、disjoint 保証済み)

--- a/src/nativeMain/kotlin/kolt/build/TestDeps.kt
+++ b/src/nativeMain/kotlin/kolt/build/TestDeps.kt
@@ -7,7 +7,3 @@ fun autoInjectedTestDeps(config: KoltConfig): Map<String, String> {
   if (config.build.testSources.isEmpty() && config.testDependencies.isEmpty()) return emptyMap()
   return mapOf("org.jetbrains.kotlin:kotlin-test-junit5" to config.kotlin.version)
 }
-
-// Priority (right wins): auto-injected < main deps < user test deps.
-fun mergeAllDeps(config: KoltConfig): Map<String, String> =
-  autoInjectedTestDeps(config) + config.dependencies + config.testDependencies

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -20,6 +20,7 @@ import kolt.build.nativedaemon.formatNativeDaemonPreconditionWarning
 import kolt.build.nativedaemon.resolveNativeDaemonPreconditions
 import kolt.config.*
 import kolt.infra.*
+import kolt.resolve.buildClasspath
 import kolt.tool.*
 import kotlin.time.TimeSource
 
@@ -141,7 +142,7 @@ internal fun doCheck(useDaemon: Boolean = true): Result<Unit, Int> {
       .getOrElse {
         return Err(it)
       }
-      .classpath
+      .mainClasspath
   val pArgs =
     resolvePluginArgs(config, paths, EXIT_BUILD_ERROR).getOrElse {
       eprintln("error: ${it.message}")
@@ -240,7 +241,11 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
     resolveDependencies(config).getOrElse {
       return Err(it)
     }
-  val classpath = resolutionOutcome.classpath
+  // Main compile sees main-only deps; doTest/doRun get the full classpath
+  // (main ∪ test) through BuildResult below. Task 3.1 will narrow doRun to
+  // main-only; for now the minimum change keeps that path intact.
+  val mainClasspath = resolutionOutcome.mainClasspath
+  val classpath = buildClasspath(resolutionOutcome.allJars.map { it.cachePath }).ifEmpty { null }
   val pluginJarPathsByAlias =
     resolveEnabledPluginJarPaths(config, paths, EXIT_BUILD_ERROR).getOrElse {
       eprintln("error: ${it.message}")
@@ -275,11 +280,13 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
   val request =
     CompileRequest(
       workingDir = cwd,
+      // Main compile only sees main closure deps (ADR 0027 §1; spec
+      // main-test-closure-separation): test-origin jars never reach kotlinc.
       // TODO(#14 S5+): teach resolveDependencies to return List<String>
       // directly and delete this split.
       classpath =
-        if (classpath.isNullOrEmpty()) emptyList()
-        else classpath.split(":").filter { it.isNotEmpty() },
+        if (mainClasspath.isNullOrEmpty()) emptyList()
+        else mainClasspath.split(":").filter { it.isNotEmpty() },
       // BTA requires individual .kt files, not directories (#117).
       sources =
         expandKotlinSources(config.build.sources.map { absolutise(it, cwd) }).getOrElse { err ->
@@ -326,7 +333,7 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
   // previous kind=app build. Manifest write failure is treated as a
   // build failure (ADR 0001: Err propagates, jar artifact is left on
   // disk mirroring the existing jarCmd failure semantics).
-  handleRuntimeClasspathManifest(config, resolutionOutcome.resolvedJars).getOrElse { err ->
+  handleRuntimeClasspathManifest(config, resolutionOutcome.mainJars).getOrElse { err ->
     val failure = err as ManifestWriteError.WriteFailed
     eprintln(
       "error: could not write runtime classpath manifest at ${failure.path}: ${failure.reason}"

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -251,8 +251,10 @@ internal fun doUpdate(): Result<Unit, Int> {
     loadProjectConfig().getOrElse {
       return Err(it)
     }
-  val allDeps = mergeAllDeps(config)
-  if (allDeps.isEmpty()) {
+  val mainSeeds = config.dependencies
+  val testSeeds = autoInjectedTestDeps(config) + config.testDependencies
+  val allSeeds = mainSeeds + testSeeds
+  if (allSeeds.isEmpty()) {
     println("no dependencies to update")
     return Ok(Unit)
   }
@@ -263,7 +265,7 @@ internal fun doUpdate(): Result<Unit, Int> {
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
-  for ((groupArtifact, version) in allDeps) {
+  for ((groupArtifact, version) in allSeeds) {
     val coord = parseCoordinate(groupArtifact, version).getOrElse { continue }
     val jarPath = "${paths.cacheBase}/${buildCachePath(coord)}"
     if (fileExists(jarPath)) {
@@ -271,15 +273,15 @@ internal fun doUpdate(): Result<Unit, Int> {
     }
   }
 
-  val resolveConfig = config.copy(dependencies = allDeps)
   println("updating dependencies...")
   val resolveResult =
-    resolve(resolveConfig, null, paths.cacheBase, createResolverDeps()).getOrElse { error ->
+    resolve(config, null, paths.cacheBase, createResolverDeps(), testSeeds = testSeeds).getOrElse {
+      error ->
       eprintln(formatResolveError(error))
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
-  val lockfile = buildLockfileFromResolved(resolveConfig, resolveResult.deps)
+  val lockfile = buildLockfileFromResolved(config, resolveResult.deps)
   val lockJson = serializeLockfile(lockfile)
   writeFileAsString(LOCK_FILE, lockJson).getOrElse { error ->
     eprintln("error: could not write ${error.path}")

--- a/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
@@ -5,9 +5,9 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.build.ResolvedJar
+import kolt.build.autoInjectedTestDeps
 import kolt.build.generateKlsClasspath
 import kolt.build.generateWorkspaceJson
-import kolt.build.mergeAllDeps
 import kolt.config.*
 import kolt.infra.*
 import kolt.resolve.*
@@ -18,13 +18,15 @@ private const val KLS_CLASSPATH = "kls-classpath"
 
 internal fun createResolverDeps(): ResolverDeps = defaultResolverDeps()
 
-// Carries both the joined classpath string (null = no deps, existing
-// semantics) and the underlying resolved jar list, so the JVM kind=app tail
-// in BuildCommands can emit the runtime classpath manifest (ADR 0027 §1)
-// without re-walking the resolver graph.
+// Splits the resolved jars by origin so the JVM kind=app tail in BuildCommands
+// can emit the runtime classpath manifest (ADR 0027 §1) from main-only jars,
+// while `kolt test` can still build its compile/run classpath from the union.
+// `allJars` is the disjoint concatenation `mainJars + testJars` (the kernel
+// guarantees disjoint-ness via main-wins-on-overlap).
 internal data class JvmResolutionOutcome(
-  val classpath: String?,
-  val resolvedJars: List<ResolvedJar>,
+  val mainClasspath: String?,
+  val mainJars: List<ResolvedJar>,
+  val allJars: List<ResolvedJar>,
 )
 
 internal data class OverlappingDep(
@@ -50,15 +52,16 @@ internal fun resolveDependencies(config: KoltConfig): Result<JvmResolutionOutcom
     )
   }
 
-  val allDeps = mergeAllDeps(config)
-  if (allDeps.isEmpty()) {
+  val mainSeeds = config.dependencies
+  val testSeeds = autoInjectedTestDeps(config) + config.testDependencies
+  if (mainSeeds.isEmpty() && testSeeds.isEmpty()) {
     if (fileExists(LOCK_FILE)) {
       deleteFile(LOCK_FILE)
     }
-    return Ok(JvmResolutionOutcome(classpath = null, resolvedJars = emptyList()))
+    return Ok(
+      JvmResolutionOutcome(mainClasspath = null, mainJars = emptyList(), allJars = emptyList())
+    )
   }
-
-  val resolveConfig = config.copy(dependencies = allDeps)
 
   val paths =
     resolveKoltPaths().getOrElse {
@@ -87,16 +90,17 @@ internal fun resolveDependencies(config: KoltConfig): Result<JvmResolutionOutcom
 
   println("resolving dependencies...")
   val resolveResult =
-    resolve(resolveConfig, existingLock, paths.cacheBase, createResolverDeps()).getOrElse { error ->
-      eprintln(formatResolveError(error))
-      if (error is ResolveError.Sha256Mismatch) {
-        eprintln("delete the cached jar and rebuild to re-download")
+    resolve(config, existingLock, paths.cacheBase, createResolverDeps(), testSeeds = testSeeds)
+      .getOrElse { error ->
+        eprintln(formatResolveError(error))
+        if (error is ResolveError.Sha256Mismatch) {
+          eprintln("delete the cached jar and rebuild to re-download")
+        }
+        return Err(EXIT_DEPENDENCY_ERROR)
       }
-      return Err(EXIT_DEPENDENCY_ERROR)
-    }
 
   if (resolveResult.lockChanged) {
-    val lockfile = buildLockfileFromResolved(resolveConfig, resolveResult.deps)
+    val lockfile = buildLockfileFromResolved(config, resolveResult.deps)
     val lockJson = serializeLockfile(lockfile)
     writeFileAsString(LOCK_FILE, lockJson).getOrElse { error ->
       eprintln("error: could not write ${error.path}")
@@ -108,18 +112,35 @@ internal fun resolveDependencies(config: KoltConfig): Result<JvmResolutionOutcom
     writeWorkspaceFiles(config, resolveResult.deps)
   }
 
-  val resolvedJars =
-    resolveResult.deps.map { dep ->
-      ResolvedJar(
-        cachePath = dep.cachePath,
-        groupArtifactVersion = "${dep.groupArtifact}:${dep.version}",
-      )
-    }
-  return Ok(
-    JvmResolutionOutcome(
-      classpath = buildClasspath(resolvedJars.map { it.cachePath }).ifEmpty { null },
-      resolvedJars = resolvedJars,
-    )
+  return Ok(splitJvmOutcome(resolveResult.deps))
+}
+
+// Extracted for testability: constructs JvmResolutionOutcome from a resolved
+// dep list by splitting on Origin. `allJars` = main ++ test (disjoint —
+// kernel enforces main-wins-on-overlap).
+internal fun splitJvmOutcome(deps: List<ResolvedDep>): JvmResolutionOutcome {
+  val mainJars =
+    deps
+      .filter { it.origin == Origin.MAIN }
+      .map { dep ->
+        ResolvedJar(
+          cachePath = dep.cachePath,
+          groupArtifactVersion = "${dep.groupArtifact}:${dep.version}",
+        )
+      }
+  val testJars =
+    deps
+      .filter { it.origin == Origin.TEST }
+      .map { dep ->
+        ResolvedJar(
+          cachePath = dep.cachePath,
+          groupArtifactVersion = "${dep.groupArtifact}:${dep.version}",
+        )
+      }
+  return JvmResolutionOutcome(
+    mainClasspath = buildClasspath(mainJars.map { it.cachePath }).ifEmpty { null },
+    mainJars = mainJars,
+    allJars = mainJars + testJars,
   )
 }
 

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -57,7 +57,7 @@ fun resolveNative(
   val childLookup = makeNativeChildLookup(processed, nativeTarget, cacheBase, repos, deps)
 
   val nodes =
-    fixpointResolve(directDeps, childLookup).getOrElse {
+    fixpointResolve(mainSeeds = directDeps, childLookup = childLookup).getOrElse {
       return Err(it)
     }
 

--- a/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolution.kt
@@ -28,6 +28,20 @@ data class Child(
 )
 
 /**
+ * Per-GA resolved state tracked inside the BFS.
+ *
+ * `fromMain` / `fromTest` accumulate across every visit to this GA so origin collapses correctly at
+ * the end of the pass: main seed or any main-origin transitive edge sets fromMain; test-only
+ * reachability keeps fromMain = false. Materialization folds this into [Origin] with main winning.
+ */
+internal data class VersionEntry(
+  val version: String,
+  val direct: Boolean,
+  val fromMain: Boolean,
+  val fromTest: Boolean,
+)
+
+/**
  * Immutable snapshot of the resolution state between fixpoint passes.
  *
  * The kernel treats a pass as `Resolution -> Result<Resolution, ResolveError>`; the fixpoint loop
@@ -35,12 +49,14 @@ data class Child(
  * pins, visited, queue) stay mutable for readability and are rebuilt each pass from the same
  * contributors, so they don't need to be threaded across passes today.
  */
-data class Resolution(val versions: Map<String, Pair<String, Boolean>>)
+internal data class Resolution(val versions: Map<String, VersionEntry>)
 
 private data class QueueEntry(
   val groupArtifact: String,
   val version: String,
   val exclusions: Set<PomExclusion>,
+  val fromMain: Boolean,
+  val fromTest: Boolean,
 )
 
 /**
@@ -55,24 +71,57 @@ private data class QueueEntry(
  * reappearing and drop out of the result.
  */
 fun fixpointResolve(
-  directDeps: Map<String, String>,
+  mainSeeds: Map<String, String>,
+  testSeeds: Map<String, String> = emptyMap(),
   childLookup: (groupArtifact: String, version: String) -> Result<List<Child>, ResolveError>,
 ): Result<List<DependencyNode>, ResolveError> {
-  for ((groupArtifact, version) in directDeps) {
+  for ((groupArtifact, version) in mainSeeds) {
+    parseCoordinate(groupArtifact, version).getOrElse {
+      return Err(ResolveError.InvalidDependency(groupArtifact))
+    }
+  }
+  for ((groupArtifact, version) in testSeeds) {
     parseCoordinate(groupArtifact, version).getOrElse {
       return Err(ResolveError.InvalidDependency(groupArtifact))
     }
   }
 
-  var state = Resolution(versions = directDeps.mapValues { (_, v) -> Pair(v, true) })
+  // Main wins on overlap: if the same GA is seeded from both sides, main's
+  // version is used and test's version is dropped. `testSeeds + mainSeeds`
+  // makes main entries override test entries with the same key.
+  val effectiveDirectDeps = testSeeds + mainSeeds
+  val mainGAs = mainSeeds.keys
+  val testGAs = testSeeds.keys
+
+  var state =
+    Resolution(
+      versions =
+        effectiveDirectDeps.mapValues { (ga, v) ->
+          VersionEntry(
+            version = v,
+            direct = true,
+            fromMain = ga in mainGAs,
+            fromTest = ga in testGAs,
+          )
+        }
+    )
 
   while (true) {
     val next =
-      iterate(state, directDeps, childLookup).getOrElse {
+      iterate(state, effectiveDirectDeps, mainGAs, testGAs, childLookup).getOrElse {
         return Err(it)
       }
     if (next.versions == state.versions) {
-      return Ok(next.versions.map { (ga, vd) -> DependencyNode(ga, vd.first, vd.second) })
+      return Ok(
+        next.versions.map { (ga, ve) ->
+          DependencyNode(
+            groupArtifact = ga,
+            version = ve.version,
+            direct = ve.direct,
+            origin = if (ve.fromMain) Origin.MAIN else Origin.TEST,
+          )
+        }
+      )
     }
     state = next
   }
@@ -81,11 +130,17 @@ fun fixpointResolve(
 private fun iterate(
   prev: Resolution,
   directDeps: Map<String, String>,
+  mainGAs: Set<String>,
+  testGAs: Set<String>,
   childLookup: (String, String) -> Result<List<Child>, ResolveError>,
 ): Result<Resolution, ResolveError> {
-  val versions = mutableMapOf<String, Pair<String, Boolean>>()
+  val versions = mutableMapOf<String, VersionEntry>()
   val queue = ArrayDeque<QueueEntry>()
-  val visited = mutableSetOf<String>()
+  // Per (ga, version, exclusions): the origin bits already processed. A later
+  // pop re-enters only if it brings a new origin bit, so each (GA, v, excl)
+  // state is processed at most twice (once per origin). Cycles are still
+  // bounded because no new origin bit can appear after (true, true).
+  val visited = mutableMapOf<String, Pair<Boolean, Boolean>>()
   // Per-GA union of rejects declared by every contributor seen so far.
   // Accumulated even when the contributor's own version proposal loses the
   // conflict, mirroring Gradle's "rejects applies to the GA globally".
@@ -94,8 +149,11 @@ private fun iterate(
   val strictPins = mutableMapOf<String, String>()
 
   for ((groupArtifact, version) in directDeps) {
-    versions[groupArtifact] = Pair(version, true)
-    queue.addLast(QueueEntry(groupArtifact, version, emptySet()))
+    val fromMain = groupArtifact in mainGAs
+    val fromTest = groupArtifact in testGAs
+    versions[groupArtifact] =
+      VersionEntry(version, direct = true, fromMain = fromMain, fromTest = fromTest)
+    queue.addLast(QueueEntry(groupArtifact, version, emptySet(), fromMain, fromTest))
   }
 
   while (queue.isNotEmpty()) {
@@ -106,13 +164,16 @@ private fun iterate(
     // visits proceed so that a child excluded on one path can still reach
     // the resolved set via the other.
     val visitKey = "${entry.groupArtifact}:${entry.version}:${exclusionsKey(entry.exclusions)}"
-    if (visitKey in visited) continue
-    visited.add(visitKey)
+    val alreadyProcessed = visited[visitKey] ?: Pair(false, false)
+    val afterProcess =
+      Pair(alreadyProcessed.first || entry.fromMain, alreadyProcessed.second || entry.fromTest)
+    if (afterProcess == alreadyProcessed) continue
+    visited[visitKey] = afterProcess
 
     // A higher version may have superseded this entry while it waited in
     // the queue. Skip the lookup for versions no longer current — only the
     // final version needs its children enumerated.
-    if (versions[entry.groupArtifact]?.first != entry.version) continue
+    if (versions[entry.groupArtifact]?.version != entry.version) continue
 
     val children =
       childLookup(entry.groupArtifact, entry.version).getOrElse {
@@ -144,42 +205,63 @@ private fun iterate(
       }
       if (child.strict) {
         val alreadyResolved = versions[depGA]
-        if (alreadyResolved != null && alreadyResolved.first != child.version) {
+        if (alreadyResolved != null && alreadyResolved.version != child.version) {
           return Err(
-            ResolveError.StrictVersionConflict(depGA, child.version, alreadyResolved.first)
+            ResolveError.StrictVersionConflict(depGA, child.version, alreadyResolved.version)
           )
         }
         strictPins[depGA] = child.version
       }
 
       val committedEntry = prev.versions[depGA]
+      // Direct-dep wins even over a transitive path with a different
+      // exclusion context: the user-declared direct dep decides the
+      // children, not a transitive's exclusion list. Matches Gradle.
+      // Still propagate origin into the current pass's state so an edge
+      // from a test-origin parent into a main direct dep marks it as
+      // test-reachable (which main-wins then collapses to MAIN anyway).
+      if (committedEntry != null && committedEntry.direct) {
+        orOrigin(versions, depGA, entry.fromMain, entry.fromTest)
+        continue
+      }
       val depVersion =
         when {
           committedEntry == null -> child.version
-          committedEntry.second -> continue
-          compareVersions(committedEntry.first, child.version) > 0 -> committedEntry.first
+          compareVersions(committedEntry.version, child.version) > 0 -> committedEntry.version
           else -> child.version
         }
 
       val existing = versions[depGA]
       if (existing != null) {
-        val (existingVersion, isDirect) = existing
-        // Direct-dep wins even over a transitive path with a different
-        // exclusion context: the user-declared direct dep decides the
-        // children, not a transitive's exclusion list. Matches Gradle.
-        if (isDirect) continue
+        if (existing.direct) {
+          orOrigin(versions, depGA, entry.fromMain, entry.fromTest)
+          continue
+        }
         // Keep enqueueing same-version entries with different exclusion
         // sets so the per-path exclusion check runs against each one.
         // Strictly-lower versions stay skipped (they'd lose the
-        // highest-wins anyway).
-        if (compareVersions(depVersion, existingVersion) < 0) continue
+        // highest-wins anyway); still OR origin for tracking.
+        if (compareVersions(depVersion, existing.version) < 0) {
+          orOrigin(versions, depGA, entry.fromMain, entry.fromTest)
+          continue
+        }
       }
 
       val mergedExclusions = entry.exclusions + child.exclusions
-      if (existing == null || compareVersions(depVersion, existing.first) > 0) {
-        versions[depGA] = Pair(depVersion, false)
+      val mergedFromMain = (existing?.fromMain ?: false) || entry.fromMain
+      val mergedFromTest = (existing?.fromTest ?: false) || entry.fromTest
+      if (existing == null || compareVersions(depVersion, existing.version) > 0) {
+        versions[depGA] =
+          VersionEntry(
+            version = depVersion,
+            direct = false,
+            fromMain = mergedFromMain,
+            fromTest = mergedFromTest,
+          )
+      } else {
+        versions[depGA] = existing.copy(fromMain = mergedFromMain, fromTest = mergedFromTest)
       }
-      queue.addLast(QueueEntry(depGA, depVersion, mergedExclusions))
+      queue.addLast(QueueEntry(depGA, depVersion, mergedExclusions, entry.fromMain, entry.fromTest))
     }
   }
 
@@ -188,14 +270,28 @@ private fun iterate(
   // earlier-accepted version (including direct deps): the BFS can't re-queue
   // mid-pass. Rejects are rebuilt each pass from the same contributors, so
   // any reject that fires in pass N also fires in pass N+1.
-  for ((groupArtifact, versionAndDirect) in versions) {
+  for ((groupArtifact, ve) in versions) {
     val patterns = rejects[groupArtifact] ?: continue
-    val version = versionAndDirect.first
+    val version = ve.version
     val matched = patterns.firstOrNull { matchesRejectPattern(version, it) } ?: continue
     return Err(ResolveError.RejectedVersionResolved(groupArtifact, version, matched))
   }
 
   return Ok(Resolution(versions = versions.toMap()))
+}
+
+private fun orOrigin(
+  versions: MutableMap<String, VersionEntry>,
+  ga: String,
+  fromMain: Boolean,
+  fromTest: Boolean,
+) {
+  val existing = versions[ga] ?: return
+  val mergedMain = existing.fromMain || fromMain
+  val mergedTest = existing.fromTest || fromTest
+  if (mergedMain != existing.fromMain || mergedTest != existing.fromTest) {
+    versions[ga] = existing.copy(fromMain = mergedMain, fromTest = mergedTest)
+  }
 }
 
 /**
@@ -206,9 +302,9 @@ fun resolveGraph(
   directDeps: Map<String, String>,
   pomLookup: (groupArtifact: String, version: String) -> PomInfo?,
 ): Result<List<DependencyNode>, ResolveError> =
-  fixpointResolve(directDeps, pomChildLookup(pomLookup))
+  fixpointResolve(mainSeeds = directDeps, childLookup = pomChildLookup(pomLookup))
 
-private fun pomChildLookup(
+internal fun pomChildLookup(
   pomLookup: (String, String) -> PomInfo?
 ): (String, String) -> Result<List<Child>, ResolveError> = { groupArtifact, version ->
   val pomInfo = pomLookup(groupArtifact, version)

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -119,9 +119,10 @@ fun resolve(
   existingLock: Lockfile?,
   cacheBase: String,
   deps: ResolverDeps,
+  testSeeds: Map<String, String> = emptyMap(),
 ): Result<ResolveResult, ResolveError> =
   if (config.build.target in NATIVE_TARGETS) resolveNative(config, cacheBase, deps)
-  else resolveTransitive(config, existingLock, cacheBase, deps)
+  else resolveTransitive(config, existingLock, cacheBase, deps, testSeeds = testSeeds)
 
 fun buildLockfileFromResolved(config: KoltConfig, deps: List<ResolvedDep>): Lockfile {
   return Lockfile(
@@ -129,6 +130,14 @@ fun buildLockfileFromResolved(config: KoltConfig, deps: List<ResolvedDep>): Lock
     kotlin = config.kotlin.version,
     jvmTarget = config.build.jvmTarget,
     dependencies =
-      deps.associate { it.groupArtifact to LockEntry(it.version, it.sha256, it.transitive) },
+      deps.associate {
+        it.groupArtifact to
+          LockEntry(
+            version = it.version,
+            sha256 = it.sha256,
+            transitive = it.transitive,
+            test = it.origin == Origin.TEST,
+          )
+      },
   )
 }

--- a/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
@@ -13,6 +13,7 @@ fun resolveTransitive(
   existingLock: Lockfile?,
   cacheBase: String,
   deps: ResolverDeps,
+  testSeeds: Map<String, String> = emptyMap(),
 ): Result<ResolveResult, ResolveError> {
   val repos = config.repositories.values.toList()
 
@@ -33,9 +34,14 @@ fun resolveTransitive(
   }
 
   val nodes =
-    resolveGraph(config.dependencies, pomLookup).getOrElse { error ->
-      return Err(error)
-    }
+    fixpointResolve(
+        mainSeeds = config.dependencies,
+        testSeeds = testSeeds,
+        childLookup = pomChildLookup(pomLookup),
+      )
+      .getOrElse { error ->
+        return Err(error)
+      }
 
   return materialize(nodes, redirects, config, existingLock, cacheBase, deps, repos)
 }
@@ -213,7 +219,14 @@ private fun materialize(
     }
 
     resolvedDeps.add(
-      ResolvedDep(node.groupArtifact, node.version, hash, fullCachePath, transitive = !node.direct)
+      ResolvedDep(
+        groupArtifact = node.groupArtifact,
+        version = node.version,
+        sha256 = hash,
+        cachePath = fullCachePath,
+        transitive = !node.direct,
+        origin = node.origin,
+      )
     )
   }
 

--- a/src/nativeTest/kotlin/kolt/build/TestDepsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/TestDepsTest.kt
@@ -47,47 +47,13 @@ class TestDepsTest {
 
   @Test
   fun userTestDepOverridesAutoInjected() {
+    // Test seeds are `autoInjectedTestDeps(config) + config.testDependencies`;
+    // explicit user test deps win over auto-inject for the same GA.
     val config =
       testConfig(testDependencies = mapOf("org.jetbrains.kotlin:kotlin-test-junit5" to "2.0.0"))
-    val allDeps = mergeAllDeps(config)
+    val testSeeds = autoInjectedTestDeps(config) + config.testDependencies
 
-    assertEquals("2.0.0", allDeps["org.jetbrains.kotlin:kotlin-test-junit5"])
-  }
-
-  @Test
-  fun mainDepOverridesAutoInjected() {
-    val config =
-      testConfig(dependencies = mapOf("org.jetbrains.kotlin:kotlin-test-junit5" to "2.0.0"))
-    val allDeps = mergeAllDeps(config)
-
-    assertEquals("2.0.0", allDeps["org.jetbrains.kotlin:kotlin-test-junit5"])
-  }
-
-  @Test
-  fun testDepOverridesMainDep() {
-    val config =
-      testConfig(
-        dependencies = mapOf("org.jetbrains.kotlin:kotlin-test-junit5" to "2.0.0"),
-        testDependencies = mapOf("org.jetbrains.kotlin:kotlin-test-junit5" to "1.9.0"),
-      )
-    val allDeps = mergeAllDeps(config)
-
-    assertEquals("1.9.0", allDeps["org.jetbrains.kotlin:kotlin-test-junit5"])
-  }
-
-  @Test
-  fun mergeAllDepsIncludesAutoInjectedAndUserDeps() {
-    val config =
-      testConfig(
-        dependencies = mapOf("com.example:lib" to "1.0.0"),
-        testDependencies = mapOf("io.kotest:kotest-runner-junit5" to "5.8.0"),
-      )
-    val allDeps = mergeAllDeps(config)
-
-    assertEquals(3, allDeps.size)
-    assertEquals("2.1.0", allDeps["org.jetbrains.kotlin:kotlin-test-junit5"])
-    assertEquals("1.0.0", allDeps["com.example:lib"])
-    assertEquals("5.8.0", allDeps["io.kotest:kotest-runner-junit5"])
+    assertEquals("2.0.0", testSeeds["org.jetbrains.kotlin:kotlin-test-junit5"])
   }
 
   @Test
@@ -119,7 +85,7 @@ class TestDepsTest {
   }
 
   @Test
-  fun mergeAllDepsNativeTargetHasNoAutoInjected() {
+  fun nativeTargetSkipsAutoInjectedTestDeps() {
     val config =
       KoltConfig(
         name = "my-app",
@@ -128,9 +94,8 @@ class TestDepsTest {
         build = BuildSection(target = "linuxX64", main = "main", sources = listOf("src")),
         dependencies = mapOf("com.example:lib" to "1.0.0"),
       )
-    val allDeps = mergeAllDeps(config)
+    val injected = autoInjectedTestDeps(config)
 
-    assertEquals(1, allDeps.size)
-    assertEquals("1.0.0", allDeps["com.example:lib"])
+    assertEquals(emptyMap(), injected)
   }
 }

--- a/src/nativeTest/kotlin/kolt/cli/DependencyResolutionTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DependencyResolutionTest.kt
@@ -3,11 +3,18 @@ package kolt.cli
 import com.github.michaelbull.result.getOrElse
 import kolt.infra.fileExists
 import kolt.infra.removeDirectoryRecursive
+import kolt.resolve.Origin
+import kolt.resolve.ResolvedDep
+import kolt.resolve.buildLockfileFromResolved
+import kolt.resolve.parseLockfile
+import kolt.resolve.serializeLockfile
 import kolt.testConfig
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.cinterop.ByteVar
@@ -112,8 +119,9 @@ class ResolveDependenciesNoDepsTest {
     val outcome =
       resolveDependencies(config).getOrElse { error("resolveDependencies failed: exit=$it") }
 
-    assertNull(outcome.classpath)
-    assertTrue(outcome.resolvedJars.isEmpty())
+    assertNull(outcome.mainClasspath)
+    assertTrue(outcome.mainJars.isEmpty())
+    assertTrue(outcome.allJars.isEmpty())
   }
 
   private fun createTempDir(prefix: String): String {
@@ -123,5 +131,165 @@ class ResolveDependenciesNoDepsTest {
       val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
       return result.toKString()
     }
+  }
+}
+
+class SplitJvmOutcomeTest {
+
+  @Test
+  fun emptyDepsProducesNullClasspathAndEmptyJarLists() {
+    val outcome = splitJvmOutcome(emptyList())
+    assertNull(outcome.mainClasspath)
+    assertTrue(outcome.mainJars.isEmpty())
+    assertTrue(outcome.allJars.isEmpty())
+  }
+
+  @Test
+  fun mixedOriginSplitsIntoMainAndAllJars() {
+    val mainDep =
+      ResolvedDep(
+        groupArtifact = "com.example:main-lib",
+        version = "1.0.0",
+        sha256 = "hashMain",
+        cachePath = "/cache/main-lib.jar",
+        origin = Origin.MAIN,
+      )
+    val mainTransitive =
+      ResolvedDep(
+        groupArtifact = "com.example:main-transitive",
+        version = "1.0.0",
+        sha256 = "hashMainT",
+        cachePath = "/cache/main-transitive.jar",
+        transitive = true,
+        origin = Origin.MAIN,
+      )
+    val testDep =
+      ResolvedDep(
+        groupArtifact = "org.junit.jupiter:junit-jupiter",
+        version = "5.10.0",
+        sha256 = "hashTest",
+        cachePath = "/cache/junit-jupiter.jar",
+        origin = Origin.TEST,
+      )
+
+    val outcome = splitJvmOutcome(listOf(mainDep, mainTransitive, testDep))
+
+    assertEquals(2, outcome.mainJars.size)
+    val mainPaths = outcome.mainJars.map { it.cachePath }.toSet()
+    assertTrue("/cache/main-lib.jar" in mainPaths)
+    assertTrue("/cache/main-transitive.jar" in mainPaths)
+    assertFalse("/cache/junit-jupiter.jar" in mainPaths)
+
+    assertEquals(3, outcome.allJars.size)
+    val allPaths = outcome.allJars.map { it.cachePath }.toSet()
+    assertTrue("/cache/main-lib.jar" in allPaths)
+    assertTrue("/cache/main-transitive.jar" in allPaths)
+    assertTrue("/cache/junit-jupiter.jar" in allPaths)
+
+    // allJars = mainJars + testJars in that order; main entries appear first.
+    assertEquals(outcome.mainJars, outcome.allJars.take(outcome.mainJars.size))
+
+    val mainClasspath = outcome.mainClasspath
+    assertNotNull(mainClasspath)
+    assertTrue(mainClasspath.split(":").toSet() == mainPaths)
+    assertFalse(mainClasspath.contains("/cache/junit-jupiter.jar"))
+  }
+
+  @Test
+  fun testOnlyDepsProduceNullMainClasspathButPopulatedAllJars() {
+    val testDep =
+      ResolvedDep(
+        groupArtifact = "org.junit.jupiter:junit-jupiter",
+        version = "5.10.0",
+        sha256 = "hashTest",
+        cachePath = "/cache/junit-jupiter.jar",
+        origin = Origin.TEST,
+      )
+
+    val outcome = splitJvmOutcome(listOf(testDep))
+
+    assertNull(outcome.mainClasspath)
+    assertTrue(outcome.mainJars.isEmpty())
+    assertEquals(1, outcome.allJars.size)
+    assertEquals("/cache/junit-jupiter.jar", outcome.allJars[0].cachePath)
+  }
+}
+
+class BuildLockfileFromResolvedTest {
+
+  @Test
+  fun mainOriginDepsAreLockedWithTestFalse() {
+    val config = testConfig()
+    val deps =
+      listOf(
+        ResolvedDep(
+          groupArtifact = "com.example:lib",
+          version = "1.0.0",
+          sha256 = "hashMain",
+          cachePath = "/cache/com/example/lib/1.0.0/lib-1.0.0.jar",
+          transitive = false,
+          origin = Origin.MAIN,
+        )
+      )
+
+    val lockfile = buildLockfileFromResolved(config, deps)
+
+    assertEquals(3, lockfile.version)
+    val entry = lockfile.dependencies["com.example:lib"]
+    assertNotNull(entry)
+    assertFalse(entry.test)
+  }
+
+  @Test
+  fun testOriginDepsAreLockedWithTestTrue() {
+    val config = testConfig()
+    val deps =
+      listOf(
+        ResolvedDep(
+          groupArtifact = "org.junit.jupiter:junit-jupiter",
+          version = "5.10.0",
+          sha256 = "hashTest",
+          cachePath = "/cache/org/junit/jupiter/junit-jupiter/5.10.0/junit-jupiter-5.10.0.jar",
+          transitive = false,
+          origin = Origin.TEST,
+        )
+      )
+
+    val lockfile = buildLockfileFromResolved(config, deps)
+
+    val entry = lockfile.dependencies["org.junit.jupiter:junit-jupiter"]
+    assertNotNull(entry)
+    assertTrue(entry.test)
+  }
+
+  @Test
+  fun serializedLockfileCarriesVersion3AndTestFlagForTestEntries() {
+    val config = testConfig()
+    val deps =
+      listOf(
+        ResolvedDep(
+          groupArtifact = "com.example:main-lib",
+          version = "1.0.0",
+          sha256 = "hashMain",
+          cachePath = "/cache/main-lib.jar",
+          origin = Origin.MAIN,
+        ),
+        ResolvedDep(
+          groupArtifact = "com.example:test-lib",
+          version = "1.0.0",
+          sha256 = "hashTest",
+          cachePath = "/cache/test-lib.jar",
+          origin = Origin.TEST,
+        ),
+      )
+
+    val lockfile = buildLockfileFromResolved(config, deps)
+    val serialized = serializeLockfile(lockfile)
+    assertTrue(serialized.contains("\"version\": 3"))
+    assertTrue(serialized.contains("\"test\": true"))
+
+    val parsed = parseLockfile(serialized).getOrElse { error("parseLockfile failed: $it") }
+    assertEquals(false, parsed.dependencies["com.example:main-lib"]?.test)
+    assertEquals(true, parsed.dependencies["com.example:test-lib"]?.test)
   }
 }

--- a/src/nativeTest/kotlin/kolt/resolve/ResolutionTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolutionTest.kt
@@ -1,5 +1,6 @@
 package kolt.resolve
 
+import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import kotlin.test.Test
@@ -524,4 +525,197 @@ class ResolutionTest {
     { groupArtifact, version ->
       this["$groupArtifact:$version"]
     }
+
+  @Test
+  fun fixpointResolveTwoSeedsTagEachNodeWithOrigin() {
+    val poms =
+      mapOf(
+        "com.example:main-lib:1.0.0" to pomInfo("com.example", "main-lib", "1.0.0"),
+        "com.example:test-lib:1.0.0" to pomInfo("com.example", "test-lib", "1.0.0"),
+      )
+    val result =
+      fixpointResolve(
+        mainSeeds = mapOf("com.example:main-lib" to "1.0.0"),
+        testSeeds = mapOf("com.example:test-lib" to "1.0.0"),
+        childLookup = pomChildLookupFor(poms),
+      )
+    val nodes = assertNotNull(result.get())
+    assertEquals(2, nodes.size)
+    val mainNode = nodes.first { it.groupArtifact == "com.example:main-lib" }
+    assertEquals(Origin.MAIN, mainNode.origin)
+    val testNode = nodes.first { it.groupArtifact == "com.example:test-lib" }
+    assertEquals(Origin.TEST, testNode.origin)
+  }
+
+  @Test
+  fun fixpointResolveMainWinsWhenSameGaSeededByBoth() {
+    val poms =
+      mapOf(
+        "com.example:lib:1.0.0" to pomInfo("com.example", "lib", "1.0.0"),
+        "com.example:lib:2.0.0" to pomInfo("com.example", "lib", "2.0.0"),
+      )
+    val result =
+      fixpointResolve(
+        mainSeeds = mapOf("com.example:lib" to "1.0.0"),
+        testSeeds = mapOf("com.example:lib" to "2.0.0"),
+        childLookup = pomChildLookupFor(poms),
+      )
+    val nodes = assertNotNull(result.get())
+    assertEquals(1, nodes.size)
+    val lib = nodes[0]
+    assertEquals("com.example:lib", lib.groupArtifact)
+    assertEquals("1.0.0", lib.version)
+    assertEquals(Origin.MAIN, lib.origin)
+  }
+
+  @Test
+  fun fixpointResolveTestOnlyTransitiveInheritsTestOrigin() {
+    val poms =
+      mapOf(
+        "com.example:junit:1.0.0" to
+          pomInfo(
+            "com.example",
+            "junit",
+            "1.0.0",
+            deps = listOf(pomDep("com.example", "hamcrest", "1.0.0")),
+          ),
+        "com.example:hamcrest:1.0.0" to pomInfo("com.example", "hamcrest", "1.0.0"),
+      )
+    val result =
+      fixpointResolve(
+        mainSeeds = emptyMap(),
+        testSeeds = mapOf("com.example:junit" to "1.0.0"),
+        childLookup = pomChildLookupFor(poms),
+      )
+    val nodes = assertNotNull(result.get())
+    assertEquals(2, nodes.size)
+    assertTrue(nodes.all { it.origin == Origin.TEST })
+  }
+
+  @Test
+  fun fixpointResolveTransitiveReachedFromBothOriginsCollapsesToMain() {
+    val poms =
+      mapOf(
+        "com.example:main-root:1.0.0" to
+          pomInfo(
+            "com.example",
+            "main-root",
+            "1.0.0",
+            deps = listOf(pomDep("com.example", "shared", "1.0.0")),
+          ),
+        "com.example:test-root:1.0.0" to
+          pomInfo(
+            "com.example",
+            "test-root",
+            "1.0.0",
+            deps = listOf(pomDep("com.example", "shared", "1.0.0")),
+          ),
+        "com.example:shared:1.0.0" to pomInfo("com.example", "shared", "1.0.0"),
+      )
+    val result =
+      fixpointResolve(
+        mainSeeds = mapOf("com.example:main-root" to "1.0.0"),
+        testSeeds = mapOf("com.example:test-root" to "1.0.0"),
+        childLookup = pomChildLookupFor(poms),
+      )
+    val nodes = assertNotNull(result.get())
+    val shared = nodes.first { it.groupArtifact == "com.example:shared" }
+    assertEquals(Origin.MAIN, shared.origin)
+  }
+
+  @Test
+  fun fixpointResolveDeepTestTransitiveReachedByMainCollapsesToMain() {
+    // main -> mid -> shared
+    // test -> shared
+    // Even though shared is directly touched by a test seed (post-transitive from main),
+    // origin must collapse to MAIN.
+    val poms =
+      mapOf(
+        "com.example:main-root:1.0.0" to
+          pomInfo(
+            "com.example",
+            "main-root",
+            "1.0.0",
+            deps = listOf(pomDep("com.example", "mid", "1.0.0")),
+          ),
+        "com.example:mid:1.0.0" to
+          pomInfo(
+            "com.example",
+            "mid",
+            "1.0.0",
+            deps = listOf(pomDep("com.example", "shared", "1.0.0")),
+          ),
+        "com.example:shared:1.0.0" to pomInfo("com.example", "shared", "1.0.0"),
+      )
+    val result =
+      fixpointResolve(
+        mainSeeds = mapOf("com.example:main-root" to "1.0.0"),
+        testSeeds = mapOf("com.example:shared" to "1.0.0"),
+        childLookup = pomChildLookupFor(poms),
+      )
+    val nodes = assertNotNull(result.get())
+    val shared = nodes.first { it.groupArtifact == "com.example:shared" }
+    assertEquals(Origin.MAIN, shared.origin)
+  }
+
+  @Test
+  fun fixpointResolveDefaultTestSeedsPreservesMainOnlyBehavior() {
+    val poms =
+      mapOf(
+        "com.example:lib:1.0.0" to
+          pomInfo(
+            "com.example",
+            "lib",
+            "1.0.0",
+            deps = listOf(pomDep("com.example", "transitive", "2.0.0")),
+          ),
+        "com.example:transitive:2.0.0" to pomInfo("com.example", "transitive", "2.0.0"),
+      )
+    val result =
+      fixpointResolve(
+        mainSeeds = mapOf("com.example:lib" to "1.0.0"),
+        childLookup = pomChildLookupFor(poms),
+      )
+    val nodes = assertNotNull(result.get())
+    assertEquals(2, nodes.size)
+    assertTrue(nodes.all { it.origin == Origin.MAIN })
+  }
+
+  @Test
+  fun fixpointResolveInvalidTestSeedReturnsErr() {
+    val result =
+      fixpointResolve(mainSeeds = emptyMap(), testSeeds = mapOf("invalid-no-colon" to "1.0.0")) {
+        _,
+        _ ->
+        Ok(emptyList())
+      }
+    assertIs<ResolveError.InvalidDependency>(result.getError())
+  }
+
+  private fun pomChildLookupFor(
+    poms: Map<String, PomInfo>
+  ): (String, String) -> com.github.michaelbull.result.Result<List<Child>, ResolveError> {
+    return { groupArtifact, version ->
+      val pomInfo = poms["$groupArtifact:$version"]
+      if (pomInfo == null) {
+        Ok(emptyList())
+      } else {
+        Ok(
+          pomInfo.dependencies.mapNotNull { pomDep ->
+            if (pomDep.scope != null && pomDep.scope != "compile" && pomDep.scope != "runtime") {
+              return@mapNotNull null
+            }
+            if (pomDep.optional) return@mapNotNull null
+            val depGA = "${pomDep.groupId}:${pomDep.artifactId}"
+            val rawVersion = pomDep.version ?: return@mapNotNull null
+            Child(
+              groupArtifact = depGA,
+              version = selectVersion(rawVersion),
+              exclusions = pomDep.exclusions.toSet(),
+            )
+          }
+        )
+      }
+    }
+  }
 }

--- a/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
@@ -242,6 +242,98 @@ class TransitiveResolverTest {
   }
 
   @Test
+  fun testSeedsArriveAsOriginTestInResolvedDeps() {
+    val config = testConfig().copy(dependencies = mapOf("com.example:main-lib" to "1.0.0"))
+    val mainPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>main-lib</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+    val testPom =
+      """
+            <project>
+                <groupId>com.example</groupId>
+                <artifactId>test-lib</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.example</groupId>
+                        <artifactId>test-child</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                </dependencies>
+            </project>
+        """
+        .trimIndent()
+    val testChildPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>test-child</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+
+    val deps =
+      fakeTransitiveDeps(
+        sha256Results =
+          mapOf(
+            "/cache/com/example/main-lib/1.0.0/main-lib-1.0.0.jar" to "hashMain",
+            "/cache/com/example/test-lib/1.0.0/test-lib-1.0.0.jar" to "hashTest",
+            "/cache/com/example/test-child/1.0.0/test-child-1.0.0.jar" to "hashTestChild",
+          ),
+        pomContents =
+          mapOf(
+            "/cache/com/example/main-lib/1.0.0/main-lib-1.0.0.pom" to mainPom,
+            "/cache/com/example/test-lib/1.0.0/test-lib-1.0.0.pom" to testPom,
+            "/cache/com/example/test-child/1.0.0/test-child-1.0.0.pom" to testChildPom,
+          ),
+      )
+    val result =
+      resolveTransitive(
+        config,
+        existingLock = null,
+        cacheBase = "/cache",
+        deps = deps,
+        testSeeds = mapOf("com.example:test-lib" to "1.0.0"),
+      )
+    val resolved = assertNotNull(result.get())
+    assertEquals(3, resolved.deps.size)
+    val mainLib = resolved.deps.first { it.groupArtifact == "com.example:main-lib" }
+    assertEquals(Origin.MAIN, mainLib.origin)
+    val testLib = resolved.deps.first { it.groupArtifact == "com.example:test-lib" }
+    assertEquals(Origin.TEST, testLib.origin)
+    val testChild = resolved.deps.first { it.groupArtifact == "com.example:test-child" }
+    assertEquals(Origin.TEST, testChild.origin)
+  }
+
+  @Test
+  fun testSeedOverlappingMainIsDroppedWithMainOriginPreserved() {
+    val config = testConfig().copy(dependencies = mapOf("com.example:shared" to "1.0.0"))
+    val sharedPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>shared</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+
+    val deps =
+      fakeTransitiveDeps(
+        sha256Results = mapOf("/cache/com/example/shared/1.0.0/shared-1.0.0.jar" to "hashShared"),
+        pomContents = mapOf("/cache/com/example/shared/1.0.0/shared-1.0.0.pom" to sharedPom),
+      )
+    val result =
+      resolveTransitive(
+        config,
+        existingLock = null,
+        cacheBase = "/cache",
+        deps = deps,
+        testSeeds = mapOf("com.example:shared" to "1.0.0"),
+      )
+    val resolved = assertNotNull(result.get())
+    assertEquals(1, resolved.deps.size)
+    val shared = resolved.deps[0]
+    assertEquals("com.example:shared", shared.groupArtifact)
+    assertEquals(Origin.MAIN, shared.origin)
+  }
+
+  @Test
   fun optionalDepsAreSkipped() {
     val config = testConfig().copy(dependencies = mapOf("com.example:lib" to "1.0.0"))
     val libPom =


### PR DESCRIPTION
Phase 2 of `main-test-closure-separation` (follow-up to #249 Foundation). Wires the 2-seed kernel, the origin-tagged adapter, and the origin-split JVM outcome end to end.

## Changes

- **Kernel (2.1)** — `fixpointResolve(mainSeeds, testSeeds = emptyMap(), childLookup)`. Per-GA origin bits (`fromMain` / `fromTest`) accumulate across every visit in the BFS; `visited` now keys `(ga, v, excl) → (mainProcessed, testProcessed)` so a tuple re-enters at most twice (cycles still bounded at `(T, T)`). main wins on overlap via `effectiveDirectDeps = testSeeds + mainSeeds` and the final fold `if (fromMain) MAIN else TEST`. `Resolution` / `VersionEntry` narrowed to `internal`.
- **Transitive adapter (2.2)** — `resolveTransitive` takes `testSeeds: Map<String, String> = emptyMap()` and calls `fixpointResolve(..., pomChildLookup(pomLookup))` directly. `materialize` transcribes `DependencyNode.origin` onto the single `ResolvedDep.add` site so the cache-hit and cache-miss paths share one emission. `pomChildLookup` bumped `private → internal` as the minimal enabler.
- **Outcome / lockfile / cli (2.3)** — `JvmResolutionOutcome` becomes `(mainClasspath, mainJars, allJars)`. `resolveDependencies` composes main/test seeds, calls `resolve()` once, and delegates outcome construction to a new `internal fun splitJvmOutcome(deps)` for direct unit-testability. `buildLockfileFromResolved` sets `test = origin == Origin.TEST` per entry. `mergeAllDeps` deleted; `doUpdate` re-walks `mainSeeds + testSeeds` for cache purge then calls `resolve(..., testSeeds = testSeeds)`.
- **BuildCommands minimal adaptation** — `doBuild` uses `mainClasspath` for kotlinc main compile and `mainJars` for the runtime classpath manifest; `BuildResult.classpath` temporarily carries the `allJars`-joined string so `doTest` / `doRun` keep working until task 3.1 narrows `doRun` to main-only.

Foundation types (Lockfile v3, `Origin` enum, auto-inject skip) from #249 are the prerequisites.

## Reviewer focus

- Kernel cycle termination and origin OR-propagation. `Resolution.kt:167-174` (visited re-entry gate) and `Resolution.kt:222-245` (committed-direct early-continue / direct-wins paths that must still OR origin via `orOrigin`). The test `fixpointResolveDeepTestTransitiveReachedByMainCollapsesToMain` specifically covers the early-continue branch.
- `splitJvmOutcome`: confirm `allJars = mainJars + testJars` ordering and that `mainClasspath` strictly excludes test-origin cache paths (`SplitJvmOutcomeTest.mixedOriginSplitsIntoMainAndAllJars`).
- `doUpdate` now loops `allSeeds = mainSeeds + testSeeds` for cache deletion. In overlap-with-different-versions scenarios it deletes the test-version path which wouldn't have been cached anyway (resolver chose main); net correctness preserved.
- The warning in `findOverlappingDependencies` said "using mainVersion" but the old merge (`main + testDeps`) let test win — that lie is now resolved by the kernel's main-wins rule.

Task 3.1 (narrow `doRun` / extend `BuildResult` with explicit main/all jars), 3.2 (Workspace split), 3.3 (`doTree` / `doInstall`), and 4.x (ADR updates + lockfile regeneration + daemon smoke) are intentionally left for subsequent PRs.

## Verification

- `./gradlew build` → BUILD SUCCESSFUL (compile + test + release link).
- Full suite green; 7 new resolver-kernel tests (ResolutionTest), 2 new adapter tests (TransitiveResolverTest), 3 new outcome tests (SplitJvmOutcomeTest), 3 new lockfile origin tests (BuildLockfileFromResolvedTest). Existing `scopeFilteringSkipsTestAndProvided` and the strict / rejects / exclusions regression set still pass unchanged.

Two independent task-local reviewers approved 2.1 and 2.2 on first pass; 2.3 was approved on the second pass after adding `SplitJvmOutcomeTest` to close a literal acceptance-criterion gap (the original tests only covered the empty outcome branch).