### PR TITLE
Drop kls-classpath emission

### DIFF
--- a/docs/adr/0008-lsp-workspace-auto-generation.md
+++ b/docs/adr/0008-lsp-workspace-auto-generation.md
@@ -1,5 +1,5 @@
 ---
-status: accepted
+status: accepted (amended 2026-04-26)
 date: 2026-04-09
 ---
 
@@ -7,7 +7,8 @@ date: 2026-04-09
 
 ## Summary
 
-- `workspace.json` (JetBrains kotlin-lsp) and `kls-classpath` (fwcd/kotlin-language-server) are generated at the project root and kept in sync with the lockfile. (§1)
+- `workspace.json` (JetBrains kotlin-lsp) is generated at the project root and kept in sync with the lockfile. (§1)
+- ~~`kls-classpath` is also emitted for fwcd/kotlin-language-server.~~ Removed 2026-04-26; see §6.
 - Regeneration triggers when the lockfile changes or either file is missing; no regeneration otherwise. (§2)
 - Generation is a pure function in `build/Workspace.kt`; I/O is a thin wrapper in `BuildCommands.kt`. (§3)
 - Both files are generated artefacts; exclude from version control — the `kolt init` template adds them to `.gitignore` by default. (§4)
@@ -84,9 +85,19 @@ Both files sit at the project root next to `kolt.toml` so the LSP can find them 
 4. **A single unified format adapted per-LSP at runtime.** Rejected. No shared "LSP project model" standard exists across the Kotlin ecosystem. Each server reads its own format.
 5. **Regenerate on every `kolt build`.** Rejected as wasteful in the no-op case.
 
+## §6 Update 2026-04-26: drop `kls-classpath`
+
+Reverses Alternatives #3. Reasons:
+
+1. fwcd/kotlin-language-server is upstream-deprecated; its README points users to JetBrains/kotlin-lsp.
+2. fwcd's `ShellClassPathResolver` reads `kls-classpath` as an **executable shell script** invoked via `ProcessBuilder` and parses its stdout. kolt has been writing a plain colon-joined text file (mode 644, no shebang), which fwcd logs a warning for and ignores. The emission has therefore never been functionally consumed by any fwcd user of a kolt project.
+3. The neovim editor smoke test for #248 confirmed that kotlin-lsp's neovim integration relies on Gradle/Maven discovery, not `kls-classpath` — so dropping the file does not regress the path that motivated keeping it.
+
+`generateKlsClasspath` and the `KLS_CLASSPATH` write are removed; the regeneration trigger now keys only on `workspace.json` presence. Existing project trees may have a stale `kls-classpath` file from prior builds; users can `rm` it.
+
 ## Related
 
-- `src/nativeMain/kotlin/kolt/build/Workspace.kt` — `generateWorkspaceJson`, `generateKlsClasspath`
-- `src/nativeMain/kotlin/kolt/cli/BuildCommands.kt` — regeneration trigger
+- `src/nativeMain/kotlin/kolt/build/Workspace.kt` — `generateWorkspaceJson`
+- `src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt` — regeneration trigger (writeWorkspaceFiles)
 - Commit `a5af50f` — initial LSP workspace integration (v0.7.0)
-- ADR 0004 — pure/IO separation; `Workspace.kt` generators are pure, wiring lives in `BuildCommands.kt`
+- ADR 0004 — pure/IO separation; `Workspace.kt` generators are pure, wiring lives in `DependencyResolution.kt`

--- a/src/nativeMain/kotlin/kolt/build/Workspace.kt
+++ b/src/nativeMain/kotlin/kolt/build/Workspace.kt
@@ -48,9 +48,6 @@ fun generateWorkspaceJson(
   return prettyJson.encodeToString(JsonObject.serializer(), json)
 }
 
-fun generateKlsClasspath(resolvedDeps: List<ResolvedDep>): String =
-  resolvedDeps.joinToString(":") { it.cachePath }
-
 private fun buildMainModule(config: KoltConfig, resolvedDeps: List<ResolvedDep>): JsonObject =
   buildJsonObject {
     put("name", "${config.name}.main")

--- a/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
@@ -9,7 +9,6 @@ import com.github.michaelbull.result.onErr
 import kolt.build.ResolvedJar
 import kolt.build.UserJdkError
 import kolt.build.autoInjectedTestDeps
-import kolt.build.generateKlsClasspath
 import kolt.build.generateWorkspaceJson
 import kolt.build.resolveUserJdkHome
 import kolt.config.*
@@ -18,7 +17,6 @@ import kolt.resolve.*
 
 internal const val LOCK_FILE = "kolt.lock"
 private const val WORKSPACE_JSON = "workspace.json"
-private const val KLS_CLASSPATH = "kls-classpath"
 
 internal fun createResolverDeps(): ResolverDeps = defaultResolverDeps()
 
@@ -112,7 +110,7 @@ internal fun resolveDependencies(config: KoltConfig): Result<JvmResolutionOutcom
     }
   }
 
