### PR TITLE
Document libraries[].type choice in workspace.json (#247)

### DIFF
--- a/src/nativeMain/kotlin/kolt/build/Workspace.kt
+++ b/src/nativeMain/kotlin/kolt/build/Workspace.kt
@@ -136,6 +136,10 @@ private fun buildTestModule(config: KoltConfig, resolvedDeps: List<ResolvedDep>)
     }
   }
 
+// `type` is only stored into LibraryEntity.typeId and never branched on
+// (see Kotlin/kotlin-lsp workspace-import/.../json/conversion.kt::importWorkspaceData;
+// GenericWorkspaceImporter omits typeId entirely). "java-imported" is the IntelliJ
+// platform library type id for externally-imported JARs.
 private fun buildLibraryEntry(dep: ResolvedDep): JsonObject = buildJsonObject {
   put("name", "${dep.groupArtifact}:${dep.version}")
   put("type", "java-imported")


### PR DESCRIPTION
Closes #247.

Investigation of kotlin-lsp (`workspace-import/.../json/conversion.kt::importWorkspaceData`) confirms that `LibraryData.type` is only passed into `LibraryEntity.typeId` and never read anywhere downstream — `GenericWorkspaceImporter` omits `typeId` outright, which is the clearest evidence the field is decorative for this importer. Sources-jar attachment is keyed off `roots[].type = "SOURCES"` (already emitted in PR #254), not the library type.

Kept `"java-imported"` rather than switching to the Gradle-importer string `"COMPILE"`: it is IntelliJ's standard library type id for externally-imported JARs, which matches what kolt is actually doing, and Gradle's value is ad hoc rather than a platform type id.

### Review notes
- Only change is a 4-line comment above `buildLibraryEntry` in `src/nativeMain/kotlin/kolt/build/Workspace.kt`, anchored at the kotlin-lsp source that justifies the choice.
- `WorkspaceTest` already asserts `"java-imported"`; unchanged and still green (`./gradlew linuxX64Test --tests "*WorkspaceTest*"`).