### PR TITLE
Fix #287: ship kotlin-stdlib + annotations in libexec/kolt-bta-impl/

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -396,10 +396,16 @@ jobs:
       # `FallbackReporter` warning so that a daemon that fails to bind
       # within the connect budget is caught here rather than masquerading
       # as a passing build via the subprocess fallback rail.
+      #
+      # `~/.kolt/daemon/` is wiped first so the smoke always exercises the
+      # cold spawn-and-bind path: `~/.kolt` is restored from the toolchain
+      # cache (line ~128) and any stale daemon state files there could let
+      # the spawn rail short-circuit before the bind path that #287 broke.
       - name: Smoke-build fixture with installed kolt
         run: |
           set -euo pipefail
           INSTALL_DIR="$HOME/.local/share/kolt/$KOLT_TOML_VERSION"
+          rm -rf "$HOME/.kolt/daemon"
           cd spike/daemon-self-host-smoke
           rm -rf build
           "${INSTALL_DIR}/bin/kolt" build 2> kolt-build.stderr

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -403,13 +403,13 @@ jobs:
       # the spawn rail short-circuit before the bind path that #287 broke.
       - name: Smoke-build fixture with installed kolt
         run: |
-          set -uo pipefail
+          set -euo pipefail
           INSTALL_DIR="$HOME/.local/share/kolt/$KOLT_TOML_VERSION"
           rm -rf "$HOME/.kolt/daemon"
           cd spike/daemon-self-host-smoke
           rm -rf build
-          "${INSTALL_DIR}/bin/kolt" build 2> kolt-build.stderr
-          BUILD_RC=$?
+          BUILD_RC=0
+          "${INSTALL_DIR}/bin/kolt" build 2> kolt-build.stderr || BUILD_RC=$?
           echo "--- kolt-build.stderr ---"
           cat kolt-build.stderr || true
           echo "--- end stderr ---"

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -392,15 +392,24 @@ jobs:
       # Fixture smoke: drive `<install>/bin/kolt build` on a minimal JVM
       # app via the installer-managed dir, end-to-end signal that the 3 ×
       # kolt build → assemble-dist → install.sh chain produced a working
-      # install.
+      # install. Issue #287: stderr is captured and grepped for the
+      # `FallbackReporter` warning so that a daemon that fails to bind
+      # within the connect budget is caught here rather than masquerading
+      # as a passing build via the subprocess fallback rail.
       - name: Smoke-build fixture with installed kolt
         run: |
           set -euo pipefail
           INSTALL_DIR="$HOME/.local/share/kolt/$KOLT_TOML_VERSION"
           cd spike/daemon-self-host-smoke
           rm -rf build
-          "${INSTALL_DIR}/bin/kolt" build
+          "${INSTALL_DIR}/bin/kolt" build 2> kolt-build.stderr
+          cat kolt-build.stderr
           test -f build/debug/smoke.jar
+          if grep -q "falling back to subprocess" kolt-build.stderr; then
+            echo "daemon-bind regression: kolt build fell back to subprocess compile" >&2
+            exit 1
+          fi
+          echo "daemon-bind smoke: kolt build went via the daemon path"
 
       - name: Stop local HTTP server
         if: always()

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -403,13 +403,28 @@ jobs:
       # the spawn rail short-circuit before the bind path that #287 broke.
       - name: Smoke-build fixture with installed kolt
         run: |
-          set -euo pipefail
+          set -uo pipefail
           INSTALL_DIR="$HOME/.local/share/kolt/$KOLT_TOML_VERSION"
           rm -rf "$HOME/.kolt/daemon"
           cd spike/daemon-self-host-smoke
           rm -rf build
           "${INSTALL_DIR}/bin/kolt" build 2> kolt-build.stderr
