### PR TITLE
Extend assemble-dist guard to libexec/kolt-bta-impl/, document #286 consumer rule (closes #291, #292)

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -212,6 +212,57 @@ jobs:
           done
           echo "guard: all daemon deps match their runtime classpath manifests"
 
+      # Issue #291 regression guard: BTA `-impl` is staged from a
+      # hand-maintained `BTA_IMPL_JARS` array in `scripts/assemble-dist.sh`,
+      # not the resolver. A stale entry (drift from upstream Kotlin's
+      # transitive set, missed update on a Kotlin bump, fat-finger edit)
+      # would break daemon classloading the same way #287 did. Diffs the
+      # filename column of `BTA_IMPL_JARS` against
+      # `libexec/kolt-bta-impl/*.jar`, then verifies each filename is on
+      # the argfile `-cp` line under `libexec/kolt-bta-impl/`.
+      - name: Verify libexec/kolt-bta-impl matches BTA_IMPL_JARS
+        run: |
+          set -euo pipefail
+          DIST_ROOT="dist/kolt-${KOLT_TOML_VERSION}-linux-x64"
+          # Parse `BTA_IMPL_JARS=( … )` block: each entry is a quoted
+          # `group:artifact:version:filename` string; extract field 4.
+          expected=$(awk '
+            /^BTA_IMPL_JARS=\(/ { in_block = 1; next }
+            in_block && /^\)/ { exit }
+            in_block {
+              sub(/^[[:space:]]*"/, "")
+              sub(/"[[:space:]]*$/, "")
+              n = split($0, parts, ":")
+              if (n == 4) print parts[4]
+            }
+          ' scripts/assemble-dist.sh | sort)
+          if [ -z "$expected" ]; then
+            echo "guard: BTA_IMPL_JARS parsed as empty — assemble-dist.sh format changed?" >&2
+            exit 1
+          fi
+          actual=$(find "$DIST_ROOT/libexec/kolt-bta-impl" -maxdepth 1 -name '*.jar' -printf '%f\n' | sort)
+          if [ "$expected" != "$actual" ]; then
+            echo "guard: libexec/kolt-bta-impl/ does not match BTA_IMPL_JARS" >&2
+            diff <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") || true
+            exit 1
+          fi
+          # Both daemons embed the same kolt-bta-impl/ entries on their
+          # argfile -cp; spot-check from the JVM daemon (the native
+          # daemon shape is identical per write_argfile in assemble-dist.sh).
+          argfile="$DIST_ROOT/libexec/classpath/kolt-jvm-compiler-daemon.argfile"
+          cp_line=$(awk 'NR == 2' "$argfile")
+          while IFS= read -r base; do
+            [ -z "$base" ] && continue
+            case "$cp_line" in
+              *"/kolt-bta-impl/${base}"*) ;;
+              *)
+                echo "guard: argfile $argfile missing kolt-bta-impl entry for $base" >&2
+                exit 1
+                ;;
+            esac
+          done < <(printf '%s\n' "$expected")
+          echo "guard: libexec/kolt-bta-impl matches BTA_IMPL_JARS and is present on the argfile"
+
       # Local HTTP server lets install.sh exercise its real download +
       # SHA-256 + extract + sed + symlink path against the assembled tarball
       # without needing a published GitHub Release.

--- a/docs/adr/0027-runtime-classpath-manifest.md
+++ b/docs/adr/0027-runtime-classpath-manifest.md
@@ -95,6 +95,14 @@ Rules:
 
 - **Plain text, UTF-8, LF line endings, no trailing blank line.** No
   header, no comment syntax. One jar per line.
+- **Consumers must read the unterminated final line.** "No trailing
+  blank line" means the last jar path is not LF-terminated, so a vanilla
+  POSIX `while IFS= read -r line; do … done` loop silently drops it
+  (issue #286 — `assemble-dist.sh` shipped each daemon without its
+  alphabetical-last jar). Consumers in shell must use
+  `while IFS= read -r line || [ -n "$line" ]; do … done`; tools that
+  delimit on LF (e.g. `awk` records, `xargs -d $'\n'`) handle the
+  unterminated record correctly.
 - **Absolute paths.** The jars live under `~/.kolt/cache` after
   resolution; the consumer does not need to walk the cache.
 - **Deps only.** `build/<name>.jar` is NOT listed; its path is a


### PR DESCRIPTION
Closes #291 and #292.

**#291 — extend the assemble-dist regression guard to `libexec/kolt-bta-impl/`.** The hand-maintained `BTA_IMPL_JARS` array in `scripts/assemble-dist.sh` is the same drift surface that bit #287: a stale entry breaks daemon classloading the same way. New `self-host-post` step parses field 4 (filename) out of `BTA_IMPL_JARS`, diffs against `dist/.../libexec/kolt-bta-impl/*.jar`, and spot-checks each filename appears on the JVM daemon argfile `-cp` (both daemons share `write_argfile` so the JVM check covers the native one).

**#292 — record the consumer obligation in ADR 0027 §1.** "No trailing blank line" was producer-side only. Adds a bullet that names the gotcha #286 hinged on: vanilla `while IFS= read -r` drops the unterminated last line; consumers in shell must use the `|| [ -n "$line" ]` guard. `awk` records and `xargs -d $'\n'` handle the unterminated record correctly.

Reviewer focus:
- The `awk` block in the new step parses `BTA_IMPL_JARS=( … )` from `assemble-dist.sh`. Locally verified it produces 11 entries that match the actual `libexec/kolt-bta-impl/` set after a self-host build. Format change to the array (e.g., switching from a quoted-string array to a heredoc) would break parsing — that's intentional, the guard catches the drift.
- The ADR addition lives in §1 alongside the existing format rules. Summary section unchanged (consumer rules are a §1 subdetail, not a top-level decision).

No runtime change. CI-only and docs-only.