### PR TITLE
Make daemon jars byte-reproducible (#238)

### DIFF
--- a/kolt-jvm-compiler-daemon/build.gradle.kts
+++ b/kolt-jvm-compiler-daemon/build.gradle.kts
@@ -28,6 +28,11 @@ kotlin {
     jvmToolchain(21)
 }
 
+tasks.jar {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+}
+
 tasks.test {
     useJUnitPlatform()
     // Pass the daemon-core main source root as a system property so

--- a/kolt-native-compiler-daemon/build.gradle.kts
+++ b/kolt-native-compiler-daemon/build.gradle.kts
@@ -25,6 +25,11 @@ kotlin {
     jvmToolchain(21)
 }
 
+tasks.jar {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+}
+
 tasks.test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
Default Gradle `jar` task neither freezes file timestamps nor sorts entries, so two clean builds of the same source produced different SHA-256s for `kolt-jvm-compiler-daemon.jar` and `kolt-native-compiler-daemon.jar`. Pre-#231 shadowJar handled this; once we dropped shadow the configuration went with it.

Set `isPreserveFileTimestamps = false` and `isReproducibleFileOrder = true` on `tasks.jar` in both daemon modules.

Verified locally (Corretto 21.0.7, WSL2): two consecutive `./gradlew clean :kolt-jvm-compiler-daemon:jar :kolt-native-compiler-daemon:jar` runs produce byte-identical jars (jvm `f9b56688…`, native `b12ee891…`), and the same sha matches a 2× run of the per-subproject `clean :jar` path — i.e. root build path produces the same artifact.

Closes #238.