### PR TITLE
Pass --generate-notes to gh release create (#281)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,10 +179,14 @@ jobs:
             *-rc.*|*-beta.*) PRERELEASE_FLAG="--prerelease" ;;
           esac
 
+          # --generate-notes auto-populates the body with merged PRs since
+          # the previous tag. Maintainers can still `gh release edit` to
+          # curate the wording afterwards.
           # shellcheck disable=SC2086 # PRERELEASE_FLAG is intentionally split
           gh release create "$TAG" \
             --target "$GITHUB_SHA" \
             --title "$TAG" \
+            --generate-notes \
             $PRERELEASE_FLAG \
             "$TARBALL" \
             "$SHA"


### PR DESCRIPTION
Closes #281.

PR #277 で導入した release.yml の publish step は \`--notes\` も \`--notes-file\` も \`--generate-notes\` も渡していなかったため、v0.16.0 で release body が空 publish になった (手動 \`gh release edit\` で埋めた)。

\`--generate-notes\` を追加して、次 tag push から「前 tag からの merged PR 一覧」が自動で body に入るようにする。maintainer が curated 内容を出したいときは従来どおり \`gh release edit\` で上書きできる。

## レビュー観点

- 1 行追加 (\`--generate-notes\`) のみ、他は無変更
- 次 tag (v0.17.0 想定) の release body に PR 一覧が出ることで動作確認可能