### PR TITLE
LSP workspace.json: exclude build dirs + emit javaSettings + test kotlinSettings

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/Workspace.kt
+++ b/src/nativeMain/kotlin/kolt/build/Workspace.kt
@@ -10,6 +10,11 @@ private val prettyJson = Json {
   prettyPrintIndent = "  "
 }
 
+// kotlin-lsp's JSON importer honors ContentRootData.excludedPatterns but drops
+// excludedUrls (see Kotlin/kotlin-lsp workspace-import/.../json/conversion.kt).
+// Keep patterns unprefixed; PatternUtil matches against file names, not paths.
+private val DEFAULT_CONTENT_ROOT_EXCLUDES = listOf("build", ".kolt-cache", ".kolt")
+
 fun generateWorkspaceJson(
   config: KoltConfig,
   mainDeps: List<ResolvedDep>,
@@ -55,6 +60,9 @@ private fun buildMainModule(config: KoltConfig, resolvedDeps: List<ResolvedDep>)
       add(
         buildJsonObject {
           put("path", "<WORKSPACE>/")
+          putJsonArray("excludedPatterns") {
+            DEFAULT_CONTENT_ROOT_EXCLUDES.forEach { add(JsonPrimitive(it)) }
+          }
           putJsonArray("sourceRoots") {
             config.build.sources.forEach { src ->
               add(
@@ -98,6 +106,9 @@ private fun buildTestModule(config: KoltConfig, resolvedDeps: List<ResolvedDep>)
       add(
         buildJsonObject {
           put("path", "<WORKSPACE>/")
+          putJsonArray("excludedPatterns") {
+            DEFAULT_CONTENT_ROOT_EXCLUDES.forEach { add(JsonPrimitive(it)) }
+          }
           putJsonArray("sourceRoots") {
             config.build.testSources.forEach { src ->
               add(

--- a/src/nativeMain/kotlin/kolt/build/Workspace.kt
+++ b/src/nativeMain/kotlin/kolt/build/Workspace.kt
@@ -30,7 +30,12 @@ fun generateWorkspaceJson(
     }
     putJsonArray("libraries") { allDeps.forEach { dep -> add(buildLibraryEntry(dep)) } }
     putJsonArray("sdks") { add(buildSdkEntry(config.build.jvmTarget)) }
-    putJsonArray("kotlinSettings") { add(buildKotlinSettings(config)) }
+    putJsonArray("kotlinSettings") {
+      add(buildKotlinSettings(config, isTest = false))
+      if (config.build.testSources.isNotEmpty()) {
+        add(buildKotlinSettings(config, isTest = true))
+      }
+    }
     putJsonArray("javaSettings") {
       add(buildJavaSettings("${config.name}.main", config.build.jvmTarget))
       if (config.build.testSources.isNotEmpty()) {
@@ -165,13 +170,13 @@ private fun buildJavaSettings(moduleName: String, jvmTarget: String): JsonObject
   putJsonObject("manifestAttributes") {}
 }
 
-private fun buildKotlinSettings(config: KoltConfig): JsonObject = buildJsonObject {
+private fun buildKotlinSettings(config: KoltConfig, isTest: Boolean): JsonObject = buildJsonObject {
+  val moduleName = "${config.name}.${if (isTest) "test" else "main"}"
+  val sources = if (isTest) config.build.testSources else config.build.sources
   put("name", "Kotlin")
-  putJsonArray("sourceRoots") {
-    config.build.sources.forEach { add(JsonPrimitive("<WORKSPACE>/$it")) }
-  }
+  putJsonArray("sourceRoots") { sources.forEach { add(JsonPrimitive("<WORKSPACE>/$it")) } }
   putJsonArray("configFileItems") {}
-  put("module", "${config.name}.main")
+  put("module", moduleName)
   put("useProjectSettings", false)
   putJsonArray("implementedModuleNames") {}
   putJsonArray("dependsOnModuleNames") {}
@@ -179,8 +184,8 @@ private fun buildKotlinSettings(config: KoltConfig): JsonObject = buildJsonObjec
   put("productionOutputPath", JsonNull)
   put("testOutputPath", JsonNull)
   putJsonArray("sourceSetNames") {}
-  put("isTestModule", false)
-  put("externalProjectId", "${config.name}.main")
+  put("isTestModule", isTest)
+  put("externalProjectId", moduleName)
   put("isHmppEnabled", true)
   putJsonArray("pureKotlinSourceFolders") {}
   put("kind", "default")

--- a/src/nativeMain/kotlin/kolt/build/Workspace.kt
+++ b/src/nativeMain/kotlin/kolt/build/Workspace.kt
@@ -31,6 +31,12 @@ fun generateWorkspaceJson(
     putJsonArray("libraries") { allDeps.forEach { dep -> add(buildLibraryEntry(dep)) } }
     putJsonArray("sdks") { add(buildSdkEntry(config.build.jvmTarget)) }
     putJsonArray("kotlinSettings") { add(buildKotlinSettings(config)) }
+    putJsonArray("javaSettings") {
+      add(buildJavaSettings("${config.name}.main", config.build.jvmTarget))
+      if (config.build.testSources.isNotEmpty()) {
+        add(buildJavaSettings("${config.name}.test", config.build.jvmTarget))
+      }
+    }
   }
 
   return prettyJson.encodeToString(JsonObject.serializer(), json)
@@ -147,6 +153,16 @@ private fun buildSdkEntry(jvmTarget: String): JsonObject = buildJsonObject {
   put("homePath", JsonNull)
   putJsonArray("roots") {}
   put("additionalData", "")
+}
+
+private fun buildJavaSettings(moduleName: String, jvmTarget: String): JsonObject = buildJsonObject {
+  put("module", moduleName)
+  put("inheritedCompilerOutput", false)
+  put("excludeOutput", false)
+  put("compilerOutput", JsonNull)
+  put("compilerOutputForTests", JsonNull)
+  put("languageLevelId", "JDK_$jvmTarget")
+  putJsonObject("manifestAttributes") {}
 }
 
 private fun buildKotlinSettings(config: KoltConfig): JsonObject = buildJsonObject {

--- a/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
@@ -164,14 +164,53 @@ class WorkspaceTest {
     val root = parseJson(result)
 
     val settings = root["kotlinSettings"]!!.jsonArray
-    assertEquals(1, settings.size)
+    assertEquals(2, settings.size)
 
-    val setting = settings[0].jsonObject
-    assertEquals("my-app.main", setting["module"]!!.jsonPrimitive.content)
+    val main = settings[0].jsonObject
+    assertEquals("my-app.main", main["module"]!!.jsonPrimitive.content)
 
-    val compilerArgs = setting["compilerArguments"]!!.jsonPrimitive.content
+    val compilerArgs = main["compilerArguments"]!!.jsonPrimitive.content
     assertTrue(compilerArgs.startsWith("J{"), "compilerArguments should start with J{ prefix")
     assertTrue(compilerArgs.contains("\"jvmTarget\":\"17\""))
+  }
+
+  // kotlin-lsp diagnoses test sources against this entry, so it must carry
+  // the same jvmTarget as main (matching the compiler the test actually
+  // runs under) and isTestModule=true so IDE features treat assertions and
+  // test-only APIs correctly.
+  @Test
+  fun generateWorkspaceJsonEmitsKotlinSettingsForTestModule() {
+    val config = testConfig(jvmTarget = "17", testSources = listOf("test", "test-integration"))
+
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
+    val root = parseJson(result)
+
+    val settings = root["kotlinSettings"]!!.jsonArray
+    assertEquals(2, settings.size)
+
+    val test = settings[1].jsonObject
+    assertEquals("my-app.test", test["module"]!!.jsonPrimitive.content)
+    assertEquals("my-app.test", test["externalProjectId"]!!.jsonPrimitive.content)
+    assertEquals(true, test["isTestModule"]!!.jsonPrimitive.content.toBoolean())
+
+    val testSourceRoots = test["sourceRoots"]!!.jsonArray.map { it.jsonPrimitive.content }
+    assertEquals(listOf("<WORKSPACE>/test", "<WORKSPACE>/test-integration"), testSourceRoots)
+
+    val compilerArgs = test["compilerArguments"]!!.jsonPrimitive.content
+    assertTrue(compilerArgs.startsWith("J{"))
+    assertTrue(compilerArgs.contains("\"jvmTarget\":\"17\""))
+  }
+
+  @Test
+  fun generateWorkspaceJsonKotlinSettingsOmitsTestEntryWhenNoTestSources() {
+    val config = testConfig(testSources = emptyList())
+
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
+    val root = parseJson(result)
+
+    val settings = root["kotlinSettings"]!!.jsonArray
+    assertEquals(1, settings.size)
+    assertEquals("my-app.main", settings[0].jsonObject["module"]!!.jsonPrimitive.content)
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
@@ -292,6 +292,37 @@ class WorkspaceTest {
     )
   }
 
+  // kotlin-lsp's JSON importer maps `excludedPatterns` to the underlying
+  // ContentRootEntity but drops `excludedUrls`, so patterns are the only
+  // effective exclusion channel for the WORKSPACE root today.
+  @Test
+  fun generateWorkspaceJsonMainContentRootExcludesBuildOutputsAndCacheDirs() {
+    val config = testConfig()
+
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
+    val root = parseJson(result)
+
+    val mainContentRoot =
+      root["modules"]!!.jsonArray[0].jsonObject["contentRoots"]!!.jsonArray[0].jsonObject
+    val excludedPatterns =
+      mainContentRoot["excludedPatterns"]!!.jsonArray.map { it.jsonPrimitive.content }
+    assertEquals(listOf("build", ".kolt-cache", ".kolt"), excludedPatterns)
+  }
+
+  @Test
+  fun generateWorkspaceJsonTestContentRootExcludesBuildOutputsAndCacheDirs() {
+    val config = testConfig()
+
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
+    val root = parseJson(result)
+
+    val testContentRoot =
+      root["modules"]!!.jsonArray[1].jsonObject["contentRoots"]!!.jsonArray[0].jsonObject
+    val excludedPatterns =
+      testContentRoot["excludedPatterns"]!!.jsonArray.map { it.jsonPrimitive.content }
+    assertEquals(listOf("build", ".kolt-cache", ".kolt"), excludedPatterns)
+  }
+
   @Test
   fun generateKlsClasspathFromResolvedDeps() {
     val deps =

--- a/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
@@ -292,6 +292,55 @@ class WorkspaceTest {
     )
   }
 
+  // Per-module java language level is carried via `javaSettings`; the JSON
+  // wire has no `-Xjdk-release` slot, so this is the only channel for
+  // kotlin-lsp to diagnose mixed Kotlin/Java code at the right level.
+  @Test
+  fun generateWorkspaceJsonEmitsJavaSettingsForMainAndTest() {
+    val config = testConfig(jvmTarget = "17")
+
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
+    val root = parseJson(result)
+
+    val javaSettings = root["javaSettings"]!!.jsonArray
+    assertEquals(2, javaSettings.size)
+
+    val main = javaSettings[0].jsonObject
+    assertEquals("my-app.main", main["module"]!!.jsonPrimitive.content)
+    assertEquals("JDK_17", main["languageLevelId"]!!.jsonPrimitive.content)
+    assertEquals(false, main["inheritedCompilerOutput"]!!.jsonPrimitive.content.toBoolean())
+    assertEquals(false, main["excludeOutput"]!!.jsonPrimitive.content.toBoolean())
+
+    val test = javaSettings[1].jsonObject
+    assertEquals("my-app.test", test["module"]!!.jsonPrimitive.content)
+    assertEquals("JDK_17", test["languageLevelId"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun generateWorkspaceJsonJavaSettingsOmitsTestEntryWhenNoTestSources() {
+    val config = testConfig(testSources = emptyList())
+
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
+    val root = parseJson(result)
+
+    val javaSettings = root["javaSettings"]!!.jsonArray
+    assertEquals(1, javaSettings.size)
+    assertEquals("my-app.main", javaSettings[0].jsonObject["module"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun generateWorkspaceJsonJavaSettingsLanguageLevelTracksJvmTarget() {
+    val config = testConfig(jvmTarget = "21")
+
+    val result = generateWorkspaceJson(config, emptyList(), emptyList())
+    val root = parseJson(result)
+
+    val javaSettings = root["javaSettings"]!!.jsonArray
+    javaSettings.forEach {
+      assertEquals("JDK_21", it.jsonObject["languageLevelId"]!!.jsonPrimitive.content)
+    }
+  }
+
   // kotlin-lsp's JSON importer maps `excludedPatterns` to the underlying
   // ContentRootEntity but drops `excludedUrls`, so patterns are the only
   // effective exclusion channel for the WORKSPACE root today.


### PR DESCRIPTION
Phase 1 of #248 (LSP workspace.json completeness). Three additive `Workspace.kt` changes, one commit each.

- **ceb1a04 — #246**: Emit `excludedPatterns = ["build", ".kolt-cache", ".kolt"]` on both content roots. kotlin-lsp no longer indexes kolt outputs or cache dirs.
- **1e3251d — #244**: Emit top-level `javaSettings` with `languageLevelId = "JDK_<jvmTarget>"`, one entry per emitted module.
- **c452c73 — #245**: Emit a second `kotlinSettings` entry for the test module (`isTestModule=true`, mirrored jvmTarget) when `testSources` is non-empty. Existing kotlinSettings test updated to expect size 2.

## Review focus

- `excludedPatterns` vs `excludedUrls` choice: the kotlin-lsp JSON importer (`workspace-import/.../json/conversion.kt`) only wires `excludedPatterns` into `ContentRootEntity`; `excludedUrls` is read from the schema but never materialized. So emitting `excludedPatterns` is the only path that actually prunes indexing today. If upstream later adds `excludedUrls` support we can mirror the list — cheap follow-up.
- `javaSettings` shape (null compilerOutput paths, empty `manifestAttributes`) matches kolt-adjacent fixtures (SimpleMaven, MultiProjectKotlinDSL, NewIJKotlinGradle). Class directories aren't addressable in kolt's layout and land under `build/` which #246 now excludes.
- `buildKotlinSettings` is now parameterized by `isTest: Boolean`. All fields are identical except `module` / `externalProjectId` / `isTestModule` / `sourceRoots`; the branching is on those four lines only.

Closes #246
Closes #244
Closes #245