### PR TITLE
Fix #286: manifest reader drops alphabetical-last dep

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -173,6 +173,45 @@ jobs:
           VERSION=$(grep -E '^version = "' kolt.toml | head -n 1 | sed -E 's/^version = "(.*)"/\1/')
           echo "KOLT_TOML_VERSION=$VERSION" >> "$GITHUB_ENV"
 
+      # Issue #286 regression guard: assemble-dist.sh reads each daemon's
+      # runtime classpath manifest with `while IFS= read -r`, which silently
+      # drops the alphabetical-last entry (ADR 0027 §1 pins the manifest as
+      # "no trailing blank line"). Cross-checks that every manifest entry
+      # landed in `libexec/<daemon>/deps/` and is present on the argfile
+      # `-cp` line — both sides of the regression.
+      - name: Verify daemon deps match runtime classpath manifest
+        run: |
+          set -euo pipefail
+          DIST_ROOT="dist/kolt-${KOLT_TOML_VERSION}-linux-x64"
+          for daemon in kolt-jvm-compiler-daemon kolt-native-compiler-daemon; do
+            manifest="$daemon/build/release/$daemon-runtime.classpath"
+            if [ ! -f "$manifest" ]; then
+              echo "guard: missing manifest $manifest" >&2
+              exit 1
+            fi
+            expected=$(awk -F/ 'NF { print $NF }' "$manifest" | sort)
+            deps_dir="$DIST_ROOT/libexec/$daemon/deps"
+            actual=$(find "$deps_dir" -maxdepth 1 -name '*.jar' -printf '%f\n' | sort)
+            if [ "$expected" != "$actual" ]; then
+              echo "guard: $daemon deps/ does not match runtime classpath manifest" >&2
+              diff <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") || true
+              exit 1
+            fi
+            argfile="$DIST_ROOT/libexec/classpath/$daemon.argfile"
+            cp_line=$(awk 'NR == 2' "$argfile")
+            while IFS= read -r base; do
+              [ -z "$base" ] && continue
+              case "$cp_line" in
+                *"/${daemon}/deps/${base}"*) ;;
+                *)
+                  echo "guard: argfile $argfile missing entry for $base" >&2
+                  exit 1
+                  ;;
+              esac
+            done < <(printf '%s\n' "$expected")
+          done
+          echo "guard: all daemon deps match their runtime classpath manifests"
+
       # Local HTTP server lets install.sh exercise its real download +
       # SHA-256 + extract + sed + symlink path against the assembled tarball
       # without needing a published GitHub Release.

--- a/scripts/assemble-dist.sh
+++ b/scripts/assemble-dist.sh
@@ -149,12 +149,19 @@ LIBEXEC_PLACEHOLDER="@KOLT_LIBEXEC@"
 # manifest into `<target_dir>/` preserving its file name. Manifest entries
 # are absolute paths (one per line, ADR 0027 §1); duplicates are flagged as
 # a bug in the resolver rather than silently overwriting.
+#
+# The `|| [[ -n "$jar" ]]` keeps the last entry: ADR 0027 §1 pins the
+# manifest format as "no trailing blank line", so the final line is
+# unterminated and a vanilla `while IFS= read -r` would silently drop it.
+# Issue #286: dropping the last entry left `kotlinx-serialization-json-jvm`
+# out of the native daemon's deps/ and `ktoml-core-jvm` out of the JVM
+# daemon's, which are precisely the alphabetical-last entries.
 copy_manifest_deps() {
   local manifest="$1"
   local target_dir="$2"
   mkdir -p "$target_dir"
   local jar base
-  while IFS= read -r jar; do
+  while IFS= read -r jar || [[ -n "$jar" ]]; do
     [[ -z "$jar" ]] && continue
     base="$(basename "$jar")"
     if [[ -e "$target_dir/$base" ]]; then
@@ -180,7 +187,8 @@ write_argfile() {
   local cp_entries=()
   cp_entries+=("${LIBEXEC_PLACEHOLDER}/${daemon}/${daemon}.jar")
   local jar base
-  while IFS= read -r jar; do
+  # See `copy_manifest_deps` for why the last-line guard is required.
+  while IFS= read -r jar || [[ -n "$jar" ]]; do
     [[ -z "$jar" ]] && continue
     base="$(basename "$jar")"
     cp_entries+=("${LIBEXEC_PLACEHOLDER}/${daemon}/deps/${base}")


### PR DESCRIPTION
The runtime classpath manifest is written without a trailing newline (ADR 0027 §1: "no trailing blank line"). Both `copy_manifest_deps` and `write_argfile` in `scripts/assemble-dist.sh` consumed it with a vanilla `while IFS= read -r jar`, which silently drops the unterminated last line. That left the alphabetical-last manifest entry out of `libexec/<daemon>/deps/` and off the daemon's argfile `-cp`, matching the v0.16.1 install symptoms (`kotlinx-serialization-json-jvm` missing from the native daemon, `ktoml-core-jvm` missing from the JVM daemon). The native daemon then died at `FrameCodec.<clinit>` on the first connection.

Switching both loops to `while IFS= read -r jar || [[ -n "$jar" ]]` keeps the unterminated last line. The manifest format is unchanged — `RuntimeClasspathManifestTest` still pins "no trailing newline" and we want consumers to be tolerant rather than re-litigate the format.

Reviewer focus:
- The `|| [[ -n "$jar" ]]` idiom is the only behavior change inside `assemble-dist.sh`. The added comment in `copy_manifest_deps` is the canonical explanation; `write_argfile` cross-references it.
- The `self-host-post` guard runs after `Assemble tarball` and before any install step. It diffs each daemon's manifest basenames against `libexec/<daemon>/deps/*.jar` and checks every basename appears on the argfile `-cp` line. Without this PR's fix the guard would FAIL on `kolt-jvm-compiler-daemon` first (alphabetical-last is `ktoml-core-jvm-0.7.1.jar`) and on `kolt-native-compiler-daemon` second.
- Locally simulated both the regression (last line dropped, guard FAILs and shows `< c.jar` diff) and the post-fix (all entries kept, guard PASSes). YAML parsed via `python3 -c "import yaml; ..."`. No Kotlin source touched.

#287 (BTA `-impl` cannot see `kotlin/jvm/internal/Intrinsics`) is independent and lands separately.