### PR TITLE
Add `--release` build profile (#261)

### DIFF
--- a/.claude/skills/kolt-usage/SKILL.md
+++ b/.claude/skills/kolt-usage/SKILL.md
@@ -49,7 +49,8 @@ Generated files for `kolt init`/`kolt new myapp` with no flags:
 ```
 kolt init [name]            Create a new project in the current directory
 kolt new <name>             Create a new project in <name>/ (same flags as init)
-kolt build                  Compile the project
+kolt build                  Compile the project (debug profile by default)
+kolt build --release        Compile under the release profile
 kolt run                    Build and run (kolt run -- args for app arguments)
 kolt test                   Build and run tests (kolt test -- args for JUnit Platform)
 kolt check                  Type-check without producing artifacts
@@ -81,6 +82,34 @@ kolt --version              Show version
 |------|-------------|
 | `--watch` | Watch source files and re-run on change (build/check/test/run) |
 | `--no-daemon` | Skip the warm compiler daemon for this invocation. Always available, even on Kotlin versions outside the daemon's supported range (ADR 0022). |
+| `--release` | Build under the release profile. Native: enables `-opt`, omits `-g`, writes artifacts to `build/release/`. JVM: declared no-op; the artifact still moves to `build/release/<name>.jar`. Debug remains the default. |
+
+### Build Profiles
+
+kolt has a Cargo-style profile model: debug is the default, `--release`
+is opt-in. Both profiles' artifacts coexist on disk so switching between
+them does not invalidate the other's incremental cache.
+
+```sh
+kolt build                  # build/debug/<name>.kexe (or .jar)
+kolt build --release        # build/release/<name>.kexe (or .jar)
+kolt test --release         # release-profile test executable
+kolt run  --release         # run the release-profile artifact
+```
+
+- **Native** (`target = "linuxX64"` etc.): debug omits `-opt` and adds
+  `-g`; release adds `-opt` and omits `-g`. The project-local
+  incremental-compile cache lives at `build/<profile>/.ic-cache`, so
+  alternating profiles preserves both caches.
+- **JVM** (`target = "jvm"`): `--release` is a declared no-op for
+  compile arg shape and for the daemon IC store at
+  `~/.kolt/daemon/ic/`. The jar still partitions under
+  `build/<profile>/<name>.jar` so the two profiles' artifacts do not
+  overwrite each other.
+
+`kolt.toml` has no `[profile]` section; the active profile is
+determined solely by the presence or absence of `--release` on the
+command line. See ADR 0030 for the full policy.
 
 ### Watch Mode
 

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Verify self-hosted binary
         run: |
           set -euo pipefail
-          version=$(./build/kolt.kexe --version)
+          version=$(./build/debug/kolt.kexe --version)
           echo "$version"
           echo "$version" | grep -Eq '^kolt [0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'
 
@@ -198,4 +198,4 @@ jobs:
           cd spike/daemon-self-host-smoke
           rm -rf build
           "${INSTALL_DIR}/bin/kolt" build
-          test -f build/smoke.jar
+          test -f build/debug/smoke.jar

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -148,19 +148,19 @@ jobs:
       - name: kolt build at root
         run: |
           set -euo pipefail
-          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build
+          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build --release
 
       - name: kolt build at kolt-jvm-compiler-daemon
         run: |
           set -euo pipefail
           cd kolt-jvm-compiler-daemon
-          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build
+          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build --release
 
       - name: kolt build at kolt-native-compiler-daemon
         run: |
           set -euo pipefail
           cd kolt-native-compiler-daemon
-          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build
+          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build --release
 
       - name: Assemble tarball
         run: |

--- a/.kiro/specs/release-build-profile/design.md
+++ b/.kiro/specs/release-build-profile/design.md
@@ -1,0 +1,410 @@
+# Technical Design: release-build-profile
+
+## Overview
+
+This feature adds a Cargo-style `--release` opt-in build profile to kolt. The default profile is `debug`; users opt into release by adding `--release` to any of the four build-driving commands (`kolt build`, `kolt test`, `kolt run`, `kolt check`). On Native targets the profile routes optimization (`-opt`) and debug-info (`-g`) flags to konanc, partitions kolt-managed artifact output into `build/<profile>/`, and partitions the local Native incremental-compile cache into `build/<profile>/.ic-cache`. On JVM targets the flag is a declared no-op: identical kotlinc invocation, identical IC store path, identical artifact bytes. `scripts/assemble-dist.sh` is switched to release so distributed binaries are unambiguously release-built. ADR 0030 documents the policy.
+
+**Users**: kolt users running daily Native iteration loops (debug profile) and kolt maintainers / CI cutting distribution tarballs (release profile).
+
+**Impact**: Native build pipeline grows a `Profile` parameter threaded from CLI flag-parsing through path computation and konanc arg assembly. JVM build pipeline accepts the parameter for type-uniformity but ignores it. Existing `~/.kolt/daemon/ic/` JVM daemon IC layout is unchanged. Pre-existing `build/.ic-cache` is replaced by `build/<profile>/.ic-cache`; pre-v1 policy means no migration shim — users wipe `build/` after upgrade.
+
+### Goals
+
+- Cargo-style `--release` opt-in accepted by all four build-driving commands.
+- Native compile differentiates release (`-opt`, no `-g`) from debug (no `-opt`, `-g`).
+- Native artifact output and Native IC cache partitioned per profile.
+- JVM `--release` is a typed no-op: same artifact bytes, same IC path, no warning.
+- `scripts/assemble-dist.sh` produces release-built distribution artifacts.
+- ADR 0030 codifies the policy and documents the JVM no-op rationale.
+
+### Non-Goals
+
+- `kolt.toml [profile.dev]` / `[profile.release]` configuration sections.
+- JVM reproducibility profile (epoch-zero timestamps, IC bypass).
+- Pass-through compiler flags (`extra_compiler_args` and similar).
+- Profile-aware behavior on macOS / linuxArm64 (deferred to #82 / #83).
+- Behavior of `--release` on non-build commands (`init`, `add`, `deps`, `fmt`, `toolchain`, `daemon`).
+- Migration of pre-existing `build/.ic-cache` content (pre-v1 policy).
+
+## Boundary Commitments
+
+### This Spec Owns
+
+- The `Profile` type and its threading through `kolt.cli` and `kolt.build` modules.
+- CLI parsing of `--release` and the rule that profile is determined solely from the command line.
+- Native compile-arg routing (`-opt`, `-g`) per profile.
+- kolt-managed artifact path layout under `build/<profile>/`.
+- Native IC cache path layout under `build/<profile>/.ic-cache`.
+- JVM target's no-op contract: identical kotlinc args, identical `~/.kolt/daemon/ic/` path, identical artifact bytes regardless of `--release` presence.
+- `scripts/assemble-dist.sh` profile selection.
+- ADR 0030 (`docs/adr/0030-build-profiles.md`) and documentation updates in README.md, README.ja.md, CLAUDE.md, `.kiro/steering/tech.md`, `.claude/skills/kolt-usage/SKILL.md`.
+- A drift-guard test asserting `Profile.Debug.dirName == "debug"` and `Profile.Release.dirName == "release"` match `assemble-dist.sh`.
+
+### Out of Boundary
+
+- `kolt.toml` schema (no profile sections).
+- JVM daemon's `~/.kolt/daemon/ic/` layout (unchanged).
+- Daemon wire protocol shape (no `Profile` field added to `Compile` / `NativeCompile` messages).
+- Cleanup or migration of stale pre-feature IC caches at `build/.ic-cache`.
+- Profile semantics for macOS / linuxArm64 targets.
+- A `kolt clean` command (does not exist today; out of scope).
+
+### Allowed Dependencies
+
+- `kolt.build.daemon` and `kolt.build.nativedaemon` modules (existing): receive `Profile` only through paths and konanc args, not as wire fields.
+- `kolt.config.KoltPaths` (existing): keeps JVM `daemonIcDir` shape unchanged; no profile suffix added on this property.
+- `kolt.config.Config.BuildSection` (existing): no fields added; profile is CLI-only.
+- `DriftGuardsTest.kt` (existing): may grow one new assertion.
+
+### Revalidation Triggers
+
+- A future addition of `kolt.toml [profile.*]` sections would require revalidating CLI precedence rules and `Config.BuildSection` shape.
+- Adding macOS / linuxArm64 targets (#82 / #83) would force re-checking whether the `build/<profile>/` layout still applies (host triple may need to layer in: `build/<profile>/<target>/`).
+- Promoting `Profile` from a CLI-only concept to a wire-protocol field would require a `kolt.daemon.wire` and `kolt.nativedaemon.protocol` review.
+- Introducing a JVM reproducibility profile would invalidate the JVM no-op contract; it must land as an ADR addendum, not a quiet behavior change.
+
+## Architecture
+
+### Existing Architecture Analysis
+
+The build pipeline is a linear top-down chain: `kolt.cli.Main` extracts kolt-level flags → dispatches to `BuildCommands.do{Build,Test,Run,Check}` → calls `kolt.build.Builder` for path computation and command assembly → invokes `CompilerBackend` (daemon or subprocess) with the assembled args.
+
+- `Builder.kt` holds path consts (`BUILD_DIR = "build"`, `NATIVE_IC_CACHE_DIR = "$BUILD_DIR/.ic-cache"`) and stateless command-builder functions.
+- Wire protocols are path-agnostic: `NativeCompile(args: List<String>)` ferries konanc argv; JVM `Compile(workingDir, classpath, sources, outputPath, ...)` carries client-computed paths.
+- Watch loop (`WatchLoop.kt`) does not cache paths; each rebuild re-evaluates path-computation functions.
+- JVM IC layout in `~/.kolt/daemon/ic/<kotlinVersion>/<projectIdHash>/` is owned by the JVM daemon (`IcStateLayout.workingDirFor`) and reached client-side via `KoltPaths.daemonIcDir`.
+
+### Architecture Pattern & Boundary Map
+
+Pattern: **parameter threading**. A new closed enum `Profile` is added at the CLI boundary and threaded down through every function that currently consumes `BUILD_DIR` or `NATIVE_IC_CACHE_DIR`. No new abstractions, adapters, or wire fields. Type system enforces complete coverage at compile time.
+
+```mermaid
+graph TD
+  Main[cli/Main.kt] -->|"--release flag extract"| Profile[build/Profile.kt]
+  Main --> BC[cli/BuildCommands.kt]
+  BC -->|"profile"| Builder[build/Builder.kt]
+  BC -->|"profile"| TestBuilder[build/TestBuilder.kt]
+  BC -->|"profile"| Runner[build/Runner.kt]
+  BC -->|"profile"| WatchLoop[cli/WatchLoop.kt]
+  Builder -->|"build/<profile>/"| OutputPaths[outputKexePath etc]
+  Builder -->|"build/<profile>/.ic-cache"| NativeIc[nativeIcCacheDir]
+  Builder -->|"-opt / -g routing"| KonancArgs[nativeLinkCommand]
+  WatchLoop -->|"profile per rebuild"| Builder
+  BC -->|"wipe per profile"| ICC[build/daemon/IcStateCleanup.kt]
+
+  classDef new fill:#e0f7fa,stroke:#006064;
+  class Profile new;
+```
+
+**Architecture integration**:
+- Pattern: parameter threading on a closed enum (smallest change satisfying all 7 requirements).
+- Boundary: `Profile` lives in `kolt.build`; `kolt.cli` constructs it from flags and passes through; `kolt.build.daemon` / `kolt.build.nativedaemon` consume it only via paths and args.
+- Existing patterns preserved: cli → build dependency direction, sealed-ADT-over-flags style not applicable (only two states); enum is sufficient and Cargo-aligned.
+- New components rationale: only one new file (`Profile.kt`); everything else extends in place.
+- Steering compliance: `Result<V, E>` does not apply (profile parsing is total — `--release` either present or absent); ADR 0001 unchanged.
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| CLI | Kotlin/Native (linuxX64) | `--release` parsing, profile dispatch | No new dep; reuses `koltLevel.contains(...)` style |
+| Build orchestration | Kotlin/Native | Path computation, command assembly with `Profile` arg | Functions extended in `Builder.kt`, `TestBuilder.kt`, `Runner.kt` |
+| Native compiler driver | konanc (Kotlin 2.3.x) | Receives `-opt` and `-g` per profile | Both flags are stable konanc CLI options |
+| JVM compiler driver | kotlinc (Kotlin 2.3.x) | Unchanged; `Profile` ignored on JVM path | Required to satisfy JVM no-op contract |
+| Distribution script | Bash (`scripts/assemble-dist.sh`) | Invokes `kolt build --release` for self-host JARs and the root native binary | Single source of truth for distribution profile |
+| Documentation | Markdown (ADR 0030 + 5 user-facing files) | Codifies the policy | New file: `docs/adr/0030-build-profiles.md` |
+
+## File Structure Plan
+
+### New files
+
+```
+src/nativeMain/kotlin/kolt/build/
+└── Profile.kt                          # enum class Profile { Debug, Release } + dirName
+
+src/nativeTest/kotlin/kolt/build/
+└── ProfileTest.kt                      # enum invariants, dirName mapping
+
+docs/adr/
+└── 0030-build-profiles.md              # NEW ADR
+```
+
+### Modified files
+
+- `src/nativeMain/kotlin/kolt/build/Builder.kt` — `outputKexePath`, `outputJarPath`, `outputRuntimeClasspathPath`, `outputNativeTestKexePath` gain `profile: Profile`; `NATIVE_IC_CACHE_DIR` const replaced by `nativeIcCacheDir(profile: Profile)` function; `nativeLibraryCommand` and `nativeLinkCommand` gain `profile: Profile` (link stage routes `-opt` and `-g`). `checkCommand` does not need a `profile` parameter — its kotlinc args are profile-independent and Req 3.1 (JVM same bytes) holds trivially without threading.
+- `src/nativeMain/kotlin/kolt/build/TestBuilder.kt` — `testBuildCommand` gains `profile: Profile` (JVM no-op).
+- `src/nativeMain/kotlin/kolt/build/Runner.kt` — `nativeRunCommand` and `runCommand` gain `profile: Profile` so they reach the profile-aware path functions.
+- `src/nativeMain/kotlin/kolt/build/daemon/IcStateCleanup.kt` — `wipeNativeIcCache` and any cleanup helper that touches `BUILD_DIR/.ic-cache` gain `profile: Profile`. Note: this file's existing `daemonIcDir` traversal (JVM IC) is **unchanged**.
+- `src/nativeMain/kotlin/kolt/cli/Main.kt` — adds `RELEASE_FLAG = "--release"` constant; extracts profile from kolt-level args; passes `Profile` to each entry function.
+- `src/nativeMain/kotlin/kolt/cli/BuildCommands.kt` — `doBuild`, `doCheck`, `doTest`, `doRun` gain `profile: Profile` parameter; `wipeNativeIcCache` call site updated.
+- `src/nativeMain/kotlin/kolt/cli/WatchLoop.kt` — threads `profile` through rebuild calls (Native and JVM paths).
+- `src/nativeTest/kotlin/kolt/build/BuilderTest.kt` — existing assertions on `-Xic-cache-dir=build/.ic-cache` updated to `-Xic-cache-dir=build/debug/.ic-cache` (and add a release variant).
+- `src/nativeTest/kotlin/kolt/build/TestBuilderTest.kt` — existing assertion on `build/classes:...` classpath updated to use the debug-profile output path; add a release-profile no-op test.
+- `src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt` — same `-Xic-cache-dir` update.
+- `src/nativeTest/kotlin/kolt/nativedaemon/wire/FrameCodecTest.kt` — same `-Xic-cache-dir` update (string fixture in wire-codec test).
+- `src/nativeTest/kotlin/kolt/build/daemon/IcStateCleanupTest.kt` — confirms JVM `daemonIcDir` cleanup unchanged; adds Native cleanup test for both profiles.
+- `src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt` — adds tests for `Profile` extraction, debug/release dispatch, and JVM no-op assertion (same args + same IC path).
+- `src/nativeTest/kotlin/kolt/build/DriftGuardsTest.kt` — adds the 4th drift assertion (`Profile.dirName` literals match `assemble-dist.sh` invocation).
+- `scripts/assemble-dist.sh` — line 120 changes from `"$KOLT" build` to `"$KOLT" build --release`; line 218 changes `ROOT_KEXE="$ROOT_DIR/build/kolt.kexe"` to `ROOT_KEXE="$ROOT_DIR/build/release/kolt.kexe"`; daemon JAR paths at lines 228-229 unchanged (JVM daemon `kolt.toml`s do not need `--release`; design decision below).
+- `kolt-jvm-compiler-daemon/kolt.toml`, `kolt-native-compiler-daemon/kolt.toml` — kept unchanged for now. The daemon `kolt.toml`s are JVM apps and JVM is no-op; their `kolt build` invocation in `assemble-dist.sh` does not need `--release` to satisfy Req 6 (release tarball semantics). However, for consistency and future-proofing (if any of these gain a Native target), `assemble-dist.sh` will pass `--release` to all three sub-builds. **Design decision**: pass `--release` uniformly to keep the script's intent explicit.
+- `README.md`, `README.ja.md` — update build command examples to mention `--release` and the `build/<profile>/` layout.
+- `CLAUDE.md` — add a one-line "Profiles" entry under Key Rules pointing at ADR 0030.
+- `.kiro/steering/tech.md` — add `--release` to the User-facing CLI snippet.
+- `.claude/skills/kolt-usage/SKILL.md` — update build/test/run/check command examples; add a brief profile section.
+
+## System Flows
+
+```mermaid
+sequenceDiagram
+  actor User
+  participant Main as cli/Main.kt
+  participant BC as cli/BuildCommands.kt
+  participant B as build/Builder.kt
+  participant Backend as CompilerBackend
+  participant FS as build/<profile>/
+
+  User->>Main: kolt build [--release]
+  Main->>Main: extract --release → Profile.Debug or Profile.Release
+  Main->>BC: doBuild(profile)
+  BC->>B: outputKexePath(config, profile)
+  B-->>BC: build/<profile>/<name>.kexe
+  BC->>B: nativeIcCacheDir(profile)
+  B-->>BC: build/<profile>/.ic-cache
+  BC->>B: nativeLinkCommand(..., profile)
+  alt profile == Release
+    B-->>BC: konanc args + ["-opt"]
+  else profile == Debug
+    B-->>BC: konanc args + ["-g"]
+  end
+  BC->>Backend: compile(args)
+  Backend->>FS: write artifact
+```
+
+Key flow decisions:
+- Profile is computed once at the CLI boundary; downstream code never re-derives it.
+- Watch loop (`WatchLoop.kt`) inherits the profile of the initial invocation; profile cannot change mid-loop (no `--release` toggle while watching). Cancel and re-invoke to switch.
+- JVM target paths (when applicable; library targets land via #21) thread the profile through but the JVM-side computations ignore it: the same `~/.kolt/daemon/ic/...` and same kotlinc args result.
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | debug default | `Main.kt`, `Profile` | profile extraction returns `Profile.Debug` when `--release` absent | top sequence |
+| 1.2 | release on `--release` | `Main.kt`, `Profile` | profile extraction returns `Profile.Release` when present | top sequence |
+| 1.3 | flag positioning | `Main.kt` | extracted by `koltLevel.contains(RELEASE_FLAG)` like `--no-daemon` | — |
+| 1.4 | CLI-only profile | no `Config` change | `BuildSection` schema unchanged | — |
+| 2.1 | debug omits `-opt` | `Builder.nativeLinkCommand` | conditional arg append | sequence (Debug branch) |
+| 2.2 | release adds `-opt` | `Builder.nativeLinkCommand` | conditional arg append | sequence (Release branch) |
+| 2.3 | debug includes `-g` | `Builder.nativeLinkCommand` | conditional arg append | sequence (Debug branch) |
+| 2.4 | release omits `-g` | `Builder.nativeLinkCommand` | conditional arg append | sequence (Release branch) |
+| 3.1 | JVM same bytes | `Builder.checkCommand`, `TestBuilder.testBuildCommand` | `checkCommand` is profile-independent by signature; `testBuildCommand` accepts profile and ignores it | — |
+| 3.2 | JVM no warning | (negative requirement; verified by test) | — | — |
+| 3.3 | JVM same IC path | `KoltPaths.daemonIcDir` unchanged; `IcStateLayout` unchanged | — | — |
+| 4.1 | debug under `build/debug/` | `outputKexePath(config, Debug)`, `outputJarPath(config, Debug)`, `outputRuntimeClasspathPath`, `outputNativeTestKexePath` | path string composition | sequence |
+| 4.2 | release under `build/release/` | same as 4.1 with `Profile.Release` | path string composition | sequence |
+| 4.3 | both coexist | emergent; integration test | — | — |
+| 4.4 | no precondition | `ensureDirectoryRecursive` (already idempotent post-#272) | — | — |
+| 5.1 | debug IC under `build/debug/.ic-cache` | `nativeIcCacheDir(Debug)` | path composition | sequence |
+| 5.2 | release IC under `build/release/.ic-cache` | `nativeIcCacheDir(Release)` | path composition | sequence |
+| 5.3 | alternation preserves IC | emergent; integration test | — | — |
+| 5.4 | recreate idempotent | `ensureDirectoryRecursive` | — | — |
+| 6.1 | dist defaults to release | `assemble-dist.sh` line 120 | invokes `kolt build --release` | — |
+| 6.2 | single source of truth | `assemble-dist.sh` only profile knob | — | — |
+| 6.3 | tarball is release-built | tarball assembly reads from `build/release/` | — | — |
+| 7.1 | README updates | `README.md`, `README.ja.md` | doc | — |
+| 7.2 | CLAUDE/steering updates | `CLAUDE.md`, `.kiro/steering/tech.md` | doc | — |
+| 7.3 | `kolt-usage` skill update | `.claude/skills/kolt-usage/SKILL.md` | doc | — |
+| 7.4 | ADR 0030 published | `docs/adr/0030-build-profiles.md` | doc | — |
+
+## Components and Interfaces
+
+### kolt.build
+
+#### Profile (NEW)
+
+| Field | Detail |
+|-------|--------|
+| Intent | Closed enum representing the two build profiles, with a single `dirName` member used in path composition. |
+| Requirements | 1.1, 1.2, 4.1, 4.2, 5.1, 5.2 |
+
+**Responsibilities & Constraints**
+
+- Provide exactly two values (`Debug`, `Release`) and a stable `dirName` per value (`"debug"`, `"release"`).
+- Be the single source of truth for profile literals; `assemble-dist.sh` and any future drift guard read these names.
+- No I/O, no fallible construction.
+
+**Dependencies**: none.
+
+**Contracts**: State [x]
+
+**State Management**
+
+- Stateless. Acts as a typed token.
+
+```kotlin
+internal enum class Profile(val dirName: String) {
+  Debug(dirName = "debug"),
+  Release(dirName = "release"),
+}
+```
+
+**Implementation Notes**
+
+- Integration: imported by every modified file that currently uses `BUILD_DIR` or `NATIVE_IC_CACHE_DIR`.
+- Risks: enum exhaustiveness in `when` blocks is a compile-time guarantee; no runtime fallback path needed.
+
+#### Builder (MODIFIED)
+
+| Field | Detail |
+|-------|--------|
+| Intent | Compute profile-aware artifact paths and konanc/kotlinc command lines. |
+| Requirements | 2.1, 2.2, 2.3, 2.4, 3.1, 4.1, 4.2, 5.1, 5.2 |
+
+**Responsibilities & Constraints**
+
+- All path-producing functions take `profile: Profile`; the const `BUILD_DIR` remains as a base, and per-profile paths are composed as `"$BUILD_DIR/${profile.dirName}/..."`.
+- `NATIVE_IC_CACHE_DIR` const is removed; replaced by `nativeIcCacheDir(profile: Profile): String`.
+- Native link stage emits `-opt` if and only if `profile == Release`; emits `-g` if and only if `profile == Debug`. Native library stage stays profile-agnostic (klibs are intermediate, no opt/debug-info impact).
+- `outputJarPath` accepts `profile` for path composition. `checkCommand` is profile-independent by signature (no path computation, no IC, no compiler-arg branching). On the JVM compile path the byte-equality contract (Req 3.1) holds trivially because the active profile never reaches the kotlinc arg builder.
+
+**Dependencies**: `kolt.build.Profile` (Inbound, P0).
+
+**Contracts**: Service [x]
+
+```kotlin
+internal fun outputKexePath(config: KoltConfig, profile: Profile): String
+internal fun outputJarPath(config: KoltConfig, profile: Profile): String
+internal fun outputRuntimeClasspathPath(config: KoltConfig, profile: Profile): String
+internal fun outputNativeTestKexePath(config: KoltConfig, profile: Profile): String
+internal fun nativeIcCacheDir(profile: Profile): String
+internal fun nativeLibraryCommand(..., profile: Profile): Command
+internal fun nativeLinkCommand(..., profile: Profile): Command
+internal fun checkCommand(...): Command  // profile-independent, no parameter
+```
+
+**Implementation Notes**
+
+- The `-opt` / `-g` routing is a single `when (profile)` branch in `nativeLinkCommand`. Add ADR 0030 reference comment per the project's "ADR citations in code" convention.
+- Risks: existing tests assert `build/.ic-cache` and `build/<name>.kexe` literals; they all need profile suffix updates.
+
+### kolt.cli
+
+#### Main (MODIFIED)
+
+| Field | Detail |
+|-------|--------|
+| Intent | Parse `--release` from kolt-level args, construct `Profile`, dispatch to entry functions. |
+| Requirements | 1.1, 1.2, 1.3 |
+
+**Responsibilities & Constraints**
+
+- Add `private const val RELEASE_FLAG = "--release"`.
+- Extract via `val profile = if (koltLevel.contains(RELEASE_FLAG)) Profile.Release else Profile.Debug`.
+- Filter `RELEASE_FLAG` out of `filteredArgs` so it does not leak into subcommand args.
+- Pass `profile` to every entry function in the dispatcher.
+
+**Dependencies**: `kolt.build.Profile` (Inbound, P0); `kolt.cli.BuildCommands` (Outbound, P0).
+
+**Contracts**: Service [x]
+
+#### BuildCommands (MODIFIED)
+
+| Field | Detail |
+|-------|--------|
+| Intent | Orchestrate the four build-driving commands with profile awareness. |
+| Requirements | 1.1, 1.2, 5.1, 5.2 (via `wipeNativeIcCache`) |
+
+**Responsibilities & Constraints**
+
+- `doBuild`, `doCheck`, `doTest`, `doRun` each take `profile: Profile` as their first added parameter (after the existing required arguments).
+- All call sites of `outputKexePath`, `outputJarPath`, `nativeIcCacheDir`, `wipeNativeIcCache`, `nativeLinkCommand`, `nativeLibraryCommand`, `testBuildCommand` pass `profile` through. `checkCommand` is exempt (profile-independent by signature).
+- Native IC retry-on-failure path (`wipeNativeIcCache`) wipes the **active profile's** IC dir only; the inactive profile's IC is preserved.
+
+**Dependencies**: `kolt.build.Builder`, `kolt.build.daemon.IcStateCleanup` (Outbound, P0).
+
+**Contracts**: Service [x]
+
+#### WatchLoop (MODIFIED)
+
+| Field | Detail |
+|-------|--------|
+| Intent | Re-run builds on file changes with the profile fixed at watch-loop start. |
+| Requirements | 1.1, 1.2 (extension) |
+
+**Responsibilities & Constraints**
+
+- Thread `profile` through the rebuild closure. Profile cannot change mid-loop; users cancel and re-invoke to switch.
+- No new branches; existing rebuild path delegates to `BuildCommands.doBuild` etc. with the captured `profile`.
+
+**Dependencies**: `kolt.cli.BuildCommands` (Outbound, P0).
+
+**Contracts**: Service [x]
+
+### kolt.build.daemon
+
+#### IcStateCleanup (MODIFIED)
+
+| Field | Detail |
+|-------|--------|
+| Intent | Wipe Native IC cache on retry; unchanged for JVM `~/.kolt/daemon/ic/` cleanup. |
+| Requirements | 5.1, 5.2, 5.3, 5.4 |
+
+**Responsibilities & Constraints**
+
+- `wipeNativeIcCache(profile: Profile)` removes `build/<profile>/.ic-cache/` only.
+- Existing JVM IC reaper logic (`~/.kolt/daemon/ic/<v>/<id>/` traversal) is **untouched** — Req 3.3 demands JVM stays on the same path.
+
+**Dependencies**: `kolt.build.Profile`, `kolt.config.KoltPaths` (Inbound, P0).
+
+**Contracts**: Service [x]
+
+## Data Models
+
+No data model changes. `Config.BuildSection` schema is unchanged. Wire protocols (`Compile`, `NativeCompile`) are unchanged. The only new "data" is the `Profile` enum, which is a typed token.
+
+## Error Handling
+
+- `--release` is a presence/absence flag. Parsing cannot fail.
+- Unknown flags after extraction (e.g., a misspelled `--realease`) are passed to subcommands and surface their existing unknown-flag errors. No new error envelope is introduced.
+- Native compile failures continue to flow through `Result<V, NativeCompileFailure>`. The retry path that wipes IC cache (`BuildCommands.kt:577`) operates on the active profile only; if the wipe also fails, the existing error path returns to the caller.
+- ADR 0030 documents that `-Xkonan-data-dir` and other konanc flags are unchanged.
+
+## Testing Strategy
+
+### Unit Tests (mirrored against requirements)
+
+- `ProfileTest.kt` — enum invariants: exactly two values, stable `dirName` strings (`"debug"`, `"release"`).
+- `BuilderTest.kt` (extended) — `outputKexePath(_, Debug)` returns `build/debug/<name>.kexe`; `outputKexePath(_, Release)` returns `build/release/<name>.kexe`. Same matrix for `outputJarPath`, `outputRuntimeClasspathPath`, `outputNativeTestKexePath`, `nativeIcCacheDir`. Covers Req 4.1, 4.2, 5.1, 5.2.
+- `BuilderTest.kt` (extended) — `nativeLinkCommand(_, Debug).args` contains `"-g"` and does not contain `"-opt"`. `nativeLinkCommand(_, Release).args` contains `"-opt"` and does not contain `"-g"`. Covers Req 2.1, 2.2, 2.3, 2.4.
+- `BuilderTest.kt` (extended) — `checkCommand` args are profile-independent by signature, verified by the absence of profile branching in the function body. The JVM end-to-end byte equality is covered separately by `BuildProfileIT.jvmReleaseBuildProducesIdenticalCompileOutputBytes`.
+- `TestBuilderTest.kt` (extended) — `testBuildCommand(_, Debug)` and `testBuildCommand(_, Release)` produce identical args. Covers Req 3.1.
+- `BuildCommandsTest.kt` (extended) — verifies `Main.kt`'s `--release` extraction routes through to `doBuild(Profile.Release)`; absence routes to `doBuild(Profile.Debug)`. Covers Req 1.1, 1.2.
+- `DriftGuardsTest.kt` (extended) — asserts `Profile.Debug.dirName == "debug"` and `Profile.Release.dirName == "release"` and that `assemble-dist.sh` contains `kolt build --release`. Covers indirect drift coverage.
+
+### Integration Tests
+
+- New: `BuildProfileIT.kt` (or similar in `src/nativeTest/kotlin/kolt/cli/`) — runs `kolt build` and `kolt build --release` against a fixture project; asserts both produce a `.kexe` under their respective `build/<profile>/` directories. Covers Req 4.3.
+- New: profile-alternation IC test — runs debug, then release, then debug again; asserts no IC invalidation across profile switches. Covers Req 5.3.
+- Existing JVM tests (`BuildCommandsTest.kt`, integration paths) extended with one assertion: `--release` on JVM produces identical compile args and identical `~/.kolt/daemon/ic/` working dir as the same invocation without `--release`. Covers Req 3.3.
+
+### E2E Tests
+
+- `self-host-post` CI job (existing) re-runs against the new `assemble-dist.sh`. Verifies tarball assembly succeeds with `kolt build --release` and that the resulting binary launches. Covers Req 6.1, 6.3.
+
+### Performance / regression tests
+
+- Out of scope for this design. Issue #261's debug-default rationale (faster iteration) is observable but not benchmarked here; #88 / #90 own performance tracking.
+
+## Migration Strategy
+
+Pre-v1 policy applies: no migration shims, no compatibility probes.
+
+- Stale `build/.ic-cache` directories from pre-feature kolt versions are abandoned. The release note for the version shipping this feature instructs users to `rm -rf build/` if mixed-profile artifacts cause confusion.
+- `~/.kolt/daemon/ic/` JVM IC store is unchanged.
+- `assemble-dist.sh` switching from default to `--release` may briefly leave dual artifact roots (`build/` and `build/release/`) in dev workspaces; harmless.
+
+## Supporting References
+
+- `research.md` — gap analysis findings, design synthesis, and resolution of issue #261's `~/.kolt/daemon/ic/` schema misattribution.
+- `docs/adr/0030-build-profiles.md` (to be authored as part of this feature) — codifies the policy, captures the JVM no-op rationale verbatim from Req 7.4, and records the discrepancy resolution.
+- ADR 0019 (incremental compile), ADR 0027 (runtime classpath manifest) — load-bearing prior decisions; both verified compatible with profile partition.

--- a/.kiro/specs/release-build-profile/requirements.md
+++ b/.kiro/specs/release-build-profile/requirements.md
@@ -1,0 +1,137 @@
+# Requirements Document
+
+## Project Description (Input)
+Add Cargo-style `--release` build profile to kolt. Default = debug, `--release` is opt-in. Resolves issue #261.
+
+### Problem
+`kolt build` currently compiles Native targets without a release/debug split, conflating "fast iteration" and "production-ready" workflows. Daily Native iteration pays optimization-class link time even when not needed, and distribution binaries are not explicitly marked as release-built. No profile concept also leaves kolt looking incomplete next to Cargo / Gradle / Bazel and blocks the Gradle-removal direction.
+
+### Definition of Done (from issue #261)
+- Adopt ADR 0030 `build-profiles.md` codifying:
+  - default = debug, `--release` opt-in (Cargo style)
+  - JVM: `--release` declared no-op. Reasons (kotlinc bytecode no significant diff, `-Xno-call-assertions` not default, line numbers always present, reproducibility is a separate concern) documented in §JVM treatment.
+  - Native: `--release` adds `-opt`, debug profile omits `-opt` (and includes `-g`), output path split into `build/<profile>/`, daemon IC store split into `~/.kolt/daemon/ic/<version>/<projectId>/<profile>/`.
+  - No `kolt.toml [profile]` section (fixed behavior). Custom compiler args / reproducibility / `extra_compiler_args` deferred.
+- All entry commands (`kolt build`, `kolt test`, `kolt run`, `kolt check`) accept `--release`.
+- Native: tests verify both `kolt build` and `kolt build --release` succeed with separated output paths and IC stores.
+- JVM: tests assert `kolt build --release` produces the same artifact bytes / IC store as `kolt build` (no-op).
+- Update README.md, CLAUDE.md, steering tech.md, `kolt-usage` skill build examples.
+- Switch `assemble-dist.sh` to `kolt build --release`.
+
+### Out of Scope (from issue #261)
+- `kolt.toml [profile.dev]` / `[profile.release]` configuration.
+- JVM reproducibility profile (epoch 0 timestamp, IC bypass) — separate issue.
+- `extra_compiler_args` / pass-through compiler flags — separate issue.
+- macOS / linuxArm64 profile-specific behavior — defer until #82 / #83.
+- Behavior of `--release` on commands other than `kolt build`, `kolt test`, `kolt run`, `kolt check` (handling on `init`, `add`, `deps`, etc. is design-time TBD).
+
+### Note on Current State
+Issue #261's Problem section claims "always runs as release-equivalent (`konanc -opt`)". A scope survey suggests konanc is currently invoked **without** `-opt` (no optimization flags routed through `nativeLinkCommand`). The intent and direction of this feature are unchanged regardless: introduce an opt-in `--release` profile that adds optimization, and a debug default that explicitly omits it. Design phase will confirm the baseline before wiring `-opt` and `-g`.
+
+### Related
+- ADR 0019 (incremental compile), ADR 0027 (runtime classpath manifest) must remain consistent after profile path split.
+- Prerequisite for #230 (curl | sh installer) and Gradle-removal plan.
+
+## Introduction
+
+kolt currently compiles Native targets with a single, profile-less compiler invocation, so users cannot trade optimization quality for iteration speed at the command line. This feature introduces a Cargo-style opt-in `--release` profile across all build-driving commands, separates Native artifact output and daemon IC state per profile, and declares the flag a no-op on JVM targets where there is no comparable cost to optimize away. The change is the precondition for distributing release-built binaries via `scripts/assemble-dist.sh` and for the upcoming `curl | sh` installer (#230).
+
+## Boundary Context
+
+**In scope**:
+- A `--release` opt-in flag accepted by `kolt build`, `kolt test`, `kolt run`, and `kolt check`.
+- Native compile behavior split by profile (optimization and debug-info routing).
+- Native output artifact path split by profile (`build/<profile>/`).
+- Native daemon IC store isolation by profile.
+- JVM target: `--release` is a declared no-op (no observable behavior change).
+- `scripts/assemble-dist.sh` switched so distribution binaries are release-built.
+- Documentation updates in `README.md`, `CLAUDE.md`, `.kiro/steering/tech.md`, and the `kolt-usage` skill.
+- ADR 0030 (`docs/adr/0030-build-profiles.md`) documenting the policy.
+
+**Out of scope**:
+- `kolt.toml [profile.dev]` / `[profile.release]` configuration sections.
+- JVM reproducibility (epoch-zero timestamps, IC bypass).
+- Pass-through compiler flags (`extra_compiler_args` and similar).
+- Profile-specific behavior on macOS or linuxArm64 (deferred to #82 / #83).
+- Behavior of `--release` on non-build commands (`init`, `new`, `add`, `deps`, `fmt`, `toolchain`, `daemon`).
+- Migration of pre-existing IC state at `~/.kolt/daemon/ic/<version>/<projectId>/`. Per project policy, breaking changes pre-v1.0 do not ship migration shims; users wipe the daemon directory if needed.
+
+**Adjacent expectations**:
+- ADR 0019 (incremental compile) and ADR 0027 (runtime classpath manifest) remain consistent after the artifact-path and IC-path split.
+- The drift-guard test suite (`DriftGuardsTest`) continues to pass after profile-aware path computation lands.
+- The `curl | sh` installer (#230) consumes release-built binaries assembled by `scripts/assemble-dist.sh`.
+
+## Requirements
+
+### Requirement 1: Profile flag acceptance on build-driving commands
+
+**Objective:** As a kolt user, I want a `--release` opt-in flag on every build-driving command, so that I can choose the profile per invocation without changing project configuration.
+
+#### Acceptance Criteria
+1. When the user invokes `kolt build`, `kolt test`, `kolt run`, or `kolt check` without `--release`, the kolt CLI shall execute that command under the debug profile.
+2. When the user invokes `kolt build`, `kolt test`, `kolt run`, or `kolt check` with `--release`, the kolt CLI shall execute that command under the release profile.
+3. The kolt CLI shall accept `--release` in the same flag position as existing kolt-level flags such as `--no-daemon` and `--watch`.
+4. While `kolt.toml` contains no profile-related configuration, the kolt CLI shall determine the active profile solely from the presence or absence of `--release` on the command line.
+
+### Requirement 2: Native compile behavior per profile
+
+**Objective:** As a kolt user building Native targets, I want the debug profile to skip optimization, so that daily iteration link time is not paid for unused optimization passes.
+
+#### Acceptance Criteria
+1. While operating under the debug profile on a Native target, the kolt CLI shall produce a binary without enabling compiler optimization passes that elongate link time.
+2. While operating under the release profile on a Native target, the kolt CLI shall produce a binary with compiler optimization enabled.
+3. While operating under the debug profile on a Native target, the kolt CLI shall include debug information in the produced binary.
+4. While operating under the release profile on a Native target, the kolt CLI shall omit debug information from the produced binary.
+
+### Requirement 3: JVM compile behavior is profile-independent
+
+**Objective:** As a kolt user building JVM targets, I want `--release` to be a documented no-op, so that I can rely on a single observable behavior on JVM regardless of profile.
+
+#### Acceptance Criteria
+1. When the user invokes `kolt build`, `kolt test`, `kolt run`, or `kolt check` on a JVM target with `--release`, the kolt CLI shall produce the same compile output bytes as the same invocation without `--release`, modulo file-system timestamps.
+2. When the user invokes a JVM target build with `--release`, the kolt CLI shall not surface a deprecation, warning, or error attributable to the flag.
+3. While operating on a JVM target, the kolt CLI shall use the same daemon IC store path regardless of `--release` presence.
+
+### Requirement 4: Output artifact path isolation per profile
+
+**Objective:** As a kolt user, I want each profile to produce artifacts in a distinct directory, so that switching profiles does not silently overwrite the other profile's artifacts.
+
+#### Acceptance Criteria
+1. While operating under the debug profile, the kolt CLI shall write the primary build artifact under a directory whose path includes a `debug` profile segment.
+2. While operating under the release profile, the kolt CLI shall write the primary build artifact under a directory whose path includes a `release` profile segment.
+3. When the user runs `kolt build` followed by `kolt build --release` (or vice versa) without intervening cleanup, the kolt CLI shall preserve both profiles' artifacts on disk.
+4. While the project has not been built under a given profile, the kolt CLI shall not require that profile's output directory to exist before invoking the build.
+
+### Requirement 5: Native daemon IC store isolation per profile
+
+**Objective:** As a kolt user iterating between profiles, I want the Native daemon's incremental-compile state partitioned per profile, so that profile switches do not invalidate each other's incremental state.
+
+#### Acceptance Criteria
+1. While operating under the debug profile on a Native target, the kolt CLI shall use a daemon IC store path containing a `debug` profile segment.
+2. While operating under the release profile on a Native target, the kolt CLI shall use a daemon IC store path containing a `release` profile segment.
+3. When the user alternates between debug and release builds of the same project, the kolt CLI shall preserve each profile's IC state across the alternation.
+4. If the user removes a profile's IC store directory, the kolt CLI shall recreate it on the next build under that profile without affecting the other profile's IC state.
+
+### Requirement 6: Distribution build is release by default
+
+**Objective:** As a kolt maintainer cutting a release, I want `scripts/assemble-dist.sh` to produce optimized binaries, so that distributed kolt binaries are unambiguously release-built.
+
+#### Acceptance Criteria
+1. When `scripts/assemble-dist.sh` is invoked without overrides, the script shall build every kolt component under the release profile.
+2. The kolt project shall keep `scripts/assemble-dist.sh` as the single source of truth for the profile selection used in the distribution tarball.
+3. When `scripts/assemble-dist.sh` finishes successfully, the produced tarball shall contain artifacts that were built under the release profile.
+
+### Requirement 7: Documentation reflects profile semantics
+
+**Objective:** As a new kolt user, I want public docs to introduce the profile distinction up front, so that I do not infer release behavior is the default.
+
+#### Acceptance Criteria
+1. The kolt project shall update `README.md` so that build command examples reflect the debug-default and `--release` opt-in behavior.
+2. The kolt project shall update `CLAUDE.md` and `.kiro/steering/tech.md` to mention the profile policy where build commands are documented.
+3. The kolt project shall update the `kolt-usage` skill so its build examples and command reference mention `--release`.
+4. The kolt project shall add ADR 0030 (`docs/adr/0030-build-profiles.md`) documenting:
+   - Default = debug, `--release` opt-in (Cargo style) decision.
+   - JVM `--release` no-op declaration with reasoning (kotlinc bytecode no significant diff, `-Xno-call-assertions` not default, line numbers always present, reproducibility is a separate concern).
+   - Native compile flag routing rules (`-opt`, debug-info handling).
+   - Output path and IC store partitioning shape (`build/<profile>/` and `~/.kolt/daemon/ic/<version>/<projectId>/<profile>/`).
+   - Explicit rejection of `kolt.toml [profile]` configuration sections.

--- a/.kiro/specs/release-build-profile/research.md
+++ b/.kiro/specs/release-build-profile/research.md
@@ -1,0 +1,202 @@
+# Gap Analysis: release-build-profile
+
+Generated: 2026-04-28T04:35:00Z
+Phase: requirements approved → pre-design
+
+## Existing State Snapshot
+
+### Build pipeline anatomy
+- **Native compile**: `src/nativeMain/kotlin/kolt/build/Builder.kt`
+  - `nativeLibraryCommand()` (lines 109-135) — klib stage; passes `-target`, sources, `-p library`, `-nopack`, `-l <klibs>`, `-o`. **No `-opt` or `-g` today.**
+  - `nativeLinkCommand()` (lines 140-169) — link stage; passes `-target`, `-p program`, `-e <main>`, `-l`, `-Xinclude=`, `-Xenable-incremental-compilation`, `-Xic-cache-dir=$NATIVE_IC_CACHE_DIR`, `-o`. **No `-opt` or `-g` today.**
+  - `outputKexePath(config)` (line 60) → `"$BUILD_DIR/${config.name}.kexe"`. `BUILD_DIR = "build"` is the kolt-managed (not Gradle) artifact root.
+  - `outputJarPath(config)` (line 20) → `"$BUILD_DIR/${config.name}.jar"`.
+  - `NATIVE_IC_CACHE_DIR` (line 18) — `internal const val "$BUILD_DIR/.ic-cache"`. **Hardcoded const.**
+- **JVM compile**: `Builder.kt:89-105` (`checkCommand`) and `TestBuilder.kt:9-35` (`testBuildCommand`). **No `-opt` / `-g`.** No optimization-class flag is currently routed to kotlinc.
+- **JVM daemon IC**: `kolt-jvm-compiler-daemon/ic/.../IcStateLayout.kt:51-52` — `<icRoot>/<kotlinVersion>/<sha256(projectRoot).take(16)>`. Path is **client-computed** in `KoltPaths.daemonIcDir` and passed via `IcRequest.workingDir` (wire schema: `kolt-jvm-compiler-daemon/.../protocol/Message.kt:11-18`).
+- **Native daemon IC**: `kolt-native-compiler-daemon/.../protocol/Message.kt:18-19` — `data class NativeCompile(val args: List<String>)`. **Path is embedded in the konanc args** (`-Xic-cache-dir=...`), not a wire-level field.
+- **CLI flag parsing**: `Main.kt:8-87`. Existing build-level flags (`--no-daemon`, `--watch`) are extracted by `koltLevel.contains(...)` and stripped via `filter`. No parametrized flags exist; `--release` fits this pattern.
+- **Entry commands**: `BuildCommands.kt` `doBuild` (206), `doCheck` (127), `doTest` (708), `doRun` (644). Each is invoked from `Main.kt` after lock + flag-extract.
+- **Watch loop**: `WatchLoop.kt:275-369` calls path-computation functions (`outputKexePath`, etc.) on each rebuild; profile changes propagate automatically per cycle.
+- **`scripts/assemble-dist.sh`**:
+  - Line 102: `KOLT="${KOLT:-./build/bin/linuxX64/releaseExecutable/kolt.kexe}"` — Gradle release path (bootstrap kolt).
+  - Line 120: `"$KOLT" build` — invokes self-host kolt; **no profile flag today**.
+  - Line 218: `ROOT_KEXE="$ROOT_DIR/build/kolt.kexe"` — self-host kolt output; **moves to `build/release/kolt.kexe` after this feature**.
+  - Line 228-229: `daemon_jar="$ROOT_DIR/$daemon/build/${daemon}.jar"` and `manifest="$ROOT_DIR/$daemon/build/${daemon}-runtime.classpath"` — JVM artifacts; **JVM is no-op so paths unchanged**, except if we still partition under `build/release/` for consistency (design decision).
+
+### No existing profile concept
+- No `Profile` type, no `release` / `debug` reserved subcommand or `kolt.toml` key.
+- `kolt.config.Config.BuildSection` (`Config.kt:65-74`) does not carry profile state.
+- `release` appears only in Gradle path strings (`releaseExecutable`) and code comments. No naming collisions.
+
+### Drift guard coverage
+- `DriftGuardsTest.kt` asserts three triangles: daemon Kotlin version pins, daemon main-class FQNs, bootstrap JDK pins. **None touch path computation.**
+- The current path consts (`BUILD_DIR`, `NATIVE_IC_CACHE_DIR`) and the upcoming profile-aware computations have **no automated drift guard**. If we encode `"debug"` / `"release"` literals in multiple places, drift surface grows.
+
+### Test fixture path coupling
+- ~44 occurrences of `build/<...>.kexe` / `build/<...>.jar` in `src/nativeTest/`.
+- The vast majority are **Gradle paths** (`build/bin/linuxX64/debugExecutable/kolt.kexe`), used by tests that resolve the bootstrap kolt binary (e.g. `DaemonJarResolverTest`, `NativeDaemonJarResolverTest`, `ConcurrentBuildIT`). Those are **out of scope** — Gradle's output layout is not changing.
+- A smaller set asserts kolt-managed paths: `TestBuilderTest.kt:43` (`build/classes:...`), classpath manifest tests, `outputKexePath` assertions. Estimated **5-10 tests** require updating to expect `build/<profile>/...`.
+
+### Documentation footprint
+- `README.md` / `README.ja.md`: 5 occurrences each of `build/...` in user-facing examples (mostly Gradle paths for self-host smoke; mixed with kolt-managed paths in cinterop / `--watch` examples).
+- `CLAUDE.md`: 0 mentions of `build/` layout; touches only `./gradlew build` invocations.
+- `.kiro/steering/tech.md`: documents user-facing CLI commands; no path examples to update.
+- `kolt-usage` skill (`.claude/skills/kolt-usage/SKILL.md`): TBD scan — Req 7 lists it.
+
+## Requirement-to-Asset Map
+
+| Req | Asset | Status | Notes |
+|-----|-------|--------|-------|
+| 1.1-1.4 (flag parsing, debug default, kolt.toml-free) | `Main.kt:8-87`, `BuildCommands.kt` doBuild/doCheck/doTest/doRun | Extend | Add `--release` to flag extraction, thread `Profile` through 4 entry functions |
+| 2.1, 2.2 (Native `-opt` routing) | `Builder.kt` `nativeLibraryCommand` / `nativeLinkCommand` | Extend | Add `-opt` only under release |
+| 2.3, 2.4 (Native debug-info routing) | `Builder.kt` `nativeLinkCommand` (and library?) | Extend | Add `-g` under debug; **research needed: does `-g` belong on library stage too, or only link?** |
+| 3.1-3.3 (JVM no-op, identical IC store) | JVM compile commands, `KoltPaths.daemonIcDir`, `IcStateLayout.workingDirFor` | Constraint | Pass `Profile` through but ignore on JVM side; assert via test |
+| 4.1, 4.2 (output path with profile segment) | `Builder.kt` `outputKexePath`, `outputJarPath`, `outputRuntimeClasspathPath`, `outputNativeTestKexePath` | Extend | Functions take `Profile`; emit `build/<profile>/...` |
+| 4.3 (both profiles coexist on disk) | n/a (emergent) | Test | Integration test alternating `kolt build` / `kolt build --release` |
+| 4.4 (no precondition on directory) | `BuildCommands.kt` build orchestration | Constraint | Existing `ensureDirectoryRecursive` already idempotent (#272 EEXIST tolerance merged) |
+| 5.1, 5.2 (Native IC path with profile segment) | `Builder.kt` `NATIVE_IC_CACHE_DIR` const → fn, `BuildCommands.kt:577-578` `wipeNativeIcCache` | Extend | Const → function `nativeIcCacheDir(profile)`; wipe takes profile |
+| 5.3 (alternation preserves IC) | n/a (emergent from 5.1+5.2) | Test | Integration test |
+| 5.4 (recreate cache idempotently) | `BuildCommands.kt` cache creation | Constraint | Existing `ensureDirectoryRecursive` covers it |
+| 6.1, 6.3 (assemble-dist.sh release default) | `scripts/assemble-dist.sh:120,218` | Extend | Pass `--release`, update output path |
+| 6.2 (single source of truth) | `scripts/assemble-dist.sh` | Constraint | No additional script created |
+| 7.1-7.4 (docs, ADR 0030) | README.md, README.ja.md, CLAUDE.md, steering/tech.md, `kolt-usage` skill, `docs/adr/0030-build-profiles.md` | New | ADR is new; others are extends |
+
+**Gaps tagged:**
+- *Missing*: `Profile` type, profile-aware path computation, ADR 0030.
+- *Unknown* (research needed for design):
+  - JVM IC store path schema decision: keep flat (Req 3.3 satisfied trivially) vs partition under unified `build/<profile>/` only on the artifact side. Issue #261 says JVM IC = same store; lean toward that.
+  - `-g` placement on Native: link stage only, library stage only, or both? Conservative read of konanc docs needed during design.
+  - `NATIVE_IC_CACHE_DIR` location: stays under `build/.ic-cache`, moves under `build/<profile>/.ic-cache`, or moves under daemon IC root like JVM. Issue text only specifies `~/.kolt/daemon/ic/...` for daemon-managed Native IC; the local kolt-side `build/.ic-cache` predates daemon IC entirely. Need to disambiguate during design.
+- *Constraint*: pre-v1 no migration shim — `~/.kolt/daemon/ic/<v>/<id>/` becomes orphan after this lands. Documentation should tell users to wipe `~/.kolt/daemon/` if iteration of mixed pre/post-flag cache is observed.
+
+## Implementation Approach Options
+
+### Option A: Extend in place — add `Profile` parameter to existing functions
+- Add `enum class Profile { Debug, Release }` somewhere small (e.g. `kolt.build.Profile`).
+- Thread `Profile` through every signature that currently uses `BUILD_DIR` or `NATIVE_IC_CACHE_DIR`: `outputKexePath`, `outputJarPath`, `outputRuntimeClasspathPath`, `outputNativeTestKexePath`, `nativeLibraryCommand`, `nativeLinkCommand`, `nativeIcCacheDir` (replaces const), `wipeNativeIcCache`.
+- CLI extracts `--release` in `Main.kt`, passes `Profile` into `doBuild` / `doCheck` / `doTest` / `doRun`.
+- `KoltPaths.daemonIcDir` gains optional profile suffix; JVM call sites pass `Profile.Debug` and never partition (no-op).
+
+**✅ Pros**:
+- Low ceremony, no new files for path computation.
+- Type system enforces every caller updates (compiler errors point at every uncovered site — useful as a discovery tool during implementation).
+- Path concentration in `Builder.kt` stays.
+
+**❌ Cons**:
+- Wide signature churn (~15-20 call sites).
+- `Builder.kt` already 200+ lines; adds parameter density.
+
+### Option B: Centralize paths in a `BuildPaths` value class
+- Introduce `class BuildPaths(profile: Profile, config: KoltConfig)` exposing `kexePath`, `jarPath`, `runtimeClasspathPath`, `testKexePath`, `nativeIcCacheDir`.
+- Replace existing path functions with `BuildPaths.<member>` calls.
+- `Profile` still threads from CLI through entry functions, but bottom-layer functions (`nativeLibraryCommand`, etc.) take `BuildPaths` instead of raw `Profile`.
+
+**✅ Pros**:
+- One canonical place for path layout; future changes (e.g. macOS / linuxArm64 path forks) consolidated.
+- Easier drift guard: a single test reads the source file and asserts profile segment appears.
+
+**❌ Cons**:
+- New abstraction with limited members today; risks under-utilization.
+- Migrating ~15 call sites to `BuildPaths` is the same churn as Option A plus a new type.
+
+### Option C: Hybrid — `Profile` enum + selective path centralization
+- Introduce `Profile` enum.
+- Path functions in `Builder.kt` keep their shape but each grows a `profile: Profile` parameter (Option A's threading).
+- `nativeIcCacheDir(profile: Profile)` function replaces the const (small, isolated change).
+- Daemon IC path computation in `KoltPaths.kt` and `IcStateLayout.kt` accepts an optional `profile: Profile?` (null = JVM no-op behavior).
+- No new `BuildPaths` class — defer that consolidation until macOS / linuxArm64 forks the layout (#82 / #83).
+
+**✅ Pros**:
+- Smallest patch that satisfies all 7 requirements.
+- Doesn't pre-commit to an abstraction (`BuildPaths`) before knowing the linuxArm64 / macOS shape.
+- Keeps the change reviewable (touchpoints are mechanical: add parameter, wire through).
+
+**❌ Cons**:
+- Path layout knowledge stays decentralized across `Builder.kt` functions.
+- Future macOS / linuxArm64 path forks may revisit Option B.
+
+**Recommendation for design**: Option C. Pre-v1 prefers small, reversible changes; `BuildPaths` consolidation can land later if needed.
+
+## Effort & Risk
+
+- **Effort**: **M (3-7 days)**.
+  - Core threading + path computation: ~2 days.
+  - Test updates (5-10 kolt-managed-path tests + 2-3 new integration tests for Req 4.3, 5.3, JVM no-op): ~1-2 days.
+  - `assemble-dist.sh` + `self-host-post` CI verification: ~0.5 day.
+  - ADR 0030 + README/CLAUDE/steering/skill docs: ~1 day.
+- **Risk**: **Medium**.
+  - Test fixture surface (44 hits) includes Gradle paths (out of scope) — actual update count is smaller, but discovery is needed.
+  - Daemon IC store path change orphans pre-v0.16 caches; pre-v1 policy absorbs this, but warrants a release-note line.
+  - Native `-g` placement (library stage vs link stage) is the only konanc-spec ambiguity; design phase must confirm.
+  - `assemble-dist.sh` change is reversible; `self-host-post` CI catches regressions.
+
+## Research Items for Design Phase
+
+1. **Native `-g` flag placement**: confirm whether konanc consumes `-g` on `-p library` (klib stage) or only on `-p program` (link stage). Docs / source survey of `kolt-native-compiler-daemon` worker.
+2. **`build/.ic-cache` location decision**: keep at `build/.ic-cache` (single shared cache, profile-segment in subdir) vs. move to `build/<profile>/.ic-cache`. Both satisfy Req 5.1/5.2; pick based on cleanup ergonomics (`rm -rf build/release/` should not erase debug IC if shared).
+3. **Daemon IC store partitioning**: confirm `~/.kolt/daemon/ic/<version>/<projectId>/<profile>/` (issue spec) is the schema. JVM IC keeps the same projectId-only path (Req 3.3).
+4. **`Profile` representation in wire protocol**: decide whether `Profile` rides along on the daemon `Compile` / `NativeCompile` message (cleaner) or stays embedded in args/paths only (less invasive). Native already embeds; JVM uses `workingDir`.
+5. **Drift guard for path partition**: should `DriftGuardsTest` gain a 4th assertion locking the `debug` / `release` literals across `Profile.Debug.dirName`, `Profile.Release.dirName`, `assemble-dist.sh`, and any test fixture that hardcodes `build/release/`? Lightweight; one new assertion.
+6. **`kolt clean`**: does kolt have a `clean` command? If yes, profile-aware behavior (`kolt clean` clears all, `kolt clean --release` clears only release) is a UX question. If no, out of scope.
+7. **`kolt-usage` skill scan**: enumerate exact build-command examples that need `--release` mention.
+
+## Recommendations for Design Phase
+
+- Adopt **Option C** (hybrid: `Profile` enum + selective path centralization).
+- Resolve research items 1-3 with a 30-minute source/doc dive before drafting `design.md`.
+- Treat research item 5 (drift guard) as a follow-up issue if it threatens design scope; otherwise include.
+- Item 6 (`kolt clean`) is plausibly out-of-scope — keep deferred unless the user surfaces it.
+
+---
+
+# Design Synthesis (2026-04-28T05:00:00Z)
+
+## Discovery resolutions for research items
+
+### Item 1: Native `-g` flag placement
+**Decision**: Add `-g` only to the link stage (`nativeLinkCommand`), not the library/klib stage.
+- Rationale: `-g` controls debug-info emission in the final binary; klib stage produces an intermediate artifact that does not embed ELF debug info.
+- Conservative call; if the design later finds klib-stage `-g` is also useful, it is a one-line follow-up.
+- `-opt` likewise added only on the link stage (final-binary optimization).
+
+### Item 2: `build/.ic-cache` location
+**Decision**: Move to **`build/<profile>/.ic-cache`** (under the same per-profile directory as artifacts).
+- Aligns with Req 4 path partition. `rm -rf build/release/` clears both release artifact and release IC together.
+- Alternatives considered:
+  - `build/.ic-cache/<profile>/` — keeps cache at one root, but mixes concerns (cleanup of one profile must traverse the other).
+  - Rejected: keeping flat `build/.ic-cache` violates Req 5.1/5.2 (no profile segment).
+
+### Item 3: Daemon IC schema
+**Resolution**: Issue #261's "daemon IC store under `~/.kolt/daemon/ic/<v>/<id>/<profile>/`" is a misattribution. The JVM daemon owns `~/.kolt/daemon/ic/` and JVM is declared no-op (Req 3.3); Native does not use that path. Final schema:
+- JVM: unchanged (`~/.kolt/daemon/ic/<kotlinVersion>/<projectIdHash>/`).
+- Native: `build/<profile>/.ic-cache` (project-local, not daemon-managed).
+- ADR 0030 will document this discrepancy resolution.
+
+### Item 4: `Profile` in wire protocol
+**Decision**: No wire-protocol change. Native daemon receives konanc args with profile-derived flags (`-opt`, `-g`) and IC path already embedded in `args`. JVM daemon receives the same `Compile.workingDir` regardless of profile (no-op).
+- Keeps Native and JVM daemon protocols unchanged for this feature.
+- Future profile-aware daemon behavior (if ever needed) is a separate ADR.
+
+### Item 5: Drift guard expansion
+**Decision**: Add a 4th `DriftGuardsTest` assertion verifying `Profile.Debug.dirName == "debug"` and `Profile.Release.dirName == "release"` literals match the `assemble-dist.sh` invocation flag.
+- Lightweight (single assertion) and prevents the next time someone renames the profile literal to `dev`/`prod`.
+- Keeps profile literal as a single source of truth in `Profile.kt`.
+
+### Item 6: `kolt clean`
+**Resolution**: kolt has no `clean` subcommand today. Out of scope for this feature; `rm -rf build/<profile>/` is the documented cleanup path.
+
+### Item 7: `kolt-usage` skill scan
+**Finding**: `.claude/skills/kolt-usage/SKILL.md` documents user-facing build commands. Update locations to be confirmed during task generation; expected ~2-3 lines.
+
+## Generalization
+The `Profile` concept is the only generalization candidate. It has exactly two values today (Debug, Release) and no requirement points to a third (custom profiles, project-defined profiles). Keep the enum closed; if `kolt.toml [profile.foo]` ever lands, it can extend the type then.
+
+## Build vs Adopt
+No external library is adopted. The change is mechanical threading of an enum through existing functions. Cargo's `--release` UX is the only "adoption" — it informs the flag name and default semantics, not implementation.
+
+## Simplification
+- No `BuildPaths` value class. Existing path functions accept a `profile: Profile` parameter (Option C from gap analysis).
+- No optional/nullable `Profile?`. Every entry function takes a non-null `Profile`; default = `Profile.Debug` is computed once in `Main.kt` and threaded.
+- No `kolt.toml` schema change.
+- ADR 0030 defers `kolt.toml [profile.*]` configuration explicitly.

--- a/.kiro/specs/release-build-profile/spec.json
+++ b/.kiro/specs/release-build-profile/spec.json
@@ -1,0 +1,22 @@
+{
+    "feature_name": "release-build-profile",
+    "created_at": "2026-04-28T04:23:58Z",
+    "updated_at": "2026-04-28T05:45:00Z",
+    "language": "en",
+    "phase": "tasks-generated",
+    "approvals": {
+        "requirements": {
+            "generated": true,
+            "approved": true
+        },
+        "design": {
+            "generated": true,
+            "approved": true
+        },
+        "tasks": {
+            "generated": true,
+            "approved": true
+        }
+    },
+    "ready_for_implementation": true
+}

--- a/.kiro/specs/release-build-profile/tasks.md
+++ b/.kiro/specs/release-build-profile/tasks.md
@@ -1,0 +1,129 @@
+# Implementation Plan
+
+## Phase 1: Foundation — Profile type
+
+- [x] 1. Foundation: Profile enum
+- [x] 1.1 Introduce the Profile enum as the single source of truth for profile literals
+  - Define a closed enum with exactly two values, each carrying a stable `dirName` string ("debug" / "release")
+  - Add a unit test asserting both values exist, are exhaustive, and produce the literal directory names that the rest of the feature depends on
+  - The new file compiles under `./gradlew linuxX64Test` and the new test runs green
+  - _Requirements: 1.1, 1.2, 4.1, 4.2, 5.1, 5.2_
+
+## Phase 2: Core — Native compile pipeline becomes profile-aware
+
+- [x] 2. Native artifact path partition
+- [x] 2.1 Thread Profile through every kolt-managed artifact path function
+  - Update output path producers (kexe, jar, runtime classpath manifest, native test kexe) so the resulting path includes the profile directory segment
+  - Update the existing unit tests that assert literal `build/<name>.kexe` / `build/<name>.jar` to expect `build/<profile>/...` and add release-variant assertions
+  - Running `kolt build` against a fixture writes to `build/debug/<name>.kexe`; `kolt build --release` writes to `build/release/<name>.kexe` (test verifies the path string returned by the path function for both profiles)
+  - _Requirements: 4.1, 4.2_
+
+- [x] 3. Native IC cache path partition
+- [x] 3.1 Replace the hardcoded native IC cache constant with a profile-aware function
+  - Remove the `NATIVE_IC_CACHE_DIR` const in favor of a function that takes a Profile and returns `build/<profile>/.ic-cache`
+  - Update the konanc link command builder so `-Xic-cache-dir=` reflects the active profile, and update existing tests asserting that arg literal (in the builder unit tests, the native daemon backend test, and the wire frame codec fixture)
+  - The function returns `build/debug/.ic-cache` for Debug and `build/release/.ic-cache` for Release; the konanc link command for each profile contains the corresponding `-Xic-cache-dir=` arg
+  - _Requirements: 5.1, 5.2_
+
+- [x] 4. Native compile arg routing per profile
+- [x] 4.1 Route `-opt` and `-g` based on Profile in the native link stage
+  - In the link-stage command builder, add `-opt` if and only if the profile is Release, and add `-g` if and only if the profile is Debug
+  - Leave the library/klib stage profile-agnostic (no `-opt`, no `-g`)
+  - Add unit tests asserting both branches: Debug's args contain `-g` and exclude `-opt`; Release's args contain `-opt` and exclude `-g`; library-stage args contain neither under either profile
+  - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+- [x] 5. JVM no-op signature propagation
+- [x] 5.1 Accept Profile on JVM-targeted command builders and runners without changing behavior
+  - Update the JVM check command builder, the JVM test build command builder, and the JVM run command so they accept a Profile argument they ignore for arg construction
+  - Add a unit test asserting that the same JVM compile command (same args, same module name, same classpath, same `outputPath`'s file name modulo profile dir) is produced whether Profile.Debug or Profile.Release is passed
+  - The JVM no-op test runs green with both profiles producing identical compile command args
+  - _Requirements: 3.1, 3.2_
+
+- [x] 6. Native IC cleanup follows profile
+- [x] 6.1 (P) Make the native IC wipe operate per profile, leave JVM IC reaper unchanged
+  - Update `wipeNativeIcCache` to take a Profile and remove only `build/<profile>/.ic-cache`
+  - Confirm the JVM `~/.kolt/daemon/ic/` traversal logic in the same module remains untouched and its existing tests still pass
+  - Add a test that creates IC content under both profiles, wipes one, and asserts only the wiped profile's directory is gone
+  - _Requirements: 5.4_
+  - _Boundary: IcStateCleanup_
+  - _Depends: 1.1, 3.1_
+
+## Phase 3: Integration — CLI threads profile through entry commands
+
+- [x] 7. CLI integration: parse `--release` and dispatch Profile
+- [x] 7.1 Extract `--release` in the kolt-level argument parser and construct a Profile token once
+  - Add the `--release` flag constant alongside existing kolt-level flag constants and follow the same `koltLevel.contains(...) + filter` style
+  - Strip the flag from `filteredArgs` so it does not leak into subcommand parsing
+  - Add a unit test asserting that, given a sample kolt-level arg list, the parser yields `Profile.Release` when `--release` is present and `Profile.Debug` when absent, and that the filtered subcommand args no longer contain `--release`
+  - _Requirements: 1.1, 1.2, 1.3_
+
+- [x] 7.2 Thread Profile into the four build-driving entry functions
+  - Update `doBuild`, `doCheck`, `doTest`, `doRun` to take Profile and pass it to every downstream call site (path producers, IC cache function, command builders, runners, IC wipe)
+  - Update existing unit tests that exercise these entry functions to pass an explicit Profile and assert the right downstream behavior
+  - The CLI dispatcher passes the parsed Profile into each entry function and existing test suites for these entry functions stay green
+  - _Requirements: 1.1, 1.2, 1.4_
+  - _Depends: 6.1, 7.1_
+
+- [x] 7.3 Carry Profile through the watch loop so rebuilds inherit the initial profile
+  - Update the watch loop to capture the Profile of the initial invocation and pass it into every rebuild it triggers
+  - Confirm via test that, given an initial `--release` invocation, every rebuild call site sees `Profile.Release` (and vice versa for Debug)
+  - _Requirements: 1.1, 1.2_
+  - _Depends: 7.2_
+
+## Phase 4: Quality — Drift guard and distribution script
+
+- [x] 8. Drift guard for profile literals
+- [x] 8.1 (P) Add an assertion that profile dirNames stay aligned with the distribution script
+  - Extend the existing drift-guards test with a fourth assertion that reads `Profile.Debug.dirName` / `Profile.Release.dirName` and asserts the distribution script contains the matching `kolt build --release` invocation
+  - The new assertion fails with a clear message if the literals or the script invocation drift apart
+  - _Requirements: 7.4_
+  - _Boundary: DriftGuardsTest_
+  - _Depends: 1.1, 9.1_
+
+- [x] 9. Distribution script switches to release
+- [x] 9.1 (P) Update assemble-dist.sh to build release artifacts and read from `build/release/`
+  - Pass `--release` to every `kolt build` invocation in the distribution script (root native build and both daemon sub-builds)
+  - Update the post-build artifact path for the root native binary to `build/release/kolt.kexe`
+  - The self-host distribution path successfully assembles a tarball whose root binary lives under `build/release/`; the existing `self-host-post` CI job exercises this end-to-end
+  - _Requirements: 6.1, 6.2, 6.3_
+  - _Boundary: assemble-dist.sh_
+  - _Depends: 2.1_
+
+## Phase 5: Validation — End-to-end behavior
+
+- [x] 10. Integration validation
+- [x] 10.1 Profile alternation integration test
+  - Run, in order, `kolt build` then `kolt build --release` then `kolt build` again against a fixture project
+  - Assert that after the sequence both `build/debug/<name>.kexe` and `build/release/<name>.kexe` exist on disk simultaneously, and that neither IC cache directory was wiped by the alternating builds
+  - _Requirements: 4.3, 5.3, 5.4_
+  - _Depends: 7.2, 6.1_
+
+- [x] 10.2 (P) JVM no-op contract integration test
+  - Build a JVM fixture project with `kolt build` and `kolt build --release`
+  - Assert: identical compile output bytes (modulo file-system timestamps), identical `~/.kolt/daemon/ic/` working directory used, and no warning or error attributable to the flag on stderr
+  - _Requirements: 3.1, 3.2, 3.3_
+  - _Boundary: JVM end-to-end_
+  - _Depends: 7.2_
+
+## Phase 6: Documentation
+
+- [x] 11. Documentation
+- [x] 11.1 (P) Author ADR 0030
+  - Write `docs/adr/0030-build-profiles.md` codifying: default = debug, `--release` opt-in, JVM no-op declaration with reasons (kotlinc bytecode no significant diff, `-Xno-call-assertions` not default, line numbers always present, reproducibility separate concern), Native flag routing rules (`-opt`, `-g`), output and IC path partitioning shape, explicit rejection of `kolt.toml [profile]` sections, and the resolution of issue #261's misattribution about `~/.kolt/daemon/ic/<v>/<id>/<profile>/`
+  - The ADR file exists with Status / Summary / Context / Decision / Consequences sections matching the project's existing ADR style
+  - _Requirements: 7.4_
+  - _Boundary: docs/adr/_
+
+- [x] 11.2 (P) Update user-facing README content
+  - Update `README.md` and `README.ja.md` so build command examples mention `--release` and reflect the `build/<profile>/` artifact layout where relevant
+  - The user-facing examples in both READMEs read coherently for a new user opening the project for the first time post-feature
+  - _Requirements: 7.1_
+  - _Boundary: README files_
+
+- [x] 11.3 (P) Update agent-facing documentation
+  - Add a one-line "Profiles" entry to CLAUDE.md Key Rules pointing at ADR 0030
+  - Update `.kiro/steering/tech.md` so the User-facing CLI snippet shows `--release` on relevant commands
+  - Update `.claude/skills/kolt-usage/SKILL.md` build/test/run/check examples and add a brief profile section
+  - All three files mention the profile concept consistently and point to ADR 0030 for the policy
+  - _Requirements: 7.2, 7.3_
+  - _Boundary: agent docs_

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -82,10 +82,10 @@ the repo is English-first.
 User-facing CLI:
 ```
 kolt init [name]                  # create project
-kolt build    [--watch]           # compile
-kolt run      [--watch]           # build + run
-kolt test     [--watch]           # build + run tests
-kolt check    [--watch]           # type-check only
+kolt build    [--watch] [--release]   # compile (debug default; --release writes build/release/)
+kolt run      [--watch] [--release]   # build + run
+kolt test     [--watch] [--release]   # build + run tests
+kolt check    [--watch] [--release]   # type-check only
 kolt fmt      [--check]           # ktfmt format (or verify in CI)
 kolt add <dep>                    # add dependency to kolt.toml
 kolt deps [install|update|tree]   # resolve / inspect deps
@@ -93,6 +93,11 @@ kolt toolchain install            # provision kotlinc for pinned version
 kolt daemon stop [--all]          # stop warm daemon
 kolt daemon reap                  # clean stale sockets
 ```
+
+`--release` is a Cargo-style opt-in profile: Native adds `-opt` and omits
+`-g`; JVM is a declared no-op (same kotlinc args, same daemon IC path)
+with the artifact moved to `build/release/<name>.jar`. Both profiles'
+artifacts coexist on disk. See ADR 0030.
 
 Development (for working on kolt itself):
 ```
@@ -112,6 +117,7 @@ Authoritative ADRs live in `docs/adr/`. The load-bearing ones:
 - **ADR 0019** — Incremental JVM compilation via kotlin-build-tools-api (BTA).
 - **ADR 0018** — Distribution layout and self-host path.
 - **ADR 0024** — Native compiler daemon (proposed) for konanc warm path.
+- **ADR 0030** — Build profiles: Cargo-style `--release` opt-in; debug default; Native routes `-opt` / `-g`; JVM no-op; `build/<profile>/` partition.
 
 When changing code that encodes one of these decisions, update the ADR in the same
 commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Reads `kolt.toml`, compiles with `kotlinc`, and runs with `java -jar`.
 - **No backward compatibility until v1.0** — kolt is pre-v1. Do not add migration shims, legacy-layout probes, or deprecation warnings for older kolt versions. Cut breaking changes cleanly; document upgrade steps in the release note and expect users to run them (e.g. `rm -rf ~/.kolt/daemon/`). Cross-version-of-external-tools compat (Kotlin compiler family, Gradle metadata) is different and still required.
 - **Comments default to deletion** — keep only design invariants, "why-not" decisions, and anchored external-tool gotchas. See `/kolt-dev`.
 - **Write all code, comments, documentation, and commit messages in English**
+- **Profiles** — `kolt build [--release]` is Cargo-style: debug default, `--release` opt-in. JVM is declared no-op; Native routes `-opt` / `-g` and partitions output under `build/<profile>/`. Single source of truth: `kolt.build.Profile`. See ADR 0030.
 - Place test files in `src/nativeTest/kotlin/kolt/<package>/XxxTest.kt` mirroring main source structure
 - Annotate POSIX API usage with `@OptIn(ExperimentalForeignApi::class)` at function level
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -56,7 +56,8 @@ kolt init custom-name
 
 ```
 kolt init [name]       新しいプロジェクトを作成
-kolt build             プロジェクトをコンパイル
+kolt build             プロジェクトをコンパイル（デフォルトは debug プロファイル）
+kolt build --release   release プロファイルでコンパイル
 kolt run               ビルドして実行（kolt run -- args でアプリ引数を渡す）
 kolt test              ビルドしてテスト実行（kolt test -- args で JUnit Platform 引数を渡す）
 kolt check             成果物を生成せずに型チェック
@@ -93,6 +94,7 @@ kolt --version         バージョンを表示
 |--------|------|
 | `--watch` | ソースファイルを監視し、変更時にコマンドを再実行（build/check/test/run） |
 | `--no-daemon` | この実行でウォームコンパイラデーモンをスキップ。daemon サポート対象外の Kotlin バージョン (ADR 0022) でも常に利用可能。 |
+| `--release` | release プロファイルでビルドする。Native は `-opt` を有効化し `-g` を外して `build/release/` に出力。JVM では宣言上 no-op（kotlinc 引数も daemon IC パスも変わらない）だが、両プロファイル成果物を相互に上書きしないよう成果物パスは `build/release/<name>.jar` に切り替わる。デフォルトは `debug` プロファイルで、両プロファイルの成果物はディスク上に共存するためプロファイルを切り替えても他方の IC が無効化されることはない。詳細は [ADR 0030](docs/adr/0030-build-profiles.md) を参照。 |
 
 ## 設定
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ kolt init custom-name
 
 ```
 kolt init [name]       Create a new project
-kolt build             Compile the project
+kolt build             Compile the project (debug profile by default)
+kolt build --release   Compile under the release profile
 kolt run               Build and run (kolt run -- args for app arguments)
 kolt test              Build and run tests (kolt test -- args for JUnit Platform arguments)
 kolt check             Type-check without producing artifacts
@@ -93,6 +94,7 @@ kolt --version         Show version
 |------|-------------|
 | `--watch` | Watch source files and re-run the command on change (build/check/test/run) |
 | `--no-daemon` | Skip the warm compiler daemon for this invocation. Always available, including on Kotlin versions outside the daemon's supported range (ADR 0022). |
+| `--release` | Build under the release profile. Native: enables `-opt`, omits `-g`, writes artifacts to `build/release/`. JVM: declared no-op (same kotlinc args, same daemon IC path) — the artifact still moves to `build/release/<name>.jar` so the two profiles' outputs do not overwrite each other. Default profile is `debug`; both profiles' artifacts coexist on disk so switching between them does not invalidate the other. See [ADR 0030](docs/adr/0030-build-profiles.md). |
 
 ## Configuration
 

--- a/docs/adr/0030-build-profiles.md
+++ b/docs/adr/0030-build-profiles.md
@@ -1,0 +1,312 @@
+---
+status: implemented
+date: 2026-04-28
+---
+
+# ADR 0030: Build profiles
+
+## Summary
+
+- kolt accepts a Cargo-style `--release` opt-in flag on the four
+  build-driving commands (`build`, `test`, `run`, `check`); the default
+  remains the debug profile, and the active profile is determined solely
+  from the command line — `kolt.toml` carries no profile section (§1).
+- On Native targets, the link stage routes `-opt` if and only if the
+  profile is Release and `-g` if and only if the profile is Debug; the
+  klib library stage stays profile-agnostic. Native artifact output and
+  the project-local Native incremental-compile cache partition into
+  `build/<profile>/` and `build/<profile>/.ic-cache` respectively (§2).
+- On JVM targets `--release` is a declared no-op: identical kotlinc
+  arguments, identical `~/.kolt/daemon/ic/<v>/<id>/` path, and identical
+  compile output bytes modulo file-system timestamps. The JVM jar still
+  partitions under `build/<profile>/<name>.jar` so a flip between
+  profiles cannot overwrite either artifact (§3).
+- `scripts/assemble-dist.sh` invokes `kolt build --release` for every
+  sub-build and reads the root binary from `build/release/kolt.kexe`;
+  distribution tarballs are unambiguously release-built (§4).
+- Issue #261 specified "daemon IC store under
+  `~/.kolt/daemon/ic/<v>/<id>/<profile>/`". That schema was a
+  misattribution: `~/.kolt/daemon/ic/` is JVM-daemon-owned (ADR 0019 §5)
+  and JVM is no-op, while the project-local Native IC cache lives at
+  `build/<profile>/.ic-cache`. The shipped layout matches the latter; no
+  daemon IC path gains a profile segment (§5).
+- Pre-v1 policy applies: stale `build/.ic-cache` from earlier kolt
+  versions is abandoned. The release note instructs `rm -rf build/` for
+  users who want a clean slate; no migration shim ships (§6).
+
+## Context and Problem Statement
+
+`kolt build` currently compiles Native targets with a single profile-less
+konanc invocation. Daily Native iteration loops pay the optimization-class
+link time even when no optimization is needed, and distribution binaries
+assembled by `scripts/assemble-dist.sh` are not explicitly marked as
+release-built. With no profile concept kolt also looks incomplete next to
+Cargo / Gradle / Bazel and blocks the planned Gradle-removal direction
+and the `curl | sh` installer (#230).
+
+This ADR records the decision to introduce an opt-in `--release` profile
+without adding `kolt.toml` configuration sections, and to declare the flag
+a no-op on JVM where there is no comparable cost to optimize away.
+
+## Decision Drivers
+
+- Daily Native iteration must not pay optimization-class link time by
+  default.
+- Distribution binaries must be unambiguously release-built so the
+  upcoming `curl | sh` installer (#230) ships optimized artifacts.
+- The JVM build path must keep observable behaviour stable: same compile
+  output bytes, same daemon IC store, no warning attributable to a flag
+  that semantically does nothing on JVM.
+- The change must be the smallest one that satisfies the seven feature
+  requirements; no new abstraction, no new wire-protocol field, no new
+  `kolt.toml` schema.
+- Pre-v1 policy: cut breaking changes cleanly without migration shims.
+
+## Decision Outcome
+
+Chosen: **introduce a closed `Profile` enum, parse `--release` once at
+the CLI boundary, and thread the typed token through every path producer
+and command builder that currently consumes `BUILD_DIR` or
+`NATIVE_IC_CACHE_DIR`**. Native compile arg routing branches on the
+enum; JVM consumers accept it for symmetry but ignore it for arg
+construction. Alternatives are listed at the end.
+
+### §1 CLI flag and profile token
+
+`kolt.cli.Main.parseKoltArgs` extracts `--release` alongside the existing
+`--no-daemon` and `--watch` kolt-level flags, returning a typed
+`KoltArgs` with a non-null `Profile`. The token is computed once and
+threaded into `doBuild`, `doCheck`, `doTest`, `doRun`, `watchCommandLoop`,
+and `watchRunLoop`. Watch mode captures the initial-invocation profile;
+profile cannot change mid-loop — users cancel and re-invoke to switch.
+
+The flag is positional-agnostic at the kolt level (same as
+`--no-daemon` / `--watch`). Anything after `--` is passthrough and is
+not interpreted as a profile flag.
+
+`kolt.toml` does not gain `[profile.dev]` / `[profile.release]` sections.
+The active profile is determined solely from the command line; this
+keeps the schema small and avoids precedence rules between flags and
+config that the feature does not need.
+
+### §2 Native compile routing and path partition
+
+`Profile.Debug.dirName == "debug"` and `Profile.Release.dirName ==
+"release"` are the single source of truth for profile literals.
+
+Native link-stage command (`Builder.nativeLinkCommand`,
+`Builder.nativeTestLinkCommand`):
+
+- Adds `-opt` if and only if `profile == Profile.Release`.
+- Adds `-g` if and only if `profile == Profile.Debug`.
+- Klib library stage (`nativeLibraryCommand`,
+  `nativeTestLibraryCommand`) stays profile-agnostic — both flags
+  control properties of the final binary, not of the intermediate klib.
+
+Path partition for kolt-managed artifacts:
+
+- `build/<profile>/<name>.kexe` (Native app).
+- `build/<profile>/<name>-test.kexe` (Native test).
+- `build/<profile>/<name>-klib` and `<name>-test-klib` (Native klibs).
+- `build/<profile>/<name>.jar` (JVM jar; see §3).
+- `build/<profile>/<name>-runtime.classpath` (JVM kind=app manifest;
+  ADR 0027 §1).
+- `build/<profile>/.ic-cache` (project-local Native IC cache).
+
+`build/classes/` and `build/test-classes/` (kotlinc compile output)
+remain flat. They are intermediate JVM directories and partitioning
+them would not satisfy any requirement.
+
+### §3 JVM no-op contract
+
+Acceptance Criteria 3.1–3.3 are met as follows:
+
+- **3.1 Same compile bytes:** `Builder.checkCommand` and
+  `TestBuilder.testBuildCommand` accept `profile` for symmetry but do
+  not use it for arg construction (the parameter is annotated
+  `@Suppress("UNUSED_PARAMETER")`). Per-profile compile invocations
+  produce byte-identical kotlinc argv lists.
+- **3.2 No warning:** the parser silently consumes `--release`; no
+  branch in any JVM code path emits a deprecation, warning, or error
+  attributable to the flag.
+- **3.3 Same JVM IC path:** `KoltPaths.daemonIcDir` is unchanged; the
+  JVM daemon's `IcStateLayout.workingDirFor` continues to compute
+  `<icRoot>/<kotlinVersion>/<sha256(projectRoot).take(16)>` regardless
+  of profile. The wire protocol for the JVM daemon (`Compile`) gains
+  no `Profile` field.
+
+The JVM jar still partitions under `build/<profile>/<name>.jar`
+(Requirement 4). This is observable behaviour but does not violate the
+no-op contract: the file's content is byte-identical between profiles
+modulo timestamp; the *path* differs because Requirement 4 is target-
+agnostic. Users that need a single canonical artifact location should
+pick a profile and stick with it; switching profiles is an explicit
+opt-in and the path partition is the documented invariant.
+
+The reasons `--release` is a no-op on JVM, captured here for posterity
+so the next reviewer does not relitigate them:
+
+- kotlinc bytecode shows no significant difference under common
+  optimization toggles for kolt's workload.
+- `-Xno-call-assertions` is not the default and is not silently safe to
+  enable across all projects.
+- Line numbers are emitted by kotlinc unconditionally; there is no
+  "strip line numbers under release" knob to attach.
+- JVM reproducibility (epoch-zero timestamps, IC bypass) is a separate
+  concern with its own design surface and is deferred.
+
+### §4 Distribution script
+
+`scripts/assemble-dist.sh` invokes `"$KOLT" build --release` for the
+root build and for both daemon sub-builds (`kolt-jvm-compiler-daemon`
+and `kolt-native-compiler-daemon`). The two daemon sub-builds are
+JVM-target apps where `--release` is a no-op for compile arg shape,
+but the script passes the flag uniformly so that:
+
+- The intent ("this is the release pipeline") is explicit at every
+  invocation.
+- The on-disk artifact paths the script reads from
+  (`<daemon>/build/release/<daemon>.jar` and the matching runtime
+  classpath manifest) align with the root binary path
+  (`build/release/kolt.kexe`).
+- Future-proofing: if a daemon sub-build ever gains a Native target,
+  the `--release` flag is already in place and would route `-opt` /
+  `-g` correctly without touching the script.
+
+`DriftGuardsTest.profileLiteralsAndDistScriptAreInSync` pins both
+`Profile.dirName` literals and the `kolt build --release` invocation in
+the script; renaming either end without updating the other fails the
+test.
+
+### §5 Issue #261 schema misattribution
+
+Issue #261's Definition of Done lists "daemon IC store split into
+`~/.kolt/daemon/ic/<version>/<projectId>/<profile>/`". The directory
+`~/.kolt/daemon/ic/` is owned exclusively by the JVM compiler daemon
+(ADR 0019 §5; `IcStateLayout.workingDirFor`); JVM is declared no-op
+under this profile feature, so partitioning that path by profile would
+either contradict Requirement 3.3 or apply only to a hypothetical
+future Native daemon IC store.
+
+The shipped schema:
+
+- **JVM daemon IC**: `~/.kolt/daemon/ic/<kotlinVersion>/<projectIdHash>/`
+  — unchanged. JVM no-op (Requirement 3.3).
+- **Native local IC**: `build/<profile>/.ic-cache` — new partition.
+  Project-local, not daemon-managed.
+
+The Native daemon (`kolt-native-compiler-daemon`) does not own a
+project-local IC store today; the konanc IC cache is the project-local
+`build/<profile>/.ic-cache` directory passed via
+`-Xic-cache-dir=...` in the link-stage args. There is therefore no
+"daemon IC store" on the Native side to partition.
+
+### §6 No migration shim
+
+Pre-v1 policy applies. The release note for the version that ships this
+ADR states `rm -rf build/` is the cleanup path for stale `build/.ic-cache`
+content from earlier kolt versions. `~/.kolt/daemon/ic/` is unchanged,
+so no daemon-side cleanup is needed.
+
+If a downstream tool started writing into `build/.ic-cache` directly
+(no kolt does), it would not coordinate with the new partition; this is
+acceptable under the same pre-v1 policy and the lock contract from
+ADR 0029 §6 applies the same way it did before.
+
+### Consequences
+
+**Positive**
+
+- Daily Native iteration skips `-opt` link time by default.
+- Distribution binaries are unambiguously release-built; the
+  `curl | sh` installer (#230) can ship optimized artifacts without an
+  out-of-band convention.
+- JVM observable behaviour is unchanged; users who never touch
+  `--release` see no diff.
+- Profile literals (`debug` / `release`) are anchored in `Profile.kt`;
+  drift against `assemble-dist.sh` is caught by `DriftGuardsTest`.
+
+**Negative**
+
+- A switch between profiles writes a fresh `build/<profile>/` tree;
+  users that flip profiles often will notice double the on-disk
+  footprint. Pre-v1 policy: documented, not migrated.
+- `~/.kolt/daemon/ic/` JVM IC state from before this ADR is
+  unchanged but the project-local `build/.ic-cache` from before this
+  ADR is orphaned. Documented in the release note.
+- No `kolt.toml [profile.*]` configuration; advanced users who want
+  per-profile compiler arg overrides have to wait for `extra_compiler_args`
+  (separate issue).
+
+### Confirmation
+
+- `Profile` enum is defined in
+  `src/nativeMain/kotlin/kolt/build/Profile.kt`. Unit tests in
+  `ProfileTest.kt` pin `dirName` mappings.
+- `BuilderTest`, `RunnerTest`, `TestBuilderTest`, and
+  `RuntimeClasspathManifestTest` pin profile-aware path strings and the
+  `-opt` / `-g` routing.
+- `DriftGuardsTest.profileLiteralsAndDistScriptAreInSync` pins the
+  cross-file invariant for `assemble-dist.sh`.
+- `BuildProfileIT` (env-gated `KOLT_PROFILE_IT=1`) drives end-to-end
+  alternation and the JVM no-op byte-equality check; the path-layer
+  cases run unconditionally.
+- `IcStateCleanupTest.WipeNativeIcCacheTest` pins per-profile wipe
+  isolation (`Profile.Debug` wipe leaves `Profile.Release` untouched
+  and vice versa).
+- `Profile` is declared with default (public) visibility rather than
+  the `internal` modifier the design draft suggested. The reason is
+  mechanical: existing public top-level functions (`runCommand`,
+  `nativeRunCommand`, `nativeTestRunCommand`, `testBuildCommand`)
+  take `Profile` as a parameter, and Kotlin rejects an internal type
+  on a public signature. There is no external module consuming
+  `kolt.build.Profile` today (the JVM and native compiler daemons are
+  separate Gradle builds with their own classpaths), so the public
+  visibility carries no actual API surface beyond the linuxX64
+  binary.
+
+## Alternatives considered
+
+1. **`BuildPaths` value class consolidating all per-profile paths.**
+   Rejected. The layout is small (six members) and pre-v1 prefers
+   reversible changes; adding a new abstraction before macOS / linuxArm64
+   forks the layout (#82 / #83) would commit to a shape we have not
+   measured. The current approach (Profile threaded through existing path
+   functions) is a strict subset of what `BuildPaths` would do.
+2. **`Profile` rides on the daemon wire protocol (`Compile` /
+   `NativeCompile` messages).** Rejected. Native already embeds the IC
+   path in konanc args (`-Xic-cache-dir=...`); JVM is no-op so the wire
+   has nothing to carry. Adding a field to a wire protocol that no
+   recipient uses is a future-cost without a present benefit.
+3. **`kolt.toml [profile.dev]` / `[profile.release]` configuration.**
+   Rejected. Cargo's UX is "the flag is the source of truth"; profiles
+   are CLI-only by design. A future per-profile compiler-arg override
+   feature would land in its own ADR with explicit precedence rules.
+4. **Hidden default of `-opt` even without `--release` (matches
+   issue #261's mistaken Problem section claim).** Rejected. Survey of
+   `Builder.nativeLinkCommand` confirmed konanc was being invoked
+   without `-opt`; there was no hidden default to preserve. The chosen
+   policy makes the optimization opt-in explicit.
+5. **`build/.ic-cache/<profile>/` instead of
+   `build/<profile>/.ic-cache`.** Rejected. The latter aligns with the
+   artifact path partition: `rm -rf build/release/` cleans both
+   release artifact and release IC together. The former mixes concerns
+   under a shared root.
+
+## Related
+
+- #261 — tracking issue.
+- ADR 0001 — `Result<V, E>` discipline; profile parsing is total so
+  this ADR introduces no new error envelope.
+- ADR 0014 — Native two-stage compile. The library stage stays
+  profile-agnostic (klibs are intermediate); only the link stage
+  routes `-opt` and `-g`.
+- ADR 0019 §5 — JVM daemon IC store (`IcStateLayout.workingDirFor`).
+  This ADR explicitly does not change that path.
+- ADR 0023 §1 — kind schema. Library kind stops at stage 1 regardless
+  of profile; the artifact path still partitions per profile.
+- ADR 0027 §1 — runtime classpath manifest. The manifest now lives at
+  `build/<profile>/<name>-runtime.classpath`.
+- README.md / README.ja.md / `.kiro/steering/tech.md` /
+  `.claude/skills/kolt-usage/SKILL.md` — user-visible surface updated
+  in lockstep with this ADR.

--- a/scripts/assemble-dist.sh
+++ b/scripts/assemble-dist.sh
@@ -117,7 +117,7 @@ for project in "." "kolt-jvm-compiler-daemon" "kolt-native-compiler-daemon"; do
   echo "assemble-dist: building $project"
   (
     cd "$project"
-    "$KOLT" build
+    "$KOLT" build --release
   )
 done
 
@@ -212,10 +212,11 @@ write_argfile() {
 # clean-slate idempotency).
 mkdir -p "$DIST_ROOT/bin" "$DIST_ROOT/libexec/classpath"
 
-# `bin/kolt` is the kolt.kexe produced by the root `kolt build` above
-# (self-hosted). `KOLT` (used to drive the three builds) may point at the
-# Gradle-built binary; `./build/kolt.kexe` is always the self-host output.
-ROOT_KEXE="$ROOT_DIR/build/kolt.kexe"
+# `bin/kolt` is the kolt.kexe produced by the root `kolt build --release`
+# above (self-hosted). `KOLT` (used to drive the three builds) may point at
+# the Gradle-built binary; `./build/release/kolt.kexe` is always the
+# self-host release-profile output.
+ROOT_KEXE="$ROOT_DIR/build/release/kolt.kexe"
 if [[ ! -x "$ROOT_KEXE" ]]; then
   echo "assemble-dist: root kolt.kexe not found at $ROOT_KEXE" >&2
   exit 1
@@ -225,8 +226,8 @@ chmod +x "$DIST_ROOT/bin/kolt"
 
 for entry in "${DAEMONS[@]}"; do
   IFS=':' read -r daemon main_class <<< "$entry"
-  daemon_jar="$ROOT_DIR/$daemon/build/${daemon}.jar"
-  manifest="$ROOT_DIR/$daemon/build/${daemon}-runtime.classpath"
+  daemon_jar="$ROOT_DIR/$daemon/build/release/${daemon}.jar"
+  manifest="$ROOT_DIR/$daemon/build/release/${daemon}-runtime.classpath"
   if [[ ! -f "$daemon_jar" ]]; then
     echo "assemble-dist: missing daemon jar: $daemon_jar" >&2
     exit 1

--- a/src/nativeMain/kotlin/kolt/build/Builder.kt
+++ b/src/nativeMain/kotlin/kolt/build/Builder.kt
@@ -7,6 +7,7 @@ import com.github.michaelbull.result.getOrElse
 import kolt.config.CinteropConfig
 import kolt.config.KoltConfig
 import kolt.config.konanTargetGradleName
+import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.writeFileAsString
 
 internal const val BUILD_DIR = "build"
@@ -15,12 +16,17 @@ internal const val CLASSES_DIR = "$BUILD_DIR/classes"
 // Native IC cache. Wiped by `kolt clean` (it lives under BUILD_DIR).
 // Spike #160: touch/abi-neutral wall-time -30–39% at 25–50 files; cold
 // builds also speed up from konanc's IC strategy. Issue #168.
-internal const val NATIVE_IC_CACHE_DIR = "$BUILD_DIR/.ic-cache"
+internal fun nativeIcCacheDir(profile: Profile): String = "$BUILD_DIR/${profile.dirName}/.ic-cache"
 
-internal fun outputJarPath(config: KoltConfig): String = "$BUILD_DIR/${config.name}.jar"
+private fun profileDir(profile: Profile): String = "$BUILD_DIR/${profile.dirName}"
 
-internal fun outputRuntimeClasspathPath(config: KoltConfig): String =
-  "$BUILD_DIR/${config.name}-runtime.classpath"
+internal fun outputJarPath(config: KoltConfig, profile: Profile = Profile.Debug): String =
+  "${profileDir(profile)}/${config.name}.jar"
+
+internal fun outputRuntimeClasspathPath(
+  config: KoltConfig,
+  profile: Profile = Profile.Debug,
+): String = "${profileDir(profile)}/${config.name}-runtime.classpath"
 
 // A resolved JVM dependency jar, kept as a pair of (a) absolute cache path and
 // (b) full GAV coordinate for the tiebreak rule in ADR 0027 §1 ("alphabetical
@@ -38,14 +44,18 @@ internal sealed class ManifestWriteError {
 internal fun writeRuntimeClasspathManifest(
   config: KoltConfig,
   resolvedJars: List<ResolvedJar>,
+  profile: Profile = Profile.Debug,
 ): Result<Unit, ManifestWriteError> {
-  val selfJarPath = outputJarPath(config)
+  val selfJarPath = outputJarPath(config, profile)
   val sorted =
     resolvedJars
       .filter { it.cachePath != selfJarPath }
       .sortedWith(compareBy({ fileName(it.cachePath) }, { it.groupArtifactVersion }))
   val content = sorted.joinToString("\n") { it.cachePath }
-  val path = outputRuntimeClasspathPath(config)
+  val path = outputRuntimeClasspathPath(config, profile)
+  ensureDirectoryRecursive(profileDir(profile)).getOrElse { error ->
+    return Err(ManifestWriteError.WriteFailed(path = error.path, reason = "mkdir failed"))
+  }
   writeFileAsString(path, content).getOrElse { error ->
     return Err(ManifestWriteError.WriteFailed(path = error.path, reason = "write failed"))
   }
@@ -57,15 +67,21 @@ private fun fileName(path: String): String {
   return if (slash < 0) path else path.substring(slash + 1)
 }
 
-internal fun outputKexePath(config: KoltConfig): String = "$BUILD_DIR/${config.name}.kexe"
+internal fun outputKexePath(config: KoltConfig, profile: Profile = Profile.Debug): String =
+  "${profileDir(profile)}/${config.name}.kexe"
 
-internal fun outputNativeTestKexePath(config: KoltConfig): String =
-  "$BUILD_DIR/${config.name}-test.kexe"
+internal fun outputNativeTestKexePath(
+  config: KoltConfig,
+  profile: Profile = Profile.Debug,
+): String = "${profileDir(profile)}/${config.name}-test.kexe"
 
-internal fun outputNativeKlibPath(config: KoltConfig): String = "$BUILD_DIR/${config.name}-klib"
+internal fun outputNativeKlibPath(config: KoltConfig, profile: Profile = Profile.Debug): String =
+  "${profileDir(profile)}/${config.name}-klib"
 
-internal fun outputNativeTestKlibPath(config: KoltConfig): String =
-  "$BUILD_DIR/${config.name}-test-klib"
+internal fun outputNativeTestKlibPath(
+  config: KoltConfig,
+  profile: Profile = Profile.Debug,
+): String = "${profileDir(profile)}/${config.name}-test-klib"
 
 data class BuildCommand(val args: List<String>, val outputPath: String)
 
@@ -106,13 +122,14 @@ fun checkCommand(
 
 // Two-stage build: konanc silently no-ops compiler plugins on single-step
 // `-p program`, so Stage 1 compiles into a klib (plugin applied), Stage 2 links.
-fun nativeLibraryCommand(
+internal fun nativeLibraryCommand(
   config: KoltConfig,
   pluginArgs: List<String> = emptyList(),
   konancPath: String? = null,
   klibs: List<String> = emptyList(),
+  profile: Profile = Profile.Debug,
 ): BuildCommand {
-  val outputBase = outputNativeKlibPath(config)
+  val outputBase = outputNativeKlibPath(config, profile)
   val nativeTarget = konanTargetGradleName(config.build.target)
   val args = buildList {
     add(konancPath ?: "konanc")
@@ -137,15 +154,16 @@ fun nativeLibraryCommand(
 // `main` is passed explicitly (not read from `config.build.main`) because
 // `BuildSection.main` became nullable in the lib-build-pipeline spec; the
 // kind gate and null-check live at the caller per ADR 0001.
-fun nativeLinkCommand(
+internal fun nativeLinkCommand(
   config: KoltConfig,
   main: String,
   konancPath: String? = null,
   klibs: List<String> = emptyList(),
+  profile: Profile = Profile.Debug,
 ): BuildCommand {
-  val outputPath = outputKexePath(config)
-  val outputBase = "$BUILD_DIR/${config.name}"
-  val klibPath = outputNativeKlibPath(config)
+  val outputPath = outputKexePath(config, profile)
+  val outputBase = "${profileDir(profile)}/${config.name}"
+  val klibPath = outputNativeKlibPath(config, profile)
   val nativeTarget = konanTargetGradleName(config.build.target)
   val args = buildList {
     add(konancPath ?: "konanc")
@@ -159,22 +177,27 @@ fun nativeLinkCommand(
       add("-l")
       add(klib)
     }
+    when (profile) {
+      Profile.Debug -> add("-g")
+      Profile.Release -> add("-opt")
+    }
     add("-Xinclude=$klibPath")
     add("-Xenable-incremental-compilation")
-    add("-Xic-cache-dir=$NATIVE_IC_CACHE_DIR")
+    add("-Xic-cache-dir=${nativeIcCacheDir(profile)}")
     add("-o")
     add(outputBase)
   }
   return BuildCommand(args = args, outputPath = outputPath)
 }
 
-fun nativeTestLibraryCommand(
+internal fun nativeTestLibraryCommand(
   config: KoltConfig,
   pluginArgs: List<String> = emptyList(),
   konancPath: String? = null,
   klibs: List<String> = emptyList(),
+  profile: Profile = Profile.Debug,
 ): BuildCommand {
-  val outputBase = outputNativeTestKlibPath(config)
+  val outputBase = outputNativeTestKlibPath(config, profile)
   val nativeTarget = konanTargetGradleName(config.build.target)
   val args = buildList {
     add(konancPath ?: "konanc")
@@ -197,14 +220,15 @@ fun nativeTestLibraryCommand(
   return BuildCommand(args = args, outputPath = outputBase)
 }
 
-fun nativeTestLinkCommand(
+internal fun nativeTestLinkCommand(
   config: KoltConfig,
   konancPath: String? = null,
   klibs: List<String> = emptyList(),
+  profile: Profile = Profile.Debug,
 ): BuildCommand {
-  val outputPath = outputNativeTestKexePath(config)
-  val outputBase = "$BUILD_DIR/${config.name}-test"
-  val klibPath = outputNativeTestKlibPath(config)
+  val outputPath = outputNativeTestKexePath(config, profile)
+  val outputBase = "${profileDir(profile)}/${config.name}-test"
+  val klibPath = outputNativeTestKlibPath(config, profile)
   val nativeTarget = konanTargetGradleName(config.build.target)
   val args = buildList {
     add(konancPath ?: "konanc")
@@ -216,6 +240,10 @@ fun nativeTestLinkCommand(
     for (klib in klibs) {
       add("-l")
       add(klib)
+    }
+    when (profile) {
+      Profile.Debug -> add("-g")
+      Profile.Release -> add("-opt")
     }
     add("-Xinclude=$klibPath")
     add("-o")
@@ -264,8 +292,12 @@ fun cinteropStamp(entry: CinteropConfig, defMtime: Long, kotlinVersion: String):
     append("package=").append(entry.packageName ?: "").append('\n')
   }
 
-fun jarCommand(config: KoltConfig, jarPath: String? = null): BuildCommand {
-  val outputPath = outputJarPath(config)
+internal fun jarCommand(
+  config: KoltConfig,
+  jarPath: String? = null,
+  profile: Profile = Profile.Debug,
+): BuildCommand {
+  val outputPath = outputJarPath(config, profile)
   return BuildCommand(
     args = listOf(jarPath ?: "jar", "cf", outputPath, "-C", CLASSES_DIR, "."),
     outputPath = outputPath,

--- a/src/nativeMain/kotlin/kolt/build/Profile.kt
+++ b/src/nativeMain/kotlin/kolt/build/Profile.kt
@@ -1,0 +1,6 @@
+package kolt.build
+
+enum class Profile(val dirName: String) {
+  Debug(dirName = "debug"),
+  Release(dirName = "release"),
+}

--- a/src/nativeMain/kotlin/kolt/build/Runner.kt
+++ b/src/nativeMain/kotlin/kolt/build/Runner.kt
@@ -14,13 +14,20 @@ fun runCommand(
   classpath: String? = null,
   appArgs: List<String> = emptyList(),
   javaPath: String? = null,
+  @Suppress("UNUSED_PARAMETER") profile: Profile = Profile.Debug,
 ): RunCommand {
   val cp = if (!classpath.isNullOrEmpty()) "$CLASSES_DIR:$classpath" else CLASSES_DIR
   return RunCommand(args = listOf(javaPath ?: "java", "-cp", cp, jvmMainClass(main)) + appArgs)
 }
 
-fun nativeRunCommand(config: KoltConfig, appArgs: List<String> = emptyList()): RunCommand =
-  RunCommand(args = listOf(outputKexePath(config)) + appArgs)
+fun nativeRunCommand(
+  config: KoltConfig,
+  appArgs: List<String> = emptyList(),
+  profile: Profile = Profile.Debug,
+): RunCommand = RunCommand(args = listOf(outputKexePath(config, profile)) + appArgs)
 
-fun nativeTestRunCommand(config: KoltConfig, testArgs: List<String> = emptyList()): RunCommand =
-  RunCommand(args = listOf(outputNativeTestKexePath(config)) + testArgs)
+fun nativeTestRunCommand(
+  config: KoltConfig,
+  testArgs: List<String> = emptyList(),
+  profile: Profile = Profile.Debug,
+): RunCommand = RunCommand(args = listOf(outputNativeTestKexePath(config, profile)) + testArgs)

--- a/src/nativeMain/kotlin/kolt/build/TestBuilder.kt
+++ b/src/nativeMain/kotlin/kolt/build/TestBuilder.kt
@@ -12,6 +12,7 @@ fun testBuildCommand(
   classpath: String? = null,
   pluginArgs: List<String> = emptyList(),
   kotlincPath: String? = null,
+  @Suppress("UNUSED_PARAMETER") profile: Profile = Profile.Debug,
 ): TestBuildCommand {
   val cp =
     buildList {

--- a/src/nativeMain/kotlin/kolt/build/daemon/IcStateCleanup.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/IcStateCleanup.kt
@@ -3,9 +3,13 @@ package kolt.build.daemon
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
+import kolt.build.Profile
+import kolt.build.nativeIcCacheDir
 import kolt.config.KoltPaths
 import kolt.infra.RemoveFailed
+import kolt.infra.eprintln
 import kolt.infra.fileExists
 import kolt.infra.listSubdirectories
 import kolt.infra.removeDirectoryRecursive
@@ -43,4 +47,18 @@ internal fun cleanDaemonIcStateForProject(
     }
   }
   return Ok(Unit)
+}
+
+// Wipes the project-local Native incremental-compile cache for the given
+// profile only; the inactive profile's cache is preserved. Used by the
+// link-stage retry path when konanc returns a non-zero exit code (which
+// can be cache corruption indistinguishable from a real source error).
+internal fun wipeNativeIcCache(profile: Profile): Boolean {
+  val cacheDir = nativeIcCacheDir(profile)
+  if (!fileExists(cacheDir)) return true
+  val result = removeDirectoryRecursive(cacheDir)
+  if (result.isOk) return true
+  val error = result.getError()!!
+  eprintln("warning: could not remove ${error.path}")
+  return false
 }

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -13,6 +13,7 @@ import kolt.build.daemon.DaemonSetup
 import kolt.build.daemon.cleanDaemonIcStateForProject
 import kolt.build.daemon.formatDaemonPreconditionWarning
 import kolt.build.daemon.resolveDaemonPreconditions
+import kolt.build.daemon.wipeNativeIcCache
 import kolt.build.nativedaemon.NativeDaemonBackend
 import kolt.build.nativedaemon.NativeDaemonPreconditionError
 import kolt.build.nativedaemon.NativeDaemonSetup
@@ -53,12 +54,13 @@ internal data class BuildResult(
 internal fun handleRuntimeClasspathManifest(
   config: KoltConfig,
   resolvedJars: List<ResolvedJar>,
+  profile: Profile = Profile.Debug,
 ): Result<Unit, ManifestWriteError> {
   val shouldEmit = config.build.target == "jvm" && !config.isLibrary()
   if (shouldEmit) {
-    return writeRuntimeClasspathManifest(config, resolvedJars)
+    return writeRuntimeClasspathManifest(config, resolvedJars, profile)
   }
-  val manifestPath = outputRuntimeClasspathPath(config)
+  val manifestPath = outputRuntimeClasspathPath(config, profile)
   if (fileExists(manifestPath)) deleteFile(manifestPath)
   return Ok(Unit)
 }
@@ -75,13 +77,16 @@ internal data class NativeStagePlan(
 // ADR 0023 §1: library kind has no entry point; app kind must carry one
 // (parser invariant). The `?: return` keeps ADR 0001 safe without `!!`;
 // it is unreachable for apps produced by `parseConfig`.
-internal fun nativeStagePlan(config: KoltConfig): Result<NativeStagePlan, Int> {
+internal fun nativeStagePlan(
+  config: KoltConfig,
+  profile: Profile = Profile.Debug,
+): Result<NativeStagePlan, Int> {
   if (config.isLibrary()) {
     return Ok(
       NativeStagePlan(
         linkMain = null,
         artifactKind = "library",
-        artifactPath = outputNativeKlibPath(config),
+        artifactPath = outputNativeKlibPath(config, profile),
       )
     )
   }
@@ -90,7 +95,7 @@ internal fun nativeStagePlan(config: KoltConfig): Result<NativeStagePlan, Int> {
     NativeStagePlan(
       linkMain = main,
       artifactKind = "executable",
-      artifactPath = outputKexePath(config),
+      artifactPath = outputKexePath(config, profile),
     )
   )
 }
@@ -124,11 +129,12 @@ internal fun loadProjectConfig(): Result<KoltConfig, Int> {
     .let { Ok(it) }
 }
 
-internal fun doCheck(useDaemon: Boolean = true): Result<Unit, Int> = withProjectLock {
-  doCheckInner(useDaemon)
-}
+internal fun doCheck(
+  useDaemon: Boolean = true,
+  profile: Profile = Profile.Debug,
+): Result<Unit, Int> = withProjectLock { doCheckInner(useDaemon, profile) }
 
-private fun doCheckInner(useDaemon: Boolean): Result<Unit, Int> {
+private fun doCheckInner(useDaemon: Boolean, profile: Profile): Result<Unit, Int> {
   val startMark = TimeSource.Monotonic.markNow()
   val config =
     loadProjectConfig().getOrElse {
@@ -137,7 +143,7 @@ private fun doCheckInner(useDaemon: Boolean): Result<Unit, Int> {
   // konanc has no syntax-only mode; a full build is the only option.
   // doBuildInner skips the outer lock acquire — doCheck already holds it.
   if (config.build.target in NATIVE_TARGETS) {
-    doBuildInner(useDaemon = useDaemon).getOrElse {
+    doBuildInner(useDaemon = useDaemon, profile = profile).getOrElse {
       return Err(it)
     }
     return Ok(Unit)
@@ -203,11 +209,12 @@ internal fun doClean(): Result<Unit, Int> {
   return Ok(Unit)
 }
 
-internal fun doBuild(useDaemon: Boolean = true): Result<BuildResult, Int> = withProjectLock {
-  doBuildInner(useDaemon)
-}
+internal fun doBuild(
+  useDaemon: Boolean = true,
+  profile: Profile = Profile.Debug,
+): Result<BuildResult, Int> = withProjectLock { doBuildInner(useDaemon, profile) }
 
-private fun doBuildInner(useDaemon: Boolean): Result<BuildResult, Int> {
+private fun doBuildInner(useDaemon: Boolean, profile: Profile): Result<BuildResult, Int> {
   val startMark = TimeSource.Monotonic.markNow()
   val config =
     loadProjectConfig().getOrElse {
@@ -215,7 +222,7 @@ private fun doBuildInner(useDaemon: Boolean): Result<BuildResult, Int> {
     }
 
   if (config.build.target in NATIVE_TARGETS) {
-    return doNativeBuildInner(config, useDaemon)
+    return doNativeBuildInner(config, useDaemon, profile)
   }
 
   val currentState =
@@ -346,7 +353,11 @@ private fun doBuildInner(useDaemon: Boolean): Result<BuildResult, Int> {
     }
   }
 
-  val jarCmd = jarCommand(config, jarPath = managedJarBin)
+  val jarCmd = jarCommand(config, jarPath = managedJarBin, profile = profile)
+  ensureDirectoryRecursive(jarCmd.outputPath.substringBeforeLast('/')).getOrElse { error ->
+    eprintln("error: could not create directory ${error.path}")
+    return Err(EXIT_BUILD_ERROR)
+  }
   executeCommand(jarCmd.args).getOrElse { error ->
     eprintln("error: " + formatProcessError(error, "jar packaging"))
     return Err(EXIT_BUILD_ERROR)
@@ -358,7 +369,7 @@ private fun doBuildInner(useDaemon: Boolean): Result<BuildResult, Int> {
   // previous kind=app build. Manifest write failure is treated as a
   // build failure (ADR 0001: Err propagates, jar artifact is left on
   // disk mirroring the existing jarCmd failure semantics).
-  handleRuntimeClasspathManifest(config, resolutionOutcome.mainJars).getOrElse { err ->
+  handleRuntimeClasspathManifest(config, resolutionOutcome.mainJars, profile).getOrElse { err ->
     val failure = err as ManifestWriteError.WriteFailed
     eprintln(
       "error: could not write runtime classpath manifest at ${failure.path}: ${failure.reason}"
@@ -389,7 +400,11 @@ private fun doBuildInner(useDaemon: Boolean): Result<BuildResult, Int> {
   )
 }
 
-private fun doNativeBuildInner(config: KoltConfig, useDaemon: Boolean): Result<BuildResult, Int> {
+private fun doNativeBuildInner(
+  config: KoltConfig,
+  useDaemon: Boolean,
+  profile: Profile,
+): Result<BuildResult, Int> {
   val startMark = TimeSource.Monotonic.markNow()
 
   val paths =
@@ -409,7 +424,7 @@ private fun doNativeBuildInner(config: KoltConfig, useDaemon: Boolean): Result<B
   // check and the success message so lib builds don't chase a missing
   // `.kexe`.
   val stagePlan =
-    nativeStagePlan(config).getOrElse {
+    nativeStagePlan(config, profile).getOrElse {
       return Err(it)
     }
   val artifactPath = stagePlan.artifactPath
@@ -481,7 +496,12 @@ private fun doNativeBuildInner(config: KoltConfig, useDaemon: Boolean): Result<B
       pluginArgs = nativePluginArgs,
       konancPath = managedKonancBin,
       klibs = klibs,
+      profile = profile,
     )
+  ensureDirectoryRecursive(libraryCmd.outputPath.substringBeforeLast('/')).getOrElse { error ->
+    eprintln("error: could not create directory ${error.path}")
+    return Err(EXIT_BUILD_ERROR)
+  }
   println("compiling ${config.name} (native)...")
   // ADR 0024 §4: backend.compile takes konanc args *after* the binary.
   // `nativeLibraryCommand` / `nativeLinkCommand` put the binary at [0]
@@ -495,7 +515,7 @@ private fun doNativeBuildInner(config: KoltConfig, useDaemon: Boolean): Result<B
   // ADR 0014 stage 2 × ADR 0023 §1: skip the native link step for library
   // kind; stage 1 already produced the `.klib` artifact.
   if (stagePlan.linkMain != null) {
-    ensureDirectoryRecursive(NATIVE_IC_CACHE_DIR).getOrElse { error ->
+    ensureDirectoryRecursive(nativeIcCacheDir(profile)).getOrElse { error ->
       eprintln("error: could not create directory ${error.path}")
       return Err(EXIT_BUILD_ERROR)
     }
@@ -506,12 +526,14 @@ private fun doNativeBuildInner(config: KoltConfig, useDaemon: Boolean): Result<B
         main = stagePlan.linkMain,
         konancPath = managedKonancBin,
         klibs = klibs,
+        profile = profile,
       )
     println("linking ${config.name} (native)...")
-    runNativeLinkWithIcFallback(backend, linkCmd.args.drop(1)).getOrElse { error ->
-      reportNativeCompileError(error, "linking")
-      return Err(EXIT_BUILD_ERROR)
-    }
+    runNativeLinkWithIcFallback(backend, linkCmd.args.drop(1)) { wipeNativeIcCache(profile) }
+      .getOrElse { error ->
+        reportNativeCompileError(error, "linking")
+        return Err(EXIT_BUILD_ERROR)
+      }
   }
 
   if (!fileExists(artifactPath)) {
@@ -525,7 +547,7 @@ private fun doNativeBuildInner(config: KoltConfig, useDaemon: Boolean): Result<B
   // cannot pick up a mismatched artifact after a retarget. The helper
   // takes the "cleanup" arm for every non-jvm-app config and only ever
   // returns Ok, so discarding the Result here is safe by construction.
-  handleRuntimeClasspathManifest(config, emptyList())
+  handleRuntimeClasspathManifest(config, emptyList(), profile)
 
   val newState = currentState.copy(classesDirMtime = fileMtime(artifactPath))
   writeFileAsString(BUILD_STATE_FILE, serializeBuildState(newState)).getOrElse {
@@ -564,22 +586,13 @@ private fun reportNativeCompileError(error: NativeCompileError, context: String)
 internal fun runNativeLinkWithIcFallback(
   backend: NativeCompilerBackend,
   args: List<String>,
-  wipeCache: () -> Boolean = ::wipeNativeIcCache,
+  wipeCache: () -> Boolean,
 ): Result<NativeCompileOutcome, NativeCompileError> {
   val first = backend.compile(args)
   val firstError = first.getError() ?: return first
   if (firstError !is NativeCompileError.CompilationFailed) return first
   if (!wipeCache()) return first
   return backend.compile(args)
-}
-
-private fun wipeNativeIcCache(): Boolean {
-  if (!fileExists(NATIVE_IC_CACHE_DIR)) return true
-  val result = removeDirectoryRecursive(NATIVE_IC_CACHE_DIR)
-  if (result.isOk) return true
-  val error = result.getError()!!
-  eprintln("warning: could not remove ${error.path}")
-  return false
 }
 
 private fun newestDefMtime(config: KoltConfig): Long? {
@@ -646,13 +659,15 @@ internal fun doRun(
   classpath: String?,
   appArgs: List<String> = emptyList(),
   javaPath: String? = null,
-): Result<Unit, Int> = withProjectLock { doRunInner(config, classpath, appArgs, javaPath) }
+  profile: Profile = Profile.Debug,
+): Result<Unit, Int> = withProjectLock { doRunInner(config, classpath, appArgs, javaPath, profile) }
 
 private fun doRunInner(
   config: KoltConfig,
   classpath: String?,
   appArgs: List<String>,
   javaPath: String?,
+  profile: Profile,
 ): Result<Unit, Int> {
   // ADR 0023 §1 kind gate: reject libraries before any artifact lookup
   // or process launch. Target-agnostic by design (R4.3).
@@ -661,12 +676,12 @@ private fun doRunInner(
   }
 
   if (config.build.target in NATIVE_TARGETS) {
-    val kexePath = outputKexePath(config)
+    val kexePath = outputKexePath(config, profile)
     if (!fileExists(kexePath)) {
       eprintln("error: $kexePath not found. Run 'kolt build' first.")
       return Err(EXIT_BUILD_ERROR)
     }
-    val cmd = nativeRunCommand(config, appArgs)
+    val cmd = nativeRunCommand(config, appArgs, profile)
     executeCommand(cmd.args).getOrElse { error ->
       return Err(
         when (error) {
@@ -693,6 +708,7 @@ private fun doRunInner(
       classpath = classpath,
       appArgs = appArgs,
       javaPath = javaPath,
+      profile = profile,
     )
   executeCommand(cmd.args).getOrElse { error ->
     return Err(
@@ -708,21 +724,26 @@ private fun doRunInner(
 internal fun doTest(
   testArgs: List<String> = emptyList(),
   useDaemon: Boolean = true,
-): Result<Unit, Int> = withProjectLock { doTestInner(testArgs, useDaemon) }
+  profile: Profile = Profile.Debug,
+): Result<Unit, Int> = withProjectLock { doTestInner(testArgs, useDaemon, profile) }
 
-private fun doTestInner(testArgs: List<String>, useDaemon: Boolean): Result<Unit, Int> {
+private fun doTestInner(
+  testArgs: List<String>,
+  useDaemon: Boolean,
+  profile: Profile,
+): Result<Unit, Int> {
   val config =
     loadProjectConfig().getOrElse {
       return Err(it)
     }
   if (config.build.target in NATIVE_TARGETS) {
-    return doNativeTest(config, testArgs)
+    return doNativeTest(config, testArgs, profile)
   }
   // doBuildInner (not doBuild) — the outer lock acquired by doTest
   // already covers the build; calling doBuild would attempt a second
   // flock(2) acquire on a fresh OFD and deadlock against ourselves.
   val buildResult =
-    doBuildInner(useDaemon = useDaemon).getOrElse {
+    doBuildInner(useDaemon = useDaemon, profile = profile).getOrElse {
       return Err(it)
     }
   // R4.1: test compile/run classpath is main ∪ test. Fall through to the
@@ -763,7 +784,14 @@ private fun doTestInner(testArgs: List<String>, useDaemon: Boolean): Result<Unit
 
   val testConfig = config.copy(build = config.build.copy(testSources = existingTestSources))
   val testCmd =
-    testBuildCommand(testConfig, CLASSES_DIR, testClasspath, pArgs, kotlincPath = managedKotlincBin)
+    testBuildCommand(
+      testConfig,
+      CLASSES_DIR,
+      testClasspath,
+      pArgs,
+      kotlincPath = managedKotlincBin,
+      profile = profile,
+    )
   println("compiling tests...")
   executeCommand(testCmd.args).getOrElse { error ->
     eprintln("error: " + formatProcessError(error, "test compilation"))
@@ -797,7 +825,11 @@ private fun doTestInner(testArgs: List<String>, useDaemon: Boolean): Result<Unit
   return Ok(Unit)
 }
 
-private fun doNativeTest(config: KoltConfig, testArgs: List<String>): Result<Unit, Int> {
+private fun doNativeTest(
+  config: KoltConfig,
+  testArgs: List<String>,
+  profile: Profile,
+): Result<Unit, Int> {
   val existingTestSources = filterExistingDirs(config.build.testSources, "test source")
   if (existingTestSources.isEmpty()) {
     eprintln("error: no test sources found in ${config.build.testSources}")
@@ -806,7 +838,7 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>): Result<Uni
 
   val testStartMark = TimeSource.Monotonic.markNow()
   val testConfig = config.copy(build = config.build.copy(testSources = existingTestSources))
-  val testKexePath = outputNativeTestKexePath(testConfig)
+  val testKexePath = outputNativeTestKexePath(testConfig, profile)
 
   val currentState =
     TestBuildState(
@@ -862,14 +894,25 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>): Result<Uni
         pluginArgs = nativePluginArgs,
         konancPath = managedKonancBin,
         klibs = klibs,
+        profile = profile,
       )
+    ensureDirectoryRecursive(libraryCmd.outputPath.substringBeforeLast('/')).getOrElse { error ->
+      eprintln("error: could not create directory ${error.path}")
+      return Err(EXIT_BUILD_ERROR)
+    }
     println("compiling tests (native)...")
     executeCommand(libraryCmd.args).getOrElse { error ->
       eprintln("error: " + formatProcessError(error, "test compilation"))
       return Err(EXIT_BUILD_ERROR)
     }
 
-    val linkCmd = nativeTestLinkCommand(testConfig, konancPath = managedKonancBin, klibs = klibs)
+    val linkCmd =
+      nativeTestLinkCommand(
+        testConfig,
+        konancPath = managedKonancBin,
+        klibs = klibs,
+        profile = profile,
+      )
     println("linking tests (native)...")
     executeCommand(linkCmd.args).getOrElse { error ->
       eprintln("error: " + formatProcessError(error, "test linking"))
@@ -887,7 +930,7 @@ private fun doNativeTest(config: KoltConfig, testArgs: List<String>): Result<Uni
     }
   }
 
-  val runCmd = nativeTestRunCommand(testConfig, testArgs)
+  val runCmd = nativeTestRunCommand(testConfig, testArgs, profile)
   println("running tests...")
   executeCommand(runCmd.args).getOrElse { error ->
     when (error) {

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -1,6 +1,7 @@
 package kolt.cli
 
 import com.github.michaelbull.result.getOrElse
+import kolt.build.Profile
 import kolt.config.versionString
 import kolt.infra.eprintln
 import kotlin.system.exitProcess
@@ -11,14 +12,11 @@ fun main(args: Array<String>) {
     return
   }
 
-  val argList = args.toList()
-  val passthroughStart = argList.indexOf("--")
-  val koltLevel = if (passthroughStart >= 0) argList.subList(0, passthroughStart) else argList
-  val passthrough =
-    if (passthroughStart >= 0) argList.subList(passthroughStart, argList.size) else emptyList()
-  val useDaemon = !koltLevel.contains(NO_DAEMON_FLAG)
-  val watch = koltLevel.contains(WATCH_FLAG)
-  val filteredArgs = koltLevel.filter { it != NO_DAEMON_FLAG && it != WATCH_FLAG } + passthrough
+  val parsed = parseKoltArgs(args.toList())
+  val useDaemon = parsed.useDaemon
+  val watch = parsed.watch
+  val profile = parsed.profile
+  val filteredArgs = parsed.filteredArgs
   if (filteredArgs.isEmpty()) {
     printUsage()
     return
@@ -28,11 +26,11 @@ fun main(args: Array<String>) {
     "init" -> doInit(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
     "new" -> doNew(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
     "build" ->
-      if (watch) watchCommandLoop("build", useDaemon)
-      else doBuild(useDaemon = useDaemon).getOrElse { exitProcess(it) }
+      if (watch) watchCommandLoop("build", useDaemon, profile = profile)
+      else doBuild(useDaemon = useDaemon, profile = profile).getOrElse { exitProcess(it) }
     "check" ->
-      if (watch) watchCommandLoop("check", useDaemon)
-      else doCheck(useDaemon = useDaemon).getOrElse { exitProcess(it) }
+      if (watch) watchCommandLoop("check", useDaemon, profile = profile)
+      else doCheck(useDaemon = useDaemon, profile = profile).getOrElse { exitProcess(it) }
     "run" -> {
       val appArgs =
         filteredArgs.let { all ->
@@ -40,7 +38,7 @@ fun main(args: Array<String>) {
           if (sep >= 0) all.subList(sep + 1, all.size) else emptyList()
         }
       if (watch) {
-        watchRunLoop(useDaemon, appArgs)
+        watchRunLoop(useDaemon, appArgs, profile = profile)
       } else {
         // ADR 0023 §1 kind gate: reject libraries before the
         // build pipeline runs (R4.2). doRun has the same guard
@@ -48,12 +46,12 @@ fun main(args: Array<String>) {
         val parsed = loadProjectConfig().getOrElse { exitProcess(it) }
         rejectIfLibrary(parsed).getOrElse { exitProcess(it) }
         val (config, classpath, javaPath) =
-          doBuild(useDaemon = useDaemon).getOrElse { exitProcess(it) }
+          doBuild(useDaemon = useDaemon, profile = profile).getOrElse { exitProcess(it) }
         // The build lock is released between doBuild and doRun. Safe today
         // because classpath is in-memory; if doRun ever re-reads
         // build/<name>-runtime.classpath, fold the doRun acquire into
         // doBuild or hold the lock across both calls.
-        doRun(config, classpath, appArgs, javaPath).getOrElse { exitProcess(it) }
+        doRun(config, classpath, appArgs, javaPath, profile = profile).getOrElse { exitProcess(it) }
       }
     }
     "test" -> {
@@ -62,8 +60,8 @@ fun main(args: Array<String>) {
           val sep = all.indexOf("--")
           if (sep >= 0) all.subList(sep + 1, all.size) else emptyList()
         }
-      if (watch) watchCommandLoop("test", useDaemon, testArgs)
-      else doTest(testArgs, useDaemon = useDaemon).getOrElse { exitProcess(it) }
+      if (watch) watchCommandLoop("test", useDaemon, testArgs, profile = profile)
+      else doTest(testArgs, useDaemon = useDaemon, profile = profile).getOrElse { exitProcess(it) }
     }
     "fmt" -> doFmt(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
     "clean" -> doClean().getOrElse { exitProcess(it) }
@@ -86,8 +84,35 @@ fun main(args: Array<String>) {
   }
 }
 
-private const val NO_DAEMON_FLAG = "--no-daemon"
-private const val WATCH_FLAG = "--watch"
+internal const val NO_DAEMON_FLAG = "--no-daemon"
+internal const val WATCH_FLAG = "--watch"
+internal const val RELEASE_FLAG = "--release"
+
+internal data class KoltArgs(
+  val useDaemon: Boolean,
+  val watch: Boolean,
+  val profile: Profile,
+  val filteredArgs: List<String>,
+)
+
+// Splits the kolt-level flags from the subcommand and from any `--`
+// passthrough segment. The kolt-level flags (--no-daemon, --watch,
+// --release) are extracted into typed fields and stripped from
+// `filteredArgs`; the passthrough block (after `--`) is appended verbatim
+// so `kolt run -- --foo` still passes `-- --foo` to the subcommand parser.
+internal fun parseKoltArgs(argList: List<String>): KoltArgs {
+  val passthroughStart = argList.indexOf("--")
+  val koltLevel = if (passthroughStart >= 0) argList.subList(0, passthroughStart) else argList
+  val passthrough =
+    if (passthroughStart >= 0) argList.subList(passthroughStart, argList.size) else emptyList()
+  val useDaemon = !koltLevel.contains(NO_DAEMON_FLAG)
+  val watch = koltLevel.contains(WATCH_FLAG)
+  val profile = if (koltLevel.contains(RELEASE_FLAG)) Profile.Release else Profile.Debug
+  val filteredArgs =
+    koltLevel.filter { it != NO_DAEMON_FLAG && it != WATCH_FLAG && it != RELEASE_FLAG } +
+      passthrough
+  return KoltArgs(useDaemon, watch, profile, filteredArgs)
+}
 
 private fun printUsage() {
   eprintln("usage: kolt <command>")
@@ -114,4 +139,5 @@ private fun printUsage() {
   eprintln("flags:")
   eprintln("  --watch      Watch source files and re-run on change")
   eprintln("  --no-daemon  Skip the warm compiler daemon for this invocation")
+  eprintln("  --release    Build under the release profile (Native: -opt; JVM: no-op)")
 }

--- a/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
+++ b/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
@@ -3,6 +3,7 @@ package kolt.cli
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
+import kolt.build.Profile
 import kolt.build.nativeRunCommand
 import kolt.build.runCommand
 import kolt.config.KoltConfig
@@ -165,12 +166,13 @@ internal fun watchCommandLoop(
   command: String,
   useDaemon: Boolean,
   testArgs: List<String> = emptyList(),
+  profile: Profile = Profile.Debug,
   commandRunner: (String, Boolean, List<String>) -> Result<*, Int> = { cmd, daemon, args ->
     when (cmd) {
-      "build" -> doBuild(useDaemon = daemon)
-      "check" -> doCheck(useDaemon = daemon)
-      "test" -> doTest(testArgs = args, useDaemon = daemon)
-      else -> doBuild(useDaemon = daemon)
+      "build" -> doBuild(useDaemon = daemon, profile = profile)
+      "check" -> doCheck(useDaemon = daemon, profile = profile)
+      "test" -> doTest(testArgs = args, useDaemon = daemon, profile = profile)
+      else -> doBuild(useDaemon = daemon, profile = profile)
     }
   },
 ) {
@@ -275,6 +277,7 @@ private fun reapChild(pid: Int): Boolean {
 internal fun watchRunLoop(
   useDaemon: Boolean,
   appArgs: List<String> = emptyList(),
+  profile: Profile = Profile.Debug,
   eprint: (String) -> Unit = ::eprintln,
 ) {
   val config =
@@ -297,7 +300,7 @@ internal fun watchRunLoop(
 
   while (!shouldExit()) {
     val buildResult =
-      doBuild(useDaemon = useDaemon).getOrElse {
+      doBuild(useDaemon = useDaemon, profile = profile).getOrElse {
         eprintln("build failed, waiting for changes...")
         waitForRelevantChange(watcher, wdKinds)
         continue
@@ -305,7 +308,7 @@ internal fun watchRunLoop(
 
     val runCmd =
       if (buildResult.config.build.target in NATIVE_TARGETS) {
-        nativeRunCommand(buildResult.config, appArgs)
+        nativeRunCommand(buildResult.config, appArgs, profile)
       } else {
         // Parser invariant `kind == "app" ⇒ main != null` guarantees
         // non-null; the lib kind gate at loop entry pre-empts libraries,
@@ -323,6 +326,7 @@ internal fun watchRunLoop(
           classpath = buildResult.classpath,
           appArgs = appArgs,
           javaPath = buildResult.javaPath,
+          profile = profile,
         )
       }
     val childPid = spawnInProcessGroup(runCmd.args)

--- a/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/BuilderTest.kt
@@ -78,16 +78,22 @@ class BuilderTest {
   fun jarCommandPackagesClassesDirToJar() {
     val cmd = jarCommand(testConfig())
 
-    assertEquals(listOf("jar", "cf", "build/my-app.jar", "-C", "build/classes", "."), cmd.args)
-    assertEquals("build/my-app.jar", cmd.outputPath)
+    assertEquals(
+      listOf("jar", "cf", "build/debug/my-app.jar", "-C", "build/classes", "."),
+      cmd.args,
+    )
+    assertEquals("build/debug/my-app.jar", cmd.outputPath)
   }
 
   @Test
   fun jarCommandOutputPathUsesProjectName() {
     val cmd = jarCommand(testConfig(name = "hello-world"))
 
-    assertEquals("build/hello-world.jar", cmd.outputPath)
-    assertEquals(listOf("jar", "cf", "build/hello-world.jar", "-C", "build/classes", "."), cmd.args)
+    assertEquals("build/debug/hello-world.jar", cmd.outputPath)
+    assertEquals(
+      listOf("jar", "cf", "build/debug/hello-world.jar", "-C", "build/classes", "."),
+      cmd.args,
+    )
   }
 
   @Test
@@ -106,7 +112,7 @@ class BuilderTest {
     val cmd = jarCommand(testConfig(), jarPath = managedJarBin)
 
     assertEquals(
-      listOf(managedJarBin, "cf", "build/my-app.jar", "-C", "build/classes", "."),
+      listOf(managedJarBin, "cf", "build/debug/my-app.jar", "-C", "build/classes", "."),
       cmd.args,
     )
   }
@@ -132,11 +138,11 @@ class BuilderTest {
         "library",
         "-nopack",
         "-o",
-        "build/my-app-klib",
+        "build/debug/my-app-klib",
       ),
       cmd.args,
     )
-    assertEquals("build/my-app-klib", cmd.outputPath)
+    assertEquals("build/debug/my-app-klib", cmd.outputPath)
   }
 
   @Test
@@ -155,7 +161,7 @@ class BuilderTest {
         "library",
         "-nopack",
         "-o",
-        "build/my-app-klib",
+        "build/debug/my-app-klib",
       ),
       cmd.args,
     )
@@ -165,7 +171,7 @@ class BuilderTest {
   fun nativeLibraryCommandWithProjectName() {
     val cmd = nativeLibraryCommand(testConfig(name = "hello", target = "linuxX64"))
 
-    assertEquals("build/hello-klib", cmd.outputPath)
+    assertEquals("build/debug/hello-klib", cmd.outputPath)
     assertEquals(
       listOf(
         "konanc",
@@ -176,7 +182,7 @@ class BuilderTest {
         "library",
         "-nopack",
         "-o",
-        "build/hello-klib",
+        "build/debug/hello-klib",
       ),
       cmd.args,
     )
@@ -205,7 +211,7 @@ class BuilderTest {
         "library",
         "-nopack",
         "-o",
-        "build/my-app-klib",
+        "build/debug/my-app-klib",
         "-Xplugin=foo.jar",
       ),
       cmd.args,
@@ -236,7 +242,7 @@ class BuilderTest {
         "-l",
         "/cache/c.klib",
         "-o",
-        "build/my-app-klib",
+        "build/debug/my-app-klib",
       ),
       cmd.args,
     )
@@ -262,15 +268,16 @@ class BuilderTest {
         "program",
         "-e",
         "com.example.main",
-        "-Xinclude=build/my-app-klib",
+        "-g",
+        "-Xinclude=build/debug/my-app-klib",
         "-Xenable-incremental-compilation",
-        "-Xic-cache-dir=build/.ic-cache",
+        "-Xic-cache-dir=build/debug/.ic-cache",
         "-o",
-        "build/my-app",
+        "build/debug/my-app",
       ),
       cmd.args,
     )
-    assertEquals("build/my-app.kexe", cmd.outputPath)
+    assertEquals("build/debug/my-app.kexe", cmd.outputPath)
   }
 
   @Test
@@ -278,7 +285,7 @@ class BuilderTest {
     val cmd =
       nativeLinkCommand(testConfig(name = "hello", target = "linuxX64"), main = "com.example.main")
 
-    assertEquals("build/hello.kexe", cmd.outputPath)
+    assertEquals("build/debug/hello.kexe", cmd.outputPath)
     assertEquals(
       listOf(
         "konanc",
@@ -288,11 +295,12 @@ class BuilderTest {
         "program",
         "-e",
         "com.example.main",
-        "-Xinclude=build/hello-klib",
+        "-g",
+        "-Xinclude=build/debug/hello-klib",
         "-Xenable-incremental-compilation",
-        "-Xic-cache-dir=build/.ic-cache",
+        "-Xic-cache-dir=build/debug/.ic-cache",
         "-o",
-        "build/hello",
+        "build/debug/hello",
       ),
       cmd.args,
     )
@@ -337,11 +345,12 @@ class BuilderTest {
         "/cache/a.klib",
         "-l",
         "/cache/b.klib",
-        "-Xinclude=build/my-app-klib",
+        "-g",
+        "-Xinclude=build/debug/my-app-klib",
         "-Xenable-incremental-compilation",
-        "-Xic-cache-dir=build/.ic-cache",
+        "-Xic-cache-dir=build/debug/.ic-cache",
         "-o",
-        "build/my-app",
+        "build/debug/my-app",
       ),
       cmd.args,
     )
@@ -396,11 +405,11 @@ class BuilderTest {
         "library",
         "-nopack",
         "-o",
-        "build/my-app-test-klib",
+        "build/debug/my-app-test-klib",
       ),
       cmd.args,
     )
-    assertEquals("build/my-app-test-klib", cmd.outputPath)
+    assertEquals("build/debug/my-app-test-klib", cmd.outputPath)
   }
 
   @Test
@@ -427,7 +436,7 @@ class BuilderTest {
         "library",
         "-nopack",
         "-o",
-        "build/my-app-test-klib",
+        "build/debug/my-app-test-klib",
       ),
       cmd.args,
     )
@@ -452,7 +461,7 @@ class BuilderTest {
         "library",
         "-nopack",
         "-o",
-        "build/my-app-test-klib",
+        "build/debug/my-app-test-klib",
         "-Xplugin=foo.jar",
         "-Xplugin=bar.jar",
       ),
@@ -483,7 +492,7 @@ class BuilderTest {
         "-l",
         "/cache/b.klib",
         "-o",
-        "build/my-app-test-klib",
+        "build/debug/my-app-test-klib",
       ),
       cmd.args,
     )
@@ -509,13 +518,14 @@ class BuilderTest {
         "-p",
         "program",
         "-generate-test-runner",
-        "-Xinclude=build/my-app-test-klib",
+        "-g",
+        "-Xinclude=build/debug/my-app-test-klib",
         "-o",
-        "build/my-app-test",
+        "build/debug/my-app-test",
       ),
       cmd.args,
     )
-    assertEquals("build/my-app-test.kexe", cmd.outputPath)
+    assertEquals("build/debug/my-app-test.kexe", cmd.outputPath)
   }
 
   @Test
@@ -529,7 +539,7 @@ class BuilderTest {
   fun nativeTestLinkCommandWithProjectName() {
     val cmd = nativeTestLinkCommand(testConfig(name = "hello", target = "linuxX64"))
 
-    assertEquals("build/hello-test.kexe", cmd.outputPath)
+    assertEquals("build/debug/hello-test.kexe", cmd.outputPath)
     assertEquals(
       listOf(
         "konanc",
@@ -538,9 +548,10 @@ class BuilderTest {
         "-p",
         "program",
         "-generate-test-runner",
-        "-Xinclude=build/hello-test-klib",
+        "-g",
+        "-Xinclude=build/debug/hello-test-klib",
         "-o",
-        "build/hello-test",
+        "build/debug/hello-test",
       ),
       cmd.args,
     )
@@ -566,9 +577,10 @@ class BuilderTest {
         "/cache/a.klib",
         "-l",
         "/cache/b.klib",
-        "-Xinclude=build/my-app-test-klib",
+        "-g",
+        "-Xinclude=build/debug/my-app-test-klib",
         "-o",
-        "build/my-app-test",
+        "build/debug/my-app-test",
       ),
       cmd.args,
     )
@@ -588,9 +600,9 @@ class BuilderTest {
 
     val cmd = jarCommand(testConfig(name = "hello-world"), jarPath = managedJarBin)
 
-    assertEquals("build/hello-world.jar", cmd.outputPath)
+    assertEquals("build/debug/hello-world.jar", cmd.outputPath)
     assertEquals(
-      listOf(managedJarBin, "cf", "build/hello-world.jar", "-C", "build/classes", "."),
+      listOf(managedJarBin, "cf", "build/debug/hello-world.jar", "-C", "build/classes", "."),
       cmd.args,
     )
   }
@@ -657,5 +669,54 @@ class BuilderTest {
 
     assertFalse(cmd.args.contains("-language-version"))
     assertFalse(cmd.args.contains("-api-version"))
+  }
+
+  @Test
+  fun nativeLinkCommandUnderReleaseAddsOptAndOmitsG() {
+    val cmd =
+      nativeLinkCommand(
+        testConfig(target = "linuxX64"),
+        main = "com.example.main",
+        profile = Profile.Release,
+      )
+
+    assertTrue(cmd.args.contains("-opt"))
+    assertFalse(cmd.args.contains("-g"))
+    assertEquals("build/release/my-app.kexe", cmd.outputPath)
+    assertTrue(cmd.args.contains("-Xinclude=build/release/my-app-klib"))
+    assertTrue(cmd.args.contains("-Xic-cache-dir=build/release/.ic-cache"))
+  }
+
+  @Test
+  fun nativeLinkCommandUnderDebugAddsGAndOmitsOpt() {
+    val cmd =
+      nativeLinkCommand(
+        testConfig(target = "linuxX64"),
+        main = "com.example.main",
+        profile = Profile.Debug,
+      )
+
+    assertTrue(cmd.args.contains("-g"))
+    assertFalse(cmd.args.contains("-opt"))
+  }
+
+  @Test
+  fun nativeLibraryCommandKeepsOptAndGOutOfArgsForBothProfiles() {
+    val debug = nativeLibraryCommand(testConfig(target = "linuxX64"), profile = Profile.Debug)
+    val release = nativeLibraryCommand(testConfig(target = "linuxX64"), profile = Profile.Release)
+
+    assertFalse(debug.args.contains("-opt"))
+    assertFalse(debug.args.contains("-g"))
+    assertFalse(release.args.contains("-opt"))
+    assertFalse(release.args.contains("-g"))
+  }
+
+  @Test
+  fun nativeTestLinkCommandUnderReleaseAddsOptAndOmitsG() {
+    val cmd = nativeTestLinkCommand(testConfig(target = "linuxX64"), profile = Profile.Release)
+
+    assertTrue(cmd.args.contains("-opt"))
+    assertFalse(cmd.args.contains("-g"))
+    assertEquals("build/release/my-app-test.kexe", cmd.outputPath)
   }
 }

--- a/src/nativeTest/kotlin/kolt/build/DriftGuardsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/DriftGuardsTest.kt
@@ -5,6 +5,7 @@ import kolt.infra.currentWorkingDirectory
 import kolt.infra.fileExists
 import kolt.infra.readFileAsString
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.fail
 
 // Test-side mirror of the Gradle `verifyDaemon*` drift guards. Migrating
@@ -81,6 +82,37 @@ class DriftGuardsTest {
         tomlPath = "$root/kolt-native-compiler-daemon/kolt.toml",
       ),
     )
+  }
+
+  // The Profile.dirName ↔ assemble-dist.sh `kolt build --release`
+  // triangle: a rename of either `dirName` literal in Profile.kt or a
+  // removal of the `--release` flag from the dist script would silently
+  // break tarball assembly (root binary at `build/release/kolt.kexe`
+  // would not exist after the build). This test pins both ends.
+  @Test
+  fun profileLiteralsAndDistScriptAreInSync() {
+    val root = projectRoot()
+    val script = "$root/scripts/assemble-dist.sh"
+    val text = readFileAsString(script).getOrElse { fail("missing $script") }
+
+    assertEquals("debug", Profile.Debug.dirName)
+    assertEquals("release", Profile.Release.dirName)
+
+    if (!text.contains("\"\$KOLT\" build --release")) {
+      fail(
+        "scripts/assemble-dist.sh must invoke \"\$KOLT\" build --release; " +
+          "Profile.Release.dirName=\"${Profile.Release.dirName}\" expects the dist " +
+          "script to opt into the release profile."
+      )
+    }
+    val expectedRootKexe = "build/${Profile.Release.dirName}/kolt.kexe"
+    if (!text.contains(expectedRootKexe)) {
+      fail(
+        "scripts/assemble-dist.sh must reference the release-profile root binary " +
+          "at \"$expectedRootKexe\"; renaming Profile.Release.dirName requires " +
+          "updating the dist script in lockstep."
+      )
+    }
   }
 
   // The triangle BOOTSTRAP_JDK_VERSION <-> daemon `kolt.toml`

--- a/src/nativeTest/kotlin/kolt/build/ProfileTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/ProfileTest.kt
@@ -1,0 +1,22 @@
+package kolt.build
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ProfileTest {
+
+  @Test
+  fun debugDirNameIsDebug() {
+    assertEquals("debug", Profile.Debug.dirName)
+  }
+
+  @Test
+  fun releaseDirNameIsRelease() {
+    assertEquals("release", Profile.Release.dirName)
+  }
+
+  @Test
+  fun profileHasExactlyTwoEntries() {
+    assertEquals(2, Profile.entries.size)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/build/RunnerTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/RunnerTest.kt
@@ -97,31 +97,31 @@ class RunnerTest {
   @Test
   fun nativeRunCommandExecutesKexeBinary() {
     val cmd = nativeRunCommand(testConfig(target = "linuxX64"))
-    assertEquals(listOf("build/my-app.kexe"), cmd.args)
+    assertEquals(listOf("build/debug/my-app.kexe"), cmd.args)
   }
 
   @Test
   fun nativeRunCommandAppendsAppArgs() {
     val cmd = nativeRunCommand(testConfig(target = "linuxX64"), listOf("--port", "8080"))
-    assertEquals(listOf("build/my-app.kexe", "--port", "8080"), cmd.args)
+    assertEquals(listOf("build/debug/my-app.kexe", "--port", "8080"), cmd.args)
   }
 
   @Test
   fun nativeRunCommandUsesProjectName() {
     val cmd = nativeRunCommand(testConfig(name = "hello", target = "linuxX64"))
-    assertEquals(listOf("build/hello.kexe"), cmd.args)
+    assertEquals(listOf("build/debug/hello.kexe"), cmd.args)
   }
 
   @Test
   fun nativeTestRunCommandExecutesTestKexeBinary() {
     val cmd = nativeTestRunCommand(testConfig(target = "linuxX64"))
-    assertEquals(listOf("build/my-app-test.kexe"), cmd.args)
+    assertEquals(listOf("build/debug/my-app-test.kexe"), cmd.args)
   }
 
   @Test
   fun nativeTestRunCommandUsesProjectName() {
     val cmd = nativeTestRunCommand(testConfig(name = "hello", target = "linuxX64"))
-    assertEquals(listOf("build/hello-test.kexe"), cmd.args)
+    assertEquals(listOf("build/debug/hello-test.kexe"), cmd.args)
   }
 
   @Test
@@ -132,7 +132,7 @@ class RunnerTest {
         testArgs = listOf("--ktest_filter=MyTest.*", "--ktest_logger=SIMPLE"),
       )
     assertEquals(
-      listOf("build/my-app-test.kexe", "--ktest_filter=MyTest.*", "--ktest_logger=SIMPLE"),
+      listOf("build/debug/my-app-test.kexe", "--ktest_filter=MyTest.*", "--ktest_logger=SIMPLE"),
       cmd.args,
     )
   }
@@ -154,5 +154,41 @@ class RunnerTest {
       listOf(managedJavaBin, "-cp", "build/classes", "com.example.MainKt", "--port", "8080"),
       cmd.args,
     )
+  }
+
+  @Test
+  fun runCommandIsByteIdenticalAcrossProfiles() {
+    val debug =
+      runCommand(
+        testConfig(),
+        main = "com.example.main",
+        classpath = "/cache/lib.jar",
+        appArgs = listOf("--flag"),
+        profile = Profile.Debug,
+      )
+    val release =
+      runCommand(
+        testConfig(),
+        main = "com.example.main",
+        classpath = "/cache/lib.jar",
+        appArgs = listOf("--flag"),
+        profile = Profile.Release,
+      )
+
+    assertEquals(debug.args, release.args)
+  }
+
+  @Test
+  fun nativeRunCommandUnderReleaseUsesReleaseKexePath() {
+    val cmd = nativeRunCommand(testConfig(target = "linuxX64"), profile = Profile.Release)
+
+    assertEquals(listOf("build/release/my-app.kexe"), cmd.args)
+  }
+
+  @Test
+  fun nativeTestRunCommandUnderReleaseUsesReleaseTestKexePath() {
+    val cmd = nativeTestRunCommand(testConfig(target = "linuxX64"), profile = Profile.Release)
+
+    assertEquals(listOf("build/release/my-app-test.kexe"), cmd.args)
   }
 }

--- a/src/nativeTest/kotlin/kolt/build/RuntimeClasspathManifestTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/RuntimeClasspathManifestTest.kt
@@ -51,9 +51,9 @@ class RuntimeClasspathManifestTest {
 
   @Test
   fun outputRuntimeClasspathPathUsesBuildDirAndProjectName() {
-    assertEquals("build/my-app-runtime.classpath", outputRuntimeClasspathPath(testConfig()))
+    assertEquals("build/debug/my-app-runtime.classpath", outputRuntimeClasspathPath(testConfig()))
     assertEquals(
-      "build/hello-world-runtime.classpath",
+      "build/debug/hello-world-runtime.classpath",
       outputRuntimeClasspathPath(testConfig(name = "hello-world")),
     )
   }

--- a/src/nativeTest/kotlin/kolt/build/TestBuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/TestBuilderTest.kt
@@ -297,4 +297,27 @@ class TestBuilderTest {
     assertEquals("2.1", cmd.args[langIdx + 1])
     assertEquals("2.1", cmd.args[apiIdx + 1])
   }
+
+  @Test
+  fun testBuildCommandIsByteIdenticalAcrossProfiles() {
+    val debug =
+      testBuildCommand(
+        config = testConfig(),
+        classesDir = "build/classes",
+        classpath = "/cache/dep.jar",
+        pluginArgs = listOf("-Xplugin=foo.jar"),
+        profile = Profile.Debug,
+      )
+    val release =
+      testBuildCommand(
+        config = testConfig(),
+        classesDir = "build/classes",
+        classpath = "/cache/dep.jar",
+        pluginArgs = listOf("-Xplugin=foo.jar"),
+        profile = Profile.Release,
+      )
+
+    assertEquals(debug.args, release.args)
+    assertEquals(debug.outputPath, release.outputPath)
+  }
 }

--- a/src/nativeTest/kotlin/kolt/build/daemon/IcStateCleanupTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/IcStateCleanupTest.kt
@@ -1,6 +1,8 @@
 package kolt.build.daemon
 
 import com.github.michaelbull.result.getError
+import kolt.build.Profile
+import kolt.build.nativeIcCacheDir
 import kolt.config.KoltPaths
 import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.fileExists
@@ -12,6 +14,17 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.chdir
+import platform.posix.getcwd
+import platform.posix.mkdtemp
 
 class IcStateCleanupTest {
   private val homeDir = "build_test_ic_cleanup_home"
@@ -63,5 +76,78 @@ class IcStateCleanupTest {
 
     assertNull(result.getError())
     assertFalse(fileExists(paths.daemonIcDir))
+  }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+class WipeNativeIcCacheTest {
+
+  private var originalCwd: String = ""
+  private var tmpDir: String = ""
+
+  @kotlin.test.BeforeTest
+  fun setUp() {
+    originalCwd = memScoped {
+      val buf = allocArray<ByteVar>(PATH_MAX)
+      getcwd(buf, PATH_MAX.toULong())?.toKString() ?: error("getcwd failed")
+    }
+    tmpDir = createTempDir("kolt-wipe-native-ic-")
+    check(chdir(tmpDir) == 0) { "chdir to $tmpDir failed" }
+  }
+
+  @AfterTest
+  fun tearDown() {
+    chdir(originalCwd)
+    if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
+      removeDirectoryRecursive(tmpDir)
+    }
+  }
+
+  @Test
+  fun wipingDebugLeavesReleaseUntouched() {
+    val debugDir = nativeIcCacheDir(Profile.Debug)
+    val releaseDir = nativeIcCacheDir(Profile.Release)
+    ensureDirectoryRecursive(debugDir)
+    ensureDirectoryRecursive(releaseDir)
+    writeFileAsString("$debugDir/marker", "debug")
+    writeFileAsString("$releaseDir/marker", "release")
+
+    val ok = wipeNativeIcCache(Profile.Debug)
+
+    assertTrue(ok, "wipe must report success")
+    assertFalse(fileExists(debugDir), "debug IC must be removed")
+    assertTrue(fileExists(releaseDir), "release IC must survive a debug wipe")
+  }
+
+  @Test
+  fun wipingReleaseLeavesDebugUntouched() {
+    val debugDir = nativeIcCacheDir(Profile.Debug)
+    val releaseDir = nativeIcCacheDir(Profile.Release)
+    ensureDirectoryRecursive(debugDir)
+    ensureDirectoryRecursive(releaseDir)
+    writeFileAsString("$debugDir/marker", "debug")
+    writeFileAsString("$releaseDir/marker", "release")
+
+    val ok = wipeNativeIcCache(Profile.Release)
+
+    assertTrue(ok)
+    assertTrue(fileExists(debugDir))
+    assertFalse(fileExists(releaseDir))
+  }
+
+  @Test
+  fun wipingNonExistentCacheIsNoOpReturnsTrue() {
+    val ok = wipeNativeIcCache(Profile.Debug)
+
+    assertTrue(ok, "missing cache must report success")
+  }
+
+  private fun createTempDir(prefix: String): String {
+    val template = "/tmp/${prefix}XXXXXX"
+    val buf = template.encodeToByteArray().copyOf(template.length + 1)
+    buf.usePinned { pinned ->
+      val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+      return result.toKString()
+    }
   }
 }

--- a/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
@@ -70,9 +70,9 @@ private val sampleArgs =
     "library",
     "-nopack",
     "-Xenable-incremental-compilation",
-    "-Xic-cache-dir=build/.ic-cache",
+    "-Xic-cache-dir=build/debug/.ic-cache",
     "-o",
-    "build/m-klib",
+    "build/debug/m-klib",
   )
 
 class NativeDaemonBackendHappyPathTest {

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsTest.kt
@@ -164,7 +164,7 @@ class CinteropNativeBuildIntegrationTest {
     val linkCmd = nativeLinkCommand(config, main = "com.example.main", klibs = listOf(klibPath))
     val linkLIdx = linkCmd.args.indexOf("-l")
     assertEquals("build/libcurl.klib", linkCmd.args[linkLIdx + 1])
-    assertEquals("build/myapp.kexe", linkCmd.outputPath)
+    assertEquals("build/debug/myapp.kexe", linkCmd.outputPath)
   }
 
   @Test
@@ -338,9 +338,10 @@ class NativeIcCacheLocationTest {
   // would silently break the "wiped by kolt clean" contract.
   @Test
   fun icCacheLivesUnderBuildDir() {
+    val cacheDir = kolt.build.nativeIcCacheDir(kolt.build.Profile.Debug)
     assertTrue(
-      kolt.build.NATIVE_IC_CACHE_DIR.startsWith("${kolt.build.BUILD_DIR}/"),
-      "NATIVE_IC_CACHE_DIR=${kolt.build.NATIVE_IC_CACHE_DIR} must live under BUILD_DIR=${kolt.build.BUILD_DIR}",
+      cacheDir.startsWith("${kolt.build.BUILD_DIR}/"),
+      "nativeIcCacheDir=$cacheDir must live under BUILD_DIR=${kolt.build.BUILD_DIR}",
     )
   }
 }

--- a/src/nativeTest/kotlin/kolt/cli/BuildLibraryTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildLibraryTest.kt
@@ -87,7 +87,7 @@ class JvmLibraryInvariantsTest {
 
     val cmd = jarCommand(libConfig)
 
-    assertEquals("build/mylib.jar", cmd.outputPath)
+    assertEquals("build/debug/mylib.jar", cmd.outputPath)
   }
 
   // R2.2: the JVM compile command for a lib config must not pass
@@ -135,7 +135,7 @@ class JvmLibraryInvariantsTest {
       "lib jar command must not declare a Main-Class attribute: ${cmd.args}",
     )
     assertEquals(
-      listOf("jar", "cf", "build/mylib.jar", "-C", "build/classes", "."),
+      listOf("jar", "cf", "build/debug/mylib.jar", "-C", "build/classes", "."),
       cmd.args,
       "lib jar command must match the thin-jar invariant shape",
     )
@@ -180,6 +180,6 @@ class JvmLibraryInvariantsTest {
       jar.args.any { it.contains("Main-Class", ignoreCase = true) },
       "app jar command must not declare a Main-Class attribute: ${jar.args}",
     )
-    assertEquals("build/myapp.jar", jar.outputPath)
+    assertEquals("build/debug/myapp.jar", jar.outputPath)
   }
 }

--- a/src/nativeTest/kotlin/kolt/cli/BuildProfileIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildProfileIT.kt
@@ -1,0 +1,334 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package kolt.cli
+
+import com.github.michaelbull.result.getOrElse
+import kolt.build.Profile
+import kolt.build.nativeIcCacheDir
+import kolt.build.outputJarPath
+import kolt.build.outputKexePath
+import kolt.infra.eprintln
+import kolt.infra.executeCommand
+import kolt.infra.fileExists
+import kolt.infra.readFileAsString
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kolt.testConfig
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.getcwd
+import platform.posix.getenv
+import platform.posix.mkdtemp
+
+// Profile alternation + JVM no-op. The path-level case in this file always
+// runs; it asserts that `Profile` threads through `outputKexePath` /
+// `outputJarPath` / `nativeIcCacheDir` to distinct directories per profile
+// so an alternation cannot silently overwrite either profile's artifact or
+// IC cache. The end-to-end alternation case is gated on KOLT_PROFILE_IT=1
+// because it shells out to a built kolt.kexe (the same gating shape as
+// ConcurrentBuildIT).
+class BuildProfileIT {
+
+  private val createdDirs = mutableListOf<String>()
+
+  @AfterTest
+  fun cleanup() {
+    for (dir in createdDirs) {
+      if (fileExists(dir)) {
+        removeDirectoryRecursive(dir)
+      }
+    }
+    createdDirs.clear()
+  }
+
+  // Req 4.3 / 5.3 path-level invariant. Output directories for each
+  // profile are disjoint, so a Debug build followed by a Release build
+  // (or vice versa) cannot overwrite the other profile's artifact or IC
+  // cache. Lives at the helper layer so it always runs in the standard
+  // suite, complementing the env-gated end-to-end case below.
+  @Test
+  fun profileAlternationDirsAreDisjointAtPathLayer() {
+    val nativeApp = testConfig(name = "alt-app", target = "linuxX64")
+    val jvmApp = testConfig(name = "alt-jvm", target = "jvm")
+
+    val debugKexe = outputKexePath(nativeApp, Profile.Debug)
+    val releaseKexe = outputKexePath(nativeApp, Profile.Release)
+    val debugJar = outputJarPath(jvmApp, Profile.Debug)
+    val releaseJar = outputJarPath(jvmApp, Profile.Release)
+    val debugIc = nativeIcCacheDir(Profile.Debug)
+    val releaseIc = nativeIcCacheDir(Profile.Release)
+
+    assertNotEquals(debugKexe, releaseKexe)
+    assertNotEquals(debugJar, releaseJar)
+    assertNotEquals(debugIc, releaseIc)
+    assertTrue(debugKexe.contains("/${Profile.Debug.dirName}/"))
+    assertTrue(releaseKexe.contains("/${Profile.Release.dirName}/"))
+    assertTrue(debugIc.contains("/${Profile.Debug.dirName}/"))
+    assertTrue(releaseIc.contains("/${Profile.Release.dirName}/"))
+  }
+
+  // Req 3.1: JVM compile invocation byte-equivalence at the path layer.
+  // The JVM jar lives under `build/<profile>/<name>.jar`, so the
+  // *outputs* differ by profile dir, but the produced compile args (the
+  // "JVM compile invocation") are the byte-identical contract. The
+  // env-gated case below verifies the on-disk artifact byte equality
+  // when a real kolt build is runnable.
+  @Test
+  fun jvmAppPathsThreadProfileButCompileArgsAreProfileIndependent() {
+    val cfg = testConfig(name = "jvm-noop", target = "jvm")
+    val debugJar = outputJarPath(cfg, Profile.Debug)
+    val releaseJar = outputJarPath(cfg, Profile.Release)
+
+    assertEquals("build/debug/jvm-noop.jar", debugJar)
+    assertEquals("build/release/jvm-noop.jar", releaseJar)
+    // checkCommand and testBuildCommand do not branch on Profile (the
+    // @Suppress UNUSED_PARAMETER is the contract). The byte-identity is
+    // pinned in the unit-test layer (BuilderTest, TestBuilderTest); this
+    // IT path-layer test only locks the path partitioning shape.
+  }
+
+  // Req 4.3 / 5.3 end-to-end. Build a JVM fixture twice (debug then
+  // release) using the bootstrapped kolt.kexe; assert both jars exist.
+  // JVM-target rather than native because Native end-to-end requires
+  // konanc + a working bootstrap toolchain in CI; JVM-target end-to-end
+  // is closer in cost to a normal `./gradlew test` run.
+  @Test
+  fun debugAndReleaseJarsCoexistAfterAlternation() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val fixture = createFixtureProject("kolt-it-profile-alt-")
+    val script =
+      """
+            set -u
+            cd "$fixture"
+            "$kolt" build > b1.stdout 2> b1.stderr
+            echo $D? > b1.exit
+            "$kolt" build --release > b2.stdout 2> b2.stderr
+            echo $D? > b2.exit
+            "$kolt" build > b3.stdout 2> b3.stderr
+            echo $D? > b3.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val e1 = readExit(fixture, "b1.exit")
+    val e2 = readExit(fixture, "b2.exit")
+    val e3 = readExit(fixture, "b3.exit")
+    assertEquals(
+      0,
+      e1,
+      "kolt build (debug) must exit 0; stderr=${readOptional(fixture, "b1.stderr")}",
+    )
+    assertEquals(
+      0,
+      e2,
+      "kolt build --release must exit 0; stderr=${readOptional(fixture, "b2.stderr")}",
+    )
+    assertEquals(
+      0,
+      e3,
+      "kolt build (debug) again must exit 0; stderr=${readOptional(fixture, "b3.stderr")}",
+    )
+
+    val debugJar = "$fixture/build/debug/${PROFILE_FIXTURE_NAME}.jar"
+    val releaseJar = "$fixture/build/release/${PROFILE_FIXTURE_NAME}.jar"
+    assertTrue(fileExists(debugJar), "debug jar must exist after alternation: $debugJar")
+    assertTrue(fileExists(releaseJar), "release jar must exist after alternation: $releaseJar")
+  }
+
+  // Req 3.1 end-to-end: identical artifact bytes between debug and
+  // release on JVM (modulo file-system timestamps; jar contents are
+  // compared, not jar files themselves, because zip entries carry an
+  // mtime). For this scope we compare the directory contents under
+  // `build/<profile>/classes` if accessible, falling back to a jar
+  // checksum when only the jar is observable.
+  @Test
+  fun jvmReleaseBuildProducesIdenticalCompileOutputBytes() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val fixture = createFixtureProject("kolt-it-profile-jvm-noop-")
+    val script =
+      """
+            set -u
+            cd "$fixture"
+            "$kolt" build > d.stdout 2> d.stderr
+            echo $D? > d.exit
+            cp -r build/classes build/classes-debug-snapshot
+            rm -rf build
+            "$kolt" build --release > r.stdout 2> r.stderr
+            echo $D? > r.exit
+            diff -r build/classes-debug-snapshot build/classes > diff.out 2>&1 || true
+            """
+        .trimIndent()
+    // First run leaves snapshot, second run --release is a fresh build
+    // — but we cleared `build/` above so the second build starts cold.
+    // Compare classes directories byte-for-byte; if any class file
+    // differs the diff output will be non-empty.
+    runHarness(
+      """
+            set -u
+            cd "$fixture"
+            "$kolt" build > d.stdout 2> d.stderr
+            echo $D? > d.exit
+            mkdir -p build-snapshot
+            cp -r build/classes build-snapshot/classes-debug || true
+            "$kolt" build --release > r.stdout 2> r.stderr
+            echo $D? > r.exit
+            diff -r build-snapshot/classes-debug build/classes > diff.out 2>&1 || true
+            test ! -s diff.out
+            echo $D? > diff.exit
+            """
+        .trimIndent()
+    )
+    val dExit = readExit(fixture, "d.exit")
+    val rExit = readExit(fixture, "r.exit")
+    val diffExit = readExit(fixture, "diff.exit")
+    assertEquals(
+      0,
+      dExit,
+      "kolt build (debug) must exit 0; stderr=${readOptional(fixture, "d.stderr")}",
+    )
+    assertEquals(
+      0,
+      rExit,
+      "kolt build --release must exit 0; stderr=${readOptional(fixture, "r.stderr")}",
+    )
+    assertEquals(
+      0,
+      diffExit,
+      "diff -r between debug-classes and release-classes must be empty " +
+        "(JVM no-op contract); diff output was: ${readOptional(fixture, "diff.out")}",
+    )
+    val rStderr = readOptional(fixture, "r.stderr") ?: ""
+    val rStdout = readOptional(fixture, "r.stdout") ?: ""
+    assertTrue(
+      !rStderr.contains("warning") && !rStderr.contains("error"),
+      "JVM --release must not surface warning/error attributable to the flag; stderr=$rStderr",
+    )
+    // No deprecation banner on stdout either.
+    assertTrue(
+      !rStdout.contains("deprecat") && !rStderr.contains("deprecat"),
+      "JVM --release must not surface a deprecation banner",
+    )
+  }
+
+  private fun locateKoltKexe(): String? {
+    val cwd = currentWorkingDir() ?: return null
+    val candidates =
+      listOf(
+        "$cwd/build/bin/linuxX64/debugExecutable/kolt.kexe",
+        "$cwd/build/bin/linuxX64/releaseExecutable/kolt.kexe",
+      )
+    val found = candidates.firstOrNull { fileExists(it) }
+    if (found == null) {
+      error(
+        "KOLT_PROFILE_IT=1 but kolt.kexe is not built. Run " +
+          "`./gradlew linkDebugExecutableLinuxX64` first. Looked under: $candidates"
+      )
+    }
+    return found
+  }
+
+  private fun createFixtureProject(prefix: String): String {
+    val dir = createTempDir(prefix)
+    writeFileAsString("$dir/kolt.toml", FIXTURE_TOML).getOrElse { error("write kolt.toml: $it") }
+    val srcDir = "$dir/src"
+    executeCommand(listOf("mkdir", "-p", srcDir)).getOrElse { error("mkdir src: $it") }
+    writeFileAsString("$srcDir/Main.kt", FIXTURE_MAIN).getOrElse { error("write Main.kt: $it") }
+    return dir
+  }
+
+  private fun createTempDir(prefix: String): String {
+    val template = "/tmp/${prefix}XXXXXX"
+    val buf = template.encodeToByteArray().copyOf(template.length + 1)
+    buf.usePinned { pinned ->
+      val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+      val path = result.toKString()
+      createdDirs.add(path)
+      return path
+    }
+  }
+
+  private fun currentWorkingDir(): String? = memScoped {
+    val buf = allocArray<ByteVar>(PATH_MAX)
+    getcwd(buf, PATH_MAX.toULong())?.toKString()
+  }
+
+  private fun runHarness(script: String) {
+    executeCommand(listOf("bash", "-c", script)).getOrElse { err ->
+      error("harness bash failed: $err — script was:\n$script")
+    }
+  }
+
+  private fun readExit(dir: String, name: String): Int {
+    val raw =
+      readFileAsString("$dir/$name").getOrElse {
+        error("missing $dir/$name — harness did not record an exit code")
+      }
+    return raw.trim().toIntOrNull() ?: error("could not parse exit code from $dir/$name: '$raw'")
+  }
+
+  private fun readOptional(dir: String, name: String): String? {
+    val path = "$dir/$name"
+    if (!fileExists(path)) return null
+    return readFileAsString(path).getOrElse {
+      return null
+    }
+  }
+
+  private fun enabled(): Boolean {
+    val on = getenv("KOLT_PROFILE_IT")?.toKString() == "1"
+    if (!on && !skipNoticePrinted) {
+      skipNoticePrinted = true
+      eprintln(
+        "BuildProfileIT: skipped (set KOLT_PROFILE_IT=1 and run linkDebugExecutableLinuxX64 to enable)"
+      )
+    }
+    return on
+  }
+
+  companion object {
+    private const val D = "$"
+
+    private var skipNoticePrinted = false
+
+    // Used in fixture kolt.toml below; the two e2e tests share the same
+    // fixture shape so the assertion paths can use one constant name.
+    private const val PROFILE_FIXTURE_NAME = "profile-it"
+
+    private val FIXTURE_TOML =
+      """
+            name = "$PROFILE_FIXTURE_NAME"
+            version = "0.0.1"
+            kind = "app"
+
+            [kotlin]
+            version = "2.3.20"
+
+            [build]
+            target = "jvm"
+            jvm_target = "21"
+            main = "main"
+            sources = ["src"]
+            test_sources = []
+            """
+        .trimIndent()
+
+    private val FIXTURE_MAIN =
+      """
+            fun main() {
+                println("hello from profile IT")
+            }
+            """
+        .trimIndent()
+  }
+}

--- a/src/nativeTest/kotlin/kolt/cli/JvmAppBuildTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/JvmAppBuildTest.kt
@@ -9,6 +9,7 @@ import kolt.build.outputJarPath
 import kolt.build.outputRuntimeClasspathPath
 import kolt.config.ConfigError
 import kolt.config.parseConfig
+import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.fileExists
 import kolt.infra.readFileAsString
 import kolt.infra.removeDirectoryRecursive
@@ -138,6 +139,9 @@ class JvmAppBuildTest {
         it.copy(kind = "lib", build = it.build.copy(main = null))
       }
     val manifestPath = outputRuntimeClasspathPath(config)
+    ensureDirectoryRecursive(manifestPath.substringBeforeLast('/')).getOrElse {
+      error("ensure failed: $it")
+    }
     // Seed a stale manifest as if a previous kind=app build ran here.
     writeFileAsString(manifestPath, "/stale/a.jar\n/stale/b.jar").getError()?.let {
       error("seed failed: $it")
@@ -163,6 +167,9 @@ class JvmAppBuildTest {
       )
     for (config in matrix) {
       val manifestPath = outputRuntimeClasspathPath(config)
+      ensureDirectoryRecursive(manifestPath.substringBeforeLast('/')).getOrElse {
+        error("ensure failed for ${config.name}: $it")
+      }
       writeFileAsString(manifestPath, "/stale/x.jar").getError()?.let {
         error("seed failed for ${config.name}: $it")
       }

--- a/src/nativeTest/kotlin/kolt/cli/KoltRunManifestIndependenceTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/KoltRunManifestIndependenceTest.kt
@@ -1,10 +1,12 @@
 package kolt.cli
 
 import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
 import kolt.build.BUILD_DIR
 import kolt.build.outputRuntimeClasspathPath
 import kolt.build.runCommand
 import kolt.infra.deleteFile
+import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.fileExists
 import kolt.infra.removeDirectoryRecursive
 import kolt.infra.writeFileAsString
@@ -114,6 +116,9 @@ class KoltRunManifestIndependenceTest {
     // Simulate the post-`kolt build` state, then delete the manifest as
     // step (a) of the Req 2.8 procedure ("after `kolt build` remove
     // `build/<name>-runtime.classpath`"). `kolt run` must still succeed.
+    ensureDirectoryRecursive(manifestPath.substringBeforeLast('/')).getOrElse {
+      error("ensure failed: $it")
+    }
     writeFileAsString(manifestPath, "/cache/stale-but-never-read.jar").getError()?.let {
       error("seed failed: $it")
     }
@@ -152,6 +157,9 @@ class KoltRunManifestIndependenceTest {
     // memory. If `runCommand` (or anything on the run path) opened the
     // manifest, the `-cp` arg would include these stale entries.
     val staleContent = "/cache/STALE/wrong-1.jar\n" + "/cache/STALE/wrong-2.jar"
+    ensureDirectoryRecursive(manifestPath.substringBeforeLast('/')).getOrElse {
+      error("ensure failed: $it")
+    }
     writeFileAsString(manifestPath, staleContent).getError()?.let { error("seed failed: $it") }
     val resolverClasspath = "/cache/org.jetbrains/kotlin-stdlib/2.3.20/kotlin-stdlib-2.3.20.jar"
 

--- a/src/nativeTest/kotlin/kolt/cli/ParseKoltArgsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ParseKoltArgsTest.kt
@@ -1,0 +1,63 @@
+package kolt.cli
+
+import kolt.build.Profile
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ParseKoltArgsTest {
+
+  @Test
+  fun absentReleaseFlagYieldsDebugProfile() {
+    val parsed = parseKoltArgs(listOf("build"))
+
+    assertEquals(Profile.Debug, parsed.profile)
+    assertEquals(listOf("build"), parsed.filteredArgs)
+  }
+
+  @Test
+  fun presentReleaseFlagYieldsReleaseProfile() {
+    val parsed = parseKoltArgs(listOf("--release", "build"))
+
+    assertEquals(Profile.Release, parsed.profile)
+  }
+
+  @Test
+  fun releaseFlagIsStrippedFromFilteredArgs() {
+    val parsed = parseKoltArgs(listOf("--release", "build"))
+
+    assertFalse(
+      parsed.filteredArgs.contains("--release"),
+      "filteredArgs must not leak --release into subcommand parsing: ${parsed.filteredArgs}",
+    )
+    assertEquals(listOf("build"), parsed.filteredArgs)
+  }
+
+  @Test
+  fun releaseCombinesWithOtherKoltLevelFlags() {
+    val parsed = parseKoltArgs(listOf("--no-daemon", "--release", "--watch", "test"))
+
+    assertEquals(Profile.Release, parsed.profile)
+    assertFalse(parsed.useDaemon)
+    assertTrue(parsed.watch)
+    assertEquals(listOf("test"), parsed.filteredArgs)
+  }
+
+  @Test
+  fun releaseAfterDoubleDashIsTreatedAsPassthrough() {
+    val parsed = parseKoltArgs(listOf("run", "--", "--release"))
+
+    assertEquals(Profile.Debug, parsed.profile)
+    assertEquals(listOf("run", "--", "--release"), parsed.filteredArgs)
+  }
+
+  @Test
+  fun releaseFlagPositionDoesNotMatter() {
+    val before = parseKoltArgs(listOf("--release", "build"))
+    val after = parseKoltArgs(listOf("build", "--release"))
+
+    assertEquals(before.profile, after.profile)
+    assertEquals(before.filteredArgs, after.filteredArgs)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/nativedaemon/wire/FrameCodecTest.kt
+++ b/src/nativeTest/kotlin/kolt/nativedaemon/wire/FrameCodecTest.kt
@@ -25,9 +25,9 @@ class FrameCodecTest {
             "library",
             "-nopack",
             "-Xenable-incremental-compilation",
-            "-Xic-cache-dir=build/.ic-cache",
+            "-Xic-cache-dir=build/debug/.ic-cache",
             "-o",
-            "build/m-klib",
+            "build/debug/m-klib",
           )
       )
 


### PR DESCRIPTION
Cargo style: default `debug`, `--release` opt-in. 4 commits, mostly mechanical Profile threading; the interesting bits are below.

## Reviewer focus

- **`Profile` visibility deviation (ADR 0030 §Confirmation)**: design called for `internal`, but `runCommand` / `nativeRunCommand` / `nativeTestRunCommand` / `testBuildCommand` are top-level public functions, and Kotlin rejects an internal type on a public signature. Promoted to public; no external module consumes `kolt.build.Profile` (the JVM and native compiler daemons are separate Gradle builds).
- **Issue #261 schema misattribution (ADR 0030 §5)**: the issue text said the Native daemon IC store should partition under `~/.kolt/daemon/ic/<v>/<id>/<profile>/`, but that path is owned by the JVM daemon and JVM is no-op. Native IC actually lives at `build/.ic-cache` and now partitions to `build/<profile>/.ic-cache`. JVM `~/.kolt/daemon/ic/` is left untouched (Req 3.3). Worth re-reading the ADR section if you remember the issue text.
- **`checkCommand` keeps no `profile` parameter** while the other JVM-targeted command builders accept and ignore one. The kotlinc args from `checkCommand` have no path or IC dependency, so the byte-equality contract holds trivially without threading. design.md was updated to reflect the asymmetry.
- **`assemble-dist.sh` passes `--release` uniformly to all three sub-builds**, including the JVM daemon kolt.toml builds where it is a no-op. Intent is explicit so a future maintainer doesn't half-flip the flag and produce a mixed-profile tarball. Daemon JAR / runtime classpath manifest paths now read from `<daemon>/build/release/`.
- **`Profile.Debug` defaults on internal helpers** are intentional Cargo-style defaults (debug = sensible default), not migration shims. Production callers thread the active profile explicitly; tests use the default.
- **`BuildProfileIT`** is env-gated on `KOLT_PROFILE_IT=1`, mirroring `ConcurrentBuildIT`. Path-layer assertions run unconditionally; the e2e alternation + JVM byte-equality cases need a built `kolt.kexe` and so are off by default.

## Signal

- 1286/1286 tests pass on `linuxX64Test`.
- Self-host smoke succeeded for both profiles: `build/debug/kolt.kexe` (~19 MB, debug-info baked in) and `build/release/kolt.kexe` (~5 MB).
- New `DriftGuardsTest.profileLiteralsAndDistScriptAreInSync` pins the `Profile.dirName` ↔ `assemble-dist.sh` invariant.

## Things deliberately not in scope

`kolt.toml [profile.*]` configuration, JVM reproducibility, `extra_compiler_args`, macOS / linuxArm64 profile-specific behavior, behavior of `--release` on non-build commands. All deferred per ADR 0030 §6 and the spec's Out of Scope.