### PR TITLE
Resolve user JDK and populate workspace.json SDK.homePath (#243)

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/UserJdk.kt
+++ b/src/nativeMain/kotlin/kolt/build/UserJdk.kt
@@ -22,12 +22,14 @@ internal sealed interface UserJdkError {
 // user code should be read against.
 //
 // Contract:
-//  - `[build] jdk` set: return the managed install if present; otherwise
-//    `ManagedMissing`. Never silently fall back to a system JDK — doing so
-//    would contradict the pin.
-//  - `[build] jdk` unset: probe `java` on PATH and return its `java.home`,
-//    tagging the version with `jvmTarget` for the SDK label. If probing
-//    fails, return `SystemProbeFailed`.
+//  - `[build] jdk` set to a non-blank value: return the managed install when
+//    `bin/java` is present; otherwise `ManagedMissing`. Probing `bin/java`
+//    (not just the directory) catches interrupted installs and manual prunes
+//    that would otherwise feed kotlin-lsp a home with no class roots. Never
+//    silently fall back to a system JDK — that would contradict the pin.
+//  - `[build] jdk` unset or blank: probe `java` on PATH and return its
+//    `java.home`, tagging the version with `jvmTarget` for the SDK label. If
+//    probing fails, return `SystemProbeFailed`.
 internal fun resolveUserJdkHome(
   config: KoltConfig,
   paths: KoltPaths,
@@ -35,9 +37,9 @@ internal fun resolveUserJdkHome(
   probe: () -> String? = ::probeSystemJavaHome,
 ): Result<UserJdkHome, UserJdkError> {
   val managed = config.build.jdk
-  if (managed != null) {
+  if (!managed.isNullOrBlank()) {
     val home = paths.jdkPath(managed)
-    return if (exists(home)) Ok(UserJdkHome(managed, home))
+    return if (exists(paths.javaBin(managed))) Ok(UserJdkHome(managed, home))
     else Err(UserJdkError.ManagedMissing(managed, home))
   }
   val systemHome = probe() ?: return Err(UserJdkError.SystemProbeFailed)

--- a/src/nativeMain/kotlin/kolt/build/UserJdk.kt
+++ b/src/nativeMain/kotlin/kolt/build/UserJdk.kt
@@ -1,0 +1,67 @@
+package kolt.build
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.config.KoltConfig
+import kolt.config.KoltPaths
+import kolt.infra.executeAndCapture
+import kolt.infra.fileExists
+
+internal data class UserJdkHome(val version: String, val home: String)
+
+internal sealed interface UserJdkError {
+  data class ManagedMissing(val version: String, val expectedPath: String) : UserJdkError
+
+  data object SystemProbeFailed : UserJdkError
+}
+
+// Resolves the IDE-facing JDK surfaced through workspace.json. Independent of
+// the bootstrap JDK (ADR 0017), which only runs the daemon and is not what
+// user code should be read against.
+//
+// Contract:
+//  - `[build] jdk` set: return the managed install if present; otherwise
+//    `ManagedMissing`. Never silently fall back to a system JDK — doing so
+//    would contradict the pin.
+//  - `[build] jdk` unset: probe `java` on PATH and return its `java.home`,
+//    tagging the version with `jvmTarget` for the SDK label. If probing
+//    fails, return `SystemProbeFailed`.
+internal fun resolveUserJdkHome(
+  config: KoltConfig,
+  paths: KoltPaths,
+  exists: (String) -> Boolean = ::fileExists,
+  probe: () -> String? = ::probeSystemJavaHome,
+): Result<UserJdkHome, UserJdkError> {
+  val managed = config.build.jdk
+  if (managed != null) {
+    val home = paths.jdkPath(managed)
+    return if (exists(home)) Ok(UserJdkHome(managed, home))
+    else Err(UserJdkError.ManagedMissing(managed, home))
+  }
+  val systemHome = probe() ?: return Err(UserJdkError.SystemProbeFailed)
+  return Ok(UserJdkHome(config.build.jvmTarget, systemHome))
+}
+
+// `-XshowSettings:properties` prints to stderr; redirect so popen's stdout-
+// only capture sees it. Returns null on any failure (java absent, non-zero
+// exit, or the property missing from output).
+internal fun probeSystemJavaHome(): String? {
+  val output =
+    executeAndCapture("java -XshowSettings:properties -version 2>&1").getOrElse {
+      return null
+    }
+  return parseJavaHomeFromProperties(output)
+}
+
+private val JAVA_HOME_LINE = Regex("""^\s*java\.home\s*=\s*(.+?)\s*$""")
+
+internal fun parseJavaHomeFromProperties(output: String): String? {
+  for (line in output.lineSequence()) {
+    val match = JAVA_HOME_LINE.matchEntire(line) ?: continue
+    val value = match.groupValues[1].trim()
+    if (value.isNotEmpty()) return value
+  }
+  return null
+}

--- a/src/nativeMain/kotlin/kolt/build/Workspace.kt
+++ b/src/nativeMain/kotlin/kolt/build/Workspace.kt
@@ -19,6 +19,7 @@ fun generateWorkspaceJson(
   config: KoltConfig,
   mainDeps: List<ResolvedDep>,
   testDeps: List<ResolvedDep>,
+  sdkHomePath: String? = null,
 ): String {
   val allDeps = mainDeps + testDeps
   val json = buildJsonObject {
@@ -29,7 +30,7 @@ fun generateWorkspaceJson(
       }
     }
     putJsonArray("libraries") { allDeps.forEach { dep -> add(buildLibraryEntry(dep)) } }
-    putJsonArray("sdks") { add(buildSdkEntry(config.build.jvmTarget)) }
+    putJsonArray("sdks") { add(buildSdkEntry(config.build.jvmTarget, sdkHomePath)) }
     putJsonArray("kotlinSettings") {
       add(buildKotlinSettings(config, isTest = false))
       if (config.build.testSources.isNotEmpty()) {
@@ -161,12 +162,15 @@ private fun buildLibraryEntry(dep: ResolvedDep): JsonObject = buildJsonObject {
   }
 }
 
-private fun buildSdkEntry(jvmTarget: String): JsonObject = buildJsonObject {
+// `roots` is intentionally omitted: per kotlin-lsp's SdkData model, an absent
+// roots key lets the LSP derive class/source/annotation roots from homePath
+// itself (including JDK 9+ jrt:/ module roots), which kolt cannot enumerate
+// without a JVM.
+private fun buildSdkEntry(jvmTarget: String, homePath: String?): JsonObject = buildJsonObject {
   put("name", jvmTarget)
   put("type", "jdk")
   put("version", "JDK_$jvmTarget")
-  put("homePath", JsonNull)
-  putJsonArray("roots") {}
+  put("homePath", homePath?.let { JsonPrimitive(it) } ?: JsonNull)
   put("additionalData", "")
 }
 

--- a/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
@@ -3,11 +3,15 @@ package kolt.cli
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getOrElse
+import com.github.michaelbull.result.onErr
 import kolt.build.ResolvedJar
+import kolt.build.UserJdkError
 import kolt.build.autoInjectedTestDeps
 import kolt.build.generateKlsClasspath
 import kolt.build.generateWorkspaceJson
+import kolt.build.resolveUserJdkHome
 import kolt.config.*
 import kolt.infra.*
 import kolt.resolve.*
@@ -109,7 +113,7 @@ internal fun resolveDependencies(config: KoltConfig): Result<JvmResolutionOutcom
   }
 
   if (resolveResult.lockChanged || !fileExists(WORKSPACE_JSON) || !fileExists(KLS_CLASSPATH)) {
-    writeWorkspaceFiles(config, resolveResult.deps)
+    writeWorkspaceFiles(config, paths, resolveResult.deps)
   }
 
   return Ok(splitJvmOutcome(resolveResult.deps))
@@ -162,12 +166,13 @@ internal fun resolveNativeDependencies(
   return Ok(result.deps.map { it.cachePath })
 }
 
-private fun writeWorkspaceFiles(config: KoltConfig, deps: List<ResolvedDep>) {
+private fun writeWorkspaceFiles(config: KoltConfig, paths: KoltPaths, deps: List<ResolvedDep>) {
   // kls-classpath is a flat union — kotlin-lsp expects one classpath
   // and resolves visibility from module scopes. workspace.json
   // carries the main/test split for richer IDE consumers.
   val (mainDeps, testDeps) = splitByOrigin(deps)
-  val workspaceJson = generateWorkspaceJson(config, mainDeps, testDeps)
+  val sdkHomePath = resolveWorkspaceSdkHomePath(config, paths)
+  val workspaceJson = generateWorkspaceJson(config, mainDeps, testDeps, sdkHomePath = sdkHomePath)
   writeFileAsString(WORKSPACE_JSON, workspaceJson).getOrElse { error ->
     eprintln("warning: could not write $WORKSPACE_JSON: ${error.path}")
     return
@@ -179,3 +184,23 @@ private fun writeWorkspaceFiles(config: KoltConfig, deps: List<ResolvedDep>) {
     return
   }
 }
+
+// Best-effort: a null homePath just means the editor falls back to its own
+// JDK detection. Warn in each failure mode so the user can act on it without
+// blocking the resolve.
+private fun resolveWorkspaceSdkHomePath(config: KoltConfig, paths: KoltPaths): String? =
+  resolveUserJdkHome(config, paths)
+    .onErr { err ->
+      when (err) {
+        is UserJdkError.ManagedMissing ->
+          eprintln(
+            "warning: workspace.json sdk homePath left unset — jdk ${err.version} not installed at ${err.expectedPath} (run `kolt toolchain install`)"
+          )
+        UserJdkError.SystemProbeFailed ->
+          eprintln(
+            "warning: workspace.json sdk homePath left unset — could not locate `java` on PATH (install a JDK or set [build] jdk)"
+          )
+      }
+    }
+    .get()
+    ?.home

--- a/src/nativeTest/kotlin/kolt/build/UserJdkTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/UserJdkTest.kt
@@ -21,7 +21,7 @@ class UserJdkTest {
       resolveUserJdkHome(
         config,
         paths,
-        exists = { path -> path == paths.jdkPath("21") },
+        exists = { path -> path == paths.javaBin("21") },
         probe = { error("must not probe system java when managed JDK resolves") },
       )
 
@@ -29,6 +29,47 @@ class UserJdkTest {
     assertEquals("21", home.version)
     assertEquals(paths.jdkPath("21"), home.home)
     assertNull(result.getError())
+  }
+
+  // An interrupted toolchain install or a manual prune can leave the JDK
+  // directory behind without `bin/java`. Treat that the same as missing — a
+  // home with no class roots would mislead kotlin-lsp.
+  @Test
+  fun managedJdkReturnsManagedMissingWhenBinJavaMissingEvenIfDirExists() {
+    val config = testConfig(jdk = "21")
+
+    val result =
+      resolveUserJdkHome(
+        config,
+        paths,
+        exists = { path -> path == paths.jdkPath("21") },
+        probe = { error("must not probe system java when managed JDK is pinned") },
+      )
+
+    assertNull(result.get())
+    assertEquals(
+      UserJdkError.ManagedMissing(version = "21", expectedPath = paths.jdkPath("21")),
+      result.getError(),
+    )
+  }
+
+  // `jdk = ""` in kolt.toml parses as a non-null blank string. Treat it like
+  // an unset pin so the warning doesn't surface an empty version label.
+  @Test
+  fun blankManagedJdkFallsBackToSystemProbe() {
+    val config = testConfig(jdk = "", jvmTarget = "17")
+
+    val result =
+      resolveUserJdkHome(
+        config,
+        paths,
+        exists = { error("must not check filesystem for a blank pin") },
+        probe = { "/usr/lib/jvm/java-17-openjdk" },
+      )
+
+    val home = assertNotNull(result.get())
+    assertEquals("17", home.version)
+    assertEquals("/usr/lib/jvm/java-17-openjdk", home.home)
   }
 
   // When the user pinned a managed JDK that hasn't been installed yet,

--- a/src/nativeTest/kotlin/kolt/build/UserJdkTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/UserJdkTest.kt
@@ -1,0 +1,124 @@
+package kolt.build
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.config.KoltPaths
+import kolt.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class UserJdkTest {
+
+  private val paths = KoltPaths(home = "/fake/home")
+
+  @Test
+  fun managedJdkReturnsPathsJdkHomeWhenInstalled() {
+    val config = testConfig(jdk = "21")
+
+    val result =
+      resolveUserJdkHome(
+        config,
+        paths,
+        exists = { path -> path == paths.jdkPath("21") },
+        probe = { error("must not probe system java when managed JDK resolves") },
+      )
+
+    val home = assertNotNull(result.get())
+    assertEquals("21", home.version)
+    assertEquals(paths.jdkPath("21"), home.home)
+    assertNull(result.getError())
+  }
+
+  // When the user pinned a managed JDK that hasn't been installed yet,
+  // silently falling back to a system `java` would contradict the pin and
+  // mislead the LSP. Surface the error so callers can emit a targeted warning.
+  @Test
+  fun managedJdkReturnsManagedMissingWhenNotInstalled() {
+    val config = testConfig(jdk = "21")
+
+    val result =
+      resolveUserJdkHome(
+        config,
+        paths,
+        exists = { false },
+        probe = { error("must not probe system java when managed JDK is pinned") },
+      )
+
+    assertNull(result.get())
+    val err = assertNotNull(result.getError())
+    assertEquals(
+      UserJdkError.ManagedMissing(version = "21", expectedPath = paths.jdkPath("21")),
+      err,
+    )
+  }
+
+  @Test
+  fun unmanagedJdkFallsBackToSystemProbe() {
+    val config = testConfig(jvmTarget = "17")
+
+    val result =
+      resolveUserJdkHome(
+        config,
+        paths,
+        exists = { error("unused for unmanaged path") },
+        probe = { "/usr/lib/jvm/java-17-openjdk" },
+      )
+
+    val home = assertNotNull(result.get())
+    assertEquals("17", home.version)
+    assertEquals("/usr/lib/jvm/java-17-openjdk", home.home)
+  }
+
+  @Test
+  fun unmanagedJdkReturnsSystemProbeFailedWhenProbeReturnsNull() {
+    val config = testConfig()
+
+    val result = resolveUserJdkHome(config, paths, exists = { false }, probe = { null })
+
+    assertNull(result.get())
+    assertEquals(UserJdkError.SystemProbeFailed, result.getError())
+  }
+
+  @Test
+  fun parseJavaHomeFromPropertiesExtractsIndentedAssignment() {
+    val output =
+      """
+      OpenJDK 64-Bit Server VM warning: ignoring option X
+      Property settings:
+          java.class.path =
+          java.home = /usr/lib/jvm/java-21-openjdk
+          java.io.tmpdir = /tmp
+      """
+        .trimIndent()
+
+    assertEquals("/usr/lib/jvm/java-21-openjdk", parseJavaHomeFromProperties(output))
+  }
+
+  @Test
+  fun parseJavaHomeFromPropertiesIgnoresSimilarKeys() {
+    // `java.home.foo` is not a real JDK property today, but harden the parser
+    // so a future namespace collision does not return the wrong value.
+    val output =
+      """
+          java.home.foo = /bogus
+          java.home = /real/home
+      """
+        .trimIndent()
+
+    assertEquals("/real/home", parseJavaHomeFromProperties(output))
+  }
+
+  @Test
+  fun parseJavaHomeFromPropertiesReturnsNullWhenAbsent() {
+    val output =
+      """
+      Property settings:
+          file.encoding = UTF-8
+      """
+        .trimIndent()
+
+    assertNull(parseJavaHomeFromProperties(output))
+  }
+}

--- a/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
@@ -6,8 +6,10 @@ import kolt.testConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -211,6 +213,46 @@ class WorkspaceTest {
     assertEquals("21", sdk["name"]!!.jsonPrimitive.content)
     assertEquals("jdk", sdk["type"]!!.jsonPrimitive.content)
     assertEquals("JDK_21", sdk["version"]!!.jsonPrimitive.content)
+  }
+
+  // kotlin-lsp needs sdks[0].homePath to navigate JDK sources and verify
+  // APIs against the intended JDK; null forces it to fall back to whatever
+  // the editor locates. Issue #243.
+  @Test
+  fun generateWorkspaceJsonSdkHomePathPopulatedWhenProvided() {
+    val config = testConfig(jvmTarget = "21")
+
+    val result =
+      generateWorkspaceJson(config, emptyList(), emptyList(), sdkHomePath = "/opt/jdk/21")
+    val root = parseJson(result)
+
+    val sdk = root["sdks"]!!.jsonArray[0].jsonObject
+    assertEquals("/opt/jdk/21", sdk["homePath"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun generateWorkspaceJsonSdkHomePathNullWhenUnresolved() {
+    val config = testConfig()
+
+    val result = generateWorkspaceJson(config, emptyList(), emptyList(), sdkHomePath = null)
+    val root = parseJson(result)
+
+    val sdk = root["sdks"]!!.jsonArray[0].jsonObject
+    assertEquals(JsonNull, sdk["homePath"])
+  }
+
+  // SdkData model (kotlin-lsp) comment: when `roots` is absent the LSP
+  // computes them from `homePath`. An empty array is not the same as absent
+  // for this importer, so kolt must omit the key entirely.
+  @Test
+  fun generateWorkspaceJsonSdkOmitsRootsKey() {
+    val config = testConfig()
+
+    val withHome = generateWorkspaceJson(config, emptyList(), emptyList(), sdkHomePath = "/opt/j")
+    val withoutHome = generateWorkspaceJson(config, emptyList(), emptyList(), sdkHomePath = null)
+
+    assertNull(parseJson(withHome)["sdks"]!!.jsonArray[0].jsonObject["roots"])
+    assertNull(parseJson(withoutHome)["sdks"]!!.jsonArray[0].jsonObject["roots"])
   }
 
   @Test


### PR DESCRIPTION
Closes #243.

`sdks[0].homePath` is populated from a newly-introduced `resolveUserJdkHome`, which is independent from the bootstrap JDK (ADR 0017, daemon-only). When `[build] jdk` is set, it points at the managed install under `~/.kolt/toolchains/jdk/<v>`. When unset, it probes `java -XshowSettings:properties -version 2>&1` on PATH and extracts `java.home`. `sdks[0].roots` is now omitted entirely so kotlin-lsp can derive roots from `homePath` (including JDK 9+ `jrt:/` module roots that kolt has no way to enumerate without a JVM).

## Review focus

- `UserJdk.kt::resolveUserJdkHome` contract: when `jdk` is pinned but not installed, we return `ManagedMissing` and surface a warning rather than silently probing the system JDK. The reasoning (pin must not drift) is worth a sanity check — the alternative is probing-as-fallback, which would contradict the pin but give the LSP something to work with. I picked strict.
- `sdks[0].name` / `version` still track `jvmTarget`, not the resolved JDK version. DoD said "continue to match the user JDK version" which I read as "don't regress existing naming" (current code uses `jvmTarget`). If the managed JDK version should flow into the label when they differ, that's a small follow-up.
- `parseJavaHomeFromProperties` is hardened against `java.home.foo`-style keys even though no such property exists today — cheap guard.

## Test plan

- Unit tests added to `WorkspaceTest` (homePath populated / null / `roots` key omitted) and a new `UserJdkTest` (managed hit, managed missing, system probe, probe failure, property parser).
- Manual smoke on a JVM project: (1) unset `jdk` → homePath picks up Corretto 21 from PATH; (2) `jdk = "21"` installed → homePath is `~/.kolt/toolchains/jdk/21`; (3) `jdk = "17"` uninstalled → warning emitted, homePath null. `roots` absent in all three.