### PR TITLE
Fix #287: ship kotlin-stdlib + annotations in libexec/kolt-bta-impl/

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -396,10 +396,16 @@ jobs:
       # `FallbackReporter` warning so that a daemon that fails to bind
       # within the connect budget is caught here rather than masquerading
       # as a passing build via the subprocess fallback rail.
+      #
+      # `~/.kolt/daemon/` is wiped first so the smoke always exercises the
+      # cold spawn-and-bind path: `~/.kolt` is restored from the toolchain
+      # cache (line ~128) and any stale daemon state files there could let
+      # the spawn rail short-circuit before the bind path that #287 broke.
       - name: Smoke-build fixture with installed kolt
         run: |
           set -euo pipefail
           INSTALL_DIR="$HOME/.local/share/kolt/$KOLT_TOML_VERSION"
+          rm -rf "$HOME/.kolt/daemon"
           cd spike/daemon-self-host-smoke
           rm -rf build
           "${INSTALL_DIR}/bin/kolt" build 2> kolt-build.stderr

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -392,15 +392,24 @@ jobs:
       # Fixture smoke: drive `<install>/bin/kolt build` on a minimal JVM
       # app via the installer-managed dir, end-to-end signal that the 3 ×
       # kolt build → assemble-dist → install.sh chain produced a working
-      # install.
+      # install. Issue #287: stderr is captured and grepped for the
+      # `FallbackReporter` warning so that a daemon that fails to bind
+      # within the connect budget is caught here rather than masquerading
+      # as a passing build via the subprocess fallback rail.
       - name: Smoke-build fixture with installed kolt
         run: |
           set -euo pipefail
           INSTALL_DIR="$HOME/.local/share/kolt/$KOLT_TOML_VERSION"
           cd spike/daemon-self-host-smoke
           rm -rf build
-          "${INSTALL_DIR}/bin/kolt" build
+          "${INSTALL_DIR}/bin/kolt" build 2> kolt-build.stderr
+          cat kolt-build.stderr
           test -f build/debug/smoke.jar
+          if grep -q "falling back to subprocess" kolt-build.stderr; then
+            echo "daemon-bind regression: kolt build fell back to subprocess compile" >&2
+            exit 1
+          fi
+          echo "daemon-bind smoke: kolt build went via the daemon path"
 
       - name: Stop local HTTP server
         if: always()

--- a/scripts/assemble-dist.sh
+++ b/scripts/assemble-dist.sh
@@ -25,12 +25,17 @@ set -euo pipefail
 # `kotlin-build-tools-impl:2.3.20` transitive closure; update the sha256s in
 # lockstep when bumping the bundled Kotlin version.
 #
-# Exclusions vs the staged set: the daemon's `kolt.toml` [dependencies] declares
-# `org.jetbrains.kotlin:kotlin-build-tools-api = 2.3.20`, whose resolver closure
-# already emits `kotlin-build-tools-api`, `kotlin-stdlib`, and `annotations-13.0`
-# into `libexec/<daemon>/deps/`. Shipping those three a second time here would
-# duplicate jars on the runtime classpath; we keep only what `-impl` brings in
-# addition to the api closure.
+# kotlin-stdlib + annotations are shipped in this directory even though the
+# daemon's `[dependencies]` resolver closure already drops a stdlib jar into
+# `libexec/<daemon>/deps/`. SharedApiClassesClassLoader is a sealed surface:
+# it only exposes `kotlin.buildtools.api.*` upward, so the `-impl` child
+# cannot reach the daemon-main `kotlin.*` classes through the parent chain.
+# Issue #287: missing here, the impl child crashes at first compile with
+# `NoClassDefFoundError: kotlin/jvm/internal/Intrinsics`. Pinning to 2.3.20
+# matches the version that `kotlin-build-tools-impl-2.3.20.pom` declares
+# directly. `kotlin-build-tools-api-2.3.20` is **not** shipped here on
+# purpose — it IS exposed through SharedApiClassesClassLoader (that is the
+# loader's whole point) and the daemon's own deps/ already carries it.
 #
 # Format: "group:artifact:version:filename" (:-separated; filename is the
 # exact Maven Central artifact name, including `-jvm` / version variants).
