### PR TITLE
Attach -sources.jar to workspace.json libraries (#242)

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/Workspace.kt
+++ b/src/nativeMain/kotlin/kolt/build/Workspace.kt
@@ -138,7 +138,17 @@ private fun buildTestModule(config: KoltConfig, resolvedDeps: List<ResolvedDep>)
 private fun buildLibraryEntry(dep: ResolvedDep): JsonObject = buildJsonObject {
   put("name", "${dep.groupArtifact}:${dep.version}")
   put("type", "java-imported")
-  putJsonArray("roots") { add(buildJsonObject { put("path", dep.cachePath) }) }
+  putJsonArray("roots") {
+    add(buildJsonObject { put("path", dep.cachePath) })
+    dep.sourcesPath?.let { src ->
+      add(
+        buildJsonObject {
+          put("path", src)
+          put("type", "SOURCES")
+        }
+      )
+    }
+  }
   putJsonObject("properties") {
     putJsonObject("attributes") {
       val parts = dep.groupArtifact.split(":")

--- a/src/nativeMain/kotlin/kolt/resolve/Dependency.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Dependency.kt
@@ -20,20 +20,37 @@ fun parseCoordinate(groupArtifact: String, version: String): Result<Coordinate, 
   return Ok(Coordinate(group, artifact, version))
 }
 
-private fun buildMavenUrl(coord: Coordinate, baseUrl: String, extension: String): String {
+private fun buildMavenUrl(
+  coord: Coordinate,
+  baseUrl: String,
+  extension: String,
+  classifier: String? = null,
+): String {
   val groupPath = coord.group.replace('.', '/')
-  return "$baseUrl/$groupPath/${coord.artifact}/${coord.version}/${coord.artifact}-${coord.version}.$extension"
+  val suffix = if (classifier != null) "-$classifier" else ""
+  return "$baseUrl/$groupPath/${coord.artifact}/${coord.version}/${coord.artifact}-${coord.version}$suffix.$extension"
 }
 
-private fun buildRelativePath(coord: Coordinate, extension: String): String {
+private fun buildRelativePath(
+  coord: Coordinate,
+  extension: String,
+  classifier: String? = null,
+): String {
   val groupPath = coord.group.replace('.', '/')
-  return "$groupPath/${coord.artifact}/${coord.version}/${coord.artifact}-${coord.version}.$extension"
+  val suffix = if (classifier != null) "-$classifier" else ""
+  return "$groupPath/${coord.artifact}/${coord.version}/${coord.artifact}-${coord.version}$suffix.$extension"
 }
 
 fun buildDownloadUrl(coord: Coordinate, baseUrl: String): String =
   buildMavenUrl(coord, baseUrl, "jar")
 
 fun buildCachePath(coord: Coordinate): String = buildRelativePath(coord, "jar")
+
+fun buildSourcesDownloadUrl(coord: Coordinate, baseUrl: String): String =
+  buildMavenUrl(coord, baseUrl, "jar", classifier = "sources")
+
+fun buildSourcesCachePath(coord: Coordinate): String =
+  buildRelativePath(coord, "jar", classifier = "sources")
 
 fun buildPomDownloadUrl(coord: Coordinate, baseUrl: String): String =
   buildMavenUrl(coord, baseUrl, "pom")

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -81,6 +81,7 @@ data class ResolvedDep(
   val cachePath: String,
   val transitive: Boolean = false,
   val origin: Origin = Origin.MAIN,
+  val sourcesPath: String? = null,
 )
 
 data class ResolveResult(val deps: List<ResolvedDep>, val lockChanged: Boolean)

--- a/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
@@ -46,6 +46,34 @@ fun resolveTransitive(
   return materialize(nodes, redirects, config, existingLock, cacheBase, deps, repos)
 }
 
+// Best-effort sources fetch. Sources are editor UX — missing upstream
+// sources are common (esp. internal artifacts) and network hiccups on
+// sources must never fail the build. A probe is attempted only when the
+// binary was freshly downloaded in this resolve, so that subsequent
+// resolves on a warm cache do not re-hit the network for negative
+// results. Ground truth is cache presence: if the file lands on disk
+// (either now or from a prior run) we emit its path; otherwise null.
+internal fun resolveSourcesPath(
+  coord: Coordinate,
+  cacheBase: String,
+  repos: List<String>,
+  deps: ResolverDeps,
+  binaryWasCached: Boolean,
+): String? {
+  val sourcesCachePath = "$cacheBase/${buildSourcesCachePath(coord)}"
+  if (deps.fileExists(sourcesCachePath)) return sourcesCachePath
+  if (binaryWasCached) return null
+  val error =
+    downloadFromRepositories(
+        repos,
+        sourcesCachePath,
+        { buildSourcesDownloadUrl(coord, it) },
+        deps::downloadFile,
+      )
+      .getError()
+  return if (error == null) sourcesCachePath else null
+}
+
 // Falls back to next repo only on 404; any other error stops immediately.
 internal fun downloadFromRepositories(
   repos: List<String>,
@@ -186,7 +214,8 @@ private fun materialize(
     val fullCachePath = "$cacheBase/$relativePath"
     val lockEntry = existingLock?.dependencies?.get(node.groupArtifact)
 
-    if (!deps.fileExists(fullCachePath)) {
+    val binaryWasCached = deps.fileExists(fullCachePath)
+    if (!binaryWasCached) {
       val parentDir = fullCachePath.substringBeforeLast('/')
       deps.ensureDirectoryRecursive(parentDir).getOrElse {
         return Err(ResolveError.DirectoryCreateFailed(parentDir))
@@ -218,6 +247,8 @@ private fun materialize(
       lockChanged = true
     }
 
+    val sourcesPath = resolveSourcesPath(coord, cacheBase, repos, deps, binaryWasCached)
+
     resolvedDeps.add(
       ResolvedDep(
         groupArtifact = node.groupArtifact,
@@ -226,6 +257,7 @@ private fun materialize(
         cachePath = fullCachePath,
         transitive = !node.direct,
         origin = node.origin,
+        sourcesPath = sourcesPath,
       )
     )
   }

--- a/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
@@ -125,6 +125,58 @@ class WorkspaceTest {
     )
   }
 
+  // kotlin-lsp's LibraryRootData reads multi-root libraries: the first
+  // entry defaults to CLASSES, an additional entry with type=SOURCES
+  // points at the -sources.jar so IDE go-to-definition navigates into
+  // Kotlin source instead of decompiled bytecode (losing inline bodies,
+  // default args, reified types).
+  @Test
+  fun generateWorkspaceJsonLibraryAttachesSourcesRootWhenAvailable() {
+    val config = testConfig()
+    val mainDeps =
+      listOf(
+        ResolvedDep(
+          "com.example:lib",
+          "1.0.0",
+          "abc123",
+          "/cache/com/example/lib/1.0.0/lib-1.0.0.jar",
+          sourcesPath = "/cache/com/example/lib/1.0.0/lib-1.0.0-sources.jar",
+        )
+      )
+
+    val result = generateWorkspaceJson(config, mainDeps, emptyList())
+    val root = parseJson(result)
+
+    val roots = root["libraries"]!!.jsonArray[0].jsonObject["roots"]!!.jsonArray
+    assertEquals(2, roots.size)
+    assertEquals(
+      "/cache/com/example/lib/1.0.0/lib-1.0.0.jar",
+      roots[0].jsonObject["path"]!!.jsonPrimitive.content,
+    )
+    assertEquals(
+      null,
+      roots[0].jsonObject["type"],
+      "binary root omits type so kotlin-lsp defaults to CLASSES",
+    )
+    assertEquals(
+      "/cache/com/example/lib/1.0.0/lib-1.0.0-sources.jar",
+      roots[1].jsonObject["path"]!!.jsonPrimitive.content,
+    )
+    assertEquals("SOURCES", roots[1].jsonObject["type"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun generateWorkspaceJsonLibraryOmitsSourcesRootWhenNull() {
+    val config = testConfig()
+    val mainDeps = listOf(ResolvedDep("com.example:lib", "1.0.0", "abc123", "/cache/lib.jar"))
+
+    val result = generateWorkspaceJson(config, mainDeps, emptyList())
+    val root = parseJson(result)
+
+    val roots = root["libraries"]!!.jsonArray[0].jsonObject["roots"]!!.jsonArray
+    assertEquals(1, roots.size)
+  }
+
   @Test
   fun generateWorkspaceJsonLibraryAttributes() {
     val config = testConfig()

--- a/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
@@ -175,6 +175,11 @@ class WorkspaceTest {
 
     val roots = root["libraries"]!!.jsonArray[0].jsonObject["roots"]!!.jsonArray
     assertEquals(1, roots.size)
+    assertEquals(
+      null,
+      roots[0].jsonObject["type"],
+      "binary root must omit `type` so kotlin-lsp defaults to CLASSES",
+    )
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/resolve/DependencyTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/DependencyTest.kt
@@ -90,6 +90,23 @@ class DependencyTest {
   }
 
   @Test
+  fun buildSourcesDownloadUrlProducesHyphenClassifier() {
+    val coord = Coordinate("org.jetbrains.kotlinx", "kotlinx-coroutines-core", "1.9.0")
+    val url = buildSourcesDownloadUrl(coord, MAVEN_CENTRAL_BASE)
+    assertEquals(
+      "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.9.0/kotlinx-coroutines-core-1.9.0-sources.jar",
+      url,
+    )
+  }
+
+  @Test
+  fun buildSourcesCachePathProducesHyphenClassifier() {
+    val coord = Coordinate("com.example", "lib", "1.0.0")
+    val path = buildSourcesCachePath(coord)
+    assertEquals("com/example/lib/1.0.0/lib-1.0.0-sources.jar", path)
+  }
+
+  @Test
   fun buildClasspathJoinsWithColon() {
     val paths = listOf("/home/user/.kolt/cache/a.jar", "/home/user/.kolt/cache/b.jar")
     assertEquals("/home/user/.kolt/cache/a.jar:/home/user/.kolt/cache/b.jar", buildClasspath(paths))

--- a/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
@@ -955,6 +955,7 @@ class TransitiveResolverTest {
     cachedFiles: MutableSet<String> = mutableSetOf(),
     sha256Results: Map<String, String> = emptyMap(),
     pomContents: Map<String, String> = emptyMap(),
+    downloadErrors: Map<String, DownloadError> = emptyMap(),
   ): ResolverDeps {
     return object : ResolverDeps {
       override fun fileExists(path: String): Boolean = path in cachedFiles
@@ -962,6 +963,8 @@ class TransitiveResolverTest {
       override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
       override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        val forcedError = downloadErrors[url]
+        if (forcedError != null) return Err(forcedError)
         cachedFiles.add(destPath)
         return Ok(Unit)
       }
@@ -976,6 +979,141 @@ class TransitiveResolverTest {
         return Ok(content)
       }
     }
+  }
+
+  // Sources are fetched best-effort the first time a binary hits the
+  // cache. All failures are silent (missing upstream sources are common
+  // and must never fail the build); once the binary is warm we do not
+  // re-probe, so a missing sources.jar on a warm cache stays missing
+  // until the user clears the cache.
+  @Test
+  fun resolveSourcesPathReturnsCachedPathWhenAlreadyOnDisk() {
+    val coord = Coordinate("com.example", "lib", "1.0.0")
+    val sourcesCachePath = "/cache/com/example/lib/1.0.0/lib-1.0.0-sources.jar"
+    val deps = fakeTransitiveDeps(cachedFiles = mutableSetOf(sourcesCachePath))
+
+    val result =
+      resolveSourcesPath(coord, "/cache", listOf("https://r"), deps, binaryWasCached = true)
+
+    assertEquals(sourcesCachePath, result)
+  }
+
+  @Test
+  fun resolveSourcesPathSkipsNetworkWhenBinaryWasCachedAndNoSourcesOnDisk() {
+    val coord = Coordinate("com.example", "lib", "1.0.0")
+    val downloadedUrls = mutableListOf<String>()
+    val deps =
+      object : ResolverDeps {
+        override fun fileExists(path: String): Boolean = false
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          downloadedUrls.add(url)
+          return Ok(Unit)
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> =
+          Err(Sha256Error(filePath))
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> =
+          Err(OpenFailed(path))
+      }
+
+    val result =
+      resolveSourcesPath(coord, "/cache", listOf("https://r"), deps, binaryWasCached = true)
+
+    assertEquals(null, result)
+    assertTrue(downloadedUrls.isEmpty(), "must not re-probe when binary was already cached")
+  }
+
+  @Test
+  fun resolveSourcesPathDownloadsWhenBinaryWasFreshAndSourcesAvailable() {
+    val coord = Coordinate("com.example", "lib", "1.0.0")
+    val deps = fakeTransitiveDeps()
+
+    val result =
+      resolveSourcesPath(coord, "/cache", listOf("https://r"), deps, binaryWasCached = false)
+
+    assertEquals("/cache/com/example/lib/1.0.0/lib-1.0.0-sources.jar", result)
+  }
+
+  @Test
+  fun resolveSourcesPathReturnsNullOn404() {
+    val coord = Coordinate("com.example", "lib", "1.0.0")
+    val sourcesUrl = "https://r/com/example/lib/1.0.0/lib-1.0.0-sources.jar"
+    val deps =
+      fakeTransitiveDeps(
+        downloadErrors = mapOf(sourcesUrl to DownloadError.HttpFailed(sourcesUrl, 404))
+      )
+
+    val result =
+      resolveSourcesPath(coord, "/cache", listOf("https://r"), deps, binaryWasCached = false)
+
+    assertEquals(null, result)
+  }
+
+  @Test
+  fun resolveSourcesPathReturnsNullOnNetworkError() {
+    val coord = Coordinate("com.example", "lib", "1.0.0")
+    val sourcesUrl = "https://r/com/example/lib/1.0.0/lib-1.0.0-sources.jar"
+    val deps =
+      fakeTransitiveDeps(
+        downloadErrors = mapOf(sourcesUrl to DownloadError.NetworkError(sourcesUrl, "timeout"))
+      )
+
+    val result =
+      resolveSourcesPath(coord, "/cache", listOf("https://r"), deps, binaryWasCached = false)
+
+    assertEquals(null, result)
+  }
+
+  @Test
+  fun resolveTransitivePopulatesSourcesPathWhenAvailable() {
+    val config = testConfig().copy(dependencies = mapOf("com.example:lib" to "1.0.0"))
+    val pomXml =
+      """
+        <project>
+            <groupId>com.example</groupId>
+            <artifactId>lib</artifactId>
+            <version>1.0.0</version>
+        </project>
+      """
+        .trimIndent()
+
+    val deps =
+      fakeTransitiveDeps(
+        sha256Results = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.jar" to "hash1"),
+        pomContents = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.pom" to pomXml),
+      )
+    val resolved = assertNotNull(resolveTransitive(config, null, "/cache", deps).get())
+
+    assertEquals("/cache/com/example/lib/1.0.0/lib-1.0.0-sources.jar", resolved.deps[0].sourcesPath)
+  }
+
+  @Test
+  fun resolveTransitiveLeavesSourcesPathNullWhen404() {
+    val config = testConfig().copy(dependencies = mapOf("com.example:lib" to "1.0.0"))
+    val pomXml =
+      """
+        <project>
+            <groupId>com.example</groupId>
+            <artifactId>lib</artifactId>
+            <version>1.0.0</version>
+        </project>
+      """
+        .trimIndent()
+    val sourcesUrl = "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0-sources.jar"
+
+    val deps =
+      fakeTransitiveDeps(
+        sha256Results = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.jar" to "hash1"),
+        pomContents = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.pom" to pomXml),
+        downloadErrors = mapOf(sourcesUrl to DownloadError.HttpFailed(sourcesUrl, 404)),
+      )
+    val resolved = assertNotNull(resolveTransitive(config, null, "/cache", deps).get())
+
+    assertEquals(null, resolved.deps[0].sourcesPath)
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
@@ -1116,6 +1116,37 @@ class TransitiveResolverTest {
     assertEquals(null, resolved.deps[0].sourcesPath)
   }
 
+  // A network error on the sources fetch must never cascade into a
+  // binary-resolve failure. End-to-end pin for the silent-fail policy.
+  @Test
+  fun resolveTransitiveLeavesSourcesPathNullOnNetworkErrorWithoutFailingBinary() {
+    val config = testConfig().copy(dependencies = mapOf("com.example:lib" to "1.0.0"))
+    val pomXml =
+      """
+        <project>
+            <groupId>com.example</groupId>
+            <artifactId>lib</artifactId>
+            <version>1.0.0</version>
+        </project>
+      """
+        .trimIndent()
+    val sourcesUrl = "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0-sources.jar"
+
+    val deps =
+      fakeTransitiveDeps(
+        sha256Results = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.jar" to "hash1"),
+        pomContents = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.pom" to pomXml),
+        downloadErrors = mapOf(sourcesUrl to DownloadError.NetworkError(sourcesUrl, "timeout")),
+      )
+    val result = resolveTransitive(config, null, "/cache", deps)
+    val resolved = assertNotNull(result.get(), "binary resolve must succeed even if sources errors")
+
+    assertEquals(1, resolved.deps.size)
+    assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
+    assertEquals("hash1", resolved.deps[0].sha256)
+    assertEquals(null, resolved.deps[0].sourcesPath)
+  }
+
   @Test
   fun downloadFromRepositoriesSucceedsOnFirstRepo() {
     val coord = Coordinate("com.example", "lib", "1.0.0")


### PR DESCRIPTION
Closes #242.

`workspace.json` libraries now carry a second `roots` entry with `type: "SOURCES"` when a `-sources.jar` was fetched from the same Maven repo that served the binary. kotlin-lsp-backed editors follow that root for go-to-definition, so dependency symbols land in Kotlin source (inline bodies, default args, reified types) instead of decompiled bytecode.

## Key policy choices

- **All failures silent on sources fetch.** 404 (unpublished sources), timeout, network errors — sources are editor UX, not correctness. They must never fail the build and must never warn.
- **No re-probe on warm binary cache.** Sources are attempted only when the binary was freshly downloaded in this resolve. If a binary is already cached and the sources file isn't, we don't hit the network again — consistent with the lockfile not being extended (cache presence is ground truth). If upstream later publishes `-sources.jar`, the user clears `~/.kolt/cache/<group>/<artifact>/` and re-resolves.

## Review focus

- `TransitiveResolver.resolveSourcesPath` — the three-branch decision (cached → path, warm-binary → null, fresh-binary → best-effort probe). Comment at the top of the function explains the why; if the policy is wrong, this is the one place to change it.
- `Dependency.kt` — `buildMavenUrl` / `buildRelativePath` gained an optional `classifier` param. Internal helper; the only existing caller paths (`jar`, `pom`, `module`, `klib`) still work because `classifier` defaults to null and produces identical output.
- `ResolvedDep.sourcesPath: String? = null` — backward-compatible; both construction sites (`TransitiveResolver`, `NativeResolver`) use named params. `NativeResolver` always passes null because klib sources for Native targets are out of scope.
- `kolt.lock` is NOT extended — `LockEntry` schema stays v3. Sources presence lives only in the cache.
- `downloadFile` removes the dest file on failure (`Downloader.kt:77`), so `fileExists(sourcesCachePath)` is a clean ground-truth check.

## Out of scope

- `-javadoc.jar` attachment
- klib sources for Native targets (`NativeResolver` unchanged)