### PR TITLE
Post-merge cosmetic cleanups for concurrent-build-safety

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -48,6 +48,10 @@ fun main(args: Array<String>) {
         rejectIfLibrary(parsed).getOrElse { exitProcess(it) }
         val (config, classpath, javaPath) =
           doBuild(useDaemon = useDaemon).getOrElse { exitProcess(it) }
+        // The build lock is released between doBuild and doRun. Safe today
+        // because classpath is in-memory; if doRun ever re-reads
+        // build/<name>-runtime.classpath, fold the doRun acquire into
+        // doBuild or hold the lock across both calls.
         doRun(config, classpath, appArgs, javaPath).getOrElse { exitProcess(it) }
       }
     }

--- a/src/nativeTest/kotlin/kolt/cli/ConcurrentBuildIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ConcurrentBuildIT.kt
@@ -3,6 +3,7 @@
 package kolt.cli
 
 import com.github.michaelbull.result.getOrElse
+import kolt.infra.eprintln
 import kolt.infra.executeAndCapture
 import kolt.infra.executeCommand
 import kolt.infra.fileExists
@@ -345,13 +346,29 @@ class ConcurrentBuildIT {
     }
   }
 
-  private fun enabled(): Boolean = getenv("KOLT_CONCURRENT_IT")?.toKString() == "1"
+  // Without an explicit env opt-in the four scenarios early-return rather
+  // than running, so the suite ships clean to default `linuxX64Test`. Print
+  // the skip notice once so a developer running tests without the env
+  // variable does not assume "4 passed" means concurrent safety was
+  // exercised.
+  private fun enabled(): Boolean {
+    val on = getenv("KOLT_CONCURRENT_IT")?.toKString() == "1"
+    if (!on && !skipNoticePrinted) {
+      skipNoticePrinted = true
+      eprintln(
+        "ConcurrentBuildIT: skipped (set KOLT_CONCURRENT_IT=1 and run linkDebugExecutableLinuxX64 to enable)"
+      )
+    }
+    return on
+  }
 
   companion object {
     // Single literal "$" token for use inside the bash heredoc raw
     // strings. Kotlin would otherwise interpret `$P1` / `$!` / `$?` as
     // template lookups against missing properties.
     private const val D = "$"
+
+    private var skipNoticePrinted = false
 
     // kotlin-result is small (a few KB), already published, and a
     // frequent dependency on Maven Central — a low-risk synthetic


### PR DESCRIPTION
Two small follow-ups from PR #262 that were called out but not blocking the merge.

`src/nativeTest/kotlin/kolt/cli/ConcurrentBuildIT.kt` — the four scenarios still early-return when `KOLT_CONCURRENT_IT` is unset, but now print a one-line stderr notice on the first call so a developer running `./gradlew linuxX64Test` does not read "4 passed" as evidence that concurrent safety was exercised. Notice fires once per test process via a companion-level flag.

`src/nativeMain/kotlin/kolt/cli/Main.kt` — comment on the `doBuild` / `doRun` boundary in the `run` dispatch path. The lock is released between the two calls; this is harmless today because the classpath is passed in memory, but a future change that re-reads `build/<name>-runtime.classpath` inside `doRun` would regress safety. The comment names the trip-wire.

Issue #239's other follow-up (TOCTOU race in `ensureDirectoryRecursive`) is tracked separately as #263. The stale-`kolt.kexe` detection idea is documented in the spec's Implementation Notes; not worth a separate issue at its current ROI.