### PR TITLE
Add curl|sh installer (#230)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+# Tag push (v*) is the production trigger. workflow_dispatch with dry_run
+# defaults to true so a manual run only exercises the gates and build,
+# without publishing assets — used to validate release.yml end-to-end before
+# the first real tag.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip gh release create and smoke job'
+        type: boolean
+        default: true
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Gates (3.2), build + assemble + sha256 + publish (3.3) land in
+      # subsequent tasks. This step is a placeholder so the skeleton
+      # validates as a complete workflow definition.
+      - name: Skeleton placeholder
+        run: echo "release.yml skeleton; gates/build/publish in tasks 3.2 / 3.3"
+
+  smoke:
+    name: Smoke
+    needs: release
+    if: github.event_name == 'push' || !inputs.dry_run
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # Real curl|sh smoke against the published assets lands in 3.4.
+      - name: Skeleton placeholder
+        run: echo "smoke skeleton; real curl|sh in task 3.4"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,81 @@ jobs:
           fi
           echo "Gate 3 OK: format valid, version not yanked"
 
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Install libcurl dev headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev
+
+      # Cache keys mirror self-host-smoke.yml so both workflows share warm
+      # caches keyed per-repo, not per-workflow.
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Cache Gradle Kotlin Native
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('build.gradle.kts') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
+
+      - name: Cache kolt toolchains
+        uses: actions/cache@v4
+        with:
+          path: ~/.kolt
+          key: kolt-${{ runner.os }}-${{ hashFiles('kolt.toml') }}
+          restore-keys: |
+            kolt-${{ runner.os }}-
+
+      - name: Bootstrap kolt.kexe via Gradle
+        run: ./gradlew --no-daemon linkDebugExecutableLinuxX64
+
+      # assemble-dist.sh runs the 3 × kolt build --release internally and
+      # emits both the tarball and .sha256 (PR #228 + task 1.2). The KOLT
+      # env var overrides its default releaseExecutable path so the
+      # bootstrapped debug kexe drives the 3 release builds.
+      - name: Assemble tarball + sha256
+        run: |
+          KOLT="$GITHUB_WORKSPACE/build/bin/linuxX64/debugExecutable/kolt.kexe" \
+            ./scripts/assemble-dist.sh
+
+      - name: Publish to GitHub Release
+        if: github.event_name == 'push' || !inputs.dry_run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          TARBALL="dist/kolt-${VERSION}-linux-x64.tar.gz"
+          SHA="${TARBALL}.sha256"
+
+          PRERELEASE_FLAG=""
+          case "$TAG" in
+            *-rc.*|*-beta.*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
+
+          # shellcheck disable=SC2086 # PRERELEASE_FLAG is intentionally split
+          gh release create "$TAG" \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
+            $PRERELEASE_FLAG \
+            "$TARBALL" \
+            "$SHA"
+
   smoke:
     name: Smoke
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -192,6 +194,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      # Real curl|sh smoke against the published assets lands in 3.4.
-      - name: Skeleton placeholder
-        run: echo "smoke skeleton; real curl|sh in task 3.4"
+      # Single step: isolated HOME, real curl|sh against raw GitHub URL,
+      # then assert kolt --version. HOME is set inside the step because
+      # exports do not propagate across steps.
+      - name: Install via curl|sh and verify
+        env:
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          TEST_HOME=$(mktemp -d)
+          export HOME="$TEST_HOME"
+          echo "Using isolated HOME: $HOME"
+
+          curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh
+
+          VERSION="${TAG#v}"
+          OUTPUT=$("$HOME/.local/bin/kolt" --version)
+          echo "kolt --version output: $OUTPUT"
+          if [ "$OUTPUT" != "kolt $VERSION" ]; then
+            echo "Smoke failed: expected 'kolt $VERSION', got '$OUTPUT'" >&2
+            exit 1
+          fi
+          echo "Smoke OK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,83 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Gates (3.2), build + assemble + sha256 + publish (3.3) land in
-      # subsequent tasks. This step is a placeholder so the skeleton
-      # validates as a complete workflow definition.
-      - name: Skeleton placeholder
-        run: echo "release.yml skeleton; gates/build/publish in tasks 3.2 / 3.3"
+      # Resolve the "tag" value used by all three gates. For tag pushes the
+      # value comes from GITHUB_REF_NAME directly. For workflow_dispatch
+      # there is no real tag, so we synthesize one from kolt.toml's version
+      # field — the gates then exercise format and YANKED checks against
+      # what would be the next legitimate release.
+      - name: Determine tag
+        id: tag
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            KOLT_TOML_VERSION=$(grep -E '^version = "' kolt.toml | head -n 1 | sed -E 's/^version = "(.*)"/\1/')
+            TAG="v$KOLT_TOML_VERSION"
+            echo "Using synthetic tag from kolt.toml: $TAG"
+          else
+            TAG="$GITHUB_REF_NAME"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Gate 1 — SemVer regex
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          REGEX='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(rc|beta)\.[1-9][0-9]*)?$'
+          if ! printf '%s' "$TAG" | grep -qE "$REGEX"; then
+            echo "Gate 1 failed: tag '$TAG' does not match SemVer regex" >&2
+            echo "  regex: $REGEX" >&2
+            exit 1
+          fi
+          echo "Gate 1 OK: tag matches SemVer"
+
+      - name: Gate 2 — tag matches kolt.toml version
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          KOLT_TOML_VERSION=$(grep -E '^version = "' kolt.toml | head -n 1 | sed -E 's/^version = "(.*)"/\1/')
+          EXPECTED="v$KOLT_TOML_VERSION"
+          if [ "$TAG" != "$EXPECTED" ]; then
+            echo "Gate 2 failed: tag does not match kolt.toml version" >&2
+            echo "  tag:       $TAG" >&2
+            echo "  kolt.toml: $EXPECTED" >&2
+            exit 1
+          fi
+          echo "Gate 2 OK: tag matches kolt.toml"
+
+      # Gate 3 mirrors install.sh's fetch_yanked_and_validate format check
+      # so the same YANKED file is accepted on both sides (ADR 0028 §5).
+      - name: Gate 3 — YANKED manifest
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ ! -f YANKED ]; then
+            echo "Gate 3 failed: YANKED file not found at repo root" >&2
+            exit 1
+          fi
+          awk -F'\t' '
+            {
+              if (length($0) == 0) { msg = "blank line not allowed" }
+              else if ($0 ~ /^#/) { msg = "comments not allowed" }
+              else if ($0 ~ /^[ \t]/ || $0 ~ /[ \t]$/) { msg = "leading or trailing whitespace not allowed" }
+              else if (NF != 3) { msg = "expected 3 tab-separated fields, got " NF }
+              else if ($1 == "" || $2 == "" || $3 == "") { msg = "empty field" }
+              else { next }
+              print "YANKED parse error at line " NR ": " msg > "/dev/stderr"
+              exit 1
+            }
+          ' YANKED
+          VERSION="${TAG#v}"
+          MATCH=$(awk -F'\t' -v v="$VERSION" '$1 == v { print "line " NR ": " $0; exit }' YANKED)
+          if [ -n "$MATCH" ]; then
+            echo "Gate 3 failed: tag version '$VERSION' is yanked" >&2
+            echo "  $MATCH" >&2
+            exit 1
+          fi
+          echo "Gate 3 OK: format valid, version not yanked"
 
   smoke:
     name: Smoke

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -167,35 +167,66 @@ jobs:
           set -euo pipefail
           KOLT="$GITHUB_WORKSPACE/bootstrap-kexe/kolt.kexe" ./scripts/assemble-dist.sh
 
-      - name: Extract tarball to install dir
+      - name: Read kolt.toml version
         run: |
           set -euo pipefail
-          mkdir -p /tmp/kolt-install
-          tar xzf dist/kolt-*-linux-x64.tar.gz -C /tmp/kolt-install
-          ls -la /tmp/kolt-install/
+          VERSION=$(grep -E '^version = "' kolt.toml | head -n 1 | sed -E 's/^version = "(.*)"/\1/')
+          echo "KOLT_TOML_VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      # Resolve the `@KOLT_LIBEXEC@` placeholder the stitcher wrote into each
-      # argfile (ADR 0018 §1: tarball is install-location agnostic). In a real
-      # install this is `install.sh`'s job; here we inline the equivalent
-      # `sed -i` pass so the argfiles are directly usable from the install dir.
-      - name: Substitute KOLT_LIBEXEC placeholder in argfiles
+      # Local HTTP server lets install.sh exercise its real download +
+      # SHA-256 + extract + sed + symlink path against the assembled tarball
+      # without needing a published GitHub Release.
+      - name: Set up local serve directory
         run: |
           set -euo pipefail
-          INSTALL_DIR=$(ls -d /tmp/kolt-install/kolt-*-linux-x64)
-          LIBEXEC="${INSTALL_DIR}/libexec"
-          for argfile in "${LIBEXEC}/classpath/"*.argfile; do
-            sed -i "s|@KOLT_LIBEXEC@|${LIBEXEC}|g" "${argfile}"
+          SERVE_DIR=$(mktemp -d)
+          cp "dist/kolt-${KOLT_TOML_VERSION}-linux-x64.tar.gz" "$SERVE_DIR/"
+          cp "dist/kolt-${KOLT_TOML_VERSION}-linux-x64.tar.gz.sha256" "$SERVE_DIR/"
+          : > "$SERVE_DIR/YANKED"
+          echo "SERVE_DIR=$SERVE_DIR" >> "$GITHUB_ENV"
+
+      - name: Start local HTTP server
+        run: |
+          set -euo pipefail
+          python3 -m http.server 8000 --bind 127.0.0.1 --directory "$SERVE_DIR" \
+            >/dev/null 2>&1 &
+          echo "HTTP_PID=$!" >> "$GITHUB_ENV"
+          # Give the server a moment to bind before the first curl.
+          for _ in 1 2 3 4 5; do
+            curl -fsS "http://127.0.0.1:8000/YANKED" >/dev/null 2>&1 && break
+            sleep 1
           done
 
-      # Fixture smoke (Task 4.1): drive `<install>/bin/kolt build` on a
-      # minimal JVM app. Success here is the end-to-end signal that the 3 ×
-      # kolt build → assemble-dist → tarball → extract chain produced a
-      # working install.
+      - name: Install via install.sh — happy path
+        env:
+          KOLT_TEST_BASE_URL: http://127.0.0.1:8000
+          KOLT_TEST_YANKED_URL: http://127.0.0.1:8000/YANKED
+        run: |
+          set -euo pipefail
+          KOLT_VERSION="$KOLT_TOML_VERSION" sh ./install.sh
+          OUTPUT=$("$HOME/.local/bin/kolt" --version)
+          if [ "$OUTPUT" != "kolt $KOLT_TOML_VERSION" ]; then
+            echo "Happy path failed: expected 'kolt $KOLT_TOML_VERSION', got '$OUTPUT'" >&2
+            exit 1
+          fi
+          echo "Happy path OK: $OUTPUT"
+
+      # Fixture smoke: drive `<install>/bin/kolt build` on a minimal JVM
+      # app via the installer-managed dir, end-to-end signal that the 3 ×
+      # kolt build → assemble-dist → install.sh chain produced a working
+      # install.
       - name: Smoke-build fixture with installed kolt
         run: |
           set -euo pipefail
-          INSTALL_DIR=$(ls -d /tmp/kolt-install/kolt-*-linux-x64)
+          INSTALL_DIR="$HOME/.local/share/kolt/$KOLT_TOML_VERSION"
           cd spike/daemon-self-host-smoke
           rm -rf build
           "${INSTALL_DIR}/bin/kolt" build
           test -f build/debug/smoke.jar
+
+      - name: Stop local HTTP server
+        if: always()
+        run: |
+          if [ -n "${HTTP_PID:-}" ]; then
+            kill "$HTTP_PID" 2>/dev/null || true
+          fi

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -187,6 +187,20 @@ jobs:
           # current kolt.toml version with replacement-test as the alias).
           printf '%s\treplacement-test\ttest yank entry\n' \
             "$KOLT_TOML_VERSION" > "$SERVE_DIR/YANKED-with-yank"
+          # Malformed YANKED for parse-error smoke: 2 tab-separated fields,
+          # missing the third. Used by the Parse error smoke step.
+          printf 'v0.1.0\trepl\n' > "$SERVE_DIR/YANKED-bad"
+          # Tampered tarball + .sha256 for the SHA-256 mismatch smoke. We
+          # reuse the real tarball bytes under a fake version name so the
+          # download succeeds, then attach a digest of all zeros to force a
+          # verification failure without disturbing the real version 0.X.Y
+          # install.
+          cp "$SERVE_DIR/kolt-${KOLT_TOML_VERSION}-linux-x64.tar.gz" \
+            "$SERVE_DIR/kolt-99.99.99-linux-x64.tar.gz"
+          printf '%s  %s\n' \
+            "0000000000000000000000000000000000000000000000000000000000000000" \
+            "kolt-99.99.99-linux-x64.tar.gz" \
+            > "$SERVE_DIR/kolt-99.99.99-linux-x64.tar.gz.sha256"
           echo "SERVE_DIR=$SERVE_DIR" >> "$GITHUB_ENV"
 
       - name: Start local HTTP server
@@ -257,6 +271,84 @@ jobs:
             exit 1
           fi
           echo "Yank override OK (exit 0, warning emitted)"
+
+      - name: Parse error smoke (malformed YANKED)
+        env:
+          KOLT_TEST_BASE_URL: http://127.0.0.1:8000
+          KOLT_TEST_YANKED_URL: http://127.0.0.1:8000/YANKED-bad
+        run: |
+          set +e
+          OUTPUT=$(KOLT_VERSION="$KOLT_TOML_VERSION" sh ./install.sh 2>&1)
+          EXIT=$?
+          set -e
+          if [ "$EXIT" != "2" ]; then
+            echo "Parse error failed: expected exit 2, got $EXIT" >&2
+            echo "$OUTPUT" >&2
+            exit 1
+          fi
+          if ! printf '%s' "$OUTPUT" | grep -q "YANKED parse error at line"; then
+            echo "Parse error failed: line-numbered error message not in stderr" >&2
+            echo "$OUTPUT" >&2
+            exit 1
+          fi
+          echo "Parse error OK (exit 2 + line-numbered message)"
+
+      - name: Non-symlink refuse smoke
+        env:
+          KOLT_TEST_BASE_URL: http://127.0.0.1:8000
+          KOLT_TEST_YANKED_URL: http://127.0.0.1:8000/YANKED
+        run: |
+          # Replace the prior happy-path symlink with a regular file so
+          # extract_and_link's [ -e ] && [ ! -L ] guard fires.
+          rm -f "$HOME/.local/bin/kolt"
+          echo "user file" > "$HOME/.local/bin/kolt"
+
+          set +e
+          OUTPUT=$(KOLT_VERSION="$KOLT_TOML_VERSION" sh ./install.sh 2>&1)
+          EXIT=$?
+          set -e
+
+          # Always remove the regular file before asserting so a step
+          # failure here does not leave a poisoned install entry.
+          rm -f "$HOME/.local/bin/kolt"
+
+          if [ "$EXIT" != "8" ]; then
+            echo "Non-symlink refuse failed: expected exit 8, got $EXIT" >&2
+            echo "$OUTPUT" >&2
+            exit 1
+          fi
+          if ! printf '%s' "$OUTPUT" | grep -q "remove this file manually"; then
+            echo "Non-symlink refuse failed: remove-this-file hint not in stderr" >&2
+            echo "$OUTPUT" >&2
+            exit 1
+          fi
+          echo "Non-symlink refuse OK (exit 8 + remove hint)"
+
+      - name: SHA-256 mismatch smoke
+        env:
+          KOLT_TEST_BASE_URL: http://127.0.0.1:8000
+          KOLT_TEST_YANKED_URL: http://127.0.0.1:8000/YANKED
+        run: |
+          set +e
+          OUTPUT=$(KOLT_VERSION=99.99.99 sh ./install.sh 2>&1)
+          EXIT=$?
+          set -e
+          if [ "$EXIT" != "5" ]; then
+            echo "SHA mismatch failed: expected exit 5, got $EXIT" >&2
+            echo "$OUTPUT" >&2
+            exit 1
+          fi
+          if ! printf '%s' "$OUTPUT" | grep -q "expected:"; then
+            echo "SHA mismatch failed: 'expected:' not in stderr" >&2
+            echo "$OUTPUT" >&2
+            exit 1
+          fi
+          if ! printf '%s' "$OUTPUT" | grep -q "actual:"; then
+            echo "SHA mismatch failed: 'actual:' not in stderr" >&2
+            echo "$OUTPUT" >&2
+            exit 1
+          fi
+          echo "SHA mismatch OK (exit 5 + both digests)"
 
       # Fixture smoke: drive `<install>/bin/kolt build` on a minimal JVM
       # app via the installer-managed dir, end-to-end signal that the 3 ×

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -183,6 +183,10 @@ jobs:
           cp "dist/kolt-${KOLT_TOML_VERSION}-linux-x64.tar.gz" "$SERVE_DIR/"
           cp "dist/kolt-${KOLT_TOML_VERSION}-linux-x64.tar.gz.sha256" "$SERVE_DIR/"
           : > "$SERVE_DIR/YANKED"
+          # Synthetic YANKED for refuse / override tests (entry yanks the
+          # current kolt.toml version with replacement-test as the alias).
+          printf '%s\treplacement-test\ttest yank entry\n' \
+            "$KOLT_TOML_VERSION" > "$SERVE_DIR/YANKED-with-yank"
           echo "SERVE_DIR=$SERVE_DIR" >> "$GITHUB_ENV"
 
       - name: Start local HTTP server
@@ -210,6 +214,49 @@ jobs:
             exit 1
           fi
           echo "Happy path OK: $OUTPUT"
+
+      - name: Yank refuse smoke (KOLT_ALLOW_YANKED unset)
+        env:
+          KOLT_TEST_BASE_URL: http://127.0.0.1:8000
+          KOLT_TEST_YANKED_URL: http://127.0.0.1:8000/YANKED-with-yank
+        run: |
+          set +e
+          OUTPUT=$(KOLT_VERSION="$KOLT_TOML_VERSION" sh ./install.sh 2>&1)
+          EXIT=$?
+          set -e
+          if [ "$EXIT" != "3" ]; then
+            echo "Yank refuse failed: expected exit 3, got $EXIT" >&2
+            echo "$OUTPUT" >&2
+            exit 1
+          fi
+          if ! printf '%s' "$OUTPUT" | grep -q "replacement-test"; then
+            echo "Yank refuse failed: 'replacement-test' not in stderr" >&2
+            echo "$OUTPUT" >&2
+            exit 1
+          fi
+          echo "Yank refuse OK (exit 3, replacement surfaced)"
+
+      - name: Yank override smoke (KOLT_ALLOW_YANKED=1)
+        env:
+          KOLT_TEST_BASE_URL: http://127.0.0.1:8000
+          KOLT_TEST_YANKED_URL: http://127.0.0.1:8000/YANKED-with-yank
+          KOLT_ALLOW_YANKED: "1"
+        run: |
+          set +e
+          OUTPUT=$(KOLT_VERSION="$KOLT_TOML_VERSION" sh ./install.sh 2>&1)
+          EXIT=$?
+          set -e
+          if [ "$EXIT" != "0" ]; then
+            echo "Yank override failed: expected exit 0, got $EXIT" >&2
+            echo "$OUTPUT" >&2
+            exit 1
+          fi
+          if ! printf '%s' "$OUTPUT" | grep -q "warning"; then
+            echo "Yank override failed: warning not in stderr" >&2
+            echo "$OUTPUT" >&2
+            exit 1
+          fi
+          echo "Yank override OK (exit 0, warning emitted)"
 
       # Fixture smoke: drive `<install>/bin/kolt build` on a minimal JVM
       # app via the installer-managed dir, end-to-end signal that the 3 ×

--- a/.kiro/specs/installer/design.md
+++ b/.kiro/specs/installer/design.md
@@ -1,0 +1,729 @@
+# Design Document — installer
+
+## Overview
+
+**Purpose**: kolt を `curl -fsSL <raw URL> | sh` の 1 コマンドで Linux x64 にインストール可能にし、ADR 0018 §4 が掲げる deno/bun/rye/uv 並みの導入 UX を実現する。
+
+**Users**: kolt を初めて試す外部利用者 (`install.sh` 経由)、tag を push して release を出す kolt メンテナ (`release.yml` 経由)、kolt 本体に変更を加える contributor (PR-time の install.sh smoke 経由)。
+
+**Impact**: 現状 git clone + Gradle bootstrap でしか入手できない kolt が、tag push を起点とする release pipeline + 公開 install script + repo HEAD の YANKED manifest という 3 軸で構成された配布経路を獲得する。`scripts/assemble-dist.sh` (PR #228) の tarball stitcher を消費する側として `install.sh` が立ち上がり、`self-host-smoke.yml` の `self-host-post` job 中 inline sed (lines 184-188) を `install.sh` 呼び出しに置き換えることで、PR ごとに本物の install 経路が exercise される。
+
+### Goals
+
+- tag push (`v*`) を起点に走り、SemVer regex / kolt.toml ↔ tag 整合 / YANKED gate を経て tarball + `.sha256` を GitHub Release に publish する `.github/workflows/release.yml` を ship する。
+- repo root に POSIX sh 準拠の `install.sh` を ship し、platform 検出・version 選択・YANKED gate・SHA-256 検証・展開・symlink を 1 ファイル内で完結させる。
+- repo root に空の `YANKED` ファイルを commit し、ADR 0028 §5 の format を release.yml と install.sh の双方で実装する。
+- `self-host-smoke.yml` 内の inline sed を `install.sh` 呼び出しに置換し、PR ごとに install 経路を smoke test する。
+- README の Installation section を curl|sh コマンドに書き換える。
+
+### Non-Goals
+
+- macOS / Windows / linuxArm64 binary の生成 (#82, #83)。install.sh の case 文 skeleton は多 platform 前提で書くが、tarball matrix は linux-x64 のみ。
+- install.sh の upgrade / uninstall / rollback / shell rc 自動編集 (ADR 0018 §4 で defer 確定)。
+- `kolt.dev` ドメイン取得・リダイレクト設定。
+- cosign / GPG / Sigstore 等の署名 (SHA-256 のみ初版採用)。
+- 過去 release (v0.15.0 以前) への retroactive な asset attach。
+- YANKED parser を release.yml と install.sh で共有する shared library 化 (本 spec では duplicate を許容、§§Components 参照)。
+
+## Boundary Commitments
+
+### This Spec Owns
+
+- `.github/workflows/release.yml` の全挙動 (tag trigger、SemVer / kolt.toml / YANKED の 3 つの pre-publish gate、`assemble-dist.sh` の起動、`.sha256` 生成、`gh release create` 経由の asset upload、tag-time install smoke)。
+- `install.sh` の全挙動 (POSIX sh、platform 検出、env var contract、YANKED parser、GitHub Releases API enumerate、tarball + .sha256 download、SHA-256 検証、`~/.local/share/kolt/<version>/` 展開、`@KOLT_LIBEXEC@` sed、`~/.local/bin/kolt` symlink 作成・上書き、PATH hint)。
+- repo root の `YANKED` ファイル (空ファイル commit が初期 deliverable)、ADR 0028 §5 format を実コードで運用する責務。
+- `scripts/assemble-dist.sh` への `.sha256` 生成追加 (末尾 1〜2 行)。
+- `.github/workflows/self-host-smoke.yml` の `self-host-post` job 中 sed step → `install.sh` 呼び出しへの置換、yank refuse smoke step の追加。
+- `README.md` の Installation section を curl|sh コマンドに書き換える。
+
+### Out of Boundary
+
+- 多 platform binary 生成 (#82, #83)。Req 4.5 は tarball 命名規約 `kolt-<version>-<platform>.tar.gz` の `<platform>` 変数化を install.sh と assemble-dist.sh の双方に求めるが、これは **forward-compat の構造的コミットメント** であって本 spec の運用 scope ではない。本 spec の運用 scope は linux-x64 のみで、darwin / linuxArm64 は #82 / #83 で別 track。
+- ADR 0018 §1 が pin する tarball layout (`bin/` + `libexec/`)、`assemble-dist.sh` の tarball 生成ロジック本体 (`.sha256` 生成 1 行追加を除く)。
+- ADR 0028 §5 が pin する YANKED format 自体 (本 spec はそれを実装する側、format の改訂権は ADR 0028 にある)。
+- `gh release create` の制約に起因する behavior (asset upload の rate limit、Release notes 編集の運用は scope 外)。
+- pre-#230 release (v0.15.0 以前) のサポート (install.sh が叩いて 404 を返した時のメッセージ文言だけ design 側で軽く保証する、§§Error Handling)。
+- daemon 起動経路 / `bin/kolt` 自身の挙動 (ADR 0018 §2 / §5 が owner)。
+- 多 platform binary 生成 (#82, #83)。
+
+### Allowed Dependencies
+
+- `scripts/assemble-dist.sh` (PR #228 で完成、ADR 0018 §1 / §2 / §4 準拠) — tarball stitcher として消費する。本 spec は `.sha256` 生成 1 行追加のみで本体ロジックは触らない。
+- `kolt.toml` の `version =` 行 — 単一の version 情報源。release.yml が tag との整合 gate でこれを参照する。
+- ADR 0018 §1 の tarball layout、§4 の install 先 / symlink 先、§6 の bundle vs auto-provision 方針。
+- ADR 0028 §1 の SemVer regex、§5 の YANKED format。
+- `.github/workflows/self-host-smoke.yml` の既存 `self-host-post` job 構造 (キャッシュキー、JDK 25 setup、libcurl install、3 × kolt build) — caching key は流用、step ordering は変更しない。
+- GitHub Actions 標準 runner (`ubuntu-latest`)、`gh` CLI (pre-installed)、`actions/checkout@v4`、`actions/setup-java@v4`、`actions/cache@v4`。
+- POSIX 標準コマンド (`sh`, `curl`, `tar`, `sed`, `grep`, `awk`, `cut`, `uname`, `mkdir`, `ln`, `chmod`, `printf`, `sha256sum`)。
+
+### Revalidation Triggers
+
+以下のいずれかが起きたとき、本 spec の consumer (`self-host-smoke.yml`、ADR 0018、ADR 0028 を参照する後続 spec) は再検証が必要:
+
+- tarball 命名規約 `kolt-<version>-<platform>.tar.gz` の変更 → install.sh の URL 構築、release.yml の asset 名、assemble-dist.sh の出力名すべてに波及。
+- `~/.local/share/kolt/<version>/` または `~/.local/bin/kolt` の install 先 path 変更 → ADR 0018 §1 / §4 の更新と #82 / #83 の追従。
+- YANKED format の変更 (ADR 0028 §5 の改訂) → release.yml と install.sh の parser 両方の更新が同 PR で必須。
+- env var (`KOLT_VERSION`, `KOLT_ALLOW_YANKED`, `KOLT_TEST_BASE_URL`, `KOLT_TEST_YANKED_URL`) の追加 / 削除 / 意味変更 → README documentation と CI smoke の env 設定の同期更新。
+- `gh release create` から GitHub REST API 直叩きへの切り替え → release.yml の permissions と secrets の見直し。
+- `assemble-dist.sh` の version 抽出ロジック変更 → release.yml の kolt.toml ↔ tag gate の整合確認。
+
+## Architecture
+
+### Existing Architecture Analysis
+
+- **`scripts/assemble-dist.sh`** (PR #228 で完成) は kolt.toml から version を読み、tarball layout (ADR 0018 §1) を構築して `dist/kolt-<version>-linux-x64.tar.gz` を出力する。`@KOLT_LIBEXEC@` placeholder を argfile に書き込む。本 spec はこれを呼び出す側、変更は末尾に `.sha256` 生成 1 行追加のみ。
+- **`self-host-smoke.yml`** の `self-host-post` job は assemble-dist.sh を実行し、tarball を `/tmp/kolt-install` に展開、inline sed で `@KOLT_LIBEXEC@` を絶対パスに置換、fixture を smoke build する。本 spec はこの sed step を install.sh 呼び出しに置き換え、yank refuse smoke step を追加する。
+- **CI workflow パターン**: `ubuntu-latest` + `setup-java@v4` (JDK 25 temurin) + libcurl4-openssl-dev + 3 種類の cache (`~/.gradle`, `~/.konan`, `~/.kolt`)。release.yml はこの雛形に乗る。
+- **kolt.toml の version**: 手動で release PR ごとに bump (PR #271 が precedent)。release.yml の gate でこれと tag を比較する。
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+    subgraph user_side[利用者側]
+        UserCurl[curl fsSL pipe sh]
+        UserHome[home dot local share kolt version]
+    end
+
+    subgraph repo[kolt repo HEAD on main]
+        InstallSh[install dot sh]
+        Yanked[YANKED]
+        ReadmeSection[README Installation]
+    end
+
+    subgraph ghactions[GitHub Actions]
+        ReleaseYml[release dot yml on tag]
+        SelfHostSmoke[self host smoke yml on PR]
+    end
+
+    subgraph release[GitHub Release on tag]
+        Tarball[kolt version linux x64 tar gz]
+        Sha256[kolt version linux x64 tar gz dot sha256]
+    end
+
+    subgraph buildtools[Build tools]
+        AssembleDist[scripts assemble dist sh]
+        KoltBuild[3 x kolt build release]
+    end
+
+    UserCurl -->|fetch| InstallSh
+    InstallSh -->|fetch YANKED| Yanked
+    InstallSh -->|enumerate releases| release
+    InstallSh -->|download| Tarball
+    InstallSh -->|verify| Sha256
+    InstallSh -->|extract| UserHome
+
+    ReleaseYml -->|tag gate YANKED gate| Yanked
+    ReleaseYml -->|invoke| KoltBuild
+    KoltBuild -->|produces| AssembleDist
+    AssembleDist -->|writes| Tarball
+    AssembleDist -->|writes| Sha256
+    ReleaseYml -->|gh release create| release
+    ReleaseYml -.->|tag time smoke| InstallSh
+
+    SelfHostSmoke -->|build| AssembleDist
+    SelfHostSmoke -->|invoke with KOLT_TEST envs| InstallSh
+```
+
+**Architecture Integration**:
+- **Selected pattern**: 単方向データフロー型 release pipeline。tag を上流 trigger、`install.sh` を下流 consumer、`YANKED` を双方向 gate (release.yml で publish 時 / install.sh で install 時)。
+- **Domain boundaries**: 「release を作る側 (release.yml + assemble-dist.sh)」と「release を消費する側 (install.sh + YANKED)」を明確分離。CI smoke は両側のテスト harness。
+- **Existing patterns preserved**: `self-host-smoke.yml` のキャッシュキー、JDK 25 setup、3 × kolt build sequence。`assemble-dist.sh` の出力ロジック。`kolt.toml` を version の単一情報源とする慣習 (PR #271 precedent)。
+- **New components rationale**: install.sh は curl|sh される self-contained script の責務、release.yml は tag → asset の責務、YANKED は 2 サイドが共有する manifest の責務。それぞれ単一責任。
+- **Steering compliance**: ADR 0018 §1 / §4 / §6 と ADR 0028 §1 / §5 を実装側として尊重。CLAUDE.md の "no backward compat until v1.0" に従い、format / env var の変更は migration shim 無しで行ってよい。
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Install script shell | POSIX sh (`#!/bin/sh`) | `install.sh` の実行環境。bash-isms (`[[ ]]`、配列、`local`) は使わない | macOS の bash 3.2 対応の保険。#82 で確定対応 |
+| Release workflow | GitHub Actions (`actions/*@v4`、`gh` CLI) | tag-triggered build + publish + smoke の orchestration | runner: `ubuntu-latest`、permissions: `contents: write` |
+| Hash | `sha256sum` (GNU coreutils) | tarball integrity の必須検証 | macOS では `shasum -a 256` だが #82 で対応。初版は Linux only |
+| HTTP | `curl -fsSL` (全 path) | release fetch / API enumerate / YANKED fetch / tarball+`.sha256` download | `-fsS` で進捗バー抑制、`-L` で redirect 追従 |
+| Archive | `tar xzf` (POSIX) | tarball 展開 | `--strip-components=0` (top-level dir 維持) |
+| JSON parse | `grep -oE` + `sed` | GitHub Releases API response から `tag_name` 抽出 | 限定 scope の文字列抽出のみ。`jq` 依存は避ける |
+| SemVer compare | `sort -V` (GNU sort) | tag list を newest-first で並べる | Linux 限定。BSD sort は #82 で別途対応 |
+
+## File Structure Plan
+
+### Directory Structure
+
+```
+kolt/                                    # repo root
+├── install.sh                          # NEW: POSIX sh script, the curl|sh entry
+├── YANKED                               # NEW: empty file at first
+├── README.md                            # MODIFIED: Installation section
+├── scripts/
+│   └── assemble-dist.sh                # MODIFIED: append .sha256 generation
+└── .github/workflows/
+    ├── release.yml                     # NEW: tag-triggered release + smoke
+    └── self-host-smoke.yml             # MODIFIED: replace sed with install.sh, add yank smoke
+```
+
+### Modified Files
+
+- **`scripts/assemble-dist.sh`** — 既存の末尾 `tar czf` の直後 (line 254 付近) に `sha256sum kolt-${VERSION}-linux-x64.tar.gz > kolt-${VERSION}-linux-x64.tar.gz.sha256` を 1 行追加 (相対パス cd 済みの dist/ 内で実行)。本体ロジックは無変更。
+- **`.github/workflows/self-host-smoke.yml`** — `self-host-post` job 中の lines 181-188 (Substitute KOLT_LIBEXEC placeholder in argfiles step) を「install.sh を `KOLT_TEST_BASE_URL` + `KOLT_VERSION` 付きで呼び出す step」に置換。直後に「合成 YANKED でテスト version を yank した状態で install.sh を実行し、refuse を assert する step」を追加。
+- **`README.md`** — `## Installation` section (lines 14-30) を、curl|sh の copy-paste-able code block + `KOLT_VERSION` / `KOLT_ALLOW_YANKED` の env var 解説 + linux-x64 only / #82 / #83 の note + PATH への追加が必要であり得る旨の note、に書き換える。Build-from-source 手順は contributor 向けセクションに移動して保持。
+
+### New Files
+
+- **`install.sh`** (~250-350 行) — repo root 直下、`#!/bin/sh` shebang。`set -eu`、後述 7 関数構成。
+- **`YANKED`** — repo root 直下、size 0 bytes。`.gitignore` 対象外。
+- **`.github/workflows/release.yml`** (~150-200 行) — tag trigger 専用。後述 4 段階の gate + build + publish + smoke。
+
+## System Flows
+
+### install.sh — 全体実行フロー
+
+```mermaid
+flowchart TD
+    Start[install dot sh start]
+    DetectPlatform[platform_detect via uname]
+    PlatformOk{platform supported}
+    PlatformFail[print fail message exit non zero]
+
+    FetchValidate[fetch_yanked_and_validate]
+    FetchOk{HTTP ok}
+    FetchFail[print fetch fail exit 6]
+    ParseOk{parse ok}
+    ParseFail[print parse error exit 2]
+
+    DetermineVersion{KOLT_VERSION set}
+    UseExplicit[use KOLT_VERSION value]
+    EnumerateAndFilter[API enumerate plus SemVer sort plus is_yanked filter pick first non yanked]
+
+    YankCheckStep[yank_check via is_yanked]
+    Yanked{is yanked}
+    AllowOverride{KOLT_ALLOW_YANKED equals 1}
+    YankRefuse[print replacement exit 3]
+    YankWarn[print warning continue]
+
+    DownloadTarball[curl tarball plus sha256]
+    DownloadOk{download ok 200}
+    DownloadFail[print HTTP error exit 4]
+
+    VerifySha[sha256sum check]
+    ShaOk{digest match}
+    ShaFail[delete tarball print digests exit 5]
+
+    SymlinkCheck[check local bin kolt]
+    SymlinkBlock{non symlink existing}
+    SymlinkRefuse[print remove and retry exit 8]
+
+    ExtractClean[rm rf existing version dir if any]
+    Extract[mkdir share kolt then tar xzf]
+    Sed[sed KOLT_LIBEXEC placeholder in argfiles]
+    Symlink[mkdir local bin then ln s force]
+    PathCheck{HOME local bin in PATH}
+    PathHint[print PATH hint to stderr]
+    Done[print success exit 0]
+
+    Start --> DetectPlatform --> PlatformOk
+    PlatformOk -- no --> PlatformFail
+    PlatformOk -- yes --> FetchValidate
+    FetchValidate --> FetchOk
+    FetchOk -- no --> FetchFail
+    FetchOk -- yes --> ParseOk
+    ParseOk -- no --> ParseFail
+    ParseOk -- yes --> DetermineVersion
+    DetermineVersion -- yes --> UseExplicit --> YankCheckStep
+    DetermineVersion -- no --> EnumerateAndFilter --> YankCheckStep
+    YankCheckStep --> Yanked
+    Yanked -- no --> SymlinkCheck
+    Yanked -- yes --> AllowOverride
+    AllowOverride -- no --> YankRefuse
+    AllowOverride -- yes --> YankWarn --> SymlinkCheck
+    SymlinkCheck --> SymlinkBlock
+    SymlinkBlock -- yes --> SymlinkRefuse
+    SymlinkBlock -- no --> DownloadTarball
+    DownloadTarball --> DownloadOk
+    DownloadOk -- no --> DownloadFail
+    DownloadOk -- yes --> VerifySha
+    VerifySha --> ShaOk
+    ShaOk -- no --> ShaFail
+    ShaOk -- yes --> ExtractClean --> Extract --> Sed --> Symlink --> PathCheck
+    PathCheck -- no --> PathHint --> Done
+    PathCheck -- yes --> Done
+```
+
+**Key decisions**:
+- YANKED manifest の fetch + format validate は最初に 1 回 (`FetchValidate`)。format error はここで止め、後続経路は validated manifest だけを参照する。
+- `EnumerateAndFilter` は内部で `is_yanked` を loop で呼んで「最新の non-yanked」を pick する (Req 3.1 を honor)。`YankCheckStep` は KOLT_VERSION 経路で active、auto-pick 経路では論理的 no-op だが defensive な double-check として flow 上残す。
+- 全 fail path で「ファイルシステムへの改変は最後」が成立。`SymlinkCheck` は download 前 (existing non-symlink を上書きせず early refuse)、`ExtractClean` で既存 version dir を rm して残骸を残さない、symlink 作成は最後。
+- `KOLT_TEST_BASE_URL` / `KOLT_TEST_YANKED_URL` が設定された場合、`FetchValidate` / `DownloadTarball` は対応 URL に向く。`KOLT_VERSION` 併用で API path を完全 bypass できる (PR-time smoke 用)。
+
+### release.yml — tag push から smoke までのフロー
+
+```mermaid
+sequenceDiagram
+    participant Maintainer
+    participant GHA as GitHub Actions
+    participant ReleaseJob as release job
+    participant SmokeJob as smoke job
+    participant GHRelease as GitHub Release
+
+    Maintainer->>GHA: git push tag v0.16.0
+    GHA->>ReleaseJob: trigger on push tags
+
+    ReleaseJob->>ReleaseJob: gate 1 SemVer regex
+    Note right of ReleaseJob: SemVer regex check
+    ReleaseJob->>ReleaseJob: gate 2 kolt.toml version equals tag
+    ReleaseJob->>ReleaseJob: gate 3 tag not in YANKED
+    ReleaseJob->>ReleaseJob: setup JDK 25 plus libcurl plus caches
+    ReleaseJob->>ReleaseJob: bootstrap kolt.kexe via gradle
+    ReleaseJob->>ReleaseJob: 3 x kolt build release
+    ReleaseJob->>ReleaseJob: scripts assemble-dist.sh
+    ReleaseJob->>ReleaseJob: sha256sum tarball
+    ReleaseJob->>GHRelease: gh release create with assets
+    Note right of GHRelease: prerelease flag if rc or beta
+
+    GHA->>SmokeJob: trigger on release job success
+    SmokeJob->>GHRelease: curl install.sh from raw URL
+    SmokeJob->>SmokeJob: HOME mktemp d isolation
+    SmokeJob->>GHRelease: install.sh fetches tarball
+    SmokeJob->>SmokeJob: assert kolt --version exit 0
+    Note right of SmokeJob: fail keeps release marked prerelease
+```
+
+**Key decisions**:
+- 3 gate は順序依存 (SemVer → kolt.toml → YANKED)。最初の cheap check で fail-fast、build に入る前に reject。
+- `gh release create` が成功すれば release は publish 状態で見える。smoke が後から失敗すると Release は public のまま残る (revert 困難) — これは `gh release create --prerelease` を一度経由する運用も検討するが、初版は単純に「smoke 失敗時は人間が手動で yank する」運用とする (頻度極低)。
+- tag-time smoke は別 job で、`needs: release` で順序保証。clean runner で実 raw URL を curl|sh する。
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | SemVer tag → release.yml が tarball upload | release.yml | tag trigger + `gh release create` | release.yml flow |
+| 1.2 | 不正 tag を upload 前に reject | release.yml | gate 1 (SemVer regex) | release.yml flow |
+| 1.3 | tarball と `.sha256` を同時 upload | release.yml + assemble-dist.sh extension | `gh release create <files...>` | release.yml flow |
+| 1.4 | YANKED 該当 tag は upload 前に reject | release.yml | gate 3 (YANKED parser) | release.yml flow |
+| 1.5 | `-rc.N` / `-beta.N` は pre-release mark | release.yml | `gh release create --prerelease` | release.yml flow |
+| 1.6 | tag と kolt.toml の version 整合 | release.yml | gate 2 (kolt.toml ↔ tag check) | release.yml flow |
+| 2.1 | linux-x64 で fresh install 完走 | install.sh | `download_and_verify` + `extract_and_link` | install.sh flow |
+| 2.2 | argfile の `@KOLT_LIBEXEC@` 置換 | install.sh | `extract_and_link` 内 sed step | install.sh flow |
+| 2.3 | `~/.local/bin/kolt` symlink 作成・上書き | install.sh | `extract_and_link` 内 `ln -sf` | install.sh flow |
+| 2.4 | `~/.local/{bin,share/kolt}` mkdir | install.sh | `extract_and_link` 内 `mkdir -p` | install.sh flow |
+| 2.5 | `kolt --version` 通る | install.sh + smoke jobs | (post-condition assert) | release.yml + self-host-smoke.yml flows |
+| 2.6 | 既存 non-symlink を上書きせず refuse | install.sh | `extract_and_link` 内 file type check | install.sh flow |
+| 2.7 | PATH 未設定なら hint | install.sh | `extract_and_link` 末尾 PATH check | install.sh flow |
+| 3.1 | `KOLT_VERSION` 未指定で latest non-yanked | install.sh | `select_version` (API enumerate + sort -V + filter) | install.sh flow |
+| 3.2 | `KOLT_VERSION=<v>` 指定 | install.sh | `select_version` early return | install.sh flow |
+| 3.3 | yank された version refuse | install.sh | `parse_yanked` + decision branch | install.sh flow |
+| 3.4 | `KOLT_ALLOW_YANKED=1` で続行 + 警告 | install.sh | `parse_yanked` + decision branch | install.sh flow |
+| 3.5 | YANKED fetch 失敗で fail | install.sh | `fetch_yanked` curl error handling | install.sh flow |
+| 3.6 | YANKED は raw GitHub URL から fetch | install.sh | `fetch_yanked` URL constant + `KOLT_TEST_YANKED_URL` override | install.sh flow |
+| 4.1 | `Linux/x86_64` → `linux-x64` 続行 | install.sh | `platform_detect` case 文 | install.sh flow |
+| 4.2 | `Darwin` は #82 参照 fail | install.sh | `platform_detect` case 文 | install.sh flow |
+| 4.3 | `Linux` 非 `x86_64` は #83 参照 fail | install.sh | `platform_detect` case 文 | install.sh flow |
+| 4.4 | その他は generic unsupported fail | install.sh | `platform_detect` case 文 | install.sh flow |
+| 4.5 | tarball 命名規約 multi-platform | install.sh + assemble-dist.sh | URL 構築の `<platform>` 変数化 | (cross-cutting) |
+| 5.1 | release が `.sha256` を upload | assemble-dist.sh extension + release.yml | `sha256sum > .sha256` + `gh release create` | release.yml flow |
+| 5.2 | install.sh が `.sha256` を fetch して検証 | install.sh | `download_and_verify` 内 `sha256sum -c` | install.sh flow |
+| 5.3 | 検証失敗で削除 + fail | install.sh | `download_and_verify` 内 verify branch | install.sh flow |
+| 5.4 | 検証は展開・sed・symlink より前 | install.sh | flow ordering invariant | install.sh flow |
+| 6.1 | repo root に `YANKED` 1 ファイル | YANKED | (file 存在自体) | (cross-cutting) |
+| 6.2 | yank が無い場合 0 bytes | YANKED | (initial state) | (cross-cutting) |
+| 6.3 | 各非空行 3 tab-separated fields | release.yml gate + install.sh `parse_yanked` | parser strict mode | (cross-cutting) |
+| 6.4 | コメント・空行不可、newest yank last | release.yml gate + install.sh `parse_yanked` | parser strict mode | (cross-cutting) |
+| 6.5 | release.yml の parse error は fail | release.yml | YANKED gate parse error handling | release.yml flow |
+| 6.6 | install.sh の parse error は fail | install.sh | `parse_yanked` exit code 2 path | install.sh flow |
+| 6.7 | 同じ manifest を repo HEAD から fetch | release.yml + install.sh | URL constants | (cross-cutting) |
+| 7.1 | PR で local tarball + install.sh smoke | self-host-smoke.yml extension | `KOLT_TEST_BASE_URL` + `KOLT_VERSION` 付き install.sh 実行 | self-host-smoke flow |
+| 7.2 | PR で yank refuse smoke | self-host-smoke.yml extension | 合成 YANKED + install.sh refuse assert | self-host-smoke flow |
+| 7.3 | tag-time real curl|sh smoke | release.yml smoke job | clean runner + raw URL curl|sh | release.yml flow |
+| 7.4 | smoke 失敗で merge block / latest 不付与 | release.yml + self-host-smoke.yml | GHA job needs / branch protection | (cross-cutting) |
+| 7.5 | PR-time smoke は実 release を不要 | self-host-smoke.yml extension | local HTTP 配信 + env override | self-host-smoke flow |
+| 8.1 | README に curl|sh code block | README.md | (text content) | (cross-cutting) |
+| 8.2 | README に env var 解説 | README.md | (text content) | (cross-cutting) |
+| 8.3 | README に linux-x64 only note | README.md | (text content) | (cross-cutting) |
+| 8.4 | README に PATH 注意 | README.md | (text content) | (cross-cutting) |
+
+## Components and Interfaces
+
+### Component summary
+
+| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies (P0/P1) | Contracts |
+|-----------|--------------|--------|--------------|--------------------------|-----------|
+| install.sh | Install script (POSIX sh) | platform 検出から symlink 作成まで一括する self-contained installer | 2.*, 3.*, 4.*, 5.2-4 | GitHub Releases API (P0), YANKED manifest (P0), `sha256sum` (P0) | Service (env var contract + exit codes) |
+| release.yml | Release workflow (GHA) | tag push → asset publish + tag-time smoke を orchestrate | 1.*, 5.1, 6.5, 7.3-4 | `assemble-dist.sh` (P0), `gh release create` (P0), kolt.toml (P0), YANKED (P0) | Batch (trigger + assets) |
+| assemble-dist.sh extension | Build script | tarball と並べて `.sha256` を出力する | 1.3, 5.1 | `sha256sum` (P0) | Batch (output paths) |
+| self-host-smoke.yml extension | Smoke workflow (GHA) | PR ごとに install.sh の本物の経路を exercise する | 7.1-2, 7.4-5 | install.sh (P0), assemble-dist.sh (P0) | Batch (trigger + assertions) |
+| YANKED file | Manifest | yank 状態の単一情報源、release.yml と install.sh の双方が parse する | 6.1-7 | ADR 0028 §5 format (P0) | Batch (file format) |
+| README.md Installation | Documentation | curl|sh の入口とユーザ向け env var 解説 | 8.* | install.sh (P1) | (text) |
+
+### Install script
+
+#### install.sh
+
+| Field | Detail |
+|-------|--------|
+| Intent | platform 検出から symlink 作成まで一括する self-contained POSIX sh installer |
+| Requirements | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 4.1, 4.2, 4.3, 4.4, 4.5, 5.2, 5.3, 5.4, 6.6, 6.7 |
+
+**Responsibilities & Constraints**
+- `#!/bin/sh` + `set -eu`、bash-isms 禁止 (将来 macOS 対応のため)
+- 全 fail path で「展開済み一時ファイルを残さない」「symlink を中途半端に書き換えない」を保証
+- 外部依存 (`curl`, `tar`, `sed`, `grep`, `sha256sum` 等) は POSIX/coreutils 標準のみ
+- 7 つの内部関数 (`platform_detect`, `fetch_yanked_and_validate`, `is_yanked`, `select_version`, `yank_check`, `download_and_verify`, `extract_and_link`, `print_path_hint`) で構成。YANKED manifest の validate (format check) は 1 回のみ、lookup (`is_yanked`) は cheap な grep ベースで複数回実行可
+
+**Dependencies**
+- External: GitHub Releases API `https://api.github.com/repos/snicmakino/kolt/releases?per_page=100` (P0) — version enumerate
+- External: GitHub raw URL `https://raw.githubusercontent.com/snicmakino/kolt/main/YANKED` (P0) — yank manifest
+- External: GitHub Release asset URL `https://github.com/snicmakino/kolt/releases/download/v<v>/kolt-<v>-<platform>.tar.gz{,.sha256}` (P0) — tarball + digest
+- External: `sha256sum`, `tar`, `curl`, `sed`, `grep`, `awk` (P0) — POSIX/coreutils
+
+**Contracts**: Service [x] / API [ ] / Event [ ] / Batch [ ] / State [ ]
+
+##### Env var contract
+
+| Variable | Default | Purpose | Audience |
+|---|---|---|---|
+| `KOLT_VERSION` | (auto: latest non-yanked) | install 対象 version の明示指定 | end user |
+| `KOLT_ALLOW_YANKED` | `0` (refuse) | `1` 設定で yanked version も install | end user |
+| `KOLT_TEST_BASE_URL` | (auto: GitHub Release URL) | tarball + `.sha256` の base URL を override | CI smoke のみ、user 向けではない |
+| `KOLT_TEST_YANKED_URL` | (auto: raw GitHub URL) | YANKED manifest の URL を override | CI smoke のみ、user 向けではない |
+
+##### Exit codes
+
+各 exit code は単一の失敗カテゴリーに対応する。stderr に出力されるメッセージから debug 時に一意に identify できることを invariant とする。
+
+| Code | Meaning |
+|---|---|
+| 0 | install 成功 |
+| 1 | platform unsupported (`platform_detect` 失敗) |
+| 2 | YANKED manifest parse error (format 違反) |
+| 3 | yanked version refuse (`KOLT_ALLOW_YANKED` 未設定で yanked を install しようとした) |
+| 4 | tarball / `.sha256` download HTTP error (404 含む) |
+| 5 | SHA-256 verification mismatch |
+| 6 | network error (`fetch_yanked_and_validate` の HTTP / API enumerate 失敗) |
+| 7 | `KOLT_VERSION` の値が malformed (空文字 / 不正文字を含む等) |
+| 8 | `~/.local/bin/kolt` が non-symlink (regular file / dir) で existing |
+
+##### Internal function contracts
+
+```
+platform_detect() -> stdout: <platform-string>
+  Reads `uname -s` and `uname -m`. Echoes "linux-x64" on Linux/x86_64.
+  Exits non-zero (code 1) for Darwin (#82 reference), Linux non-x86_64 (#83
+  reference), or other (generic unsupported) with explicit stderr message.
+
+fetch_yanked_and_validate() -> stdout: <validated-tempfile-path>
+  Curls KOLT_TEST_YANKED_URL or default raw URL into a tempfile.
+  Validates each non-empty line as exactly 3 tab-separated non-empty
+  fields (ADR 0028 §5: no comments, no blank lines, no leading or
+  trailing whitespace). On HTTP error, exits with code 6. On parse
+  error, exits with code 2 (stderr: "YANKED parse error at line N: ...").
+  Returns local tempfile path on stdout. Called exactly ONCE per
+  install.sh invocation.
+
+is_yanked(manifest_file, target_version) -> exit code + stdout
+  Cheap lookup against an already-validated manifest. Searches for a
+  line whose first tab-separated field equals target_version. Returns:
+    exit 0: target version is yanked, stdout: "<replacement>\t<reason>"
+    exit 1: target version is NOT yanked
+  Does NOT perform format validation (caller must have already run
+  fetch_yanked_and_validate). Safe to call multiple times.
+
+select_version(platform, manifest_file) -> stdout: <version-string>
+  If KOLT_VERSION is set, echoes its value (no API call, no yank filter).
+  Otherwise curls https://api.github.com/.../releases?per_page=100,
+  extracts tag_name fields, filters out prereleases (tag containing "-"),
+  sorts via `sort -V` (descending), and iterates picking the topmost
+  tag for which is_yanked(manifest_file, v) returns 1 (not yanked).
+  Honors Req 3.1 by skipping yanked tags during latest selection.
+  Returns version without "v" prefix.
+
+yank_check(manifest_file, version) -> may exit
+  Calls is_yanked(manifest_file, version). If yanked and KOLT_ALLOW_YANKED
+  is not "1", exits 3 with replacement and reason on stderr. If yanked and
+  KOLT_ALLOW_YANKED=1, prints warning to stderr and returns. If not
+  yanked, returns silently. For the auto-pick path this is a logical
+  no-op (select_version guarantees the picked version is not yanked);
+  kept in the flow as a uniform, defensive double-check that activates
+  the explicit-version path.
+
+download_and_verify(version, platform) -> stdout: <local-tarball-path>
+  Curls tarball + .sha256 from KOLT_TEST_BASE_URL or default GitHub
+  Release URL. Verifies via `sha256sum -c`. On HTTP error, exits 4.
+  On verification failure, deletes tarball and exits 5 with both
+  expected and actual digests in stderr.
+
+extract_and_link(tarball_path, version)
+  mkdir -p ~/.local/share/kolt ~/.local/bin (4)
+  Check ~/.local/bin/kolt: if non-symlink, exit 8 (2.6)
+  If ~/.local/share/kolt/<version>/ exists, rm -rf it before extracting
+    (idempotent re-install / repair semantics, rustup-init style).
+  tar xzf <tarball> -C ~/.local/share/kolt (creates kolt-<v>-linux-x64/)
+  rename to ~/.local/share/kolt/<version>/ (canonical name)
+  sed -i -- 's|@KOLT_LIBEXEC@|<absolute-libexec-path>|g' for each argfile (2.2)
+  ln -sf ~/.local/share/kolt/<version>/bin/kolt ~/.local/bin/kolt (2.3)
+
+print_path_hint()
+  Checks if `:$PATH:` contains `:$HOME/.local/bin:` (literal $HOME
+  expansion only, not tilde — PATH is stored with expanded paths).
+  If not, prints stderr hint about adding it (2.7).
+```
+
+**Implementation Notes**
+- Integration: `KOLT_TEST_*` env vars が設定されたとき、`select_version` は API enumerate を skip すべく `KOLT_VERSION` 必須にする (test mode の前提)。CI smoke は両方 set する。
+- Validation: 全 step の入口で先行 step の post-condition を再 assert (例: `extract_and_link` 入口で tarball 存在確認)。
+- Idempotency: `extract_and_link` は既存 `~/.local/share/kolt/<version>/` を `rm -rf` してから tar 展開する (rustup-init 流)。同一 version で再実行すると clean repair として機能し、過去 install の残骸 (削除されたファイル等) が漏れない。
+- Risks: GitHub API rate limit (60/h unauth) は通常のユーザー単発実行では non-issue。CI smoke は test mode で API を叩かないので影響なし。
+- Risks: macOS の sed は `-i` の引数 syntax が異なる (`-i ''` 必須)。初版 linux only なので Linux GNU sed のみ想定、コメントで `[future] macOS sed handling for #82` を記す。
+- Implementation latitude: `fetch_yanked_and_validate` の format check と `is_yanked` の lookup は概念的に分離されているが、POSIX sh で sub-shell capture (`result=$(...)`) と `set -e` の干渉が問題化した場合は、両者を独立 step として CI yaml レベルで切り出す余地もある。本 design は contract のみ pin、内部実装の単一関数化 / 分離は impl-time 判断で許容する。
+
+### Release workflow
+
+#### release.yml
+
+| Field | Detail |
+|-------|--------|
+| Intent | tag push を起点に SemVer / kolt.toml / YANKED の 3 gate を経て tarball + `.sha256` を publish し、tag-time smoke を実走する |
+| Requirements | 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 5.1, 6.5, 7.3, 7.4 |
+
+**Responsibilities & Constraints**
+- Trigger: `push: tags: ['v*']` および `workflow_dispatch` (input `dry_run: boolean` default true)。`workflow_dispatch + dry_run=true` は first tag 前の事前検証のため、gates → build → assemble → sha256 までを実行し、`gh release create` と smoke job を skip する。`workflow_dispatch + dry_run=false` は実 publish と等価で誤発火対策に default を true にしておく。
+- Permissions: `contents: write` (asset upload に必須)。`actions/checkout@v4` の default GITHUB_TOKEN で `gh release create` が動く。
+- 2 jobs: `release` (gate + build + publish) と `smoke` (`needs: release`、curl|sh real-run)。`gh release create` step は `if: github.event_name == 'push' || !inputs.dry_run`、`smoke` job は同条件を job-level `if:` に持つ。
+
+**Dependencies**
+- External: `gh` CLI (P0) — pre-installed on `ubuntu-latest`
+- External: `actions/checkout@v4`, `actions/setup-java@v4`, `actions/cache@v4` (P0)
+- Internal: `scripts/assemble-dist.sh` (P0) — tarball stitcher
+- Internal: `kolt.toml` の `version =` 行 (P0) — gate 2 の照合先
+- Internal: `YANKED` (P0) — gate 3 の参照先
+
+**Contracts**: Service [ ] / API [ ] / Event [ ] / Batch [x] / State [ ]
+
+##### Batch / Job Contract
+
+- **Trigger**: `on: push: tags: ['v*']` または `on: workflow_dispatch: inputs: dry_run`
+- **Input**: pushed tag (`${{ github.ref_name }}`)、`workflow_dispatch` の場合は `inputs.dry_run`、kolt.toml HEAD、YANKED HEAD
+- **Output (push trigger or dry_run=false)**: GitHub Release (tag に対応) に attach された 2 assets:
+  - `kolt-<version>-linux-x64.tar.gz`
+  - `kolt-<version>-linux-x64.tar.gz.sha256`
+  - `--prerelease` flag for `-rc.N` / `-beta.N` tags
+- **Output (workflow_dispatch with dry_run=true)**: GitHub Release は作成されない。gates / build / assemble / sha256 の生成までは走り、artifact は GHA log に残る。tag-time smoke job も skip。
+- **Idempotency & recovery**: 既に同 tag に対応する Release が存在する場合 `gh release create` は fail する。これを「同 tag を 2 回 publish しない」safety 機能として扱う (re-trigger は手動で yank → re-tag が必要)。
+
+##### Job structure (release job)
+
+| Step | Purpose | Fail mode |
+|---|---|---|
+| Checkout | repo を取得 | (n/a) |
+| Gate 1: SemVer regex | tag が ADR 0028 §1 regex に match することを assert | step fail (要件 1.2) |
+| Gate 2: kolt.toml↔tag | `${GITHUB_REF#refs/tags/v}` == `kolt.toml` の version であることを assert | step fail (要件 1.6) |
+| Gate 3: YANKED | tag の version が `YANKED` の最初の column に出現しないことを assert。parse error も fail | step fail (要件 1.4, 6.5) |
+| Setup JDK 25 + libcurl + caches | self-host-smoke と同じ pattern | (warmup) |
+| Bootstrap kolt.kexe via Gradle | `./gradlew --no-daemon linkDebugExecutableLinuxX64` | step fail |
+| 3 × kolt build --release | self-host post job と同じ手順 | step fail |
+| Run scripts/assemble-dist.sh | tarball + (extension で) `.sha256` 生成 | step fail |
+| gh release create | `--target $SHA <tag> dist/kolt-...tar.gz dist/kolt-...tar.gz.sha256` + `--prerelease` if rc/beta。`if: github.event_name == 'push' \|\| !inputs.dry_run` で dry_run 時 skip | step fail (要件 1.3, 1.5) |
+
+##### Job structure (smoke job)
+
+| Step | Purpose | Fail mode |
+|---|---|---|
+| `needs: release` + `if: github.event_name == 'push' \|\| !inputs.dry_run` | release job 成功後のみ起動、dry_run 時 skip | (skip) |
+| Setup `HOME=$(mktemp -d)` | clean state 保証 | (warmup) |
+| `curl -fsSL <raw URL> \| sh` | real raw GitHub URL 経由で install.sh を起動 (要件 7.3) | step fail |
+| `~/.local/bin/kolt --version` assert | exit 0 + version 文字列確認 (要件 2.5) | step fail |
+
+**Implementation Notes**
+- Integration: gate logic は inline Bash steps (10-30 行/step)。YANKED parser は `awk -F'\t'` で 3-field check + version match。
+- Validation: gate 1-3 はいずれも build に入る前に走る。fail-fast で CI minutes を浪費しない。
+- Risks: `gh release create` 失敗時、build 成果物は捨てられる (artifact upload してない)。再 push (force-push tag) は人間判断で行う。
+
+### Build script extension
+
+#### scripts/assemble-dist.sh — diff
+
+| Field | Detail |
+|-------|--------|
+| Intent | 既存 tarball 出力直後に `.sha256` を併産する |
+| Requirements | 1.3, 5.1 |
+
+**Responsibilities & Constraints**
+- 既存 line 254 直後に 1 行追加: `(cd dist && sha256sum "kolt-${VERSION}-linux-x64.tar.gz" > "kolt-${VERSION}-linux-x64.tar.gz.sha256")`
+- 出力 format は `sha256sum` 標準 (`<hex>  <filename>`)、改行 1 つ
+- subshell で `cd dist` を使い、`.sha256` 内の filename が basename になることを保証 (絶対パス埋め込みを避ける)
+
+**Implementation Notes**
+- `set -euo pipefail` 下なので sha256sum 失敗は script 全体を fail させる
+- self-host-smoke.yml の self-host-post job も extension の影響を受ける (`.sha256` が dist/ 配下に出る)。これは下流の install.sh smoke が期待するもので、整合する
+- cwd 整合性 verified: 既存 assemble-dist.sh は line 87 で `cd "$ROOT_DIR"`、line 254 で `tar czf "dist/kolt-${VERSION}-linux-x64.tar.gz" -C dist ...` と `dist/` を相対パスで参照する。提案の subshell `(cd dist && sha256sum ...)` は同 cwd 前提で整合し、追加 cd は不要
+
+### Smoke workflow extension
+
+#### .github/workflows/self-host-smoke.yml — diff
+
+| Field | Detail |
+|-------|--------|
+| Intent | PR ごとに install.sh の本物の経路を exercise する |
+| Requirements | 7.1, 7.2, 7.4, 7.5 |
+
+**Responsibilities & Constraints**
+- 既存 lines 181-188 (Substitute KOLT_LIBEXEC placeholder in argfiles step) を **削除**
+- 代わりに「local HTTP server で `dist/` を serve + install.sh を `KOLT_TEST_BASE_URL` + `KOLT_TEST_YANKED_URL` + `KOLT_VERSION` 付きで起動 + `kolt --version` assert」step を挿入 (7.1, 7.5)。serve directory には dist/ 配下の tarball + .sha256 と、その隣に空 YANKED ファイルを配置する
+- 続けて「synthetic YANKED ファイルにテスト version 行を加えた状態で install.sh を呼び、refuse exit code 3 を assert」step を追加 (7.2)。同じ HTTP server を流用し、別 path (`YANKED-with-yank`) を serve する
+- fixture smoke build (lines 194-201) は無変更で残す
+
+**Implementation Notes**
+- Local HTTP serving: `python3 -m http.server 8000 --bind 127.0.0.1 --directory <serve-dir> &`、PID を trap で kill
+  - serve-dir に `kolt-<v>-linux-x64.tar.gz` + `.sha256` + `YANKED` (空) + `YANKED-with-yank` (テスト entry 入り) を配置
+  - install.sh から見える URL: `http://127.0.0.1:8000/kolt-<v>-linux-x64.tar.gz` 等
+- 環境変数:
+  - happy path: `KOLT_TEST_BASE_URL=http://127.0.0.1:8000`、`KOLT_TEST_YANKED_URL=http://127.0.0.1:8000/YANKED`、`KOLT_VERSION=<kolt.toml の version>`
+  - yank refuse path: 同上 + `KOLT_TEST_YANKED_URL=http://127.0.0.1:8000/YANKED-with-yank`
+- file:// scheme は使わない (curl の `--proto` 制限が distro 依存のため、tarball 経路と同じ HTTP に揃える)
+- `set +e` で install.sh の exit code を `$?` で捕まえ、期待値 (0 / 3) と比較
+- Job needs: 既存 `needs: self-host` を維持、PR-time も tag-time も同 job が動く
+
+### YANKED manifest
+
+#### YANKED (file at repo root)
+
+| Field | Detail |
+|-------|--------|
+| Intent | yank 状態の単一情報源、release.yml と install.sh の双方が parse する |
+| Requirements | 6.1, 6.2, 6.3, 6.4, 6.7 |
+
+**Responsibilities & Constraints**
+- 初期 commit 時点で 0 bytes (改行を含まない)
+- ADR 0028 §5 完全準拠: 各行 exactly 3 tab-separated non-empty fields (`<version>\t<replacement>\t<reason>`)、コメント・空行・先頭末尾空白不許容
+- newest yank last (時系列順、append)
+- `.gitignore` に含めない
+
+**Contracts**: Service [ ] / API [ ] / Event [ ] / Batch [x] / State [ ]
+
+##### Batch / Job Contract (parse format)
+
+- **Trigger**: release.yml の gate 3、install.sh の `parse_yanked`
+- **Input**: 1 行 = 1 yank entry、各 entry は `<v>\t<r>\t<reason>` (tab 区切り、3 fields)
+- **Output**: parser は (a) target version が listed か否か、(b) listed なら replacement と reason を返す
+- **Idempotency & recovery**: parse error は両側で非ゼロ終了。修正は YANKED ファイル直接編集 + 通常の git commit
+
+### README
+
+#### README.md Installation section
+
+| Field | Detail |
+|-------|--------|
+| Intent | curl|sh の入口とユーザ向け env var 解説 |
+| Requirements | 8.1, 8.2, 8.3, 8.4 |
+
+**Responsibilities & Constraints**
+- 既存 lines 14-30 (Build from source 手順) を:
+  - 冒頭: curl|sh コマンドを copy-paste-able code block (8.1)
+  - `KOLT_VERSION=<v>` と `KOLT_ALLOW_YANKED=1` の 1 行説明 (8.2)
+  - linux-x64 only 明記、macOS / linuxArm64 は #82 / #83 で track (8.3)
+  - PATH に `~/.local/bin` を追加する必要があり得る note (8.4)
+  - Build-from-source 手順は contributor 向け section に移動 (#97 言及は削除、self-host shipped 済み)
+- Quick Start (lines 32+) は影響なし
+
+## Error Handling
+
+### Error Strategy
+
+install.sh は **「展開前に失敗する」** を invariant とする:
+- platform / version / YANKED / SHA-256 の各 check は順序保証され、失敗時はファイルシステムへの改変前に exit する
+- `extract_and_link` 内でも、symlink 作成は最後の操作。中間 fail で `~/.local/share/kolt/<version>/` の半完成 dir が残ることはあり得るが、`~/.local/bin/kolt` が古い version を指す状態は避けられる
+
+release.yml は **「gate 失敗で build に入らない」** を invariant とする:
+- 3 gate (SemVer / kolt.toml / YANKED) は build より前
+- gate 失敗時に GitHub Release は作られない (gh release create に到達しない)
+
+### Error Categories and Responses
+
+**install.sh User-side errors (exit 1, 3, 4, 5, 6)**:
+- Platform unsupported (1) → 具体的な検出 OS/arch + 対応する issue (#82 / #83) を stderr に出力
+- Yanked version refuse (3) → replacement version + reason を表示、`KOLT_ALLOW_YANKED=1` の override を案内
+- HTTP 404 / network error on tarball (4) → URL と HTTP status + 「`<v>` にはバイナリが publish されていません (the installer was introduced in #230, earlier releases predate it)」を pre-#230 version 用 hint として併記
+- SHA-256 mismatch (5) → expected と actual の digest 両方を出力、tarball を削除
+- Network error on YANKED / API (6) → URL と curl error を出力
+
+**install.sh System-side errors (exit 1)**:
+- `~/.local/bin/kolt` が non-symlink で existing (regular file / dir) → 「remove this file manually then re-run install.sh」と案内
+
+**release.yml errors**:
+- SemVer gate fail → tag 名と regex を error message に含める
+- kolt.toml ↔ tag mismatch → tag value と kolt.toml value を両方表示
+- YANKED gate hit → 該当行を表示
+- YANKED parse error → 違反行番号と `<reason>` (field 数 / 空行 / コメント等) を表示
+- Build / assemble-dist fail → 既存の `set -e` で fail-fast、log は GHA UI に残る
+
+### Monitoring
+
+- install.sh: stderr に逐次 progress (curl の `-fsSL` で minimal logging)。失敗時は exit code + 1-2 行のメッセージ
+- release.yml: GHA UI で job 単位の log。`gh release create` 成功 / 失敗は GitHub Releases ページに直接反映される
+- 永続的な monitoring (Sentry、Datadog 等) は scope 外
+
+## Testing Strategy
+
+### Unit-ish tests
+
+install.sh の関数粒度のテストは **専用テスト harness を持たず、CI smoke で end-to-end 経路 + edge case を validate する**戦略を取る。理由は (a) install.sh は POSIX sh、unit test framework が乏しい、(b) 既に self-host-smoke.yml + tag-time smoke で経路全体を回せる、(c) 個別関数の logic は短く inline で済むレベル。
+
+ただし以下の 3 個は smoke で網羅できないため CI の Bash step として独立に exercise する:
+
+1. **`parse_yanked` の strict format chec**k (Req 6.3, 6.4, 6.6)
+   - 不正フォーマットの YANKED に対して install.sh が exit 2 することを assert
+   - test 入力: 2 fields のみの行、空行入りの manifest、tab → 4 spaces に置換した行、コメント `# foo`
+2. **`platform_detect` の 4 分岐** (Req 4.1-4.4)
+   - `uname` を mock して各分岐の exit code とメッセージを assert
+   - macOS / linuxArm64 / unknown 各分岐
+3. **YANKED gate (release.yml 側)** の同等 strict format check (Req 6.5)
+
+これらは PR-time CI で `bash -c '...'` style に追加する短い step として実装。
+
+### Integration Tests (PR-time CI smoke)
+
+self-host-smoke.yml extension で以下 5 経路を exercise (Req 7.1, 7.2, 7.5):
+
+1. **happy path**: assemble-dist.sh → local HTTP serve → install.sh `KOLT_TEST_BASE_URL` + `KOLT_VERSION` → `kolt --version` 成功
+2. **YANKED refuse**: synthetic YANKED に dev version を書く → install.sh `KOLT_TEST_YANKED_URL` + `KOLT_VERSION` → exit 3 を assert + replacement 文字列が stderr に出ることを assert
+3. **YANKED override**: 上記 + `KOLT_ALLOW_YANKED=1` → exit 0 + warning が stderr に出ることを assert
+4. **non-symlink refuse**: `touch ~/.local/bin/kolt`、install.sh 実行 → exit 1 を assert
+5. **SHA-256 mismatch** (optional, 時間あれば): 故意に壊した `.sha256` で install.sh → exit 5 を assert
+
+### E2E Tests (tag-time CI smoke)
+
+release.yml の smoke job (Req 7.3):
+- real raw GitHub URL を curl|sh
+- `HOME=$(mktemp -d)` で隔離
+- `~/.local/bin/kolt --version` 成功 assert
+
+これは「first real tag (v0.16.0 想定)」までは実地検証できない (chicken-and-egg)。緩和策として、PR merge 前に手動で `v0.16.0-rc.1` 相当の test tag を 1 度発射し、release.yml が動くことを確認する運用を recommend する (本 spec の scope 外、release 実施手順として別途記録)。
+
+### Boundary tests
+
+- ADR 0028 §5 に未来 format 拡張があった場合、release.yml gate と install.sh `parse_yanked` の両方を更新する必要があり、CI で両方が新 format を受け入れることを確認できる経路 (= self-host-smoke の YANKED smoke step) を保つ
+
+## Operations
+
+### Smoke 失敗時の yank サイクル
+
+`gh release create` が成功した後 (= GitHub Release が public になった後) に tag-time smoke が失敗した、もしくは利用者から regression が報告された場合の運用:
+
+1. 即座に `YANKED` manifest に当該 version の entry を追加する PR を作る (`<v>\t<replacement>\t<reason>` 1 行 append)
+2. 同 PR を merge し main に commit
+3. 修正 fix は別 PR で進め、次 patch tag (例: `v0.16.0` の次は `v0.16.1`) で publish
+4. YANKED entry が main に存在する間、install.sh は当該 version を refuse し、replacement への誘導を行う
+
+YANKED 反映は PR merge 1 サイクル分の遅延 (CI smoke を含めて数分〜数十分) があるため、broken release を「即時 take down」はできない。本 spec は「shipped tags are immutable」(ADR 0028 §5) を尊重し、yank を advisory な mechanism として扱う。緊急時の運用詳細 (Slack 通知、利用者向け案内文の置き場所等) は follow-up issue に切り出して `docs/release-yank-runbook.md` 相当に集約する余地があるが、本 spec の deliverable には含めない。
+
+### tag を切る前の事前検証
+
+first real tag (v0.16.0 想定) を push する前に release.yml が通ることを確認する手段として、本 spec は `workflow_dispatch + dry_run=true` を提供する (release.yml component 参照)。GHA UI から workflow を手動起動し、gates / build / assemble / sha256 までを exercise して問題ないことを確認した上で、本番 tag を push する運用を推奨する。
+
+## Security Considerations
+
+- **curl | sh の信頼根拠**: install.sh が GitHub の TLS 証明書 + raw URL の repo permission に gate される。github.com / raw.githubusercontent.com / api.github.com の HTTPS は GitHub が責任を持つ範囲。
+- **SHA-256 verification**: tarball の MITM / CDN 改竄に対する第一防衛線。`.sha256` も同じ TLS path で取得するため、両方を MITM される攻撃者は GitHub の証明書を破る必要がある (現実的に sha256 単独では完璧防御ではないが、平易な改竄は防げる)。
+- **cosign / GPG 署名**: 本 spec の scope 外。導入時は `.sig` を `.sha256` と同列で扱う追加 contract になる。
+- **`KOLT_ALLOW_YANKED=1`**: ユーザ明示同意の opt-in。silent override にしない (warning を必ず stderr に出す、Req 3.4)。
+- **GitHub Actions permissions**: release.yml は `contents: write` のみ要求。secrets には触らない (default `GITHUB_TOKEN` で `gh release create` が動く範囲)。
+- **install location**: `~/.local/share/kolt/<v>/` と `~/.local/bin/kolt`。system-wide の `/usr/local/` は触らない (sudo 不要、user 単位 install で完結)。
+- **placeholder substitution**: `@KOLT_LIBEXEC@` の sed 置換は install 時刻に発生し、tarball 自体には絶対パスを埋め込まない (tarball を別ホストに copy しても install.sh が再 sed で動く)。

--- a/.kiro/specs/installer/requirements.md
+++ b/.kiro/specs/installer/requirements.md
@@ -1,0 +1,131 @@
+# Requirements Document
+
+## Introduction
+
+kolt は v0.15.0 まで「git clone → Gradle bootstrap → 自力で PATH 通し」が唯一の入手手段で、外部ユーザが軽く試す導線が無い。ADR 0018 §4 は tarball を `curl | sh` でインストールする UX を v1.0 までの必達ゴールとして定めており、PR #228 で `scripts/assemble-dist.sh` の tarball stitcher は完成済み、ADR 0028 §1/§5 で tag SemVer regex と YANKED manifest の format も pin 済みである。残っているのは (a) tag push を起点とする GitHub Actions release workflow、(b) 公開された `install.sh`、(c) repo HEAD の `YANKED` manifest、(d) install.sh と release workflow の CI smoke、の 4 つを束ねて出荷することのみ。
+
+本 spec はこの 4 点を Linux x64 only で出荷する。多 platform バイナリ (#82 / #83) は tarball 命名と install.sh の case 文を初版から多 platform 前提で書くことで additive な diff として後から追加できるようにし、本 spec のスコープには含めない。SHA-256 verification は初版から install.sh が必須として実施し、cosign / GPG 署名は別 issue に defer する。YANKED gate は release workflow と install.sh の双方に同じ format で実装し、Bash 側 (install.sh) と Kotlin 側 (release workflow gate) で format が drift しないよう ADR 0028 §5 を唯一の正とする。
+
+## Boundary Context
+
+- **In scope**:
+  - tag push (`v*`) を起点に走り、SemVer regex gate と YANKED gate を経て `assemble-dist.sh` を実行し、`kolt-<version>-linux-x64.tar.gz` と `kolt-<version>-linux-x64.tar.gz.sha256` を GitHub Release に upload する `.github/workflows/release.yml`。
+  - repo root に置かれた `install.sh` (`curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh` で起動)。
+  - repo root の空の `YANKED` ファイル。
+  - `scripts/assemble-dist.sh` への `.sha256` 生成追加 (既存 tarball 生成パスへの最小拡張)。
+  - install.sh smoke (PR 毎、ローカル組み立て tarball + 合成 YANKED に対して) と release workflow smoke (tag 毎、実 release assets に対して) の CI ジョブ。
+  - README の install command と環境変数 (`KOLT_VERSION`、`KOLT_ALLOW_YANKED`) ドキュメント。
+- **Out of scope**:
+  - macOS / Windows / linuxArm64 サポート (#82, #83 で別 track)。install.sh の case 文に「未対応 platform」分岐を持つことは本 spec のスコープだが、各 platform 用 binary を produce することは含めない。
+  - install.sh の upgrade / uninstall 経路、複数 version の rollback、shell rc への PATH 追記自動化。
+  - `kolt.dev` ドメイン取得 / DNS 設定 / `https://kolt.dev/install.sh` redirect (raw GitHub URL を初版で採用)。
+  - cosign / GPG / Sigstore 署名 (SHA-256 のみ)。
+  - 多 platform 同時 release (linux-x64 のみ生成)。
+- **Adjacent expectations**:
+  - `scripts/assemble-dist.sh` (PR #228) は tarball layout (ADR 0018 §1: `bin/` + `libexec/`) と `@KOLT_LIBEXEC@` placeholder の sed 戦略を確定済み。本 spec はこれを呼び出す側に立ち、tarball 生成ロジック自体は変更しない (`.sha256` 生成のみ追加)。
+  - ADR 0018 §1/§4 が tarball layout、install 先 (`~/.local/share/kolt/<version>/`)、symlink 先 (`~/.local/bin/kolt`)、platform 検出方針を pin 済み。本 spec はこれに準拠する。
+  - ADR 0028 §1 が tag SemVer regex `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(rc|beta)\.[1-9]\d*)?$` を、§5 が `YANKED` manifest format (tab-separated `version<TAB>replacement<TAB>reason`、コメント・空行不可、newest yank last) を pin 済み。本 spec はこれに準拠する。
+  - `self-host-smoke.yml` は既に PR 毎に `assemble-dist.sh` を走らせて tarball 生成と install レイアウト展開を検証している。本 spec の install.sh smoke はこの既存検証と重複しないよう「install.sh 自身の挙動」に focus する。
+  - CLAUDE.md の "no backward compatibility until v1.0" 方針に従い、release workflow / install.sh / YANKED の format に対する pre-v1 における breaking change は migration shim を伴わず行ってよい。
+
+## Requirements
+
+### Requirement 1: tag push を起点とする release workflow が成果物を発行する
+
+**Objective:** kolt メンテナとして、SemVer 形式の tag を push するだけで対応する tarball と SHA-256 が GitHub Release に自動で公開されることを望む。手元で `assemble-dist.sh` を実行して assets を手動 upload する手間を排し、release が tag SHA に bind された再現可能な手順となるためである。
+
+#### Acceptance Criteria
+
+1. When ADR 0028 §1 の SemVer regex `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(rc|beta)\.[1-9]\d*)?$` に match する tag が push された時、the release workflow shall `scripts/assemble-dist.sh` を実行し、生成された `kolt-<version>-linux-x64.tar.gz` を tag に対応する GitHub Release に upload する。
+2. If push された tag が上記 SemVer regex に match しない時、then the release workflow shall asset の upload を一切行わず非ゼロ終了で job を fail させ、Release を draft として残さない。
+3. When the release workflow が tarball を upload する時、the release workflow shall 同一 Release に `kolt-<version>-linux-x64.tar.gz.sha256` を `sha256sum` の標準出力フォーマット (`<hex digest>  <filename>\n`) で併せて upload する。
+4. If push された tag の version が repo HEAD の `YANKED` の最初の column に出現する時、then the release workflow shall asset の upload を行わず非ゼロ終了で job を fail させ、エラーメッセージに該当行を含める。
+5. When push された tag が `-rc.N` または `-beta.N` 形式の pre-release suffix を持つ時、the release workflow shall 対応する GitHub Release を pre-release として mark し、`latest` Release として扱われない状態にする。
+6. The release workflow shall tarball の version 文字列を `kolt.toml` の `version =` 値ではなく push された tag (`v` prefix を除いたもの) から導出し、tag と tarball ファイル名と Release タイトルが齟齬なく一致する状態を保つ。
+
+### Requirement 2: install.sh が linux-x64 上で fresh install を完了させる
+
+**Objective:** kolt を初めて試す利用者として、`curl -fsSL <raw URL> | sh` の 1 コマンドで kolt が動く状態にしてもらえることを望む。git clone や package manager を介さずに deno / bun / rye / uv 並みの導入体験で kolt を評価できるためである。
+
+#### Acceptance Criteria
+
+1. When 利用者が linux-x64 ホスト上で install.sh を実行した時、the install script shall 対象 version の tarball と `.sha256` を GitHub Release から download し、SHA-256 verification 成功後に `~/.local/share/kolt/<version>/` 配下に展開する。
+2. When 展開が完了した時、the install script shall `~/.local/share/kolt/<version>/libexec/classpath/` 配下の全 `*.argfile` 中の `@KOLT_LIBEXEC@` placeholder を `~/.local/share/kolt/<version>/libexec` の絶対パスに in-place 置換する。
+3. When argfile の置換が完了した時、the install script shall `~/.local/bin/kolt` symlink を `~/.local/share/kolt/<version>/bin/kolt` に作成または既存 symlink を上書き更新する。
+4. While `~/.local/bin` または `~/.local/share/kolt` ディレクトリが利用者のホームに存在しない時、the install script shall それらを `mkdir -p` で先回り作成し、permission error 以外の理由で fail しない。
+5. When install.sh が成功終了した時、the install script shall `~/.local/bin/kolt --version` が exit code 0 で対象 version 文字列を stdout に出力する状態を保証する。
+6. If `~/.local/bin/kolt` が既存しかつ symlink ではない (regular file / directory) 時、then the install script shall その既存ファイルを上書きせず非ゼロ終了し、利用者に削除を求めるメッセージを出力する。
+7. When the install script がインストールを完了し、かつ利用者の `PATH` 環境変数に `~/.local/bin` が含まれていない時、the install script shall 「`~/.local/bin` を `PATH` に追加してください」相当の hint を stderr に出力する (shell rc の自動編集は行わない)。
+
+### Requirement 3: install.sh の version 選択と YANKED 取り扱いが明確である
+
+**Objective:** kolt 利用者として、`KOLT_VERSION` 未指定では maintainer が現時点で推奨する最新版がインストールされ、yank された version は明示同意なしには引かれないことを望む。誤って既知不具合のある version をインストールしないこと、および特定 version への pin を必要とする CI / 再現テストでも install.sh が同じ経路で使えることが目的である。
+
+#### Acceptance Criteria
+
+1. When 利用者が `KOLT_VERSION` 環境変数を設定せず install.sh を実行した時、the install script shall GitHub Releases を SemVer 順に降順列挙し、pre-release (rc / beta) 以外でかつ `YANKED` に出現しない最新の tag を install 対象として pick する。
+2. When `KOLT_VERSION=<v>` が設定された時、the install script shall `<v>` を install 対象として用い (本 AC は AC 3 / AC 4 に従って yank チェックを行う)、最新版検出ロジックを bypass する。
+3. If install 対象 version が repo HEAD の `YANKED` の最初の column に出現し、かつ `KOLT_ALLOW_YANKED` 環境変数が `1` に設定されていない時、then the install script shall tarball を download せず非ゼロ終了し、`YANKED` から読み取った replacement version をエラーメッセージに含めて利用者に提示する。
+4. When 同条件で `KOLT_ALLOW_YANKED=1` が設定されている時、the install script shall インストールを続行しつつ「version `<v>` は yank 済み、replacement は `<r>` です」相当の警告を stderr に出力する。
+5. If `YANKED` manifest の fetch が HTTP error / 404 / network error で失敗した時、then the install script shall tarball download を行わず非ゼロ終了し、manifest URL と取得失敗の事実をエラーメッセージに含める。
+6. The install script shall `YANKED` manifest を `https://raw.githubusercontent.com/snicmakino/kolt/main/YANKED` から fetch し、その他のソース (キャッシュ、バンドル、過去 release の埋め込みなど) を参照しない。
+
+### Requirement 4: install.sh が unsupported platform を明示拒否する
+
+**Objective:** kolt 利用者として、非対応 platform で install.sh を実行した時に「サイレントに動かない」のではなく「何が動かず、いつ動く予定か」を即座に伝えてもらえることを望む。利用者が次に何をすべきか判断でき、また将来 #82 / #83 が darwin / arm64 を実装した時に install.sh への変更が darwin 分岐の fail メッセージ除去と case 文への entry 追加のみで済む構造にしておくことが目的である。
+
+#### Acceptance Criteria
+
+1. When `uname -s` が `Linux` かつ `uname -m` が `x86_64` の時、the install script shall platform 文字列 `linux-x64` を確定し install 経路を続行する。
+2. If `uname -s` が `Darwin` の時、then the install script shall tarball download を行わず非ゼロ終了し、エラーメッセージに「macOS support is tracked in #82, not yet released」相当の文と issue へのリンクを含める。
+3. If `uname -s` が `Linux` で `uname -m` が `x86_64` 以外 (`aarch64` 等) の時、then the install script shall tarball download を行わず非ゼロ終了し、エラーメッセージに「linuxArm64 support is tracked in #83, not yet released」相当の文を含める。
+4. If `uname -s` が `Linux` / `Darwin` 以外の時、then the install script shall tarball download を行わず非ゼロ終了し、エラーメッセージに detect された OS / arch 文字列と「unsupported platform」相当の文を含める。
+5. The tarball naming convention shall `kolt-<version>-<platform>.tar.gz` の形に従い、platform 部分が変数として置換可能な状態を保つ (#82 / #83 が新 platform を additive に追加できる前提を作る)。
+
+### Requirement 5: SHA-256 verification が tarball 取得経路に組み込まれる
+
+**Objective:** kolt 利用者として、curl で取得した tarball が転送中に改竄・破損していないことが install.sh によって自動検証されることを望む。download の整合性を maintainer の手作業ではなく仕組みで保証し、cosign / GPG への将来の拡張を容易にするためである。
+
+#### Acceptance Criteria
+
+1. When the release workflow が tarball を upload する時、the release workflow shall 同 tarball の SHA-256 digest を `sha256sum` を用いて算出し `<hex digest>  <filename>\n` 形式の `.sha256` ファイルとして同 Release に upload する (Requirement 1 AC 3 と整合)。
+2. When the install script が tarball を download した時、the install script shall 同 Release から `.sha256` ファイルを併せて download し、tarball の実 SHA-256 と `.sha256` 内 digest が一致することを `sha256sum -c` 相当の方法で検証する。
+3. If SHA-256 検証が失敗した時、then the install script shall download した tarball を削除し、`~/.local/share/kolt/<version>/` への展開を一切行わず非ゼロ終了し、エラーメッセージに期待 digest と実 digest の双方を含める。
+4. The install script shall SHA-256 検証を tarball 展開・argfile 置換・symlink 作成のいずれより前に実施し、検証未通過の状態でファイルシステムに改変を加えない。
+
+### Requirement 6: YANKED manifest の format と repo 配置が確定する
+
+**Objective:** kolt メンテナおよび install 経路実装として、yank 状態が単一の machine-readable な manifest にのみ存在し、Bash (install.sh) と GitHub Actions (release workflow gate) の双方が同じ format で読めることを望む。format drift による「release workflow は通ったが install.sh は refuse する」のような不整合を防ぎ、ADR 0028 §5 を唯一の権威とするためである。
+
+#### Acceptance Criteria
+
+1. The kolt repository shall repo root に `YANKED` という名前のテキストファイルを 1 つ持つ。
+2. Where 現時点で yank されている version が無い時、the YANKED manifest shall サイズ 0 bytes (改行のみの行も含まない) として commit されている。
+3. The YANKED manifest shall 各非空行について exactly 3 つの tab (`\t`) 区切りフィールドを持ち、左から `<yanked-version>`、`<replacement-version>`、`<reason>` の順で並ぶ (ADR 0028 §5 完全準拠)。
+4. The YANKED manifest shall コメント行・空行・先頭末尾の余分な空白を許容しない。新しい yank entry は manifest の末尾に追記する (newest yank last)。
+5. If the release workflow が YANKED manifest の構文違反 (フィールド数不一致 / 空行 / コメント等) を検出した時、then the release workflow shall 非ゼロ終了し、エラーメッセージに違反行番号と検出された問題を含める。
+6. If the install script が YANKED manifest の構文違反を検出した時、then the install script shall 非ゼロ終了し、エラーメッセージに違反行番号と検出された問題を含める。
+7. The release workflow および the install script shall 同じ YANKED manifest を repo HEAD (main branch) から fetch し、過去 commit / 過去 Release / バンドル済みコピーを参照しない。
+
+### Requirement 7: install.sh と release workflow が CI で smoke test される
+
+**Objective:** kolt メンテナとして、install.sh または release workflow に対する変更が CI を通過するためには「実際に動くこと」が要求される状態を望む。手元での動作確認漏れや、`install.sh` の Bash regression、release workflow の YAML 構文エラー、YANKED gate の format drift 等を本番 release 前に検出するためである。
+
+#### Acceptance Criteria
+
+1. When pull request が main に対して open / update された時、the CI shall `scripts/assemble-dist.sh` を実行して tarball を生成し、HOME を `mktemp -d` で隔離した状態で install.sh を当該ローカル tarball に対して実行し、`kolt --version` の exit code 0 と version 文字列の一致を assert する。
+2. When 同 PR CI ジョブで yank refuse path が exercising される時、the CI shall 合成 `YANKED` manifest にテスト version の entry を加えた状態で install.sh を当該 version 指定で実行し、`KOLT_ALLOW_YANKED` 未設定では非ゼロ終了し replacement version が stderr に出力されることを assert する。
+3. When SemVer 形式の tag が push されて release workflow が assets を publish した時、the CI shall 直後に新規の clean GHA `ubuntu-latest` runner を立ち上げて install.sh を生 GitHub URL から `curl | sh` で実行し、`~/.local/bin/kolt --version` の成功を assert する。
+4. If 上記いずれかの smoke ジョブが fail した時、then the CI shall 当該 PR の merge をブロックする (PR 時) もしくは tag に対応する GitHub Release を pre-release のまま残し latest mark を付けない (tag 時)。
+5. The PR-time install smoke shall 実 GitHub Release assets を必要とせず、release が出ていない HEAD であっても install.sh の経路が常に exercise される状態を保つ。
+
+### Requirement 8: README が install command と環境変数を文書化する
+
+**Objective:** kolt 評価者として、README の冒頭を読むだけで install コマンドと version 指定方法が分かることを望む。GitHub の Releases ページや ADR を辿らずに「最初の 1 コマンド」と「特定 version を入れたい時の手順」が同じ場所で見つかるためである。
+
+#### Acceptance Criteria
+
+1. The README shall インストール手順を示すセクションに `curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh` (もしくは同等の表記) を copy-paste 可能な code block として含む。
+2. The README shall `KOLT_VERSION=<v>` を「特定 version を入れる時に設定する環境変数」として、`KOLT_ALLOW_YANKED=1` を「yank された version を強制インストールする環境変数」として、それぞれ 1 文以上で文書化する。
+3. The README shall 初版が linux-x64 のみであること、macOS / linuxArm64 が #82 / #83 で別 track であることを明記する。
+4. The README shall インストール後に `~/.local/bin` を `PATH` に追加する必要があり得ることに 1 文以上で言及する。

--- a/.kiro/specs/installer/research.md
+++ b/.kiro/specs/installer/research.md
@@ -1,0 +1,247 @@
+# Gap Analysis — installer
+
+## Analysis Summary
+
+- **既存資産は薄い** (release.yml / install.sh / YANKED いずれも未存在) が、`scripts/assemble-dist.sh` (PR #228, 256 lines) と `.github/workflows/self-host-smoke.yml` の `self-host-post` job が「tarball を生成して install レイアウトに展開する」流れを既に CI 上で動かしており、本 spec はこの基盤への薄い拡張に近い。
+- **実装の重心は `install.sh` (新規 Bash script)**。release.yml はテンプレ的な構成、`assemble-dist.sh` への変更は `.sha256` 生成 1 行、YANKED は空ファイル commit のみ。本 spec の総 LoC のうち install.sh が 60〜70% を占める想定。
+- **`self-host-post` job の inline sed 部 (lines 184-188) を install.sh に置き換える**ことで、PR-time smoke が「install.sh の本物の経路」を毎 PR で exercise できるようになる。これは spec が明示的に求めているわけではないが、実装上の自然な統合点。
+- **GitHub Releases API からの version 列挙** (Req 3 AC 1) と **version <=> tag 整合 gate** (Req 1 AC 6) が、design phase で詰めるべき主要な未確定事項。
+- **Effort: M (3-7 days)**、**Risk: Medium** (install.sh の edge case 多数、tag-time smoke は first tag まで実地検証不可)。
+
+## Document Status
+
+Gap analysis を `.kiro/specs/installer/research.md` に新規 write。既存コード (`scripts/assemble-dist.sh`、`.github/workflows/*.yml`、README、`kolt.toml`) と ADR 0018/0028 の整合性を踏まえて、3 つの実装オプションと推奨を記載。
+
+## 1. Current State Investigation
+
+### 既存の release / distribution 関連資産
+
+| Path | 状態 | 役割 |
+|---|---|---|
+| `scripts/assemble-dist.sh` | 存在 (#228 で完成、256 lines) | tarball stitcher。3 × `kolt build --release` + Maven Central から BTA-impl 取得 + `bin/` + `libexec/` レイアウト構築 + `tar czf`。`@KOLT_LIBEXEC@` placeholder を argfile に書き込む。`kolt.toml` の `version =` を読む。 |
+| `.github/workflows/self-host-smoke.yml` | 存在 (200 lines) | `self-host` job (Gradle bootstrap → kolt.kexe) と `self-host-post` job (3 × kolt build → assemble-dist.sh → tarball extract → inline sed → fixture smoke) の 2 段構成。**`self-host-post` lines 184-188 が「install 後の sed 置換」を inline で実装しており、これが install.sh の責務に対応する**。 |
+| `.github/workflows/unit-tests.yml` | 存在 (50+ lines) | linuxX64Test の standard runner 構成 (ubuntu-latest + JDK 25 + libcurl + caches)。新 workflow の雛形として再利用可能。 |
+| `README.md` lines 14-30 | 存在 | 「Build from source: git clone → ./gradlew build → cp kexe to PATH」を案内。Req 8 で curl|sh に書き換え対象。 |
+| `kolt.toml` の `version = "0.15.0"` | 存在 | tarball 命名と `VERSION` ファイルの単一情報源。release ごとに手動 bump (PR #271 「Bump version to 0.15.0」が precedent)。 |
+| `.github/workflows/release.yml` | **未存在** | 本 spec で新規作成 |
+| `install.sh` (repo root) | **未存在** | 本 spec で新規作成 |
+| `YANKED` (repo root) | **未存在** | 本 spec で空ファイル commit |
+| `assemble-dist.sh` の `.sha256` 生成 | **未存在** | 本 spec で 1〜2 行追加 |
+| 過去 release への asset attach | **未存在** | v0.15.0 含む全 release が assets 0 件。本 spec では retroactive attach せず、初版 installer が最新 tag (v0.16.0 想定) から有効になる |
+
+### 関連 ADR の制約
+
+- **ADR 0018 §1**: tarball layout (`bin/` + `libexec/{kolt-jvm-compiler-daemon, kolt-native-compiler-daemon, kolt-bta-impl, classpath}/`) は既に確定済み。assemble-dist.sh が完全準拠している。
+- **ADR 0018 §4**: install.sh は `~/.local/share/kolt/<version>/` 展開 + `~/.local/bin/kolt` symlink を行う。「First release covers fresh install only。Upgrade / uninstall / shell-rc PATH bootstrap は follow-up」と明記。
+- **ADR 0018 Confirmation**: 「`install.sh` は `curl | sh` CI job で release ごとに 1 度 exercise される」が confirmation の必要条件。
+- **ADR 0028 §1**: tag SemVer regex `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(rc|beta)\.[1-9]\d*)?$` 確定。release workflow の pre-publish gate でこれに従う。
+- **ADR 0028 §5**: YANKED manifest format は tab-separated 3 フィールド `<version>\t<replacement>\t<reason>`、コメント・空行不可、parser failure は release-workflow error。install.sh が repo HEAD `main` から fetch する前提。
+
+### 既存の規約・パターン
+
+- **CI workflow 構造**: ubuntu-latest + setup-java@v4 (JDK 25 temurin) + libcurl4-openssl-dev + 3 種類のキャッシュ (`~/.gradle`, `~/.konan`, `~/.kolt`)。release.yml もこの雛形に乗せる。
+- **`kolt.toml` の version**: 手動で release PR ごとに bump (#271 等が precedent)。release.yml は「pushed tag の version-prefix 除去 == kolt.toml version」を assert する gate を持つことで drift を防ぐ。
+- **`gh release create`**: 既存 release は手動で作成 (assets 0 件)。release.yml で `gh release create --target $SHA <tag> <assets>` を使う想定。`GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` + `permissions: contents: write` が必要。
+- **assemble-dist.sh の version 抽出**: `grep -E '^version = "' kolt.toml` の単一ライン抽出。release.yml で同等のロジックで tag check も可能。
+
+## 2. Requirements Feasibility Analysis
+
+### Requirement-to-Asset Map
+
+| Requirement | 既存資産 | Gap | タグ |
+|---|---|---|---|
+| Req 1: tag-triggered release.yml | なし | `.github/workflows/release.yml` 全部新規 | Missing |
+| Req 1 AC 1-3: SemVer gate + asset upload | unit-tests.yml の boilerplate を雛形化可能 | `gh release create` 使用法、tag-from-ref 抽出、asset upload の確認 | Missing |
+| Req 1 AC 4: YANKED gate (release-side) | ADR 0028 §5 で format pin | YANKED parser を release.yml の Bash step として実装 | Missing |
+| Req 1 AC 6: tag <=> kolt.toml version 整合 | `kolt.toml` の version = 行は単一情報源 | gate logic 追加 (release.yml 内 1 step) | Missing |
+| Req 2 全体: install.sh fresh install | self-host-smoke の inline sed が部分プロトタイプ | install.sh 新規 (~200-300 lines、deno/bun の install.sh が参考) | Missing |
+| Req 2 AC 2: @KOLT_LIBEXEC@ sed | self-host-smoke.yml lines 184-188 が同等処理 | install.sh 内に移植 | Constraint (既存挙動と一致必須) |
+| Req 2 AC 5: kolt --version 通る | self-host-post の `kolt build` が後段で assert | smoke job の assertion 追加 | Constraint |
+| Req 3 AC 1: SemVer 順最新 non-yanked | なし | GitHub Releases API enumerate + SemVer 比較 + YANKED 突合 | Unknown (API 詳細は design phase で詰める) |
+| Req 3 AC 3-4: KOLT_ALLOW_YANKED override | なし | install.sh 内 env var 処理 | Missing |
+| Req 4: platform 検出 | なし | `uname -s`/`uname -m` case 文 | Missing |
+| Req 5 AC 1: .sha256 生成 | assemble-dist.sh 末尾に追加点あり | `sha256sum tarball > tarball.sha256` 1〜2 行 | Missing (簡易) |
+| Req 5 AC 2-4: install.sh 検証 | なし | install.sh 内で `sha256sum -c` 相当 | Missing |
+| Req 6: YANKED 空ファイル | なし | `touch YANKED && git add YANKED` | Missing (簡易) |
+| Req 6 AC 3-7: format parser 整合 | ADR 0028 §5 が format pin | release.yml と install.sh の双方で同 parser ロジック | Constraint (drift 不可) |
+| Req 7 AC 1: PR-time install smoke | self-host-smoke.yml が近い基盤 | install.sh 経路の挿入 + 合成 YANKED テスト追加 | Missing |
+| Req 7 AC 3: tag-time real curl|sh smoke | なし | release.yml の最終 step | Missing |
+| Req 8: README install command | README lines 14-30 | curl|sh + 環境変数表記に書き換え | Missing |
+
+**タグ凡例**: Missing = 完全新規、Unknown = design で要詳細決定、Constraint = 既存挙動・規約との整合必須。
+
+### Non-functional 観点
+
+- **Reliability**: install.sh は単発実行で失敗時はクリーンに非ゼロ終了する責務。中途半端な install state を残さない (展開前に SHA-256 検証、symlink 作成は最後)。
+- **Security**: SHA-256 verification は MITM / CDN 改竄に対する第一防衛線。cosign / GPG は将来 issue。
+- **Idempotency**: 同一 version の install.sh 再実行は no-op もしくは re-overwrite で成功する想定。upgrade (異なる version) は symlink 上書きで natural に動く。
+- **Performance**: install.sh は 1 回のネットワーク + 数秒の展開で完了。バックグラウンド処理は不要。
+
+## 3. Implementation Approach Options
+
+### Option A: 既存 self-host-smoke.yml を release+smoke 兼用に拡張
+
+self-host-smoke.yml に tag trigger と asset upload step を加え、PR / push / tag の 3 系統を 1 ファイルで扱う。
+
+**Trade-offs**
+- ✅ workflow ファイル 1 個で済む。重複が無い
+- ❌ 「smoke (PR)」「smoke (push)」「release (tag)」が同居して責務が混雑する
+- ❌ tag 時の経路が PR 時の trigger 条件と異なる箇所が多く、`if:` 分岐が増えて読みにくい
+
+### Option B: release.yml 新規 + self-host-smoke.yml に install.sh 経路を組み込む（推奨）
+
+- 新 `.github/workflows/release.yml` を tag-trigger 専用に作る (gate → assemble-dist → upload → tag-time smoke)。
+- 既存 `self-host-smoke.yml` の `self-host-post` job の inline sed (lines 184-188) を `install.sh` 呼び出しに置き換え、PR-time install smoke を兼ねる。同 job 内に「合成 YANKED で yank refuse path をテスト」step を追加。
+- assemble-dist.sh に `.sha256` 生成 1 行を追加。
+
+**Trade-offs**
+- ✅ 「release」と「smoke」の責務が明確に分かれる
+- ✅ install.sh の本物の経路が PR ごとに exercise される (release が出ていない HEAD でも)
+- ✅ 既存 `self-host-post` job の知見 (キャッシュ戦略、JDK 25 setup) を再利用できる
+- ❌ workflow ファイル数が増える (1 → 2)
+- ❌ self-host-smoke.yml と install.sh の責務重複が生じる場合がある (例: 両方が `@KOLT_LIBEXEC@` 置換ロジックを持つ — install.sh が source-of-truth で、smoke はそれを呼ぶ形になるため最終的に重複は無い)
+
+### Option C: release.yml 完全独立 + 新 install-smoke.yml + self-host-smoke.yml は無変更
+
+- 3 つの workflow ファイル: release.yml (tag-only), install-smoke.yml (PR-only, install.sh 経路 + YANKED refuse), self-host-smoke.yml (現状維持)。
+- install.sh は完全独立、self-host-post の inline sed はそのまま残す。
+
+**Trade-offs**
+- ✅ 既存 self-host-smoke.yml は無変更で安心
+- ❌ self-host-post の inline sed と install.sh で「同じ責務の 2 実装」が永続化する。drift の温床
+- ❌ workflow ファイル数が増える (1 → 3)
+- ❌ install-smoke.yml が self-host-post の caching と重複する (`~/.kolt`, `~/.gradle` を再設定)
+
+### 推奨: Option B
+
+理由:
+1. install.sh が source-of-truth として複数 workflow から呼ばれる構造は健全
+2. self-host-post の inline sed を install.sh 呼び出しに置き換える diff は機械的で小さい (lines 184-188 を 1 行に置換)
+3. CI minutes / cache の節約 (job を増やさない)
+4. release と smoke の責務分離は、release.yml は新規・self-host-smoke.yml は拡張、と書き方を変えるだけで実現可能
+
+## 4. Effort & Risk
+
+- **Effort: M (3-7 days)**
+  - install.sh 新規実装 + 各 edge case の手動テスト: 2 日
+  - release.yml 新規 + gates + `gh release create` + tag-time smoke job: 1 日
+  - assemble-dist.sh への `.sha256` 追加 + self-host-smoke.yml の sed 部 install.sh 化 + YANKED refuse smoke step: 0.5 日
+  - YANKED 空ファイル + README 書き換え: 0.5 日
+  - PR cycle で発覚する整合バグ修正 (test mode の追加、SemVer parsing edge case 等): 1〜2 日
+  - **合計: 約 5 日 (Medium)**
+
+- **Risk: Medium**
+  - install.sh は edge case が多い (platform detection、JSON 解析、SHA 検証、idempotency)。Bash の portable 性 (POSIX sh vs bash) を確認しないと curl|sh で死ぬ
+  - GitHub Releases API の rate limit (60/h unauth) は普通の使い方なら問題ないが、CI で何度も叩くと当たり得る
+  - tag-time smoke は first real tag push まで実地検証できない (chicken-and-egg)。RC tag を pre-flight で 1 度発射して挙動を確かめるのが妥当
+  - 緩和策: PR-time smoke で全経路を exercise する設計を取る。テスト用 base URL の env override は必須
+
+## 5. Research Items for Design Phase
+
+1. **GitHub Releases API endpoint と response 解析**
+   - `/repos/{owner}/{repo}/releases` を newest-first で enumerate
+   - 各 release の `tag_name`, `prerelease`, `draft` フィールドを読む
+   - SemVer 比較は Bash の `sort -V` で済むか、明示的な parser が必要か
+   - JSON パースは `jq` が最も信頼できるが、user 環境にあるとは限らない (deno/bun の install.sh は grep+sed で済ませている。要参考)
+
+2. **install.sh のテストモード**
+   - PR-time smoke が実 GitHub Release を叩かずに済む方法
+   - 候補: `KOLT_BASE_URL` env で `https://github.com/.../releases/download/<tag>/` を上書き、`KOLT_YANKED_URL` で manifest URL を上書き。ローカル `python3 -m http.server` で配信
+   - install.sh の「test mode」を明示するか、env override で透過的に扱うか
+
+3. **`kolt.toml` version vs tag の整合 gate**
+   - release.yml の最初の step で `[[ "$(extract version from kolt.toml)" == "${GITHUB_REF#refs/tags/v}" ]]` を assert
+   - assemble-dist.sh は kolt.toml を読むので、release.yml が前段で gate しないと「tag は v0.16.0 だが tarball は 0.15.0」の不整合が出る
+   - assemble-dist.sh 自身が tag check を持つべきか、release.yml が前段で gate するべきか
+
+4. **404 (asset 不在) のエラーハンドリング**
+   - 過去 release (v0.15.0 等) には asset が無い。`KOLT_VERSION=0.15.0` 指定で install.sh が hit するシナリオ
+   - 親切なメッセージ: 「version `<v>` にはバイナリが publish されていません (the installer was introduced in #230, earlier releases predate it)」
+   - これは Req 5 と Req 3 のギャップに位置する。design phase でメッセージ文言を pin
+
+5. **GitHub Actions permissions と secrets**
+   - release.yml は `permissions: contents: write` が必須 (asset upload のため)
+   - `${{ secrets.GITHUB_TOKEN }}` で `gh release create` が動くことを確認
+   - PR-time smoke は `contents: read` のみで十分
+
+6. **Bash portability**
+   - install.sh は `#!/bin/sh` (POSIX sh) か `#!/bin/bash` (bash) か
+   - macOS (将来) の bash は古い (3.2)。POSIX sh で書く方が長期的に安全
+   - `case` 文・`[[ ]]` の使用可否、`local` の有無、配列の使用可否、を design phase で確定
+
+7. **install.sh の I/O 体裁**
+   - 進捗表示 (curl の `-#` flag、stage ごとの `echo` 等)
+   - 成功時の最終メッセージ (「kolt 0.16.0 installed at ~/.local/bin/kolt」)
+   - 失敗時のメッセージ formatting (色付け? plaintext?)
+   - これは UX 設計、design phase で決める
+
+8. **`gh release create` の使い方**
+   - `--target` の SHA 指定 (tag created at SHA は GitHub が自動で持つ)
+   - `--prerelease` flag for `-rc.N` / `-beta.N`
+   - `--notes` / `--notes-file` の運用 (release notes は手動か、自動生成か。本 spec の scope 外と思われるが design で確認)
+
+## 6. Recommendations for Design Phase
+
+### Preferred approach
+**Option B**: release.yml 新規 + self-host-smoke.yml の inline sed を install.sh 呼び出しに置換 + assemble-dist.sh に `.sha256` 生成追加。
+
+### Key design decisions to nail down
+1. **install.sh の shell**: POSIX sh か bash か → 推奨 sh (macOS 将来対応の保険)
+2. **JSON 解析**: `jq` の動的検出 + grep+sed フォールバック か、grep+sed のみか → 推奨 grep+sed (依存最小)
+3. **テストモードの env**: `KOLT_BASE_URL` / `KOLT_YANKED_URL` の名前と意味論
+4. **404 メッセージ文言** (Req 5/Req 3 のギャップ補完)
+5. **release.yml の job 構成**: 1 job (gates → assemble → upload → smoke) か 2 job (build / smoke を split) か → 推奨 1 job (state transfer の overhead 回避)
+6. **`assemble-dist.sh` への .sha256 追加位置**: 末尾の `tar czf` の直後 (1〜2 行)。`sha256sum kolt-${VERSION}-linux-x64.tar.gz > kolt-${VERSION}-linux-x64.tar.gz.sha256`
+
+### Carry-forward research items
+- GitHub Releases API response format の確認 (実際に curl で叩いて構造を見る)
+- deno / bun / rye / uv の install.sh 実装を 1 つ参照 (JSON 解析、SemVer 比較、エラーハンドリングのパターン)
+- POSIX sh で macOS の古い `sed` (BSD sed) と GNU sed の差を確認 (in-place flag が `-i ''` vs `-i` の違い)
+
+### Out of scope for design phase
+- cosign / GPG 署名 (別 issue)
+- 多 platform binary 生成 (#82, #83)
+- install.sh の upgrade/uninstall (follow-up issue)
+
+---
+
+## Synthesis (追加 — design phase)
+
+### Generalization
+
+- **YANKED parser は release.yml と install.sh の 2 箇所で必要**だが、共有コードを切り出す価値は薄い。理由 3 点:
+  1. install.sh は curl|sh で叩かれる self-contained script、外部依存を持てない (parse-yanked.sh への分割は install.sh 側で source できないので破綻する)。
+  2. release.yml は GitHub Actions YAML、Bash step として inline で書く方が読みやすい
+  3. ADR 0028 §5 が format を pin しており、両側で 10-20 行の単純実装がドリフトする risk は低い (parse error 時のメッセージ文言だけ少し違う程度)
+- 結論: **両側で実装重複を許容し、install.sh の `parse_yanked` 関数のコメントに「release.yml の同等ロジックと一致させること」を明記する**。drift 検出は将来 native test で行う余地を残す。
+
+### Build vs Adopt
+
+- **Bash shell**: POSIX sh (`#!/bin/sh`) を採用。理由: 将来 macOS 対応 (#82) のとき bash 3.2 の制約に巻き込まれない。bash-isms (`[[ ]]`、配列、`local`) を避ける。
+- **GitHub Releases API**: REST endpoint `/repos/snicmakino/kolt/releases?per_page=100` を curl で直接叩く。`gh` CLI は user 環境にあるとは限らない (curl|sh される側の前提)。
+- **`gh release create`** (release.yml 側のみ): GHA runner は `gh` を pre-install しており、REST API より簡潔。
+- **JSON parsing**: 必要なのは `tag_name` 文字列の抽出のみ。grep + sed で十分:
+  ```sh
+  grep -oE '"tag_name":\s*"[^"]+"' | sed -E 's/"tag_name":\s*"([^"]+)"/\1/'
+  ```
+  `jq` 依存は採らない (curl|sh される user 環境にあるとは限らない)。
+- **SHA-256**: `sha256sum` (GNU coreutils on Linux)。macOS では `shasum -a 256` だが #82 で対応。初版は `sha256sum` 直書き + `command -v sha256sum` 検出のスケルトンを入れて将来分岐できる構造を残す。
+- **SemVer 比較**: `sort -V` (GNU sort) で十分。BSD sort は `-V` を Catalina 以降サポート。初版 linux-x64 のみは GNU sort 前提。
+- **Tarball 展開**: `tar xzf` (POSIX 標準)。
+
+### Simplification
+
+- **JSON parser を持たない**: `tag_name` 抽出のみ。response shape は GitHub の安定 contract、過剰な防御不要。
+- **SemVer parser を持たない**: `sort -V` の出力をそのまま使う。`v0.16.0` と `v0.15.10` の比較もこれで通る。
+- **download manager / progress UI なし**: `curl -fsSL` の `-sS` で進捗バー抑制、エラーは見せる。シンプル。
+- **upgrade / rollback / lock なし**: 初版は fresh install のみ (ADR 0018 §4)。同 version 再 install は no-op に近い idempotent overwrite、異 version は symlink 上書き、で natural に動く。並行 install の race は accept (vanishingly rare)。
+- **release.yml は単一 job + 隣接 smoke job の 2 job 構成**: build/publish を分けると state transfer (artifact upload/download) overhead。1 job 内 sequential step が最短。
+
+### Test mode env vars (PR-time smoke の自然な統合)
+
+PR-time install smoke は実 GitHub Releases を叩かずに install.sh の経路を完走させる必要がある。これを以下の 2 env vars で透過的に扱う:
+
+- `KOLT_TEST_BASE_URL`: 設定時、tarball + `.sha256` の取得元 base URL を override (default: `https://github.com/snicmakino/kolt/releases/download/v<VERSION>`)。CI は `python3 -m http.server` 等で local serve し、その URL を渡す。
+- `KOLT_TEST_YANKED_URL`: 設定時、YANKED manifest の取得元 URL を override (default: `https://raw.githubusercontent.com/snicmakino/kolt/main/YANKED`)。CI は synthetic YANKED ファイルへの URL を渡す。
+
+これらは「テスト用」と install.sh のヘルプ / コメントで明記し、user 向けではないことを示す。`KOLT_VERSION` を併用することで API enumeration を完全 bypass できる。

--- a/.kiro/specs/installer/spec.json
+++ b/.kiro/specs/installer/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "installer",
+  "created_at": "2026-04-28T09:10:48Z",
+  "updated_at": "2026-04-28T11:42:04Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -81,7 +81,7 @@
   - _Requirements: 5.2, 5.3, 5.4_
   - _Boundary: install.sh_
 
-- [ ] 2.7 extract_and_link 関数の実装 (idempotent)
+- [x] 2.7 extract_and_link 関数の実装 (idempotent)
   - `mkdir -p ~/.local/share/kolt ~/.local/bin` (必要なら作成)
   - `~/.local/bin/kolt` の existing を `[ -L ... ]` で check: 既存しかつ symlink ではない (regular file / dir) → exit 8 + 「remove this file manually then re-run」を stderr
   - `~/.local/share/kolt/<v>/` 既存なら `rm -rf` (rustup-init 流の clean repair)

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -39,7 +39,7 @@
   - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5_
   - _Boundary: install.sh_
 
-- [ ] 2.3 fetch_yanked_and_validate 関数の実装
+- [x] 2.3 fetch_yanked_and_validate 関数の実装
   - `KOLT_TEST_YANKED_URL` 設定時はそれを、未設定時は raw GitHub URL を curl で fetch
   - HTTP error → exit 6 + URL と HTTP error をメッセージに含める
   - 各非空行に対し、`awk -F'\t' 'NF != 3 || $1=="" || $2=="" || $3==""'` 相当で format validation。コメント行 (`#` 始まり) と空行と先頭末尾空白を全て reject (ADR 0028 §5)
@@ -207,3 +207,7 @@
   - 手動 GHA UI 操作のため optional 扱い (本タスクは実装の完了条件ではなく first tag 前の pre-flight として実行を推奨)
   - Observable: GHA UI に dry_run 起動の workflow run が記録され、`dist/kolt-...sha256` 生成までは成功、Release が作成されていない (Releases ページに新 entry なし)
   - _Depends: 3.3_
+
+## Implementation Notes
+
+- POSIX sh (dash) の strict `set -eu` 下では `var=$(failing-cmd)` 形式の assignment が即時 abort する (bash と異なる)。`if ! var=$(cmd); then ... fi` の form を使えば command-substitution の non-zero exit が if context で吸収され、$var に capture した stdout を以降の error path で使える (task 2.3 で hit、後続の 2.4-2.8 でも同パターンを採る)。

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -70,7 +70,7 @@
   - _Requirements: 3.1, 3.2_
   - _Boundary: install.sh_
 
-- [ ] 2.6 download_and_verify 関数の実装
+- [x] 2.6 download_and_verify 関数の実装
   - `KOLT_TEST_BASE_URL` 設定時はそれを base、未設定時は `https://github.com/snicmakino/kolt/releases/download/v<v>` を base にする
   - tarball (`kolt-<v>-<platform>.tar.gz`) と `.sha256` を curl で fetch
   - HTTP 404 / error → exit 4 + URL と HTTP status をメッセージに含める。tarball が無い version (pre-#230 release) のケースに「the installer was introduced in #230, earlier releases predate it」相当の hint を 404 時に追加

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -58,7 +58,7 @@
   - _Requirements: 3.3, 3.4_
   - _Boundary: install.sh_
 
-- [ ] 2.5 select_version 関数の実装
+- [x] 2.5 select_version 関数の実装
   - `KOLT_VERSION` set → 値をそのまま echo (API 不問、yank filter なし)
   - 未 set → `https://api.github.com/repos/snicmakino/kolt/releases?per_page=100` を curl
   - response から `grep -oE '"tag_name":\s*"[^"]+"'` + `sed -E 's/.../\1/'` で tag_name を抽出

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -10,7 +10,7 @@
   - _Requirements: 6.1, 6.2_
   - _Boundary: YANKED file_
 
-- [ ] 1.2 (P) assemble-dist.sh に .sha256 生成 step を追加
+- [x] 1.2 (P) assemble-dist.sh に .sha256 生成 step を追加
   - 既存 `tar czf` 直後 (line 254 付近) に `(cd dist && sha256sum "kolt-${VERSION}-linux-x64.tar.gz" > "kolt-${VERSION}-linux-x64.tar.gz.sha256")` を追記
   - subshell 内で cd するので `.sha256` 内の filename は basename になる (絶対パス埋め込み無し)
   - 既存 cwd は `$ROOT_DIR` で `dist/...` 相対参照、subshell 統合に問題なし

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -2,7 +2,7 @@
 
 ## 1. Foundation: YANKED manifest と assemble-dist.sh extension
 
-- [ ] 1.1 (P) repo root に空の YANKED ファイルを commit
+- [x] 1.1 (P) repo root に空の YANKED ファイルを commit
   - 0 bytes (改行を含まない) のファイルを `YANKED` として追加
   - `.gitignore` 対象外
   - `git add YANKED` + commit でファイルが repo HEAD に出現する

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -104,7 +104,7 @@
 
 ## 3. release.yml の実装
 
-- [ ] 3.1 (P) workflow file の skeleton + triggers + permissions
+- [x] 3.1 (P) workflow file の skeleton + triggers + permissions
   - `.github/workflows/release.yml` を新規作成
   - `on: push: tags: ['v*']` および `on: workflow_dispatch: inputs: dry_run: {type: boolean, default: true, required: true}`
   - `permissions: contents: write`

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -28,7 +28,7 @@
   - Observable: `sh install.sh` が `platform_detect` stub に到達して exit 1 する (set -u で env var の参照ミスが起きない)
   - _Boundary: install.sh_
 
-- [ ] 2.2 platform_detect 関数の実装
+- [x] 2.2 platform_detect 関数の実装
   - `uname -s` + `uname -m` を case 文 1 箇所で読む
   - `Linux` + `x86_64` → "linux-x64" を stdout、続行
   - `Darwin/*` → exit 1 + "macOS support is tracked in #82, not yet released" を stderr

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -147,7 +147,7 @@
 
 ## 4. self-host-smoke.yml extension
 
-- [ ] 4.1 inline sed step を install.sh + 環境変数経由に置換 (happy path)
+- [x] 4.1 inline sed step を install.sh + 環境変数経由に置換 (happy path)
   - 既存 lines 181-188 (Substitute KOLT_LIBEXEC placeholder in argfiles step) を削除
   - serve directory を `mktemp -d` で用意し、`dist/kolt-<v>-linux-x64.tar.gz` + `.sha256` + 空 `YANKED` を copy / 生成
   - `python3 -m http.server 8000 --bind 127.0.0.1 --directory <serve-dir> &` で local serve、PID を変数に保存し step 終了時に `trap 'kill $PID' EXIT`

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -133,7 +133,7 @@
   - _Boundary: release.yml_
   - _Depends: 1.2_
 
-- [ ] 3.4 smoke job: clean runner + raw URL curl|sh + assertion
+- [x] 3.4 smoke job: clean runner + raw URL curl|sh + assertion
   - `runs-on: ubuntu-latest` + clean state (`HOME=$(mktemp -d)` を export)
   - `curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh` で install.sh を起動
   - `~/.local/bin/kolt --version` の exit 0 + `^kolt <expected-version>$` regex match を assert

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -20,7 +20,7 @@
 
 ## 2. install.sh の実装
 
-- [ ] 2.1 install.sh の skeleton + env var contract
+- [x] 2.1 install.sh の skeleton + env var contract
   - `#!/bin/sh` shebang + `set -eu`
   - `KOLT_VERSION` / `KOLT_ALLOW_YANKED` / `KOLT_TEST_BASE_URL` / `KOLT_TEST_YANKED_URL` の default 値設定 (default URL は raw GitHub URL / GitHub Release URL)
   - 7 関数の stub (各 stub は echo "TODO: <name>" + exit 1) と main flow の関数 call 順序

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -122,7 +122,7 @@
   - _Requirements: 1.2, 1.4, 1.6, 6.5_
   - _Boundary: release.yml_
 
-- [ ] 3.3 release job: build + assemble + sha256 + publish
+- [x] 3.3 release job: build + assemble + sha256 + publish
   - Setup steps: `actions/checkout@v4` + `actions/setup-java@v4` (JDK 25 temurin) + libcurl4-openssl-dev install + `actions/cache@v4` 3 種 (gradle / konan / kolt)。self-host-smoke.yml と同じキャッシュキーを使い両 workflow で cache 共有
   - Bootstrap step: `./gradlew --no-daemon linkDebugExecutableLinuxX64`
   - Build step: 3 × `kolt build --release` (root / kolt-jvm-compiler-daemon / kolt-native-compiler-daemon)

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -94,7 +94,7 @@
   - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.6_
   - _Boundary: install.sh_
 
-- [ ] 2.8 print_path_hint + main flow 完成 + 成功メッセージ
+- [x] 2.8 print_path_hint + main flow 完成 + 成功メッセージ
   - `print_path_hint`: `case ":$PATH:" in *":$HOME/.local/bin:"*) ;; *) echo hint to stderr ;;` (literal `$HOME` のみ check、tilde `~` は見ない)
   - main flow: stub を全部実装関数の呼び出しに置換、各関数の stdout を変数 capture して順送り
   - 成功時 stdout に "kolt <version> installed at ~/.local/bin/kolt" を 1 行出力

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -169,7 +169,7 @@
   - _Boundary: self-host-smoke.yml_
   - _Depends: 2.8_
 
-- [ ] 4.3 install.sh の edge case smokes (parse error / non-symlink / SHA mismatch)
+- [x] 4.3 install.sh の edge case smokes (parse error / non-symlink / SHA mismatch)
   - parse error: serve directory に `YANKED-bad` (例: 2 fields のみの行) を置き、`KOLT_TEST_YANKED_URL=...YANKED-bad` で install.sh を呼んで exit 2 + 違反行番号が stderr に出ることを assert
   - non-symlink refuse: `touch ~/.local/bin/kolt` (regular file) を作って install.sh を呼び、exit 8 + 「remove this file manually」を stderr で assert。後始末で `rm ~/.local/bin/kolt`
   - SHA-256 mismatch: serve directory の `kolt-<v>-linux-x64.tar.gz.sha256` の digest を 1 文字書き換え、install.sh を呼んで exit 5 + 期待・実 digest 両方が stderr に出ることを assert

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -181,7 +181,7 @@
 
 ## 5. (P) README Installation セクション書き換え
 
-- [ ] 5. README.md の Installation section を curl|sh コマンドに書き換え
+- [x] 5. README.md の Installation section を curl|sh コマンドに書き換え
   - 既存 lines 14-30 (Build from source 手順 + #97 言及) を削除
   - 新セクション冒頭: copy-paste-able code block で `curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh`
   - 環境変数解説 (1-2 行ずつ): `KOLT_VERSION=<v>` で特定 version 指定、`KOLT_ALLOW_YANKED=1` で yanked 強制 install

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -194,7 +194,7 @@
 
 ## 6. End-to-end validation
 
-- [ ] 6.1 PR-time CI が green になることを確認
+- [x] 6.1 PR-time CI が green になることを確認
   - 4.1 + 4.2 + 4.3 の 3 step を含む self-host-smoke.yml が PR 上で全て pass
   - 既存 jobs (self-host bootstrap、unit-tests) も regression なく pass
   - `unit-tests.yml` の linuxX64Test も従来通り green

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -159,7 +159,7 @@
   - _Boundary: self-host-smoke.yml_
   - _Depends: 2.8_
 
-- [ ] 4.2 yank refuse + override smoke step を追加
+- [x] 4.2 yank refuse + override smoke step を追加
   - 同 HTTP server の serve directory に `YANKED-with-yank` を生成 (1 行: `<kolt.toml-version>\treplacement-test\ttest yank entry`)
   - `KOLT_TEST_YANKED_URL=http://127.0.0.1:8000/YANKED-with-yank KOLT_VERSION=<v>` で install.sh を起動 (set +e でくくって exit code を捕まえる)
   - exit code が 3 であること、replacement version 文字列 (`replacement-test`) が stderr に含まれることを assert

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -50,7 +50,7 @@
   - _Requirements: 3.5, 3.6, 6.3, 6.4, 6.6, 6.7_
   - _Boundary: install.sh_
 
-- [ ] 2.4 is_yanked + yank_check 関数の実装
+- [x] 2.4 is_yanked + yank_check 関数の実装
   - `is_yanked(manifest, version)`: validated manifest を逐行読み、第 1 field が version と一致すれば exit 0 + `<replacement>\t<reason>` を stdout、無ければ exit 1。format validation は再実施しない (caller が事前 validate 済み前提)
   - `yank_check(manifest, version)`: `is_yanked` を呼び、(a) yanked かつ `KOLT_ALLOW_YANKED!=1` → exit 3 + replacement と reason を stderr、(b) yanked かつ `=1` → "warning: <v> is yanked, replacement is <r>" を stderr 出力後 return、(c) non-yanked → silent return
   - `set -e` 干渉対策として sub-shell capture (`result=$(is_yanked ...)`) を使う場合は `|| true` パターンを併用

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -113,7 +113,7 @@
   - _Requirements: 1.1_
   - _Boundary: release.yml_
 
-- [ ] 3.2 release job: SemVer + kolt.toml + YANKED gates
+- [x] 3.2 release job: SemVer + kolt.toml + YANKED gates
   - Step 1 (SemVer): `${{ github.ref_name }}` を ADR 0028 §1 regex `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(rc|beta)\.[1-9]\d*)?$` に match させる。fail 時 step 失敗 + 該当 tag と regex を stderr
   - Step 2 (kolt.toml↔tag): `${{ github.ref_name }}` から `v` prefix を除いた値が `kolt.toml` の `version =` 行と一致することを assert。mismatch 時 両 value を stderr
   - Step 3 (YANKED gate): repo HEAD の `YANKED` を `awk` で逐行読み、各非空行が exactly 3 tab-separated non-empty fields であること (format validation) を assert。format error 時 違反行番号と reason を stderr で fail。tag の version が第 1 field に出現する行があれば fail (該当行を stderr)

--- a/.kiro/specs/installer/tasks.md
+++ b/.kiro/specs/installer/tasks.md
@@ -1,0 +1,209 @@
+# Implementation Plan
+
+## 1. Foundation: YANKED manifest と assemble-dist.sh extension
+
+- [ ] 1.1 (P) repo root に空の YANKED ファイルを commit
+  - 0 bytes (改行を含まない) のファイルを `YANKED` として追加
+  - `.gitignore` 対象外
+  - `git add YANKED` + commit でファイルが repo HEAD に出現する
+  - Observable: `ls -l YANKED` で size 0、`wc -c YANKED` で 0 が表示される
+  - _Requirements: 6.1, 6.2_
+  - _Boundary: YANKED file_
+
+- [ ] 1.2 (P) assemble-dist.sh に .sha256 生成 step を追加
+  - 既存 `tar czf` 直後 (line 254 付近) に `(cd dist && sha256sum "kolt-${VERSION}-linux-x64.tar.gz" > "kolt-${VERSION}-linux-x64.tar.gz.sha256")` を追記
+  - subshell 内で cd するので `.sha256` 内の filename は basename になる (絶対パス埋め込み無し)
+  - 既存 cwd は `$ROOT_DIR` で `dist/...` 相対参照、subshell 統合に問題なし
+  - Observable: `bash scripts/assemble-dist.sh` 実行後、`dist/kolt-<v>-linux-x64.tar.gz.sha256` が `<hex>  kolt-<v>-linux-x64.tar.gz` の 1 行を含むファイルとして存在する
+  - _Requirements: 1.3, 5.1_
+  - _Boundary: assemble-dist.sh extension_
+
+## 2. install.sh の実装
+
+- [ ] 2.1 install.sh の skeleton + env var contract
+  - `#!/bin/sh` shebang + `set -eu`
+  - `KOLT_VERSION` / `KOLT_ALLOW_YANKED` / `KOLT_TEST_BASE_URL` / `KOLT_TEST_YANKED_URL` の default 値設定 (default URL は raw GitHub URL / GitHub Release URL)
+  - 7 関数の stub (各 stub は echo "TODO: <name>" + exit 1) と main flow の関数 call 順序
+  - bash-isms (`[[ ]]`, `local`, 配列) を使わない方針を冒頭コメントで明記
+  - Observable: `sh install.sh` が `platform_detect` stub に到達して exit 1 する (set -u で env var の参照ミスが起きない)
+  - _Boundary: install.sh_
+
+- [ ] 2.2 platform_detect 関数の実装
+  - `uname -s` + `uname -m` を case 文 1 箇所で読む
+  - `Linux` + `x86_64` → "linux-x64" を stdout、続行
+  - `Darwin/*` → exit 1 + "macOS support is tracked in #82, not yet released" を stderr
+  - `Linux/aarch64` 等 → exit 1 + "linuxArm64 support is tracked in #83, not yet released" を stderr
+  - その他 → exit 1 + "unsupported platform: <os>/<arch>" を stderr
+  - tarball 命名規約 `kolt-<version>-<platform>.tar.gz` の `<platform>` 変数化を維持 (URL 構築側で参照)
+  - Observable: 各 OS/arch を環境で偽装した状態で exit code とメッセージが期待通り
+  - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5_
+  - _Boundary: install.sh_
+
+- [ ] 2.3 fetch_yanked_and_validate 関数の実装
+  - `KOLT_TEST_YANKED_URL` 設定時はそれを、未設定時は raw GitHub URL を curl で fetch
+  - HTTP error → exit 6 + URL と HTTP error をメッセージに含める
+  - 各非空行に対し、`awk -F'\t' 'NF != 3 || $1=="" || $2=="" || $3==""'` 相当で format validation。コメント行 (`#` 始まり) と空行と先頭末尾空白を全て reject (ADR 0028 §5)
+  - parse error → exit 2 + "YANKED parse error at line N: <reason>" を stderr
+  - 成功時、validated tempfile の絶対 path を stdout
+  - install.sh 1 回の実行で 1 度のみ呼ばれる前提
+  - Observable: 不正フォーマット (2 fields のみ、空行入り、コメント `# foo` 入り、tab→spaces 置換) の YANKED を渡すと exit 2 + 違反行番号がメッセージに含まれる
+  - _Requirements: 3.5, 3.6, 6.3, 6.4, 6.6, 6.7_
+  - _Boundary: install.sh_
+
+- [ ] 2.4 is_yanked + yank_check 関数の実装
+  - `is_yanked(manifest, version)`: validated manifest を逐行読み、第 1 field が version と一致すれば exit 0 + `<replacement>\t<reason>` を stdout、無ければ exit 1。format validation は再実施しない (caller が事前 validate 済み前提)
+  - `yank_check(manifest, version)`: `is_yanked` を呼び、(a) yanked かつ `KOLT_ALLOW_YANKED!=1` → exit 3 + replacement と reason を stderr、(b) yanked かつ `=1` → "warning: <v> is yanked, replacement is <r>" を stderr 出力後 return、(c) non-yanked → silent return
+  - `set -e` 干渉対策として sub-shell capture (`result=$(is_yanked ...)`) を使う場合は `|| true` パターンを併用
+  - Observable: yanked entry を持つ manifest と `KOLT_VERSION=<v>` を併用して install.sh を呼ぶと exit 3 + replacement が stderr に出る。`KOLT_ALLOW_YANKED=1` 付与で warning 出力後に続行する
+  - _Requirements: 3.3, 3.4_
+  - _Boundary: install.sh_
+
+- [ ] 2.5 select_version 関数の実装
+  - `KOLT_VERSION` set → 値をそのまま echo (API 不問、yank filter なし)
+  - 未 set → `https://api.github.com/repos/snicmakino/kolt/releases?per_page=100` を curl
+  - response から `grep -oE '"tag_name":\s*"[^"]+"'` + `sed -E 's/.../\1/'` で tag_name を抽出
+  - pre-release (tag に `-` を含む) を除外
+  - `sort -V -r` で降順 SemVer 並べ替え、loop 内で `is_yanked` を呼んで最初の non-yanked tag を pick
+  - `v` prefix を除去して echo
+  - API 失敗 (HTTP error / timeout) → exit 6
+  - Observable: `KOLT_VERSION` 未設定時に GitHub Releases から SemVer 順で最新の non-yanked tag が選ばれる (yanked tag が最新でも skip される)。`KOLT_VERSION=<v>` 指定時はそのまま `<v>` が返る
+  - _Requirements: 3.1, 3.2_
+  - _Boundary: install.sh_
+
+- [ ] 2.6 download_and_verify 関数の実装
+  - `KOLT_TEST_BASE_URL` 設定時はそれを base、未設定時は `https://github.com/snicmakino/kolt/releases/download/v<v>` を base にする
+  - tarball (`kolt-<v>-<platform>.tar.gz`) と `.sha256` を curl で fetch
+  - HTTP 404 / error → exit 4 + URL と HTTP status をメッセージに含める。tarball が無い version (pre-#230 release) のケースに「the installer was introduced in #230, earlier releases predate it」相当の hint を 404 時に追加
+  - `sha256sum -c` 相当で digest verify (download した `.sha256` を `sha256sum -c` に渡す)
+  - 検証 mismatch → tarball を削除 + exit 5 + 期待 digest と実 digest 両方を stderr
+  - 成功時 tarball の local path を stdout
+  - Observable: 改竄した `.sha256` (digest を 1 文字書き換え) を serve した状態で install.sh を呼ぶと exit 5 + 両 digest がメッセージに出力される
+  - _Requirements: 5.2, 5.3, 5.4_
+  - _Boundary: install.sh_
+
+- [ ] 2.7 extract_and_link 関数の実装 (idempotent)
+  - `mkdir -p ~/.local/share/kolt ~/.local/bin` (必要なら作成)
+  - `~/.local/bin/kolt` の existing を `[ -L ... ]` で check: 既存しかつ symlink ではない (regular file / dir) → exit 8 + 「remove this file manually then re-run」を stderr
+  - `~/.local/share/kolt/<v>/` 既存なら `rm -rf` (rustup-init 流の clean repair)
+  - `tar xzf <tarball> -C ~/.local/share/kolt` で展開 (`kolt-<v>-linux-x64/` が作られる)
+  - canonical name (`<v>/`) に rename
+  - `libexec/classpath/*.argfile` 中の `@KOLT_LIBEXEC@` を `<install-dir>/libexec` の絶対 path に sed `-i` で置換
+  - `ln -sf <install-dir>/bin/kolt ~/.local/bin/kolt` で symlink 作成・上書き
+  - 全失敗 path で symlink 作成は最後 (展開済み・sed 済みでも symlink が古いままにならない順序)
+  - Observable: 同 version で 2 度実行すると古い `~/.local/share/kolt/<v>/` が削除されて新規展開された状態になり、`~/.local/bin/kolt --version` が exit 0 で対象 version 文字列を返す
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.6_
+  - _Boundary: install.sh_
+
+- [ ] 2.8 print_path_hint + main flow 完成 + 成功メッセージ
+  - `print_path_hint`: `case ":$PATH:" in *":$HOME/.local/bin:"*) ;; *) echo hint to stderr ;;` (literal `$HOME` のみ check、tilde `~` は見ない)
+  - main flow: stub を全部実装関数の呼び出しに置換、各関数の stdout を変数 capture して順送り
+  - 成功時 stdout に "kolt <version> installed at ~/.local/bin/kolt" を 1 行出力
+  - Observable: PATH に `$HOME/.local/bin` が無い状態で実行すると hint が stderr に出る、含まれていれば hint なし。`kolt --version` を別シェルで叩いて exit 0 + version 出力を確認できる
+  - _Requirements: 2.5, 2.7_
+  - _Boundary: install.sh_
+
+## 3. release.yml の実装
+
+- [ ] 3.1 (P) workflow file の skeleton + triggers + permissions
+  - `.github/workflows/release.yml` を新規作成
+  - `on: push: tags: ['v*']` および `on: workflow_dispatch: inputs: dry_run: {type: boolean, default: true, required: true}`
+  - `permissions: contents: write`
+  - 2 jobs: `release` (steps を後続 task で埋める) + `smoke` (`needs: release` + job-level `if: github.event_name == 'push' || !inputs.dry_run`)
+  - Observable: GHA UI で release.yml が visible、`v0.16.0-rc.test` 風の dummy tag (push せず手元で workflow yaml lint) で構文エラー無し、workflow_dispatch 入力 `dry_run` が UI で選択可能
+  - _Requirements: 1.1_
+  - _Boundary: release.yml_
+
+- [ ] 3.2 release job: SemVer + kolt.toml + YANKED gates
+  - Step 1 (SemVer): `${{ github.ref_name }}` を ADR 0028 §1 regex `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(rc|beta)\.[1-9]\d*)?$` に match させる。fail 時 step 失敗 + 該当 tag と regex を stderr
+  - Step 2 (kolt.toml↔tag): `${{ github.ref_name }}` から `v` prefix を除いた値が `kolt.toml` の `version =` 行と一致することを assert。mismatch 時 両 value を stderr
+  - Step 3 (YANKED gate): repo HEAD の `YANKED` を `awk` で逐行読み、各非空行が exactly 3 tab-separated non-empty fields であること (format validation) を assert。format error 時 違反行番号と reason を stderr で fail。tag の version が第 1 field に出現する行があれば fail (該当行を stderr)
+  - 3 gate は build より前に直列実行、いずれかの failure で job fail
+  - Observable: 不正 tag (例 `v0.16` のような pseudo-SemVer)、kolt.toml mismatch、yanked tag、不正 YANKED format の各ケースで release job が build に到達せず fail し、stderr に原因が一意に identify できる
+  - _Requirements: 1.2, 1.4, 1.6, 6.5_
+  - _Boundary: release.yml_
+
+- [ ] 3.3 release job: build + assemble + sha256 + publish
+  - Setup steps: `actions/checkout@v4` + `actions/setup-java@v4` (JDK 25 temurin) + libcurl4-openssl-dev install + `actions/cache@v4` 3 種 (gradle / konan / kolt)。self-host-smoke.yml と同じキャッシュキーを使い両 workflow で cache 共有
+  - Bootstrap step: `./gradlew --no-daemon linkDebugExecutableLinuxX64`
+  - Build step: 3 × `kolt build --release` (root / kolt-jvm-compiler-daemon / kolt-native-compiler-daemon)
+  - Assemble step: `KOLT="$GITHUB_WORKSPACE/build/bin/linuxX64/debugExecutable/kolt.kexe" ./scripts/assemble-dist.sh` (self-host-smoke.yml の bootstrap kexe 経由 invocation pattern と同形、KOLT 環境変数は assemble-dist.sh の line 102 default を override する形で渡す)。1.2 で .sha256 が dist/ 配下に出る前提
+  - Publish step: `gh release create --target $GITHUB_SHA <tag> dist/kolt-<v>-linux-x64.tar.gz dist/kolt-<v>-linux-x64.tar.gz.sha256`。tag が `-rc.N` / `-beta.N` の場合 `--prerelease` flag を付与。`if: github.event_name == 'push' || !inputs.dry_run` で dry_run 時は publish step だけ skip
+  - Observable: 実 tag push (例 `v0.16.0`) で GitHub Release に 2 assets (`kolt-0.16.0-linux-x64.tar.gz` + `.sha256`) が attach される。`workflow_dispatch + dry_run=true` 起動時は GHA log に `dist/kolt-...sha256` 生成までの記録は残るが Release は作成されない
+  - _Requirements: 1.1, 1.3, 1.5_
+  - _Boundary: release.yml_
+  - _Depends: 1.2_
+
+- [ ] 3.4 smoke job: clean runner + raw URL curl|sh + assertion
+  - `runs-on: ubuntu-latest` + clean state (`HOME=$(mktemp -d)` を export)
+  - `curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh` で install.sh を起動
+  - `~/.local/bin/kolt --version` の exit 0 + `^kolt <expected-version>$` regex match を assert
+  - smoke fail で job fail (release は既に publish 済みなので Release は public のまま残るが、smoke job 失敗が GHA UI に表示される)
+  - `if: github.event_name == 'push' || !inputs.dry_run` で dry_run 時は job 全体 skip
+  - 注: 本 step の curl|sh は install.sh が main にマージされてから初めて意味を持つ。実 exercise は first real tag (v0.16.0 想定) の workflow run で発生する
+  - Observable: tag-time の workflow run で smoke job が success、`kolt --version` の出力が GHA log に記録される
+  - _Requirements: 2.5, 7.3, 7.4_
+  - _Boundary: release.yml_
+  - _Depends: 2.8_
+
+## 4. self-host-smoke.yml extension
+
+- [ ] 4.1 inline sed step を install.sh + 環境変数経由に置換 (happy path)
+  - 既存 lines 181-188 (Substitute KOLT_LIBEXEC placeholder in argfiles step) を削除
+  - serve directory を `mktemp -d` で用意し、`dist/kolt-<v>-linux-x64.tar.gz` + `.sha256` + 空 `YANKED` を copy / 生成
+  - `python3 -m http.server 8000 --bind 127.0.0.1 --directory <serve-dir> &` で local serve、PID を変数に保存し step 終了時に `trap 'kill $PID' EXIT`
+  - install.sh をローカル checkout から実行: `KOLT_TEST_BASE_URL=http://127.0.0.1:8000 KOLT_TEST_YANKED_URL=http://127.0.0.1:8000/YANKED KOLT_VERSION=<kolt.toml の version> sh ./install.sh`
+  - 完了後 `~/.local/bin/kolt --version` を assert (exit 0 + version 文字列一致)
+  - 既存の fixture smoke build (lines 194-201) のロジックは保持しつつ、INSTALL_DIR の path を install.sh が作る `~/.local/share/kolt/<v>/` に取り直す形に書き換える (variable 1 つの差し替え)
+  - Observable: PR-time CI で install.sh の本物の経路 (download → SHA verify → extract → sed → symlink → version 確認) が緑になる。dist/ 配下のファイルが install dir (`~/.local/share/kolt/<v>/`) に正しく配置される
+  - _Requirements: 7.1, 7.5, 2.5_
+  - _Boundary: self-host-smoke.yml_
+  - _Depends: 2.8_
+
+- [ ] 4.2 yank refuse + override smoke step を追加
+  - 同 HTTP server の serve directory に `YANKED-with-yank` を生成 (1 行: `<kolt.toml-version>\treplacement-test\ttest yank entry`)
+  - `KOLT_TEST_YANKED_URL=http://127.0.0.1:8000/YANKED-with-yank KOLT_VERSION=<v>` で install.sh を起動 (set +e でくくって exit code を捕まえる)
+  - exit code が 3 であること、replacement version 文字列 (`replacement-test`) が stderr に含まれることを assert
+  - 続けて `KOLT_ALLOW_YANKED=1` 付与で同じ command を再実行、exit 0 + warning が stderr に出ることを assert
+  - Observable: PR-time CI で「yanked refuse path で exit 3」と「override で exit 0 + warning」の 2 シナリオが両方緑になる
+  - _Requirements: 7.2, 3.3, 3.4_
+  - _Boundary: self-host-smoke.yml_
+  - _Depends: 2.8_
+
+- [ ] 4.3 install.sh の edge case smokes (parse error / non-symlink / SHA mismatch)
+  - parse error: serve directory に `YANKED-bad` (例: 2 fields のみの行) を置き、`KOLT_TEST_YANKED_URL=...YANKED-bad` で install.sh を呼んで exit 2 + 違反行番号が stderr に出ることを assert
+  - non-symlink refuse: `touch ~/.local/bin/kolt` (regular file) を作って install.sh を呼び、exit 8 + 「remove this file manually」を stderr で assert。後始末で `rm ~/.local/bin/kolt`
+  - SHA-256 mismatch: serve directory の `kolt-<v>-linux-x64.tar.gz.sha256` の digest を 1 文字書き換え、install.sh を呼んで exit 5 + 期待・実 digest 両方が stderr に出ることを assert
+  - 各 case で `set +e` で exit code を捕まえ、HTTP server / 一時ファイルの cleanup を trap で行う
+  - Observable: 3 つの edge case それぞれで install.sh が期待 exit code を返し、stderr メッセージが識別可能
+  - _Requirements: 6.3, 6.4, 6.6, 5.3_
+  - _Boundary: self-host-smoke.yml_
+  - _Depends: 2.8_
+
+## 5. (P) README Installation セクション書き換え
+
+- [ ] 5. README.md の Installation section を curl|sh コマンドに書き換え
+  - 既存 lines 14-30 (Build from source 手順 + #97 言及) を削除
+  - 新セクション冒頭: copy-paste-able code block で `curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh`
+  - 環境変数解説 (1-2 行ずつ): `KOLT_VERSION=<v>` で特定 version 指定、`KOLT_ALLOW_YANKED=1` で yanked 強制 install
+  - サポート platform 明記: 「初版は linux-x64 のみ。macOS は #82、linuxArm64 は #83 で別 track」
+  - PATH 注意: 「インストール後 `~/.local/bin` を `PATH` に追加する必要があり得る」
+  - Build-from-source 手順は contributor 向けの別セクション (例: `### Building from source` 等) として README 下部に移動。`#97` 言及は self-host shipped 済のため削除
+  - Observable: `cat README.md` で curl|sh コマンドと環境変数解説が冒頭近くに表示され、Build-from-source は contributor section に残る
+  - _Requirements: 8.1, 8.2, 8.3, 8.4_
+  - _Boundary: README.md_
+
+## 6. End-to-end validation
+
+- [ ] 6.1 PR-time CI が green になることを確認
+  - 4.1 + 4.2 + 4.3 の 3 step を含む self-host-smoke.yml が PR 上で全て pass
+  - 既存 jobs (self-host bootstrap、unit-tests) も regression なく pass
+  - `unit-tests.yml` の linuxX64Test も従来通り green
+  - Observable: PR の CI checks が全て green、self-host-post job のステップ一覧に install.sh smoke / yank refuse / edge case が表示されている
+  - _Depends: 4.1, 4.2, 4.3_
+
+- [ ]* 6.2 workflow_dispatch dry_run の手動検証 (optional / pre-flight)
+  - PR を main にマージする前に release.yml を `workflow_dispatch + dry_run=true` で起動 (or fork branch で確認)
+  - GHA UI で 3 gate (SemVer / kolt.toml / YANKED) + setup + bootstrap + 3 × kolt build + assemble-dist + sha256 までの step が全て成功し、`gh release create` step と smoke job が skip されたことを log で確認
+  - 手動 GHA UI 操作のため optional 扱い (本タスクは実装の完了条件ではなく first tag 前の pre-flight として実行を推奨)
+  - Observable: GHA UI に dry_run 起動の workflow run が記録され、`dist/kolt-...sha256` 生成までは成功、Release が作成されていない (Releases ページに新 entry なし)
+  - _Depends: 3.3_

--- a/README.md
+++ b/README.md
@@ -13,21 +13,26 @@ The tool itself starts instantly. Actual compilation delegates to `kotlinc` / `k
 
 ## Installation
 
-Build from source:
+Install the latest release on Linux x64:
 
 ```sh
-git clone https://github.com/snicmakino/kolt.git
-cd kolt
-./gradlew build
+curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh
 ```
 
-The binary is produced at `build/bin/linuxX64/debugExecutable/kolt.kexe`. Copy it to a directory on your PATH:
+The installer fetches the matching tarball from GitHub Releases, verifies its SHA-256, and unpacks it under `~/.local/share/kolt/<version>/` with a symlink at `~/.local/bin/kolt`. You may need to add `~/.local/bin` to your `PATH`:
 
 ```sh
-cp build/bin/linuxX64/debugExecutable/kolt.kexe ~/.local/bin/kolt
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
-kolt is built with Gradle. Partial self-hosting works (kolt can compile the native binary from `kolt.toml`), but the compiler daemon JAR still requires Gradle to build ([#97](https://github.com/snicmakino/kolt/issues/97)).
+### Environment variables
+
+- `KOLT_VERSION=<v>` — install a specific version instead of the latest stable.
+- `KOLT_ALLOW_YANKED=1` — install a yanked version anyway (otherwise the installer refuses and prints the recommended replacement).
+
+### Supported platforms
+
+The first release ships **linux-x64 only**. macOS support is tracked in [#82](https://github.com/snicmakino/kolt/issues/82); linuxArm64 in [#83](https://github.com/snicmakino/kolt/issues/83). For other platforms see [Building from source](#building-from-source).
 
 ## Quick Start
 
@@ -350,6 +355,22 @@ kolt aims to be what `go build` is to Go or `cargo build` is to Rust — a fast,
 ## Architecture
 
 See [docs/architecture.md](docs/architecture.md) ([日本語](docs/architecture.ja.md)) for the internal design — component overview, build flow, daemon lifecycle, and architectural decisions.
+
+## Building from source
+
+Contributors and platforms not yet covered by the installer can build kolt from source:
+
+```sh
+git clone https://github.com/snicmakino/kolt.git
+cd kolt
+./gradlew build
+```
+
+The binary is produced at `build/bin/linuxX64/debugExecutable/kolt.kexe`. Copy it to a directory on your PATH:
+
+```sh
+cp build/bin/linuxX64/debugExecutable/kolt.kexe ~/.local/bin/kolt
+```
 
 ## Claude Code Integration
 

--- a/install.sh
+++ b/install.sh
@@ -183,8 +183,39 @@ download_and_verify() {
 }
 
 extract_and_link() {
-    echo "TODO: extract_and_link" >&2
-    exit 1
+    el_tarball="$1"
+    el_version="$2"
+
+    el_share_dir="$HOME/.local/share/kolt"
+    el_bin_dir="$HOME/.local/bin"
+    el_install_dir="$el_share_dir/$el_version"
+    el_symlink="$el_bin_dir/kolt"
+
+    mkdir -p "$el_share_dir" "$el_bin_dir"
+
+    if [ -e "$el_symlink" ] && [ ! -L "$el_symlink" ]; then
+        echo "extract_and_link: $el_symlink exists and is not a symlink" >&2
+        echo "remove this file manually then re-run install.sh" >&2
+        exit 8
+    fi
+
+    if [ -d "$el_install_dir" ]; then
+        rm -rf "$el_install_dir"
+    fi
+
+    tar xzf "$el_tarball" -C "$el_share_dir"
+
+    el_extracted="$el_share_dir/kolt-${el_version}-linux-x64"
+    mv "$el_extracted" "$el_install_dir"
+
+    el_libexec_abs="$el_install_dir/libexec"
+    for el_argfile in "$el_install_dir/libexec/classpath/"*.argfile; do
+        if [ -f "$el_argfile" ]; then
+            sed -i "s|@KOLT_LIBEXEC@|$el_libexec_abs|g" "$el_argfile"
+        fi
+    done
+
+    ln -sf "$el_install_dir/bin/kolt" "$el_symlink"
 }
 
 print_path_hint() {

--- a/install.sh
+++ b/install.sh
@@ -44,8 +44,33 @@ platform_detect() {
 }
 
 fetch_yanked_and_validate() {
-    echo "TODO: fetch_yanked_and_validate" >&2
-    exit 1
+    url="${KOLT_TEST_YANKED_URL:-$DEFAULT_YANKED_URL}"
+    tempfile=$(mktemp)
+
+    if ! curl -fsSL -o "$tempfile" "$url"; then
+        rm -f "$tempfile"
+        echo "fetch_yanked: failed to fetch $url" >&2
+        exit 6
+    fi
+
+    if ! err=$(awk -F'\t' '
+        {
+            if (length($0) == 0) { msg = "blank line not allowed" }
+            else if ($0 ~ /^#/) { msg = "comments not allowed" }
+            else if ($0 ~ /^[ \t]/ || $0 ~ /[ \t]$/) { msg = "leading or trailing whitespace not allowed" }
+            else if (NF != 3) { msg = "expected 3 tab-separated fields, got " NF }
+            else if ($1 == "" || $2 == "" || $3 == "") { msg = "empty field" }
+            else { next }
+            print "YANKED parse error at line " NR ": " msg
+            exit 1
+        }
+    ' "$tempfile"); then
+        rm -f "$tempfile"
+        echo "$err" >&2
+        exit 2
+    fi
+
+    echo "$tempfile"
 }
 
 is_yanked() {

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# kolt installer for Linux x64.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh
+#   KOLT_VERSION=0.16.0 sh install.sh
+#   KOLT_ALLOW_YANKED=1 sh install.sh
+#
+# POSIX sh, not bash. Avoid bash-isms ([[ ]], local, arrays, pipefail) so
+# the script runs unchanged on BusyBox and macOS bash 3.2.
+#
+# References: ADR 0018 §4, ADR 0028 §1/§5.
+
+set -eu
+
+KOLT_VERSION="${KOLT_VERSION:-}"
+KOLT_ALLOW_YANKED="${KOLT_ALLOW_YANKED:-0}"
+KOLT_TEST_BASE_URL="${KOLT_TEST_BASE_URL:-}"
+KOLT_TEST_YANKED_URL="${KOLT_TEST_YANKED_URL:-}"
+
+DEFAULT_YANKED_URL="https://raw.githubusercontent.com/snicmakino/kolt/main/YANKED"
+DEFAULT_RELEASES_API="https://api.github.com/repos/snicmakino/kolt/releases?per_page=100"
+
+platform_detect() {
+    echo "TODO: platform_detect" >&2
+    exit 1
+}
+
+fetch_yanked_and_validate() {
+    echo "TODO: fetch_yanked_and_validate" >&2
+    exit 1
+}
+
+is_yanked() {
+    echo "TODO: is_yanked" >&2
+    exit 1
+}
+
+select_version() {
+    echo "TODO: select_version" >&2
+    exit 1
+}
+
+yank_check() {
+    echo "TODO: yank_check" >&2
+    exit 1
+}
+
+download_and_verify() {
+    echo "TODO: download_and_verify" >&2
+    exit 1
+}
+
+extract_and_link() {
+    echo "TODO: extract_and_link" >&2
+    exit 1
+}
+
+print_path_hint() {
+    echo "TODO: print_path_hint" >&2
+    exit 1
+}
+
+main() {
+    platform=$(platform_detect)
+    yanked_manifest=$(fetch_yanked_and_validate)
+    version=$(select_version "$platform" "$yanked_manifest")
+    yank_check "$yanked_manifest" "$version"
+    tarball=$(download_and_verify "$version" "$platform")
+    extract_and_link "$tarball" "$version"
+    print_path_hint
+    echo "kolt $version installed at ~/.local/bin/kolt"
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -139,8 +139,47 @@ yank_check() {
 }
 
 download_and_verify() {
-    echo "TODO: download_and_verify" >&2
-    exit 1
+    dv_version="$1"
+    dv_platform="$2"
+
+    if [ -n "$KOLT_TEST_BASE_URL" ]; then
+        dv_base="$KOLT_TEST_BASE_URL"
+    else
+        dv_base="https://github.com/snicmakino/kolt/releases/download/v${dv_version}"
+    fi
+
+    dv_tarball_name="kolt-${dv_version}-${dv_platform}.tar.gz"
+    dv_tarball_url="${dv_base}/${dv_tarball_name}"
+    dv_sha256_url="${dv_tarball_url}.sha256"
+
+    dv_tempdir=$(mktemp -d)
+    dv_tarball_path="${dv_tempdir}/${dv_tarball_name}"
+    dv_sha256_path="${dv_tarball_path}.sha256"
+
+    if ! curl -fsSL -o "$dv_tarball_path" "$dv_tarball_url"; then
+        rm -rf "$dv_tempdir"
+        echo "download_and_verify: failed to fetch $dv_tarball_url" >&2
+        echo "(version $dv_version may predate the installer rollout — see #230)" >&2
+        exit 4
+    fi
+
+    if ! curl -fsSL -o "$dv_sha256_path" "$dv_sha256_url"; then
+        rm -rf "$dv_tempdir"
+        echo "download_and_verify: failed to fetch $dv_sha256_url" >&2
+        exit 4
+    fi
+
+    if ! (cd "$dv_tempdir" && sha256sum -c "${dv_tarball_name}.sha256" >/dev/null 2>&1); then
+        dv_expected=$(awk '{print $1}' "$dv_sha256_path")
+        dv_actual=$(sha256sum "$dv_tarball_path" | awk '{print $1}')
+        rm -rf "$dv_tempdir"
+        echo "download_and_verify: SHA-256 mismatch for $dv_tarball_name" >&2
+        echo "  expected: $dv_expected" >&2
+        echo "  actual:   $dv_actual" >&2
+        exit 5
+    fi
+
+    echo "$dv_tarball_path"
 }
 
 extract_and_link() {

--- a/install.sh
+++ b/install.sh
@@ -83,8 +83,43 @@ is_yanked() {
 }
 
 select_version() {
-    echo "TODO: select_version" >&2
-    exit 1
+    sv_platform="$1"
+    sv_manifest="$2"
+
+    if [ -n "$KOLT_VERSION" ]; then
+        printf '%s' "${KOLT_VERSION#v}"
+        return
+    fi
+
+    sv_response=$(mktemp)
+    if ! curl -fsSL -o "$sv_response" "$DEFAULT_RELEASES_API"; then
+        rm -f "$sv_response"
+        echo "select_version: failed to fetch $DEFAULT_RELEASES_API" >&2
+        exit 6
+    fi
+
+    sv_tags=$(grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]+"' "$sv_response" \
+        | sed -E 's/^"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)"$/\1/')
+    rm -f "$sv_response"
+
+    if [ -z "$sv_tags" ]; then
+        echo "select_version: no tags found in API response" >&2
+        exit 6
+    fi
+
+    sv_filtered=$(printf '%s\n' "$sv_tags" | grep -v -- '-' || true)
+    sv_sorted=$(printf '%s\n' "$sv_filtered" | sort -V -r)
+
+    for sv_tag in $sv_sorted; do
+        sv_version="${sv_tag#v}"
+        if ! is_yanked "$sv_manifest" "$sv_version" >/dev/null; then
+            printf '%s' "$sv_version"
+            return
+        fi
+    done
+
+    echo "select_version: no non-yanked release found" >&2
+    exit 6
 }
 
 yank_check() {

--- a/install.sh
+++ b/install.sh
@@ -22,8 +22,25 @@ DEFAULT_YANKED_URL="https://raw.githubusercontent.com/snicmakino/kolt/main/YANKE
 DEFAULT_RELEASES_API="https://api.github.com/repos/snicmakino/kolt/releases?per_page=100"
 
 platform_detect() {
-    echo "TODO: platform_detect" >&2
-    exit 1
+    os=$(uname -s)
+    arch=$(uname -m)
+    case "$os/$arch" in
+        Linux/x86_64)
+            echo "linux-x64"
+            ;;
+        Darwin/*)
+            echo "macOS support is tracked in #82, not yet released" >&2
+            exit 1
+            ;;
+        Linux/*)
+            echo "linuxArm64 support is tracked in #83, not yet released" >&2
+            exit 1
+            ;;
+        *)
+            echo "unsupported platform: $os/$arch" >&2
+            exit 1
+            ;;
+    esac
 }
 
 fetch_yanked_and_validate() {

--- a/install.sh
+++ b/install.sh
@@ -219,8 +219,15 @@ extract_and_link() {
 }
 
 print_path_hint() {
-    echo "TODO: print_path_hint" >&2
-    exit 1
+    case ":$PATH:" in
+        *":$HOME/.local/bin:"*)
+            ;;
+        *)
+            echo "$HOME/.local/bin is not in your PATH" >&2
+            echo "add this line to your shell startup file:" >&2
+            echo "  export PATH=\"\$HOME/.local/bin:\$PATH\"" >&2
+            ;;
+    esac
 }
 
 main() {

--- a/install.sh
+++ b/install.sh
@@ -74,8 +74,12 @@ fetch_yanked_and_validate() {
 }
 
 is_yanked() {
-    echo "TODO: is_yanked" >&2
-    exit 1
+    iy_manifest="$1"
+    iy_version="$2"
+    awk -F'\t' -v v="$iy_version" '
+        $1 == v { print $2 "\t" $3; found = 1; exit }
+        END { if (!found) exit 1 }
+    ' "$iy_manifest"
 }
 
 select_version() {
@@ -84,8 +88,19 @@ select_version() {
 }
 
 yank_check() {
-    echo "TODO: yank_check" >&2
-    exit 1
+    yc_manifest="$1"
+    yc_version="$2"
+    if result=$(is_yanked "$yc_manifest" "$yc_version"); then
+        yc_replacement=$(printf '%s' "$result" | cut -f1)
+        yc_reason=$(printf '%s' "$result" | cut -f2)
+        if [ "$KOLT_ALLOW_YANKED" = "1" ]; then
+            echo "warning: $yc_version is yanked, replacement is $yc_replacement ($yc_reason)" >&2
+            return
+        fi
+        echo "version $yc_version is yanked, replacement is $yc_replacement ($yc_reason)" >&2
+        echo "set KOLT_ALLOW_YANKED=1 to install anyway" >&2
+        exit 3
+    fi
 }
 
 download_and_verify() {

--- a/scripts/assemble-dist.sh
+++ b/scripts/assemble-dist.sh
@@ -253,4 +253,12 @@ printf '%s\n' "$VERSION" > "$DIST_ROOT/VERSION"
 TARBALL="dist/kolt-${VERSION}-linux-x64.tar.gz"
 tar czf "$TARBALL" -C dist "kolt-${VERSION}-linux-x64"
 
+# Emit `<TARBALL>.sha256` in `sha256sum -c` input format (`<hex>  <basename>`).
+# install.sh fetches both the tarball and this digest file and verifies
+# integrity before extraction (ADR 0018 §4 + installer design §5).
+# `(cd dist && ...)` keeps the digest's `<basename>` as just the filename so
+# the file is install-location agnostic.
+(cd dist && sha256sum "kolt-${VERSION}-linux-x64.tar.gz" > "kolt-${VERSION}-linux-x64.tar.gz.sha256")
+
 echo "assemble-dist: wrote $TARBALL"
+echo "assemble-dist: wrote $TARBALL.sha256"


### PR DESCRIPTION
Implements #230. Adds:

- `install.sh` (POSIX sh, ~250 lines) for one-line curl|sh install on Linux x64
- `.github/workflows/release.yml` with SemVer / kolt.toml / YANKED gates, JDK + libcurl + caches setup mirroring self-host-smoke.yml, `assemble-dist.sh` invocation, `gh release create` for tarball + .sha256, and a tag-time real curl|sh smoke job
- `assemble-dist.sh` now emits `<tarball>.sha256` alongside the tarball
- `self-host-smoke.yml` self-host-post job replaces the inline sed step with a python3 http.server + install.sh happy-path flow, then runs five negative paths (yank refuse / override / parse error / non-symlink / SHA mismatch). Cache keys character-identical to release.yml so the two workflows share warmed caches
- Empty `YANKED` manifest at repo root (ADR 0028 §5)
- README installation section rewritten to lead with the curl|sh command; build-from-source moved to a contributor section near the bottom

## Reviewer focus

- **Gate 2 literal equality**: tag must equal `v$KOLT_TOML_VERSION` exactly. RC/beta tags therefore require `kolt.toml` to also include the suffix. If that becomes painful during the v1 RC window, consider stripping the pre-release suffix before comparison.
- **YANKED parser duplication**: install.sh `fetch_yanked_and_validate` (awk) and release.yml Gate 3 (awk) both implement ADR 0028 §5 format checks. They are byte-identical today; drift will only show up if the format itself changes. A native drift-guard test could be added later.
- **install.sh exit code map** (1 platform / 2 parse / 3 yanked / 4 download / 5 SHA / 6 network / 7 KOLT_VERSION malformed / 8 non-symlink) — each path is exercised by the smoke matrix except 1 (platform; uname mock would be needed) and 7 (no test).
- **dash strict set -e + assignment**: noted in `.kiro/specs/installer/tasks.md` Implementation Notes. install.sh and release.yml gates use `if !var=\$(...); then` to capture exit codes without aborting.
- **README.ja.md** intentionally left as a follow-up; not part of this spec's boundary.

## First-tag flow

- `workflow_dispatch + dry_run=true` validates gates + build + assemble + sha256 without publishing — recommended pre-flight before the first real tag.
- The tag-time curl|sh smoke is meaningful only after install.sh lands on main; first real exercise will be the v0.16.0 push.