### PR TITLE
Yank v0.16.1 + v0.16.2 -> v0.16.3

### DIFF
--- a/YANKED
+++ b/YANKED
@@ -1,0 +1,2 @@
+0.16.1	0.16.3	daemon distribution missing classpath jars (#286, #287)
+0.16.2	0.16.3	daemon distribution missing classpath jars (#286, #287)


### PR DESCRIPTION
Both releases ship a daemon distribution that does not work end to end on a clean install: native daemon's `deps/` is missing `kotlinx-serialization-json-jvm-1.7.3.jar` (#286 / #289) and BTA `-impl` cannot resolve `kotlin/jvm/internal/Intrinsics` (#287 / #293). Subprocess fallback masks the breakage at the user level but the daemon path advertised by these releases does not bind.

v0.16.3 is the first release where the daemon path comes up cleanly. Yank both prior releases pointing at it.

YANKED format is tab-separated `<version>\t<replacement>\t<reason>` per ADR 0028; entries pass the `install.sh` `fetch_yanked_and_validate` checker (no leading/trailing whitespace, exactly 3 fields, all non-empty). `KOLT_ALLOW_YANKED=1` still installs them for users who explicitly override.