### PR TITLE
Integrate origin filter into build / IDE / docs (#229 Phase 3 + 4.1)

### DIFF
--- a/.kiro/specs/main-test-closure-separation/tasks.md
+++ b/.kiro/specs/main-test-closure-separation/tasks.md
@@ -110,7 +110,7 @@
 
 ## 4. Validation: ADR / 成果物の更新とスモーク
 
-- [ ] 4.1 (P) ADR 0027 §1 と ADR 0003 §2 の文言を新契約に揃える
+- [x] 4.1 (P) ADR 0027 §1 と ADR 0003 §2 の文言を新契約に揃える
   - ADR 0027 §1 の "transitive closure, post-exclusion" を「main closure (非test closure) の transitive closure, post-exclusion」に限定する文言を追加
   - ADR 0027 §4 の kind マトリクス脚注に「emit 対象は main closure のみ」の補足
   - ADR 0003 §2 の schema evolution 節に v2 → v3 (`LockEntry.test: Boolean` 追加、v1/v2 は unsupported で reject) の行を追記

--- a/.kiro/specs/main-test-closure-separation/tasks.md
+++ b/.kiro/specs/main-test-closure-separation/tasks.md
@@ -69,7 +69,7 @@
 
 ## 3. Integration: caller 側の origin filter と出力経路
 
-- [ ] 3.1 (P) `BuildCommands` の build / run / test 経路を新 `JvmResolutionOutcome` に追従
+- [x] 3.1 (P) `BuildCommands` の build / run / test 経路を新 `JvmResolutionOutcome` に追従
   - `doBuild` の返り (`BuildResult`) を拡張し `mainJars` と `allJars` を後段に持ち回る経路を確保
   - `doRun` は既存 `classpath` (main-only) をそのまま `java` subproc に渡す (意味のみ狭まる)
   - `doTest` は compile (L709 相当) と run (L723 相当) の両方で `allJars` から classpath を組み立てる (disjoint 前提で単純結合)
@@ -85,7 +85,7 @@
   - _Boundary: kolt.cli.BuildCommands, kolt.build.Builder_
   - _Depends: 2.3_
 
-- [ ] 3.2 (P) `Workspace.generateWorkspaceJson` を main / test 分離入力に切り替え
+- [x] 3.2 (P) `Workspace.generateWorkspaceJson` を main / test 分離入力に切り替え
   - `generateWorkspaceJson(config, mainDeps, testDeps)` に signature 変更
   - `buildMainModule` は `mainDeps` のみを library 列挙
   - `buildTestModule` は `mainDeps + testDeps` を列挙 (test コードは main も見る)
@@ -98,7 +98,7 @@
   - _Boundary: kolt.build.Workspace, kolt.cli.DependencyResolution_
   - _Depends: 2.3_
 
-- [ ] 3.3 (P) `DependencyCommands.doTree` / `doInstall` を origin 別に組み直す
+- [x] 3.3 (P) `DependencyCommands.doTree` / `doInstall` を origin 別に組み直す
   - `doTree` (L254, L334 付近) の `mergeAllDeps` 呼び出しを main seeds (`config.dependencies`) と test seeds (`autoInjectedTestDeps + config.testDependencies`) の別 tree 表示に置換 (既存「test dependencies:」セクション出力は維持)
   - `doInstall` は `resolveDependencies` 経由で統一 (直接 resolver 呼び出しの箇所があれば新 `JvmResolutionOutcome` に追従)
   - 既存の deps tree 整形出力 (`formatDependencyTree`) はそのまま使用

--- a/docs/adr/0003-toml-config-json-lockfile.md
+++ b/docs/adr/0003-toml-config-json-lockfile.md
@@ -24,7 +24,7 @@ The lockfile is different — never edited by hand, so human ergonomics are irre
 
 - Users must be able to comment out a dependency or annotate a pinned version in `kolt.toml`.
 - Lockfile diffs must be stable across runs so a changed line signals a real dependency move.
-- Schema evolution (`v1 → v2`) must require no hand-written JSON walking.
+- Schema evolution (`v1 → v2 → v3`) must require no hand-written JSON walking.
 - No new Kotlin/Native-incompatible dependency.
 
 ## Decision Outcome
@@ -37,7 +37,14 @@ Chosen option: **TOML for `kolt.toml`, JSON for `kolt.lock`**, because each form
 
 ### §2 `kolt.lock` — kotlinx-serialization-json
 
-`Lockfile.kt` owns the v1 and v2 schemas. Writes go through `Json { prettyPrint = true; prettyPrintIndent = "  " }` for reviewable diffs. kotlinx-serialization orders fields by data class declaration (not by hash), so output is stable across runs. Schema evolution uses `@SerialName` plus nullable/default fields. Tests live in `LockfileTest.kt`.
+`Lockfile.kt` owns the schema. Writes go through `Json { prettyPrint = true; prettyPrintIndent = "  " }` for reviewable diffs. kotlinx-serialization orders fields by data class declaration (not by hash), so output is stable across runs. Schema evolution uses `@SerialName` plus nullable/default fields.
+
+Schema history:
+
+- **v1 → v2**: added `LockEntry.transitive: Boolean = false` so direct vs transitive origin is recoverable from the lockfile alone.
+- **v2 → v3**: added `LockEntry.test: Boolean = false` so main vs test closure is recoverable offline (spec `main-test-closure-separation`). Per the pre-v1 clean-break policy (CLAUDE.md), `parseLockfile` rejects v1 and v2 with `LockfileError.UnsupportedVersion`; users regenerate via `kolt deps install`. ADR 0027 §1 consumes this flag to keep test-origin deps out of the runtime classpath manifest.
+
+Tests live in `LockfileTest.kt`.
 
 ### §3 ktoml quoted-key workaround
 
@@ -52,7 +59,7 @@ Neither `kolt.toml` nor `kolt.lock` is binary. Both are diffable, grep-able, and
 **Positive**
 - Users can comment out a dependency or annotate a pinned version in `kolt.toml`.
 - Lockfile diffs are stable and reviewable; a changed line is a meaningful signal.
-- Schema evolution (v1 → v2 lockfile bump) required only `@SerialName` and a version-discriminated parser — no hand-written JSON walking.
+- Schema evolution (v1 → v2 → v3 lockfile bumps) required only `@SerialName` and a version-discriminated parser — no hand-written JSON walking.
 - TOML is familiar to anyone who has used Cargo, Poetry, or uv.
 
 **Negative**
@@ -75,5 +82,5 @@ Neither `kolt.toml` nor `kolt.lock` is binary. Both are diffable, grep-able, and
 ## Related
 
 - `src/nativeMain/kotlin/kolt/config/Config.kt` — `parseConfig` and the quoted-key workaround
-- `src/nativeMain/kotlin/kolt/resolve/Lockfile.kt` — v1/v2 schemas, JSON writer
+- `src/nativeMain/kotlin/kolt/resolve/Lockfile.kt` — v3 schema, JSON writer (v1/v2 rejected per pre-v1 clean-break)
 - Commit `3325d37` — migration from `kolt.json` to `kolt.toml`

--- a/docs/adr/0027-runtime-classpath-manifest.md
+++ b/docs/adr/0027-runtime-classpath-manifest.md
@@ -9,8 +9,8 @@ date: 2026-04-22
 
 - Emit `build/<name>-runtime.classpath` alongside `build/<name>.jar` for
   JVM `kind = "app"` builds. Plain text, one absolute jar path per line,
-  dependencies only (self jar excluded), sorted alphabetically by file
-  name (§1).
+  main closure only (self jar and test-origin deps excluded), sorted
+  alphabetically by file name (§1).
 - Keep `.kolt.lock` as pure resolution state. Runtime jar paths depend
   on the local `~/.kolt/cache` layout and do not belong in a
   checked-in lockfile (§2).
@@ -111,10 +111,16 @@ Rules:
   a normal transitive dependency (ADR 0011's skip is native-only,
   since konanc bundles stdlib in its distribution). The daemon JVM
   has no ambient stdlib, so listing it is required for launch.
-- **Transitive closure, post-exclusion.** The manifest is the
-  effective runtime classpath: exactly what the resolver selected
-  after BFS, version intervals, and `exclusions` (the Phase 3
-  algorithm shipped in v0.3.0).
+- **Main closure, transitive, post-exclusion.** The manifest lists
+  the effective runtime classpath of the **main dependency closure
+  only** — what the resolver selected for `[dependencies]` after BFS,
+  version intervals, and `exclusions` (the Phase 3 algorithm shipped
+  in v0.3.0). Test-origin entries (`[test-dependencies]`, the
+  auto-injected `kotlin-test-junit5`, and their transitive closure)
+  are excluded so the manifest matches `kolt run`'s in-process
+  classpath (§5) and the daemon self-host tarball assembled by
+  `scripts/assemble-dist.sh` (§3). ADR 0003 §2 records the lockfile
+  `test: Boolean` flag that makes this split recoverable offline.
 
 Helper `outputRuntimeClasspathPath(config): String` in
 `kolt/build/Builder.kt` parallels `outputJarPath(config)` /
@@ -171,6 +177,11 @@ The "no" cases are active — kolt MUST NOT produce
 `build/<name>-runtime.classpath` for them. A regression test in
 `JvmLibraryInvariantsTest` / `NativeStagePlanTest` pins the
 non-emission for lib and native paths.
+
+Emit scope: for the sole emitter (JVM `kind = "app"`), the manifest
+always lists the **main closure only**. Test-origin deps are filtered
+out regardless of whether the project declares `[test-dependencies]`
+or carries test sources (spec `main-test-closure-separation`).
 
 ### §5 Relationship with `kolt run`
 

--- a/src/nativeMain/kotlin/kolt/build/BuildCache.kt
+++ b/src/nativeMain/kotlin/kolt/build/BuildCache.kt
@@ -13,7 +13,13 @@ data class BuildState(
   @SerialName("sources_newest_mtime") val sourcesNewestMtime: Long,
   @SerialName("classes_dir_mtime") val classesDirMtime: Long?,
   @SerialName("lockfile_mtime") val lockfileMtime: Long?,
-  val classpath: String? = null,
+  // The `main_classpath` rename is load-bearing: older state files
+  // stored the all-deps classpath under `classpath`. Keeping that
+  // SerialName would let those files round-trip into a BuildResult
+  // that hands an all-deps classpath to `kolt run` (which expects
+  // main-only). Strict decode failure forces a rebuild instead.
+  @SerialName("main_classpath") val classpath: String? = null,
+  @SerialName("test_classpath") val testClasspath: String? = null,
   @SerialName("resources_newest_mtime") val resourcesNewestMtime: Long? = null,
   @SerialName("def_newest_mtime") val defNewestMtime: Long? = null,
 )

--- a/src/nativeMain/kotlin/kolt/build/Workspace.kt
+++ b/src/nativeMain/kotlin/kolt/build/Workspace.kt
@@ -10,15 +10,20 @@ private val prettyJson = Json {
   prettyPrintIndent = "  "
 }
 
-fun generateWorkspaceJson(config: KoltConfig, resolvedDeps: List<ResolvedDep>): String {
+fun generateWorkspaceJson(
+  config: KoltConfig,
+  mainDeps: List<ResolvedDep>,
+  testDeps: List<ResolvedDep>,
+): String {
+  val allDeps = mainDeps + testDeps
   val json = buildJsonObject {
     putJsonArray("modules") {
-      add(buildMainModule(config, resolvedDeps))
+      add(buildMainModule(config, mainDeps))
       if (config.build.testSources.isNotEmpty()) {
-        add(buildTestModule(config, resolvedDeps))
+        add(buildTestModule(config, allDeps))
       }
     }
-    putJsonArray("libraries") { resolvedDeps.forEach { dep -> add(buildLibraryEntry(dep)) } }
+    putJsonArray("libraries") { allDeps.forEach { dep -> add(buildLibraryEntry(dep)) } }
     putJsonArray("sdks") { add(buildSdkEntry(config.build.jvmTarget)) }
     putJsonArray("kotlinSettings") { add(buildKotlinSettings(config)) }
   }

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -26,10 +26,15 @@ import kotlin.time.TimeSource
 
 internal const val KOLT_TOML = "kolt.toml"
 
+// `classpath` is the main closure, `testClasspath` is main ∪ test. The
+// split lets doRun / watch-run launch against main-only while doTest
+// compiles and runs against the union without a second resolver walk.
+// Both are null for native targets.
 internal data class BuildResult(
   val config: KoltConfig,
   val classpath: String?,
   val javaPath: String? = null,
+  val testClasspath: String? = null,
 )
 
 // ADR 0027 §4 kind/target matrix: JVM `kind = "app"` emits
@@ -227,7 +232,14 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
     // Invariant: the up-to-date path must stay a pure mtime compare —
     // no plugin jar resolution or toolchain provisioning — so offline
     // cached builds don't hard-exit on a failed fetch.
-    return Ok(BuildResult(config, cachedState!!.classpath, managedJavaBin))
+    return Ok(
+      BuildResult(
+        config = config,
+        classpath = cachedState!!.classpath,
+        javaPath = managedJavaBin,
+        testClasspath = cachedState.testClasspath,
+      )
+    )
   }
   // Out of date → rebuild. Drop the state file first so any failure
   // below leaves cached=null for the next run (#50).
@@ -241,11 +253,9 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
     resolveDependencies(config).getOrElse {
       return Err(it)
     }
-  // Main compile sees main-only deps; doTest/doRun get the full classpath
-  // (main ∪ test) through BuildResult below. Task 3.1 will narrow doRun to
-  // main-only; for now the minimum change keeps that path intact.
   val mainClasspath = resolutionOutcome.mainClasspath
-  val classpath = buildClasspath(resolutionOutcome.allJars.map { it.cachePath }).ifEmpty { null }
+  val testClasspath =
+    buildClasspath(resolutionOutcome.allJars.map { it.cachePath }).ifEmpty { null }
   val pluginJarPathsByAlias =
     resolveEnabledPluginJarPaths(config, paths, EXIT_BUILD_ERROR).getOrElse {
       eprintln("error: ${it.message}")
@@ -345,7 +355,8 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
     currentState.copy(
       classesDirMtime = newestMtimeAll(CLASSES_DIR),
       lockfileMtime = if (fileExists(LOCK_FILE)) fileMtime(LOCK_FILE) else null,
-      classpath = classpath,
+      classpath = mainClasspath,
+      testClasspath = testClasspath,
     )
   writeFileAsString(BUILD_STATE_FILE, serializeBuildState(newState)).getOrElse {
     eprintln("warning: could not write build state file")
@@ -353,7 +364,14 @@ internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> {
 
   val elapsed = startMark.elapsedNow()
   println("built ${jarCmd.outputPath} in ${formatDuration(elapsed)}")
-  return Ok(BuildResult(config, classpath, managedJavaBin))
+  return Ok(
+    BuildResult(
+      config = config,
+      classpath = mainClasspath,
+      javaPath = managedJavaBin,
+      testClasspath = testClasspath,
+    )
+  )
 }
 
 private fun doNativeBuild(config: KoltConfig, useDaemon: Boolean): Result<BuildResult, Int> {
@@ -676,10 +694,15 @@ internal fun doTest(
   if (config.build.target in NATIVE_TARGETS) {
     return doNativeTest(config, testArgs)
   }
-  val (_, classpath, javaPath) =
+  val buildResult =
     doBuild(useDaemon = useDaemon).getOrElse {
       return Err(it)
     }
+  // R4.1: test compile/run classpath is main ∪ test. Fall through to the
+  // main-only classpath if the resolver found no test origin deps (the
+  // union collapses to the main closure).
+  val testClasspath = buildResult.testClasspath ?: buildResult.classpath
+  val javaPath = buildResult.javaPath
 
   val existingTestSources = filterExistingDirs(config.build.testSources, "test source")
   if (existingTestSources.isEmpty()) {
@@ -713,7 +736,7 @@ internal fun doTest(
 
   val testConfig = config.copy(build = config.build.copy(testSources = existingTestSources))
   val testCmd =
-    testBuildCommand(testConfig, CLASSES_DIR, classpath, pArgs, kotlincPath = managedKotlincBin)
+    testBuildCommand(testConfig, CLASSES_DIR, testClasspath, pArgs, kotlincPath = managedKotlincBin)
   println("compiling tests...")
   executeCommand(testCmd.args).getOrElse { error ->
     eprintln("error: " + formatProcessError(error, "test compilation"))
@@ -727,7 +750,7 @@ internal fun doTest(
       testClassesDir = testCmd.outputPath,
       consoleLauncherPath = consoleLauncherPath,
       testResourceDirs = existingTestResourceDirs,
-      classpath = classpath,
+      classpath = testClasspath,
       testArgs = testArgs,
       javaPath = javaPath,
     )

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -291,17 +291,31 @@ internal fun doUpdate(): Result<Unit, Int> {
   return Ok(Unit)
 }
 
+internal data class DepsTreeSeeds(
+  val mainSeeds: Map<String, String>,
+  val testSeeds: Map<String, String>,
+) {
+  val isEmpty: Boolean
+    get() = mainSeeds.isEmpty() && testSeeds.isEmpty()
+}
+
+internal fun depsTreeSeeds(config: KoltConfig): DepsTreeSeeds =
+  DepsTreeSeeds(
+    mainSeeds = config.dependencies,
+    // Native targets don't auto-inject `kotlin-test-junit5`; the
+    // `autoInjectedTestDeps` helper already filters by target, so both
+    // JVM and native paths share this expression.
+    testSeeds = autoInjectedTestDeps(config) + config.testDependencies,
+  )
+
 internal fun doTree(): Result<Unit, Int> {
   val config =
     loadProjectConfig().getOrElse {
       return Err(it)
     }
 
-  val hasAnyDeps =
-    config.dependencies.isNotEmpty() ||
-      config.testDependencies.isNotEmpty() ||
-      autoInjectedTestDeps(config).isNotEmpty()
-  if (!hasAnyDeps) {
+  val seeds = depsTreeSeeds(config)
+  if (seeds.isEmpty) {
     println("no dependencies")
     return Ok(Unit)
   }
@@ -320,30 +334,29 @@ internal fun doTree(): Result<Unit, Int> {
         createResolverDeps(),
         nativeTarget = konanTargetGradleName(config.build.target),
       )
-    if (config.dependencies.isNotEmpty()) {
-      val tree = buildNativeDependencyTree(config.dependencies, nativeLookup)
+    if (seeds.mainSeeds.isNotEmpty()) {
+      val tree = buildNativeDependencyTree(seeds.mainSeeds, nativeLookup)
       println(formatDependencyTree(tree))
     }
-    if (config.testDependencies.isNotEmpty()) {
-      if (config.dependencies.isNotEmpty()) println()
+    if (seeds.testSeeds.isNotEmpty()) {
+      if (seeds.mainSeeds.isNotEmpty()) println()
       println("test dependencies:")
-      val testTree = buildNativeDependencyTree(config.testDependencies, nativeLookup)
+      val testTree = buildNativeDependencyTree(seeds.testSeeds, nativeLookup)
       println(formatDependencyTree(testTree))
     }
     return Ok(Unit)
   }
 
-  val allTestDeps = autoInjectedTestDeps(config) + config.testDependencies
   val pomLookup =
     createPomLookup(config.repositories.values.toList(), paths.cacheBase, createResolverDeps())
-  if (config.dependencies.isNotEmpty()) {
-    val tree = buildDependencyTree(config.dependencies, pomLookup)
+  if (seeds.mainSeeds.isNotEmpty()) {
+    val tree = buildDependencyTree(seeds.mainSeeds, pomLookup)
     println(formatDependencyTree(tree))
   }
-  if (allTestDeps.isNotEmpty()) {
-    if (config.dependencies.isNotEmpty()) println()
+  if (seeds.testSeeds.isNotEmpty()) {
+    if (seeds.mainSeeds.isNotEmpty()) println()
     println("test dependencies:")
-    val testTree = buildDependencyTree(allTestDeps, pomLookup)
+    val testTree = buildDependencyTree(seeds.testSeeds, pomLookup)
     println(formatDependencyTree(testTree))
   }
   return Ok(Unit)

--- a/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
@@ -115,6 +115,9 @@ internal fun resolveDependencies(config: KoltConfig): Result<JvmResolutionOutcom
   return Ok(splitJvmOutcome(resolveResult.deps))
 }
 
+internal fun splitByOrigin(deps: List<ResolvedDep>): Pair<List<ResolvedDep>, List<ResolvedDep>> =
+  deps.partition { it.origin == Origin.MAIN }
+
 // Extracted for testability: constructs JvmResolutionOutcome from a resolved
 // dep list by splitting on Origin. `allJars` = main ++ test (disjoint —
 // kernel enforces main-wins-on-overlap).
@@ -160,13 +163,17 @@ internal fun resolveNativeDependencies(
 }
 
 private fun writeWorkspaceFiles(config: KoltConfig, deps: List<ResolvedDep>) {
-  val workspaceJson = generateWorkspaceJson(config, deps)
+  // kls-classpath is a flat union — kotlin-lsp expects one classpath
+  // and resolves visibility from module scopes. workspace.json
+  // carries the main/test split for richer IDE consumers.
+  val (mainDeps, testDeps) = splitByOrigin(deps)
+  val workspaceJson = generateWorkspaceJson(config, mainDeps, testDeps)
   writeFileAsString(WORKSPACE_JSON, workspaceJson).getOrElse { error ->
     eprintln("warning: could not write $WORKSPACE_JSON: ${error.path}")
     return
   }
 
-  val klsContent = generateKlsClasspath(deps)
+  val klsContent = generateKlsClasspath(mainDeps + testDeps)
   writeFileAsString(KLS_CLASSPATH, klsContent).getOrElse { error ->
     eprintln("warning: could not write $KLS_CLASSPATH: ${error.path}")
     return

--- a/src/nativeTest/kotlin/kolt/build/BuildCacheTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuildCacheTest.kt
@@ -155,6 +155,56 @@ class BuildCacheTest {
     assertEquals("/cache/okhttp-jvm-5.3.2.jar:/cache/okio-jvm-3.16.4.jar", parsed!!.classpath)
   }
 
+  // The state cache carries both the main classpath (for `kolt run` /
+  // watch-run) and the main ∪ test classpath (for `kolt test`) so an
+  // up-to-date return path can hand either back without re-resolving.
+  @Test
+  fun testClasspathPreservedInBuildState() {
+    val state =
+      BuildState(
+        configMtime = 1000L,
+        sourcesNewestMtime = 2000L,
+        classesDirMtime = 3000L,
+        lockfileMtime = 500L,
+        classpath = "/cache/main.jar",
+        testClasspath = "/cache/main.jar:/cache/junit-jupiter.jar",
+      )
+    val json = serializeBuildState(state)
+    val parsed = parseBuildState(json)
+    assertEquals(
+      "/cache/main.jar:/cache/junit-jupiter.jar",
+      parsed!!.testClasspath,
+      "testClasspath must roundtrip",
+    )
+    assertEquals("/cache/main.jar", parsed.classpath, "main classpath still roundtrips")
+  }
+
+  @Test
+  fun serializationUsesMainAndTestClasspathKeys() {
+    val state =
+      BuildState(
+        configMtime = 1L,
+        sourcesNewestMtime = 2L,
+        classesDirMtime = 3L,
+        lockfileMtime = null,
+        classpath = "/cache/main.jar",
+        testClasspath = "/cache/main.jar:/cache/junit.jar",
+      )
+    val json = serializeBuildState(state)
+    assertTrue(json.contains("main_classpath"), "Expected 'main_classpath' in: $json")
+    assertTrue(json.contains("test_classpath"), "Expected 'test_classpath' in: $json")
+  }
+
+  @Test
+  fun legacyClasspathKeyIsInvalidatedOnParse() {
+    // Older state files used the bare "classpath" key for the all-deps
+    // classpath. Refusing that shape forces a rebuild so the new
+    // main/test split is populated cleanly (pre-v1 clean break).
+    val legacyJson =
+      """{"config_mtime":1,"sources_newest_mtime":2,"classes_dir_mtime":3,"lockfile_mtime":null,"classpath":"/cache/all.jar"}"""
+    assertNull(parseBuildState(legacyJson))
+  }
+
   @Test
   fun serializationUsesClassesDirMtimeKey() {
     val state =

--- a/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
@@ -1,9 +1,11 @@
 package kolt.build
 
+import kolt.resolve.Origin
 import kolt.resolve.ResolvedDep
 import kolt.testConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -20,9 +22,8 @@ class WorkspaceTest {
   @Test
   fun generateWorkspaceJsonMinimalProject() {
     val config = testConfig()
-    val deps = emptyList<ResolvedDep>()
 
-    val result = generateWorkspaceJson(config, deps)
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
     val root = parseJson(result)
 
     val modules = root["modules"]!!.jsonArray
@@ -38,9 +39,8 @@ class WorkspaceTest {
   @Test
   fun generateWorkspaceJsonNoTestSources() {
     val config = testConfig(testSources = emptyList())
-    val deps = emptyList<ResolvedDep>()
 
-    val result = generateWorkspaceJson(config, deps)
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
     val root = parseJson(result)
 
     val modules = root["modules"]!!.jsonArray
@@ -51,9 +51,8 @@ class WorkspaceTest {
   @Test
   fun generateWorkspaceJsonIncludesSourceRoots() {
     val config = testConfig(sources = listOf("src", "generated"))
-    val deps = emptyList<ResolvedDep>()
 
-    val result = generateWorkspaceJson(config, deps)
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
     val root = parseJson(result)
 
     val module = root["modules"]!!.jsonArray[0].jsonObject
@@ -69,9 +68,8 @@ class WorkspaceTest {
   @Test
   fun generateWorkspaceJsonIncludesTestSourceRoots() {
     val config = testConfig(testSources = listOf("test", "test-integration"))
-    val deps = emptyList<ResolvedDep>()
 
-    val result = generateWorkspaceJson(config, deps)
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
     val root = parseJson(result)
 
     val modules = root["modules"]!!.jsonArray
@@ -90,13 +88,14 @@ class WorkspaceTest {
   @Test
   fun generateWorkspaceJsonIncludesLibraries() {
     val config = testConfig()
-    val deps =
+    val mainDeps =
       listOf(
         ResolvedDep(
           "com.example:lib",
           "1.0.0",
           "abc123",
           "/home/user/.kolt/cache/com/example/lib/1.0.0/lib-1.0.0.jar",
+          origin = Origin.MAIN,
         ),
         ResolvedDep(
           "org.other:util",
@@ -104,10 +103,11 @@ class WorkspaceTest {
           "def456",
           "/home/user/.kolt/cache/org/other/util/2.0.0/util-2.0.0.jar",
           transitive = true,
+          origin = Origin.MAIN,
         ),
       )
 
-    val result = generateWorkspaceJson(config, deps)
+    val result = generateWorkspaceJson(config, mainDeps, emptyList())
     val root = parseJson(result)
 
     val libraries = root["libraries"]!!.jsonArray
@@ -128,9 +128,9 @@ class WorkspaceTest {
   @Test
   fun generateWorkspaceJsonLibraryAttributes() {
     val config = testConfig()
-    val deps = listOf(ResolvedDep("com.example:lib", "1.0.0", "abc123", "/cache/lib.jar"))
+    val mainDeps = listOf(ResolvedDep("com.example:lib", "1.0.0", "abc123", "/cache/lib.jar"))
 
-    val result = generateWorkspaceJson(config, deps)
+    val result = generateWorkspaceJson(config, mainDeps, emptyList())
     val root = parseJson(result)
 
     val lib = root["libraries"]!!.jsonArray[0].jsonObject
@@ -143,9 +143,8 @@ class WorkspaceTest {
   @Test
   fun generateWorkspaceJsonIncludesSdk() {
     val config = testConfig(jvmTarget = "21")
-    val deps = emptyList<ResolvedDep>()
 
-    val result = generateWorkspaceJson(config, deps)
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
     val root = parseJson(result)
 
     val sdks = root["sdks"]!!.jsonArray
@@ -160,9 +159,8 @@ class WorkspaceTest {
   @Test
   fun generateWorkspaceJsonIncludesKotlinSettings() {
     val config = testConfig(jvmTarget = "17")
-    val deps = emptyList<ResolvedDep>()
 
-    val result = generateWorkspaceJson(config, deps)
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
     val root = parseJson(result)
 
     val settings = root["kotlinSettings"]!!.jsonArray
@@ -179,9 +177,9 @@ class WorkspaceTest {
   @Test
   fun generateWorkspaceJsonModuleDependenciesReferenceLibraries() {
     val config = testConfig()
-    val deps = listOf(ResolvedDep("com.example:lib", "1.0.0", "abc123", "/cache/lib.jar"))
+    val mainDeps = listOf(ResolvedDep("com.example:lib", "1.0.0", "abc123", "/cache/lib.jar"))
 
-    val result = generateWorkspaceJson(config, deps)
+    val result = generateWorkspaceJson(config, mainDeps, emptyList())
     val root = parseJson(result)
 
     val module = root["modules"]!!.jsonArray[0].jsonObject
@@ -196,9 +194,8 @@ class WorkspaceTest {
   @Test
   fun generateWorkspaceJsonTestModuleDependsOnMainModule() {
     val config = testConfig()
-    val deps = emptyList<ResolvedDep>()
 
-    val result = generateWorkspaceJson(config, deps)
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
     val root = parseJson(result)
 
     val testModule = root["modules"]!!.jsonArray[1].jsonObject
@@ -207,6 +204,92 @@ class WorkspaceTest {
     val moduleDep =
       testDeps.map { it.jsonObject }.first { it["type"]!!.jsonPrimitive.content == "module" }
     assertEquals("my-app.main", moduleDep["name"]!!.jsonPrimitive.content)
+  }
+
+  // - Main module's dependency list carries main origin jars only so
+  //   IDE navigation on main sources cannot cross into test-only
+  //   classes.
+  // - Test module sees main + test (test sources typically reference
+  //   both). The depends-on-main link still comes via `type=module`.
+  // - Top-level `libraries` lists every known jar (main + test) so IDE
+  //   caches and library index views are complete.
+  @Test
+  fun generateWorkspaceJsonSplitsMainAndTestIntoRightModules() {
+    val config = testConfig()
+    val mainDeps =
+      listOf(
+        ResolvedDep(
+          groupArtifact = "com.example:main-lib",
+          version = "1.0.0",
+          sha256 = "hashMain",
+          cachePath = "/cache/main-lib-1.0.0.jar",
+          origin = Origin.MAIN,
+        )
+      )
+    val testDeps =
+      listOf(
+        ResolvedDep(
+          groupArtifact = "org.junit.jupiter:junit-jupiter",
+          version = "5.10.0",
+          sha256 = "hashJupiter",
+          cachePath = "/cache/junit-jupiter-5.10.0.jar",
+          origin = Origin.TEST,
+        ),
+        ResolvedDep(
+          groupArtifact = "org.opentest4j:opentest4j",
+          version = "1.3.0",
+          sha256 = "hashOpentest4j",
+          cachePath = "/cache/opentest4j-1.3.0.jar",
+          transitive = true,
+          origin = Origin.TEST,
+        ),
+      )
+
+    val result = generateWorkspaceJson(config, mainDeps, testDeps)
+    val root = parseJson(result)
+
+    val modules = root["modules"]!!.jsonArray
+    val mainLibNames =
+      modules[0]
+        .jsonObject["dependencies"]!!
+        .jsonArray
+        .map { it.jsonObject }
+        .filter { it["type"]!!.jsonPrimitive.content == "library" }
+        .map { it["name"]!!.jsonPrimitive.content }
+    assertEquals(listOf("com.example:main-lib:1.0.0"), mainLibNames)
+    assertFalse(
+      mainLibNames.any { it.contains("junit") || it.contains("opentest4j") },
+      "main module must not list test-origin libraries: $mainLibNames",
+    )
+
+    val testLibNames =
+      modules[1]
+        .jsonObject["dependencies"]!!
+        .jsonArray
+        .map { it.jsonObject }
+        .filter { it["type"]!!.jsonPrimitive.content == "library" }
+        .map { it["name"]!!.jsonPrimitive.content }
+    assertEquals(
+      listOf(
+        "com.example:main-lib:1.0.0",
+        "org.junit.jupiter:junit-jupiter:5.10.0",
+        "org.opentest4j:opentest4j:1.3.0",
+      ),
+      testLibNames,
+      "test module lists main first, then test origin deps",
+    )
+
+    val topLibs =
+      root["libraries"]!!.jsonArray.map { it.jsonObject["name"]!!.jsonPrimitive.content }
+    assertEquals(
+      listOf(
+        "com.example:main-lib:1.0.0",
+        "org.junit.jupiter:junit-jupiter:5.10.0",
+        "org.opentest4j:opentest4j:1.3.0",
+      ),
+      topLibs,
+      "top-level libraries must index main ∪ test",
+    )
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/cli/DependencyCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DependencyCommandsTest.kt
@@ -1,8 +1,116 @@
 package kolt.cli
 
+import kolt.testConfig
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+
+// `kolt deps tree` must render main and test closures as separate
+// sections and suppress the test section when the auto-inject skip
+// kicks in (empty test_sources + empty [test-dependencies] on JVM).
+// Tests exercise the pure seed decider so assertions do not depend on
+// POM network fetches.
+class DepsTreeSeedsTest {
+
+  @Test
+  fun bothSectionsPopulatedWhenMainAndTestDeclared() {
+    val config =
+      testConfig(
+        target = "jvm",
+        dependencies = mapOf("com.example:lib" to "1.0"),
+        testDependencies = mapOf("com.example:junit-ext" to "2.0"),
+        testSources = listOf("test"),
+      )
+
+    val seeds = depsTreeSeeds(config)
+
+    assertEquals(mapOf("com.example:lib" to "1.0"), seeds.mainSeeds)
+    assertTrue(
+      "com.example:junit-ext" in seeds.testSeeds,
+      "test section must carry declared test deps: ${seeds.testSeeds}",
+    )
+    assertTrue(
+      "org.jetbrains.kotlin:kotlin-test-junit5" in seeds.testSeeds,
+      "JVM test section must also carry the auto-injected kotlin-test-junit5: ${seeds.testSeeds}",
+    )
+    assertFalse(seeds.isEmpty)
+  }
+
+  @Test
+  fun testSectionEmptyWhenAutoInjectSkipsAndNoTestDepsDeclared() {
+    // test_sources empty + test-dependencies empty on JVM: the
+    // kotlin-test-junit5 auto-inject is skipped so the test section is
+    // empty. `kolt deps tree` must suppress the "test dependencies:"
+    // header in that case (doTree's `seeds.testSeeds.isNotEmpty()` gate).
+    val config =
+      testConfig(
+        target = "jvm",
+        dependencies = mapOf("com.example:lib" to "1.0"),
+        testDependencies = emptyMap(),
+        testSources = emptyList(),
+      )
+
+    val seeds = depsTreeSeeds(config)
+
+    assertEquals(mapOf("com.example:lib" to "1.0"), seeds.mainSeeds)
+    assertTrue(seeds.testSeeds.isEmpty(), "test section must be empty: ${seeds.testSeeds}")
+  }
+
+  @Test
+  fun testSectionCarriesOnlyAutoInjectedJunitWhenTestSourcesPresent() {
+    val config =
+      testConfig(
+        target = "jvm",
+        dependencies = emptyMap(),
+        testDependencies = emptyMap(),
+        testSources = listOf("test"),
+      )
+
+    val seeds = depsTreeSeeds(config)
+
+    assertTrue(seeds.mainSeeds.isEmpty())
+    assertEquals(
+      setOf("org.jetbrains.kotlin:kotlin-test-junit5"),
+      seeds.testSeeds.keys,
+      "only the auto-injected junit seed should remain",
+    )
+  }
+
+  @Test
+  fun nativeTargetSuppressesAutoInjection() {
+    val config =
+      testConfig(
+        target = "linuxX64",
+        dependencies = emptyMap(),
+        testDependencies = mapOf("com.example:nativetest" to "1.0"),
+        testSources = listOf("test"),
+      )
+
+    val seeds = depsTreeSeeds(config)
+
+    assertEquals(mapOf("com.example:nativetest" to "1.0"), seeds.testSeeds)
+    assertFalse(
+      "org.jetbrains.kotlin:kotlin-test-junit5" in seeds.testSeeds,
+      "native target must not carry the JVM-only auto-injection",
+    )
+  }
+
+  @Test
+  fun emptyMainAndTestProducesEmptySeeds() {
+    val config =
+      testConfig(
+        target = "jvm",
+        dependencies = emptyMap(),
+        testDependencies = emptyMap(),
+        testSources = emptyList(),
+      )
+
+    val seeds = depsTreeSeeds(config)
+
+    assertTrue(seeds.isEmpty)
+  }
+}
 
 class ValidateDepsSubcommandTest {
 

--- a/src/nativeTest/kotlin/kolt/cli/JvmAppBuildTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/JvmAppBuildTest.kt
@@ -12,6 +12,8 @@ import kolt.infra.fileExists
 import kolt.infra.readFileAsString
 import kolt.infra.removeDirectoryRecursive
 import kolt.infra.writeFileAsString
+import kolt.resolve.Origin
+import kolt.resolve.ResolvedDep
 import kolt.testConfig
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -200,6 +202,99 @@ class JvmAppBuildTest {
     }
 
     assertFalse(fileExists(manifestPath), "kind flip app→lib must remove the manifest")
+  }
+
+  // Given a resolution outcome that mixes main and test origin deps,
+  // the main-only slice fed into `handleRuntimeClasspathManifest` must
+  // exclude junit-jupiter / opentest4j / apiguardian etc., so daemon
+  // tarballs don't pick them up via `scripts/assemble-dist.sh`.
+  @Test
+  fun jvmAppManifestExcludesTestOriginJarsFromSplitOutcome() {
+    val config = testConfig(name = "app-with-tests", target = "jvm").copy(kind = "app")
+    val outcome =
+      splitJvmOutcome(
+        listOf(
+          ResolvedDep(
+            groupArtifact = "com.example:main-lib",
+            version = "1.0.0",
+            sha256 = "hashMain",
+            cachePath = "/cache/com/example/main-lib/1.0.0/main-lib-1.0.0.jar",
+            origin = Origin.MAIN,
+          ),
+          ResolvedDep(
+            groupArtifact = "org.junit.jupiter:junit-jupiter",
+            version = "5.10.0",
+            sha256 = "hashJupiter",
+            cachePath = "/cache/org/junit/jupiter/junit-jupiter/5.10.0/junit-jupiter-5.10.0.jar",
+            origin = Origin.TEST,
+          ),
+          ResolvedDep(
+            groupArtifact = "org.opentest4j:opentest4j",
+            version = "1.3.0",
+            sha256 = "hashOpentest4j",
+            cachePath = "/cache/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
+            transitive = true,
+            origin = Origin.TEST,
+          ),
+          ResolvedDep(
+            groupArtifact = "org.apiguardian:apiguardian-api",
+            version = "1.1.2",
+            sha256 = "hashApiguardian",
+            cachePath = "/cache/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
+            transitive = true,
+            origin = Origin.TEST,
+          ),
+        )
+      )
+
+    handleRuntimeClasspathManifest(config, outcome.mainJars).getOrElse { error("emit failed: $it") }
+
+    val manifestPath = outputRuntimeClasspathPath(config)
+    val content = readFileAsString(manifestPath).getOrElse { error("read failed: $it") }
+    val entries = content.split('\n')
+    assertEquals(1, entries.size, "main-only manifest must hold exactly the main dep")
+    assertTrue(
+      entries.single().endsWith("main-lib-1.0.0.jar"),
+      "main origin jar must be present: $content",
+    )
+    for (forbidden in listOf("junit-jupiter", "opentest4j", "apiguardian", "kotlin-test")) {
+      assertFalse(
+        entries.any { it.contains(forbidden) },
+        "manifest must exclude test-origin jar matching '$forbidden': $content",
+      )
+    }
+  }
+
+  // The disjoint-ness invariant holds upstream (main wins on overlap in
+  // the resolver kernel); `splitJvmOutcome.allJars` is simply
+  // `mainJars + testJars` with no dedup step required. Pin the property
+  // so a regression in the kernel or the split helper shows as a
+  // mixed-origin test rather than an obscure classpath duplicate.
+  @Test
+  fun mainAndTestAllJarsAreDisjointByConstruction() {
+    val outcome =
+      splitJvmOutcome(
+        listOf(
+          ResolvedDep(
+            groupArtifact = "com.example:overlap",
+            version = "1.0.0",
+            sha256 = "hashMain",
+            cachePath = "/cache/overlap-main.jar",
+            origin = Origin.MAIN,
+          ),
+          ResolvedDep(
+            groupArtifact = "org.junit.jupiter:junit-jupiter",
+            version = "5.10.0",
+            sha256 = "hashTest",
+            cachePath = "/cache/junit.jar",
+            origin = Origin.TEST,
+          ),
+        )
+      )
+
+    val gas = outcome.allJars.map { it.groupArtifactVersion.substringBeforeLast(":") }
+    assertEquals(gas, gas.distinct(), "allJars must be GA-disjoint")
+    assertEquals(outcome.mainJars + outcome.allJars.drop(outcome.mainJars.size), outcome.allJars)
   }
 
   // Req 2.3 defence-in-depth: even if the resolver accidentally surfaces


### PR DESCRIPTION
Thread the main/test origin split from the resolver outcome (shipped in #250) through JVM build/run/test, IDE workspace.json, the `kolt deps tree` command, and the two ADRs that codify the manifest and lockfile contracts.

Closes part of #229. Follow-up tasks 4.2 (regenerate daemon + spike lockfiles at v3) and 4.3 (self-host manifest smoke in CI) land next session — the code contract is here, the dogfood artifacts wait until this merges.

### Review focus

- **`BuildCommands.kt`** — `BuildResult` now carries both `classpath` (main-only, used by doRun and watch-run) and `testClasspath` (main ∪ test, used by doTest). doTest falls through to the main classpath when there are no test-origin deps, so a project without test deps keeps compiling. `BuildState` caches both, and the legacy `classpath` JSON key is renamed to `main_classpath` so pre-task state files fail strict decode and trigger a clean rebuild (pre-v1 clean-break policy). Reviewer judgment call: the rename vs. silent ignore-unknown-keys. Chose rename because a stale cache holding the old all-deps classpath would silently leak test jars into `kolt run` on the first post-upgrade build.
- **`Workspace.kt`** — `generateWorkspaceJson(config, mainDeps, testDeps)` is split. Main module lists main only, test module lists main ∪ test (test sources reference main), top-level `libraries` indexes the union for the IDE library cache. kotlin-lsp's `kls-classpath` stays a flat union because kotlin-lsp expects one classpath and resolves visibility from module scopes.
- **`DependencyCommands.kt`** — `doTree` is rephrased around a new `depsTreeSeeds` pure helper that mirrors the section-gating logic. Lets the regression tests (both-sections-populated, auto-inject-skip) run without hitting the POM network.
- **ADR 0027 §1 / §4** — restated as main closure only; new §4 paragraph states that emit scope is main-only regardless of whether the project declares `[test-dependencies]` or carries test sources. Summary bullet updated to match.
- **ADR 0003 §2** — new schema history block. v1 → v2 added `transitive`; v2 → v3 adds `test: Boolean`, and `parseLockfile` rejects v1 / v2 with `UnsupportedVersion` per the pre-v1 clean-break policy.

### Out of scope for this PR

- `kolt-jvm-compiler-daemon/kolt.lock` and `spike/daemon-self-host-smoke/kolt.lock` regeneration (task 4.2) — depends on this PR being on `main` so the rebuild runs against the v3 schema.
- `self-host-post` CI smoke that greps the generated manifest for junit-jupiter / opentest4j / apiguardian / kotlin-test (task 4.3).