@@ -43,7 +48,9 @@ BTA_IMPL_JARS=(
   "org.jetbrains.kotlin:kotlin-daemon-embeddable:2.3.20:kotlin-daemon-embeddable-2.3.20.jar"
   "org.jetbrains.kotlin:kotlin-reflect:1.6.10:kotlin-reflect-1.6.10.jar"
   "org.jetbrains.kotlin:kotlin-script-runtime:2.3.20:kotlin-script-runtime-2.3.20.jar"
+  "org.jetbrains.kotlin:kotlin-stdlib:2.3.20:kotlin-stdlib-2.3.20.jar"
   "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0:kotlinx-coroutines-core-jvm-1.8.0.jar"
+  "org.jetbrains:annotations:13.0:annotations-13.0.jar"
 )
 
 # SHA-256 digests in `sha256sum -c` input format: "<digest>  <filename>".
@@ -57,7 +64,9 @@ BTA_IMPL_SHA256=(
   "8870bab840b8087c96c4ddc06088b4aedf5131c408af3674306304f1f96af3f4  kotlin-daemon-embeddable-2.3.20.jar"
   "3277ac102ae17aad10a55abec75ff5696c8d109790396434b496e75087854203  kotlin-reflect-1.6.10.jar"
   "6fcdb7da6e65cf8cc43e5aabab94bdcc48825e7933686f8a1bf694eb88f8e00e  kotlin-script-runtime-2.3.20.jar"
+  "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e  kotlin-stdlib-2.3.20.jar"
   "9860906a1937490bf5f3b06d2f0e10ef451e65b95b269f22daf68a3d1f5065c5  kotlinx-coroutines-core-jvm-1.8.0.jar"
+  "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478  annotations-13.0.jar"
 )
 
 MAVEN_CENTRAL_BASE="https://repo1.maven.org/maven2"


### PR DESCRIPTION
Stacked on #289 (#286 fix).

`SharedApiClassesClassLoader` is a sealed surface: it exposes only `kotlin.buildtools.api.*` upward, never the parent's `kotlin.*` classes. The previous comment in `assemble-dist.sh` assumed the opposite — that the daemon's main `[dependencies]` stdlib would be reachable through the parent chain — and excluded `kotlin-stdlib` + `annotations` from `libexec/kolt-bta-impl/`. The impl child therefore had no `kotlin.*` in reach and crashed at first compile with `NoClassDefFoundError: kotlin/jvm/internal/Intrinsics`, which manifested as the JVM compiler daemon failing to bind on a clean v0.16.x install.

Adds `kotlin-stdlib-2.3.20.jar` + `annotations-13.0.jar` to `BTA_IMPL_JARS`. 2.3.20 matches what `kotlin-build-tools-impl-2.3.20.pom` declares directly. The two jars now land on the impl URLClassLoader's URL list, so the child resolves `Intrinsics` from its own URLs without parent delegation. SHA-256s were verified against fresh Maven Central downloads.

Reviewer focus:
- The two stdlibs (impl-side 2.3.20 + daemon-deps-side 2.3.10) live in disjoint classloader graphs — `SharedApiClassesClassLoader` blocks both directions of `kotlin.*` delegation. The argfile `-cp` lists both, but the BTA child loader uses its own URL list, and the daemon-main loader hits the deps/ entry first. Confirmed by re-reading `BtaIncrementalCompiler.create` (`URLClassLoader(urls, SharedApiClassesClassLoader())`) and Gradle Kotlin plugin's matching topology.
- `kotlin-build-tools-api-2.3.20` is intentionally **not** added to `BTA_IMPL_JARS` — it IS exposed through `SharedApiClassesClassLoader` (that's the loader's whole point) and the daemon's `deps/` already carries it.
- The runtime smoke step in `self-host-post` captures stderr from the fixture build and fails on the `FallbackReporter` warning. After both this PR and #289 land, the daemon binds and the build goes via the daemon path; without either fix, the smoke fails.

This PR is stacked on #289. The CI run on this branch already includes #289's bash fix + assemble-side guard, so the new daemon-bind smoke exercises both fixes together. Rebase after #289 merges.