### PR TITLE
Interactive prompts for kolt init / kolt new

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/InitCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/InitCommand.kt
@@ -15,7 +15,7 @@ import platform.posix.PATH_MAX
 import platform.posix.getcwd
 
 @OptIn(ExperimentalForeignApi::class)
-internal fun doInit(args: List<String>): Result<Unit, Int> {
+internal fun doInit(args: List<String>, io: ScaffoldIO = SystemScaffoldIO): Result<Unit, Int> {
   val parsed =
     parseInitArgs(args).getOrElse { msg ->
       eprintln("error: $msg")
@@ -46,8 +46,14 @@ internal fun doInit(args: List<String>): Result<Unit, Int> {
     return Err(EXIT_CONFIG_ERROR)
   }
 
+  val resolved =
+    resolveInteractive(parsed, io).getOrElse { msg ->
+      eprintln("error: $msg")
+      return Err(EXIT_CONFIG_ERROR)
+    }
+
   return scaffoldProject(
     ".",
-    ScaffoldOptions(projectName, parsed.kind, parsed.target, parsed.group),
+    ScaffoldOptions(projectName, resolved.kind, resolved.target, resolved.group),
   )
 }

--- a/src/nativeMain/kotlin/kolt/cli/NewCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/NewCommand.kt
@@ -7,7 +7,7 @@ import kolt.infra.ensureDirectory
 import kolt.infra.eprintln
 import kolt.infra.fileExists
 
-internal fun doNew(args: List<String>): Result<Unit, Int> {
+internal fun doNew(args: List<String>, io: ScaffoldIO = SystemScaffoldIO): Result<Unit, Int> {
   val parsed =
     parseInitArgs(args).getOrElse { msg ->
       eprintln("error: $msg")
@@ -33,6 +33,12 @@ internal fun doNew(args: List<String>): Result<Unit, Int> {
     return Err(EXIT_CONFIG_ERROR)
   }
 
+  val resolved =
+    resolveInteractive(parsed, io).getOrElse { msg ->
+      eprintln("error: $msg")
+      return Err(EXIT_CONFIG_ERROR)
+    }
+
   ensureDirectory(projectName).getOrElse { error ->
     eprintln("error: could not create directory ${error.path}")
     return Err(EXIT_BUILD_ERROR)
@@ -40,6 +46,6 @@ internal fun doNew(args: List<String>): Result<Unit, Int> {
 
   return scaffoldProject(
     projectName,
-    ScaffoldOptions(projectName, parsed.kind, parsed.target, parsed.group),
+    ScaffoldOptions(projectName, resolved.kind, resolved.target, resolved.group),
   )
 }

--- a/src/nativeMain/kotlin/kolt/cli/Prompt.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Prompt.kt
@@ -1,0 +1,92 @@
+package kolt.cli
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.config.DEFAULT_SCAFFOLD_TARGET
+import kolt.config.NATIVE_TARGETS
+import kolt.config.ScaffoldKind
+import kolt.config.isValidGroup
+
+internal data class ResolvedScaffoldOptions(
+  val kind: ScaffoldKind,
+  val target: String,
+  val group: String?,
+)
+
+internal fun resolveInteractive(
+  parsed: ParsedInitArgs,
+  io: ScaffoldIO,
+): Result<ResolvedScaffoldOptions, String> {
+  val tty = io.isStdinTty()
+
+  val kind =
+    parsed.kind
+      ?: if (tty) {
+        promptKind(io).getOrElse {
+          return Err(it)
+        }
+      } else ScaffoldKind.APP
+
+  val target =
+    parsed.target
+      ?: if (tty) {
+        promptTarget(io).getOrElse {
+          return Err(it)
+        }
+      } else DEFAULT_SCAFFOLD_TARGET
+
+  val group =
+    if (parsed.groupSpecified) parsed.group
+    else if (tty) {
+      promptGroup(io).getOrElse {
+        return Err(it)
+      }
+    } else null
+
+  return Ok(ResolvedScaffoldOptions(kind, target, group))
+}
+
+private val PROMPT_TARGETS = listOf(DEFAULT_SCAFFOLD_TARGET) + NATIVE_TARGETS.toList().sorted()
+
+private fun promptKind(io: ScaffoldIO): Result<ScaffoldKind, String> {
+  io.println("Project kind:")
+  io.println("  1) app (default)")
+  io.println("  2) lib")
+  val raw = io.readLine()?.trim().orEmpty()
+  return when (raw) {
+    "",
+    "1",
+    "app" -> Ok(ScaffoldKind.APP)
+    "2",
+    "lib" -> Ok(ScaffoldKind.LIB)
+    else -> Err("invalid kind '$raw' (expected 1, 2, app, or lib)")
+  }
+}
+
+private fun promptTarget(io: ScaffoldIO): Result<String, String> {
+  io.println("Target:")
+  PROMPT_TARGETS.forEachIndexed { idx, name ->
+    val suffix = if (name == DEFAULT_SCAFFOLD_TARGET) " (default)" else ""
+    io.println("  ${idx + 1}) $name$suffix")
+  }
+  val raw = io.readLine()?.trim().orEmpty()
+  if (raw.isEmpty()) return Ok(DEFAULT_SCAFFOLD_TARGET)
+  val byNumber = raw.toIntOrNull()?.let { PROMPT_TARGETS.getOrNull(it - 1) }
+  if (byNumber != null) return Ok(byNumber)
+  if (raw in PROMPT_TARGETS) return Ok(raw)
+  return Err(
+    "invalid target '$raw' (expected 1..${PROMPT_TARGETS.size} or one of ${PROMPT_TARGETS.joinToString(", ")})"
+  )
+}
+
+private fun promptGroup(io: ScaffoldIO): Result<String?, String> {
+  io.println("Group (e.g. com.example, blank for none):")
+  val raw = io.readLine()?.trim().orEmpty()
+  if (raw.isEmpty()) return Ok(null)
+  if (!isValidGroup(raw)) {
+    return Err("invalid group '$raw' (must be a dotted Kotlin package, e.g. com.example)")
+  }
+  return Ok(raw)
+}

--- a/src/nativeMain/kotlin/kolt/cli/Scaffold.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Scaffold.kt
@@ -34,9 +34,10 @@ internal data class ScaffoldOptions(
 
 internal data class ParsedInitArgs(
   val projectName: String?,
-  val kind: ScaffoldKind = ScaffoldKind.APP,
-  val target: String = DEFAULT_SCAFFOLD_TARGET,
-  val group: String? = null,
+  val kind: ScaffoldKind?,
+  val target: String?,
+  val group: String?,
+  val groupSpecified: Boolean,
 )
 
 internal fun parseInitArgs(args: List<String>): Result<ParsedInitArgs, String> {
@@ -44,6 +45,7 @@ internal fun parseInitArgs(args: List<String>): Result<ParsedInitArgs, String> {
   var kind: ScaffoldKind? = null
   var target: String? = null
   var group: String? = null
+  var groupSpecified = false
   val iter = args.iterator()
   while (iter.hasNext()) {
     val arg = iter.next()
@@ -74,6 +76,7 @@ internal fun parseInitArgs(args: List<String>): Result<ParsedInitArgs, String> {
           mergeGroup(group, value).getOrElse {
             return Err(it)
           }
+        groupSpecified = true
       }
       arg.startsWith("--") -> return Err("unknown flag '$arg'")
       else -> {
@@ -85,9 +88,10 @@ internal fun parseInitArgs(args: List<String>): Result<ParsedInitArgs, String> {
   return Ok(
     ParsedInitArgs(
       projectName = projectName,
-      kind = kind ?: ScaffoldKind.APP,
-      target = target ?: DEFAULT_SCAFFOLD_TARGET,
+      kind = kind,
+      target = target,
       group = group,
+      groupSpecified = groupSpecified,
     )
   )
 }

--- a/src/nativeMain/kotlin/kolt/cli/ScaffoldIO.kt
+++ b/src/nativeMain/kotlin/kolt/cli/ScaffoldIO.kt
@@ -1,0 +1,22 @@
+package kolt.cli
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.STDIN_FILENO
+import platform.posix.isatty
+
+internal interface ScaffoldIO {
+  fun isStdinTty(): Boolean
+
+  fun readLine(): String?
+
+  fun println(msg: String)
+}
+
+internal object SystemScaffoldIO : ScaffoldIO {
+  @OptIn(ExperimentalForeignApi::class)
+  override fun isStdinTty(): Boolean = isatty(STDIN_FILENO) == 1
+
+  override fun readLine(): String? = readlnOrNull()
+
+  override fun println(msg: String) = kotlin.io.println(msg)
+}

--- a/src/nativeMain/kotlin/kolt/cli/ScaffoldIO.kt
+++ b/src/nativeMain/kotlin/kolt/cli/ScaffoldIO.kt
@@ -14,7 +14,7 @@ internal interface ScaffoldIO {
 
 internal object SystemScaffoldIO : ScaffoldIO {
   @OptIn(ExperimentalForeignApi::class)
-  override fun isStdinTty(): Boolean = isatty(STDIN_FILENO) == 1
+  override fun isStdinTty(): Boolean = isatty(STDIN_FILENO) != 0
 
   override fun readLine(): String? = readlnOrNull()
 

--- a/src/nativeTest/kotlin/kolt/cli/PromptTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/PromptTest.kt
@@ -1,0 +1,236 @@
+package kolt.cli
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.fileExists
+import kolt.infra.readFileAsString
+import kolt.infra.removeDirectoryRecursive
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.chdir
+import platform.posix.getcwd
+import platform.posix.mkdtemp
+import platform.posix.setenv
+import platform.posix.unsetenv
+
+private class FakeScaffoldIO(private val tty: Boolean, inputs: List<String>) : ScaffoldIO {
+  private val iter = inputs.iterator()
+  val outputs = mutableListOf<String>()
+
+  override fun isStdinTty(): Boolean = tty
+
+  override fun readLine(): String? = if (iter.hasNext()) iter.next() else null
+
+  override fun println(msg: String) {
+    outputs += msg
+  }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+class PromptTest {
+  private var originalCwd: String = ""
+  private var tmpDir: String = ""
+
+  @BeforeTest
+  fun setUp() {
+    originalCwd = memScoped {
+      val buf = allocArray<ByteVar>(PATH_MAX)
+      getcwd(buf, PATH_MAX.toULong())?.toKString() ?: error("getcwd failed")
+    }
+    tmpDir = createTempDir("kolt-prompt-")
+    check(chdir(tmpDir) == 0) { "chdir to $tmpDir failed" }
+    setenv("GIT_CEILING_DIRECTORIES", tmpDir.substringBeforeLast('/'), 1)
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unsetenv("GIT_CEILING_DIRECTORIES")
+    chdir(originalCwd)
+    if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
+      removeDirectoryRecursive(tmpDir)
+    }
+  }
+
+  @Test
+  fun ttyNoFlagsPromptsKindThenTargetThenGroup() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
+
+    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    val kindIdx = joined.indexOf("Project kind:")
+    val targetIdx = joined.indexOf("Target:")
+    val groupIdx = joined.indexOf("Group ")
+    assertTrue(kindIdx >= 0, "kind prompt missing: $joined")
+    assertTrue(targetIdx > kindIdx, "target must follow kind: $joined")
+    assertTrue(groupIdx > targetIdx, "group must follow target: $joined")
+  }
+
+  @Test
+  fun ttyKindPromptDefaultIsApp() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
+
+    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+
+    assertTrue(fileExists("src/Main.kt"), "blank kind input must default to app")
+    val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
+    assertFalse(toml.contains("kind = \"lib\""), "default app must not write kind = lib")
+    assertTrue(toml.contains("main = \"main\""), "app must declare main")
+  }
+
+  @Test
+  fun ttyKindPromptExplicitLib() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("2", "", ""))
+
+    doInit(listOf("mylib"), io).getOrElse { error("doInit failed: exit=$it") }
+
+    assertTrue(fileExists("src/Lib.kt"))
+    assertFalse(fileExists("src/Main.kt"))
+  }
+
+  @Test
+  fun ttyKindPromptAcceptsTextualLib() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("lib", "", ""))
+
+    doInit(listOf("mylib"), io).getOrElse { error("doInit failed: exit=$it") }
+
+    assertTrue(fileExists("src/Lib.kt"))
+  }
+
+  @Test
+  fun ttyTargetPromptDefaultIsJvm() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
+
+    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+
+    val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
+    assertTrue(toml.contains("target = \"jvm\""), "blank target must default to jvm")
+  }
+
+  @Test
+  fun ttyTargetPromptByNumberPicksNativeTarget() {
+    // Targets are listed: 1=jvm, 2=linuxArm64, 3=linuxX64, 4=macosArm64, 5=macosX64, 6=mingwX64
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "3", ""))
+
+    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+
+    val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
+    assertTrue(toml.contains("target = \"linuxX64\""), "expected linuxX64, got: $toml")
+  }
+
+  @Test
+  fun ttyTargetPromptByNameAccepted() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "linuxX64", ""))
+
+    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+
+    val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
+    assertTrue(toml.contains("target = \"linuxX64\""))
+  }
+
+  @Test
+  fun ttyGroupPromptBlankMeansNoGroup() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
+
+    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+
+    assertTrue(fileExists("src/Main.kt"))
+    val source = readFileAsString("src/Main.kt").getOrElse { error("read failed") }
+    assertFalse(source.startsWith("package "), "blank group must not add package decl")
+  }
+
+  @Test
+  fun ttyGroupPromptValidValueNestsSource() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", "com.example"))
+
+    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+
+    assertTrue(fileExists("src/com/example/myapp/Main.kt"))
+  }
+
+  @Test
+  fun ttyMixedFlagAndPromptOnlyAsksMissing() {
+    // --lib supplied → only target + group prompted
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "com.example"))
+
+    doNew(listOf("mylib", "--lib"), io).getOrElse { error("doNew failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    assertFalse(joined.contains("Project kind:"), "kind must not be prompted when --lib given")
+    assertTrue(joined.contains("Target:"))
+    assertTrue(joined.contains("Group "))
+    assertTrue(fileExists("mylib/src/com/example/mylib/Lib.kt"))
+  }
+
+  @Test
+  fun nonTtyNoPromptsAndDefaultsApply() {
+    val io = FakeScaffoldIO(tty = false, inputs = emptyList())
+
+    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+
+    assertTrue(io.outputs.isEmpty(), "non-TTY must not print prompts: ${io.outputs}")
+    assertTrue(fileExists("src/Main.kt"))
+    val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
+    assertFalse(toml.contains("kind = \"lib\""))
+    assertTrue(toml.contains("target = \"jvm\""))
+    assertTrue(toml.contains("main = \"main\""))
+  }
+
+  @Test
+  fun ttyKindInvalidInputExitsNonZero() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("bogus"))
+
+    val exit = doInit(listOf("myapp"), io).getError()
+
+    assertEquals(EXIT_CONFIG_ERROR, exit)
+    assertFalse(fileExists("kolt.toml"), "no scaffold output on invalid prompt")
+  }
+
+  @Test
+  fun ttyTargetInvalidInputExitsNonZero() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "wasm"))
+
+    val exit = doInit(listOf("myapp"), io).getError()
+
+    assertEquals(EXIT_CONFIG_ERROR, exit)
+  }
+
+  @Test
+  fun ttyGroupInvalidInputExitsNonZero() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", "9bad"))
+
+    val exit = doInit(listOf("myapp"), io).getError()
+
+    assertEquals(EXIT_CONFIG_ERROR, exit)
+  }
+
+  @Test
+  fun ttyDoNewPromptsWhenFlagsOmitted() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("2", "", ""))
+
+    doNew(listOf("mylib"), io).getOrElse { error("doNew failed: exit=$it") }
+
+    assertTrue(fileExists("mylib/src/Lib.kt"))
+  }
+
+  private fun createTempDir(prefix: String): String {
+    val template = "/tmp/${prefix}XXXXXX"
+    val buf = template.encodeToByteArray().copyOf(template.length + 1)
+    buf.usePinned { pinned ->
+      val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+      return result.toKString()
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/cli/PromptTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/PromptTest.kt
@@ -169,8 +169,10 @@ class PromptTest {
 
     val joined = io.outputs.joinToString("\n")
     assertFalse(joined.contains("Project kind:"), "kind must not be prompted when --lib given")
-    assertTrue(joined.contains("Target:"))
-    assertTrue(joined.contains("Group "))
+    val targetIdx = joined.indexOf("Target:")
+    val groupIdx = joined.indexOf("Group ")
+    assertTrue(targetIdx >= 0, "target prompt missing")
+    assertTrue(groupIdx > targetIdx, "target must precede group even when kind is fixed")
     assertTrue(fileExists("mylib/src/com/example/mylib/Lib.kt"))
   }
 
@@ -214,6 +216,22 @@ class PromptTest {
     val exit = doInit(listOf("myapp"), io).getError()
 
     assertEquals(EXIT_CONFIG_ERROR, exit)
+  }
+
+  @Test
+  fun ttyEofOnFirstPromptCollapsesToDefaults() {
+    // Ctrl-D / closed stdin under TTY: readlnOrNull returns null on every
+    // call. The pipeline should treat it as blank input on each prompt and
+    // produce the default scaffold (app/jvm/no group) without erroring.
+    val io = FakeScaffoldIO(tty = true, inputs = emptyList())
+
+    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+
+    assertTrue(fileExists("src/Main.kt"))
+    val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
+    assertFalse(toml.contains("kind = \"lib\""))
+    assertTrue(toml.contains("target = \"jvm\""))
+    assertTrue(toml.contains("main = \"main\""))
   }
 
   @Test


### PR DESCRIPTION
Closes #265.

When stdin is a TTY and a flag is missing, prompt for it in the order
kind -> target -> group. Non-TTY (`kolt init < /dev/null`, CI, piped
stdin) keeps the silent-defaults behavior shipped in #266, so every
existing scripted call site is unaffected.

## Reviewer attention

- `ScaffoldIO` (`src/nativeMain/kotlin/kolt/cli/ScaffoldIO.kt`) is the
  test seam from the issue. `SystemScaffoldIO` uses POSIX
  `isatty(STDIN_FILENO)` and `readlnOrNull`. Tests inject a fake to
  assert prompt sequencing without needing a real TTY (the unit tests
  drive the same `doInit` / `doNew` entry points the binary calls,
  just with a fake `ScaffoldIO`).

- `ParsedInitArgs.kind` and `target` flipped from non-null with
  defaults to nullable. The "default" decision moved one layer down
  into `resolveInteractive` because the prompt layer needs to know the
  user did not specify the flag. `groupSpecified: Boolean` covers the
  case where group is legitimately null after a blank prompt response.
  No external callers — `parseInitArgs` is `internal`.

- Invalid prompt input is a hard exit (`EXIT_CONFIG_ERROR`), not a
  retry loop. Matches the issue's out-of-scope list.

- Target prompt list ordering is `[jvm] + NATIVE_TARGETS.sorted()`,
  giving 1=jvm, 2=linuxArm64, 3=linuxX64, 4=macosArm64, 5=macosX64,
  6=mingwX64. Sorting `NATIVE_TARGETS` (a `Set`) keeps the displayed
  order stable across Kotlin stdlib changes — important since the
  prompt UX would otherwise be invisibly load-bearing on
  `LinkedHashSet` iteration order.

- Smoke-tested via `script(1)` with the release binary: kind=2,
  target=3, group=com.example produced `kind = "lib"`, `target =
  "linuxX64"`, and the `com/example/mylib/Lib.kt` nested layout.