### PR TITLE
Document ~/.kolt/toolchains/ as a v1-stable CI cache contract (#240)

### DIFF
--- a/.claude/skills/kolt-usage/SKILL.md
+++ b/.claude/skills/kolt-usage/SKILL.md
@@ -187,6 +187,24 @@ kolt toolchain install   # Download kotlinc version from kolt.toml
 
 Stored at `~/.kolt/toolchains/kotlinc/{version}/`. Used automatically when available, falls back to system `kotlinc`.
 
+### CI cache
+
+`~/.kolt/toolchains/` is a stable cache target across the 1.x line (per ADR 0028 §3): the `jdk/<version>/`, `kotlinc/<version>/`, and `konanc/<version>/` subpaths will not be reorganised without a major release. Cache the directory on a key derived from `kolt.toml` (so a Kotlin/JDK pin bump invalidates) and you'll keep hits across patch and minor upgrades. The bootstrap JDK that powers the warm compiler daemon (ADR 0017) lives in the same directory, so a single cache step also avoids re-downloading the daemon JDK on every run.
+
+GitHub Actions:
+
+```yaml
+- name: Cache kolt toolchains
+  uses: actions/cache@v4
+  with:
+    path: ~/.kolt/toolchains
+    key: ${{ runner.os }}-kolt-toolchains-${{ hashFiles('kolt.toml') }}
+    restore-keys: |
+      ${{ runner.os }}-kolt-toolchains-
+```
+
+The `restore-keys` fallback lets a `kolt.toml` edit reuse the previous cache as a base and only re-download the changed tool. Cache `~/.kolt/daemon/` and the build output directory separately if at all — they have different invalidation lifetimes.
+
 ## Kotlin Version Support
 
 kolt supports **Kotlin 2.3.0 and above** on the daemon path, including `[kotlin.plugins]` projects. Kotlin 2.3.20 is the bundled default (no fetch on first build); other 2.3.x patches get `kotlin-build-tools-impl` fetched from Maven Central on first use. Below 2.3.0 is a soft floor — `kolt build` falls back to subprocess with a one-line warning, or silence it with `--no-daemon`. Forward support (2.4.x+) is re-evaluated at each Kotlin language release. Policy: ADR 0022.

--- a/docs/adr/0028-v1-release-policy.md
+++ b/docs/adr/0028-v1-release-policy.md
@@ -112,6 +112,14 @@ informal decision that currently lives only in conversation.
   artifact layout per ADR 0025). Reorganisations require either a
   one-time migration on first run or a deprecation window; the
   proposing ADR picks which.
+- **Toolchain cache layout.** `~/.kolt/toolchains/{jdk|kotlinc|konanc}/<version>/`
+  is a v1-stable subset of the on-disk layout above: the three
+  per-tool subdirectories and their per-version slots will not move
+  or rename across 1.x without a major. CI pipelines may cache the
+  `~/.kolt/toolchains/` root on a key derived from `kolt.toml` plus
+  kolt version and rely on hits surviving patch and minor upgrades.
+  The bootstrap JDK (ADR 0017 §1) shares this directory, so caching
+  also warms the daemon's first run.
 - **Wire protocol.** The daemon protocol carries its own version
   (existing `protocolVersion` in the frame header, ADR 0016). A bump
   is allowed at a minor boundary if the native client negotiates down.
@@ -216,6 +224,8 @@ informal decision that currently lives only in conversation.
 - #230 — `install.sh` + release workflow that RCs consume (ADR 0018 §4).
 - #84 — multi-platform binary distribution, unblocks §4.
 - ADR 0018 §4 — release tarball packaging (this ADR sits on top of it).
+- ADR 0017 §1 — bootstrap JDK lives under the toolchain cache layout
+  this ADR's §3 commits to.
 - CLAUDE.md — the "no back-compat until v1.0" rule is the
   contributor-facing side; this ADR is the user-facing counterpart
   that activates when v1.0 ships.


### PR DESCRIPTION
Two changes:

- **ADR 0028 §3** — new "Toolchain cache layout" bullet that commits `~/.kolt/toolchains/{jdk|kotlinc|konanc}/<version>/` as a v1-stable subpath. CI keys built against 1.x can rely on hits across patch and minor upgrades. Cross-link to ADR 0017 §1 (the bootstrap JDK lives in the same directory, so warming the cache also warms the daemon).
- **`/kolt-usage`** — add a "CI cache" subsection under "Toolchain Management" with a GitHub Actions recipe keyed on `hashFiles('kolt.toml')` plus `runner.os`, with `restore-keys` fallback. Calls out that `kolt.toml`-derived keys invalidate naturally on a Kotlin/JDK pin bump and that `~/.kolt/daemon/` and the build dir have different invalidation lifetimes (caching them needs separate thought).

Reviewer focus: the §3 bullet wording (does the commitment match what we're actually willing to keep stable across 1.x?) and the recipe — `hashFiles('kolt.toml')` is the simplest "exact key TBD in PR" answer the issue left open; happy to swap for a more elaborate scheme if you'd rather pin on `kolt --version` too.

Closes #240.