### PR TITLE
Fix profile-naive up-to-date check on JVM target (#275)

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -148,19 +148,19 @@ jobs:
       - name: kolt build at root
         run: |
           set -euo pipefail
-          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build --release
+          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build
 
       - name: kolt build at kolt-jvm-compiler-daemon
         run: |
           set -euo pipefail
           cd kolt-jvm-compiler-daemon
-          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build --release
+          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build
 
       - name: kolt build at kolt-native-compiler-daemon
         run: |
           set -euo pipefail
           cd kolt-native-compiler-daemon
-          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build --release
+          "$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" build
 
       - name: Assemble tarball
         run: |

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -248,7 +248,12 @@ private fun doBuildInner(useDaemon: Boolean, profile: Profile): Result<BuildResu
       return Err(it)
     }
 
-  if (isBuildUpToDate(current = currentState, cached = cachedState)) {
+  // BuildState.classesDirMtime tracks `build/classes/` (profile-naive on JVM
+  // because kotlinc args are profile-independent). The active profile's jar
+  // may still be missing if the previous build wrote a different profile's
+  // jar, so the artifact existence check is the per-profile gate.
+  val jarPath = outputJarPath(config, profile)
+  if (isBuildUpToDate(current = currentState, cached = cachedState) && fileExists(jarPath)) {
     val elapsed = startMark.elapsedNow()
     println("${config.name} is up to date (${formatDuration(elapsed)})")
     // Invariant: the up-to-date path must stay a pure mtime compare —


### PR DESCRIPTION
Two-line fix + workaround revert. Tiny PR.

## Reviewer focus

- **`BuildCommands.kt` change is the only behavior change**: gating the JVM up-to-date short-circuit on `fileExists(outputJarPath(config, profile))`. Native already gets this right because `classesDirMtime` is the profile-aware artifact mtime there.
- **JVM-only**: confirm Native didn't grow a parallel symptom that I missed. `BuildState.classesDirMtime` for Native is set from the profile-aware kexe mtime (BuildCommands.kt around the `nativeStagePlan` site), so an absent `build/<profile>/<name>.kexe` already produces `null` and breaks the state match.
- **`self-host-smoke.yml` revert**: the `--release` pre-build was the workaround landed during #261's CI fight. With the up-to-date fix, `assemble-dist.sh` recompiles to release on a debug-warmed tree, so the explicit pre-build is redundant. Net effect on CI: one fewer build step per sub-project, dist profile decision lives in one place.
- **No new test added**: the env-gated `BuildProfileIT.debugAndReleaseJarsCoexistAfterAlternation` already pins the alternation contract (build debug → build release → build debug → both jars on disk). The reverted CI exercises the same shape implicitly via `assemble-dist.sh`.

## Signal

- 1286/1286 `linuxX64Test` pass locally.
- The CI self-host-post job is the live regression test: if the fix breaks, the assemble-dist step will fail with `missing daemon jar: <daemon>/build/release/...` (the original #275 symptom).