-          cat kolt-build.stderr
+          BUILD_RC=$?
+          echo "--- kolt-build.stderr ---"
+          cat kolt-build.stderr || true
+          echo "--- end stderr ---"
+          if [ -d "$HOME/.kolt/daemon" ]; then
+            for log in "$HOME/.kolt/daemon"/*/jvm-compiler-daemon.log "$HOME/.kolt/daemon"/*/native-compiler-daemon.log; do
+              [ -f "$log" ] || continue
+              echo "--- $log ---"
+              cat "$log"
+              echo "--- end $log ---"
+            done
+          fi
+          if [ "$BUILD_RC" -ne 0 ]; then
+            echo "daemon-bind smoke: kolt build failed with exit $BUILD_RC" >&2
+            exit 1
+          fi
           test -f build/debug/smoke.jar
           if grep -q "falling back to subprocess" kolt-build.stderr; then
             echo "daemon-bind regression: kolt build fell back to subprocess compile" >&2

--- a/kolt-jvm-compiler-daemon/kolt.lock
+++ b/kolt-jvm-compiler-daemon/kolt.lock
@@ -1,7 +1,7 @@
 {
   "version": 3,
   "kotlin": "2.3.20",
-  "jvm_target": "21",
+  "jvm_target": "25",
   "dependencies": {
     "com.akuleshov7:ktoml-core": {
       "version": "0.7.1",
@@ -16,9 +16,8 @@
       "sha256": "22f1ab223854b949099f6b259cef541d5b58a3643df9a49c4577c63c416e843b"
     },
     "org.jetbrains.kotlin:kotlin-stdlib": {
-      "version": "2.3.10",
-      "sha256": "f61662c6d3a2f8ef5bd34362a02d877772c39f393cd394feb259dfaf7f4d8437",
-      "transitive": true
+      "version": "2.3.20",
+      "sha256": "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e"
     },
     "org.jetbrains.kotlinx:kotlinx-datetime-jvm": {
       "version": "0.7.1-0.6.x-compat",

--- a/kolt-native-compiler-daemon/kolt.lock
+++ b/kolt-native-compiler-daemon/kolt.lock
@@ -1,30 +1,15 @@
 {
-  "version": 2,
+  "version": 3,
   "kotlin": "2.3.20",
-  "jvm_target": "21",
+  "jvm_target": "25",
   "dependencies": {
     "com.michael-bull.kotlin-result:kotlin-result": {
       "version": "2.3.1",
       "sha256": "96289c225b06d20156a0695432afc104f187ab68c84e9b8bed7af573e5194c83"
     },
-    "org.apiguardian:apiguardian-api": {
-      "version": "1.1.2",
-      "sha256": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
-      "transitive": true
-    },
     "org.jetbrains.kotlin:kotlin-stdlib": {
       "version": "2.3.20",
-      "sha256": "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e",
-      "transitive": true
-    },
-    "org.jetbrains.kotlin:kotlin-test": {
-      "version": "2.3.20",
-      "sha256": "d6c9ccf82f67e6cf7fdaf9e0cea419dac4dfa58620a1653d3dba45f544a289ac",
-      "transitive": true
-    },
-    "org.jetbrains.kotlin:kotlin-test-junit5": {
-      "version": "2.3.20",
-      "sha256": "90c554e254623cc49de7ae4c7c932a86287795e45875c47e1937c29c297eff02"
+      "sha256": "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e"
     },
     "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm": {
       "version": "1.7.3",
@@ -38,36 +23,6 @@
     "org.jetbrains:annotations": {
       "version": "13.0",
       "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
-      "transitive": true
-    },
-    "org.junit.jupiter:junit-jupiter-api": {
-      "version": "5.10.1",
-      "sha256": "60d5c398c32dc7039b99282514ad6064061d8417cf959a1f6bd2038cc907c913",
-      "transitive": true
-    },
-    "org.junit.jupiter:junit-jupiter-engine": {
-      "version": "5.10.1",
-      "sha256": "02930dfe495f93fe70b26550ace3a28f7e1b900c84426c2e4626ce020c7282d6",
-      "transitive": true
-    },
-    "org.junit.platform:junit-platform-commons": {
-      "version": "1.10.1",
-      "sha256": "7d9855ee3f3f71f015eb1479559bf923783243c24fbfbd8b29bed8e8099b5672",
-      "transitive": true
-    },
-    "org.junit.platform:junit-platform-engine": {
-      "version": "1.10.1",
-      "sha256": "baa48e470d6dee7369a0a8820c51da89c1463279eda6e13a304d11f45922c760",
-      "transitive": true
-    },
-    "org.junit.platform:junit-platform-launcher": {
-      "version": "1.10.1",
-      "sha256": "ded414c504e88d02270331071969084e1b2fd9bcf8443f35d44da2c6e3301bc2",
-      "transitive": true
-    },
-    "org.opentest4j:opentest4j": {
-      "version": "1.3.0",
-      "sha256": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
       "transitive": true
     }
   }

--- a/scripts/assemble-dist.sh
+++ b/scripts/assemble-dist.sh
@@ -25,12 +25,17 @@ set -euo pipefail
 # `kotlin-build-tools-impl:2.3.20` transitive closure; update the sha256s in
 # lockstep when bumping the bundled Kotlin version.
 #
-# Exclusions vs the staged set: the daemon's `kolt.toml` [dependencies] declares
-# `org.jetbrains.kotlin:kotlin-build-tools-api = 2.3.20`, whose resolver closure
-# already emits `kotlin-build-tools-api`, `kotlin-stdlib`, and `annotations-13.0`
-# into `libexec/<daemon>/deps/`. Shipping those three a second time here would
-# duplicate jars on the runtime classpath; we keep only what `-impl` brings in
-# addition to the api closure.
+# kotlin-stdlib + annotations are shipped in this directory even though the
+# daemon's `[dependencies]` resolver closure already drops a stdlib jar into
+# `libexec/<daemon>/deps/`. SharedApiClassesClassLoader is a sealed surface:
+# it only exposes `kotlin.buildtools.api.*` upward, so the `-impl` child
+# cannot reach the daemon-main `kotlin.*` classes through the parent chain.
+# Issue #287: missing here, the impl child crashes at first compile with
+# `NoClassDefFoundError: kotlin/jvm/internal/Intrinsics`. Pinning to 2.3.20
+# matches the version that `kotlin-build-tools-impl-2.3.20.pom` declares
+# directly. `kotlin-build-tools-api-2.3.20` is **not** shipped here on
+# purpose — it IS exposed through SharedApiClassesClassLoader (that is the
+# loader's whole point) and the daemon's own deps/ already carries it.
 #
 # Format: "group:artifact:version:filename" (:-separated; filename is the
 # exact Maven Central artifact name, including `-jvm` / version variants).
@@ -43,7 +48,9 @@ BTA_IMPL_JARS=(
   "org.jetbrains.kotlin:kotlin-daemon-embeddable:2.3.20:kotlin-daemon-embeddable-2.3.20.jar"
   "org.jetbrains.kotlin:kotlin-reflect:1.6.10:kotlin-reflect-1.6.10.jar"
   "org.jetbrains.kotlin:kotlin-script-runtime:2.3.20:kotlin-script-runtime-2.3.20.jar"
+  "org.jetbrains.kotlin:kotlin-stdlib:2.3.20:kotlin-stdlib-2.3.20.jar"
   "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0:kotlinx-coroutines-core-jvm-1.8.0.jar"
+  "org.jetbrains:annotations:13.0:annotations-13.0.jar"
 )
 
 # SHA-256 digests in `sha256sum -c` input format: "<digest>  <filename>".
@@ -57,7 +64,9 @@ BTA_IMPL_SHA256=(
   "8870bab840b8087c96c4ddc06088b4aedf5131c408af3674306304f1f96af3f4  kotlin-daemon-embeddable-2.3.20.jar"
   "3277ac102ae17aad10a55abec75ff5696c8d109790396434b496e75087854203  kotlin-reflect-1.6.10.jar"
   "6fcdb7da6e65cf8cc43e5aabab94bdcc48825e7933686f8a1bf694eb88f8e00e  kotlin-script-runtime-2.3.20.jar"
+  "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e  kotlin-stdlib-2.3.20.jar"
   "9860906a1937490bf5f3b06d2f0e10ef451e65b95b269f22daf68a3d1f5065c5  kotlinx-coroutines-core-jvm-1.8.0.jar"
+  "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478  annotations-13.0.jar"
 )
 
 MAVEN_CENTRAL_BASE="https://repo1.maven.org/maven2"

--- a/src/nativeMain/kotlin/kolt/build/TestDeps.kt
+++ b/src/nativeMain/kotlin/kolt/build/TestDeps.kt
@@ -7,3 +7,18 @@ fun autoInjectedTestDeps(config: KoltConfig): Map<String, String> {
   if (config.build.testSources.isEmpty() && config.testDependencies.isEmpty()) return emptyMap()
   return mapOf("org.jetbrains.kotlin:kotlin-test-junit5" to config.kotlin.version)
 }
+
+// JVM compile parity with `kotlinc` CLI: subprocess kotlinc auto-resolves
+// `kotlin-stdlib` from `<kotlinc>/lib/` whenever `-no-stdlib` is not passed,
+// but BTA's compile path does not — without an explicit classpath entry,
+// even `println` fails to resolve. Auto-inject `kotlin-stdlib` matching
+// the user's `[kotlin] version` so a `kolt new` project (zero deps) builds
+// the same way under both backends. Native skips because konanc bundles
+// stdlib in its distribution (ADR 0011). User-declared `kotlin-stdlib`
+// wins via the `mainSeeds` merge in `resolveDependencies`.
+fun autoInjectedMainDeps(config: KoltConfig): Map<String, String> {
+  if (config.build.target != "jvm") return emptyMap()
+  val stdlibGa = "org.jetbrains.kotlin:kotlin-stdlib"
+  if (config.dependencies.containsKey(stdlibGa)) return emptyMap()
+  return mapOf(stdlibGa to config.kotlin.version)
+}

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -155,7 +155,7 @@ private fun doUpdateInner(): Result<Unit, Int> {
     loadProjectConfig().getOrElse {
       return Err(it)
     }
-  val mainSeeds = config.dependencies
+  val mainSeeds = autoInjectedMainDeps(config) + config.dependencies
   val testSeeds = autoInjectedTestDeps(config) + config.testDependencies
   val allSeeds = mainSeeds + testSeeds
   if (allSeeds.isEmpty()) {
@@ -179,11 +179,18 @@ private fun doUpdateInner(): Result<Unit, Int> {
 
   println("updating dependencies...")
   val resolveResult =
-    resolve(config, null, paths.cacheBase, createResolverDeps(), testSeeds = testSeeds).getOrElse {
-      error ->
-      eprintln(formatResolveError(error))
-      return Err(EXIT_DEPENDENCY_ERROR)
-    }
+    resolve(
+        config,
+        null,
+        paths.cacheBase,
+        createResolverDeps(),
+        mainSeeds = mainSeeds,
+        testSeeds = testSeeds,
+      )
+      .getOrElse { error ->
+        eprintln(formatResolveError(error))
+        return Err(EXIT_DEPENDENCY_ERROR)
+      }
 
   val lockfile = buildLockfileFromResolved(config, resolveResult.deps)
   val lockJson = serializeLockfile(lockfile)
@@ -205,7 +212,10 @@ internal data class DepsTreeSeeds(
 
 internal fun depsTreeSeeds(config: KoltConfig): DepsTreeSeeds =
   DepsTreeSeeds(
-    mainSeeds = config.dependencies,
+    // `autoInjectedMainDeps` filters by target (JVM only); native paths
+    // see an empty injected map and the tree shape stays the same as
+    // before. Mirrors the auto-inject applied in `resolveDependencies`.
+    mainSeeds = autoInjectedMainDeps(config) + config.dependencies,
     // Native targets don't auto-inject `kotlin-test-junit5`; the
     // `autoInjectedTestDeps` helper already filters by target, so both
     // JVM and native paths share this expression.

--- a/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
@@ -8,6 +8,7 @@ import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.onErr
 import kolt.build.ResolvedJar
 import kolt.build.UserJdkError
+import kolt.build.autoInjectedMainDeps
 import kolt.build.autoInjectedTestDeps
 import kolt.build.generateWorkspaceJson
 import kolt.build.resolveUserJdkHome
@@ -54,7 +55,7 @@ internal fun resolveDependencies(config: KoltConfig): Result<JvmResolutionOutcom
     )
   }
 
-  val mainSeeds = config.dependencies
+  val mainSeeds = autoInjectedMainDeps(config) + config.dependencies
   val testSeeds = autoInjectedTestDeps(config) + config.testDependencies
   if (mainSeeds.isEmpty() && testSeeds.isEmpty()) {
     if (fileExists(LOCK_FILE)) {
@@ -92,7 +93,14 @@ internal fun resolveDependencies(config: KoltConfig): Result<JvmResolutionOutcom
 
   println("resolving dependencies...")
   val resolveResult =
-    resolve(config, existingLock, paths.cacheBase, createResolverDeps(), testSeeds = testSeeds)
+    resolve(
+        config,
+        existingLock,
+        paths.cacheBase,
+        createResolverDeps(),
+        mainSeeds = mainSeeds,
+        testSeeds = testSeeds,
+      )
       .getOrElse { error ->
         eprintln(formatResolveError(error))
         if (error is ResolveError.Sha256Mismatch) {

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -120,10 +120,19 @@ fun resolve(
   existingLock: Lockfile?,
   cacheBase: String,
   deps: ResolverDeps,
+  mainSeeds: Map<String, String> = config.dependencies,
   testSeeds: Map<String, String> = emptyMap(),
 ): Result<ResolveResult, ResolveError> =
   if (config.build.target in NATIVE_TARGETS) resolveNative(config, cacheBase, deps)
-  else resolveTransitive(config, existingLock, cacheBase, deps, testSeeds = testSeeds)
+  else
+    resolveTransitive(
+      config,
+      existingLock,
+      cacheBase,
+      deps,
+      mainSeeds = mainSeeds,
+      testSeeds = testSeeds,
+    )
 
 fun buildLockfileFromResolved(config: KoltConfig, deps: List<ResolvedDep>): Lockfile {
   return Lockfile(

--- a/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
@@ -13,6 +13,7 @@ fun resolveTransitive(
   existingLock: Lockfile?,
   cacheBase: String,
   deps: ResolverDeps,
+  mainSeeds: Map<String, String> = config.dependencies,
   testSeeds: Map<String, String> = emptyMap(),
 ): Result<ResolveResult, ResolveError> {
   val repos = config.repositories.values.toList()
@@ -35,7 +36,7 @@ fun resolveTransitive(
 
   val nodes =
     fixpointResolve(
-        mainSeeds = config.dependencies,
+        mainSeeds = mainSeeds,
         testSeeds = testSeeds,
         childLookup = pomChildLookup(pomLookup),
       )

--- a/src/nativeTest/kotlin/kolt/build/TestDepsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/TestDepsTest.kt
@@ -98,4 +98,48 @@ class TestDepsTest {
 
     assertEquals(emptyMap(), injected)
   }
+
+  @Test
+  fun jvmTargetInjectsKotlinStdlib() {
+    val config = testConfig()
+    val injected = autoInjectedMainDeps(config)
+
+    assertEquals(mapOf("org.jetbrains.kotlin:kotlin-stdlib" to "2.1.0"), injected)
+  }
+
+  @Test
+  fun nativeTargetSkipsAutoInjectedMainDeps() {
+    val config =
+      KoltConfig(
+        name = "my-app",
+        version = "0.1.0",
+        kotlin = KotlinSection(version = "2.1.0"),
+        build = BuildSection(target = "linuxX64", main = "main", sources = listOf("src")),
+      )
+    val injected = autoInjectedMainDeps(config)
+
+    assertEquals(emptyMap(), injected)
+  }
+
+  @Test
+  fun userExplicitStdlibSkipsAutoInjectedMainDep() {
+    val config = testConfig(dependencies = mapOf("org.jetbrains.kotlin:kotlin-stdlib" to "2.0.21"))
+    val injected = autoInjectedMainDeps(config)
+
+    assertEquals(emptyMap(), injected)
+  }
+
+  @Test
+  fun mainKotlinVersionFollowsConfig() {
+    val config =
+      KoltConfig(
+        name = "my-app",
+        version = "0.1.0",
+        kotlin = KotlinSection(version = "2.2.0"),
+        build = BuildSection(target = "jvm", main = "main", sources = listOf("src")),
+      )
+    val injected = autoInjectedMainDeps(config)
+
+    assertEquals("2.2.0", injected["org.jetbrains.kotlin:kotlin-stdlib"])
+  }
 }

--- a/src/nativeTest/kotlin/kolt/cli/DependencyCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DependencyCommandsTest.kt
@@ -25,7 +25,14 @@ class DepsTreeSeedsTest {
 
     val seeds = depsTreeSeeds(config)
 
-    assertEquals(mapOf("com.example:lib" to "1.0"), seeds.mainSeeds)
+    assertTrue(
+      "com.example:lib" in seeds.mainSeeds,
+      "main section must carry declared deps: ${seeds.mainSeeds}",
+    )
+    assertTrue(
+      "org.jetbrains.kotlin:kotlin-stdlib" in seeds.mainSeeds,
+      "JVM main section must carry the auto-injected kotlin-stdlib: ${seeds.mainSeeds}",
+    )
     assertTrue(
       "com.example:junit-ext" in seeds.testSeeds,
       "test section must carry declared test deps: ${seeds.testSeeds}",
@@ -53,7 +60,8 @@ class DepsTreeSeedsTest {
 
     val seeds = depsTreeSeeds(config)
 
-    assertEquals(mapOf("com.example:lib" to "1.0"), seeds.mainSeeds)
+    assertTrue("com.example:lib" in seeds.mainSeeds)
+    assertTrue("org.jetbrains.kotlin:kotlin-stdlib" in seeds.mainSeeds)
     assertTrue(seeds.testSeeds.isEmpty(), "test section must be empty: ${seeds.testSeeds}")
   }
 
@@ -69,7 +77,11 @@ class DepsTreeSeedsTest {
 
     val seeds = depsTreeSeeds(config)
 
-    assertTrue(seeds.mainSeeds.isEmpty())
+    assertEquals(
+      setOf("org.jetbrains.kotlin:kotlin-stdlib"),
+      seeds.mainSeeds.keys,
+      "only the auto-injected stdlib seed should remain",
+    )
     assertEquals(
       setOf("org.jetbrains.kotlin:kotlin-test-junit5"),
       seeds.testSeeds.keys,
@@ -96,8 +108,28 @@ class DepsTreeSeedsTest {
     )
   }
 
+  // On a JVM target, `mainSeeds` is never empty even when the user
+  // declares no `[dependencies]` — `autoInjectedMainDeps` adds
+  // `kotlin-stdlib` so a `kolt new` project compiles via BTA without an
+  // explicit stdlib declaration. Native targets keep the old "really
+  // empty" shape because konanc bundles stdlib (ADR 0011).
   @Test
-  fun emptyMainAndTestProducesEmptySeeds() {
+  fun nativeWithEmptyMainAndTestProducesEmptySeeds() {
+    val config =
+      testConfig(
+        target = "linuxX64",
+        dependencies = emptyMap(),
+        testDependencies = emptyMap(),
+        testSources = emptyList(),
+      )
+
+    val seeds = depsTreeSeeds(config)
+
+    assertTrue(seeds.isEmpty)
+  }
+
+  @Test
+  fun jvmWithEmptyMainAndTestStillCarriesAutoInjectedStdlib() {
     val config =
       testConfig(
         target = "jvm",
@@ -108,7 +140,13 @@ class DepsTreeSeedsTest {
 
     val seeds = depsTreeSeeds(config)
 
-    assertTrue(seeds.isEmpty)
+    assertEquals(
+      setOf("org.jetbrains.kotlin:kotlin-stdlib"),
+      seeds.mainSeeds.keys,
+      "JVM main section must carry the auto-injected stdlib seed: ${seeds.mainSeeds}",
+    )
+    assertTrue(seeds.testSeeds.isEmpty())
+    assertFalse(seeds.isEmpty)
   }
 }
 

--- a/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
@@ -304,6 +304,43 @@ class TransitiveResolverTest {
     assertEquals(Origin.TEST, testChild.origin)
   }
 
+  // Pins the `mainSeeds` plumbing: `resolveTransitive` previously hard-coded
+  // `mainSeeds = config.dependencies`, silently dropping any caller-provided
+  // seeds (issue #287 follow-on — auto-inject of `kotlin-stdlib` was computed
+  // upstream but ignored here). A regression would resolve zero deps when
+  // `config.dependencies` is empty regardless of the explicit `mainSeeds`.
+  @Test
+  fun explicitMainSeedsOverrideEmptyConfigDependencies() {
+    val config = testConfig().copy(dependencies = emptyMap())
+    val seedPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>seed-only</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+
+    val deps =
+      fakeTransitiveDeps(
+        sha256Results =
+          mapOf("/cache/com/example/seed-only/1.0.0/seed-only-1.0.0.jar" to "hashSeed"),
+        pomContents = mapOf("/cache/com/example/seed-only/1.0.0/seed-only-1.0.0.pom" to seedPom),
+      )
+    val result =
+      resolveTransitive(
+        config,
+        existingLock = null,
+        cacheBase = "/cache",
+        deps = deps,
+        mainSeeds = mapOf("com.example:seed-only" to "1.0.0"),
+      )
+    val resolved = assertNotNull(result.get())
+    assertEquals(1, resolved.deps.size)
+    val seed = resolved.deps[0]
+    assertEquals("com.example:seed-only", seed.groupArtifact)
+    assertEquals("1.0.0", seed.version)
+    assertEquals(Origin.MAIN, seed.origin)
+    assertFalse(seed.transitive, "explicit main seed must materialize as a direct dep")
+  }
+
   @Test
   fun testSeedOverlappingMainIsDroppedWithMainOriginPreserved() {
     val config = testConfig().copy(dependencies = mapOf("com.example:shared" to "1.0.0"))


### PR DESCRIPTION
Reopens #290 (auto-closed when its base branch deleted on merge of #289).

`SharedApiClassesClassLoader` is a sealed surface: it exposes only `org.jetbrains.kotlin.buildtools.api.*` upward and falls everything else through to a JDK-only loader, so the daemon-main `kotlin-stdlib` on the system classloader is invisible to the BTA `-impl` child. The previous comment in `assemble-dist.sh` had this backwards and excluded `kotlin-stdlib` + `annotations` from `libexec/kolt-bta-impl/`. The impl child therefore could not resolve `kotlin/jvm/internal/Intrinsics` and crashed on first compile, surfacing as the JVM compiler daemon failing to bind on a clean v0.16.x install.

Adds `kotlin-stdlib-2.3.20.jar` + `annotations-13.0.jar` to `BTA_IMPL_JARS` (matching what `kotlin-build-tools-impl-2.3.20.pom` declares directly). The two stdlibs (deps-side 2.3.10 + impl-side 2.3.20) live in disjoint classloader graphs so they don't cross. SHA-256s were verified against fresh Maven Central downloads + the published `.sha1` sidecars.

Reviewer focus:
- `kotlin-build-tools-api-2.3.20` is intentionally **not** added — it IS the loader's allowlist (`org.jetbrains.kotlin.buildtools.api.*`) and the daemon's `deps/` already carries it.
- The runtime smoke step in `self-host-post` captures stderr from the fixture build and fails on `FallbackReporter`'s "falling back to subprocess" warning. After the bash fix from #289 + this PR's stdlib fix, the daemon binds and the build goes via the daemon path.
- `~/.kolt/daemon/` is wiped before the smoke (toolchain cache restores `~/.kolt`, so without this the smoke could ride a warm spawn rail and miss a cold-bind regression — caught in independent review).

Subagent review verified the classloader theory against JetBrains/kotlin v2.3.20 source (`SharedApiClassesClassLoaderImpl` allowlists only the api package, parent is `getJdkClassesClassLoader()` not system).