-  if (resolveResult.lockChanged || !fileExists(WORKSPACE_JSON) || !fileExists(KLS_CLASSPATH)) {
+  if (resolveResult.lockChanged || !fileExists(WORKSPACE_JSON)) {
     writeWorkspaceFiles(config, paths, resolveResult.deps)
   }
 
@@ -167,20 +165,11 @@ internal fun resolveNativeDependencies(
 }
 
 private fun writeWorkspaceFiles(config: KoltConfig, paths: KoltPaths, deps: List<ResolvedDep>) {
-  // kls-classpath is a flat union — kotlin-lsp expects one classpath
-  // and resolves visibility from module scopes. workspace.json
-  // carries the main/test split for richer IDE consumers.
   val (mainDeps, testDeps) = splitByOrigin(deps)
   val sdkHomePath = resolveWorkspaceSdkHomePath(config, paths)
   val workspaceJson = generateWorkspaceJson(config, mainDeps, testDeps, sdkHomePath = sdkHomePath)
   writeFileAsString(WORKSPACE_JSON, workspaceJson).getOrElse { error ->
     eprintln("warning: could not write $WORKSPACE_JSON: ${error.path}")
-    return
-  }
-
-  val klsContent = generateKlsClasspath(mainDeps + testDeps)
-  writeFileAsString(KLS_CLASSPATH, klsContent).getOrElse { error ->
-    eprintln("warning: could not write $KLS_CLASSPATH: ${error.path}")
     return
   }
 }

--- a/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/WorkspaceTest.kt
@@ -509,23 +509,4 @@ class WorkspaceTest {
       testContentRoot["excludedPatterns"]!!.jsonArray.map { it.jsonPrimitive.content }
     assertEquals(listOf("build", ".kolt-cache", ".kolt"), excludedPatterns)
   }
-
-  @Test
-  fun generateKlsClasspathFromResolvedDeps() {
-    val deps =
-      listOf(
-        ResolvedDep("com.example:lib", "1.0.0", "abc", "/cache/lib-1.0.0.jar"),
-        ResolvedDep("org.other:util", "2.0.0", "def", "/cache/util-2.0.0.jar"),
-      )
-
-    val result = generateKlsClasspath(deps)
-
-    assertEquals("/cache/lib-1.0.0.jar:/cache/util-2.0.0.jar", result)
-  }
-
-  @Test
-  fun generateKlsClasspathEmptyDeps() {
-    val result = generateKlsClasspath(emptyList())
-    assertEquals("", result)
-  }
 }


### PR DESCRIPTION
fwcd/kotlin-language-server is upstream-deprecated (README banner points to JetBrains/kotlin-lsp). Inspecting fwcd's `ShellClassPathResolver` shows it expects `kls-classpath` to be an **executable shell script** invoked via `ProcessBuilder` whose stdout is parsed for jars; kolt has been writing a colon-joined plain-text file (mode 644, no shebang), so the emission has never actually been consumed by any fwcd user of a kolt project. The smoke test for #248 also confirmed kotlin-lsp's neovim integration relies on Gradle/Maven discovery, not `kls-classpath`, so dropping the file does not regress anything that was working.

Reviewer focus:

- `DependencyResolution.kt`: regeneration trigger now keys on `workspace.json` only. Verified by deleting `workspace.json` from a smoke project (`/tmp/kolt-248-smoke`) and running `kolt deps install` — only `workspace.json` regenerates, no `kls-classpath`.
- ADR 0008 §6: reversal of "Alternatives considered #3" with the reasoning above. Status moved to `accepted (amended 2026-04-26)`. Existing project trees may have stale `kls-classpath` files from prior builds; users `rm` it manually (no migration shim per CLAUDE.md pre-v1 policy).
- Existing `WorkspaceTest` cases for `generateKlsClasspath` removed; no replacement test needed since the smoke verification covers the file-not-emitted assertion at the integration boundary.