### PR TITLE
Switch release notes to --notes-file workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,14 +182,17 @@ jobs:
             *-rc.*|*-beta.*) PRERELEASE_FLAG="--prerelease" ;;
           esac
 
-          # --generate-notes auto-populates the body with merged PRs since
-          # the previous tag. Maintainers can still `gh release edit` to
-          # curate the wording afterwards.
+          NOTES_FILE="docs/release-notes/${TAG}.md"
+          if [[ ! -f "$NOTES_FILE" ]]; then
+            echo "Release notes file missing: $NOTES_FILE" >&2
+            exit 1
+          fi
+
           # shellcheck disable=SC2086 # PRERELEASE_FLAG is intentionally split
           gh release create "$TAG" \
             --target "$GITHUB_SHA" \
             --title "$TAG" \
-            --generate-notes \
+            --notes-file "$NOTES_FILE" \
             $PRERELEASE_FLAG \
             "$TARBALL" \
             "$SHA"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Reads `kolt.toml`, compiles with `kotlinc`, and runs with `java -jar`.
 - Issues: problem, definition of done, scope. Skip project background and tech prerequisites — the reader already knows what kolt is.
 - PRs: what changed and where the reviewer should focus (judgment calls, places to double-check). Don't restate what the diff shows. Don't repeat the issue's background.
 - Write prose, not checklists. Don't mechanically fill a `## Summary` / `## Test plan` template — default `gh pr create` scaffolding is fine to discard.
+- Release notes: hand-write `docs/release-notes/v<X>.md` in the bump-version PR. `release.yml` consumes it via `--notes-file`; do not rely on `--generate-notes`. PR-title autoenum is internal-voiced and not user-facing.
 
 ## Skills
 

--- a/docs/release-notes/v0.10.0.md
+++ b/docs/release-notes/v0.10.0.md
@@ -1,0 +1,23 @@
+## Highlights
+
+### Compiler daemon with incremental compilation
+
+A warm JVM compiler daemon (`kolt-compiler-daemon`) now runs in the background, delivering ~7× faster builds compared to subprocess compilation. The daemon uses kotlin-build-tools-api for incremental compilation — only changed files are recompiled.
+
+- `kolt daemon stop` to manually stop the daemon
+- `--no-daemon` flag to bypass the daemon
+- Stale daemon/socket/IC state is automatically reaped
+
+### `--watch` flag
+
+`kolt build`, `kolt check`, `kolt test`, and `kolt run` now accept `--watch` to rebuild automatically when source files change.
+
+### Plugin jars from Maven
+
+Compiler plugin jars (e.g. kotlinx-serialization) are now fetched from Maven repositories, dropping the dependency on a local kotlinc sidecar distribution.
+
+### Internal improvements
+
+- All build commands return `Result` instead of calling `exitProcess` directly
+- `ClasspathEntrySnapshot` caching for faster incremental builds
+- Scaling benchmarks for daemon performance validation

--- a/docs/release-notes/v0.10.1.md
+++ b/docs/release-notes/v0.10.1.md
@@ -1,0 +1,30 @@
+Patch release covering the daemon hardening work since v0.10.0.
+
+## Highlights
+
+### Per-version daemon spawn (#138)
+
+The daemon now matches your `kolt.toml` `kotlin = "..."` across the full 2.3.x family instead of silently using 2.3.20 for every project. Other 2.3.x patches (2.3.0, 2.3.10) are fetched from Maven Central on first use and reused across projects. See ADR 0022 for the version support policy.
+
+### Plugin-using projects on Kotlin 2.3.0 / 2.3.10 through the daemon (#148)
+
+kolt.toml `[plugins]` entries (serialization / allopen / noarg) now run through the daemon on any 2.3.x Kotlin release. Previously plugin-using projects on 2.3.0 / 2.3.10 fell back to subprocess because BTA's structured `COMPILER_PLUGINS` argument key was 2.3.20-only; the adapter now uses `-Xplugin=` passthrough, which BTA accepts across the whole family (see `spike/bta-compat-138/REPORT.md`).
+
+### Daemon reliability fixes
+
+- **#145**: The reaper no longer unlinks a live new-layout daemon socket when sweeping a stale pre-#142 legacy socket in the same project dir. This was a narrow post-upgrade race but produced a silent "daemon keeps running but clients can't connect" failure.
+- **#146**: Daemon socket paths now preflight the Linux `sun_path` 108-byte limit before spawn. CI runners with deep `$HOME` paths (`/home/runner/work/<org>/<repo>/...`) and NFS-mounted homes now fall back to subprocess cleanly instead of `bind() ENAMETOOLONG` mid-spawn.
+
+### Daemon IC state cleaned on `kolt clean` (#135)
+
+Incremental-compile state under `~/.kolt/daemon/<projectHash>/<kotlinVersion>/` is now swept by `kolt clean`, so a stale IC cache can't outlive a cleanup.
+
+## Under the hood
+
+- ADR 0022 formalises the Kotlin version support policy: soft floor at 2.3.0, forward re-evaluation at each language release.
+- ADR 0019 §9 gets a short note on the new `-Xplugin=` passthrough mechanism and its ordering invariant.
+- Spike harness at `spike/bta-compat-138/` is reusable for the 2.4.0 forward re-evaluation.
+
+## Upgrade notes
+
+No `kolt.toml` schema changes. No user-facing behaviour changes for plugin-free projects on Kotlin 2.3.20 (the previous default target). Projects that previously fell back to subprocess because of `kolt.toml kotlin != 2.3.20` or `[plugins]` + older Kotlin will now take the faster daemon path.

--- a/docs/release-notes/v0.11.0.md
+++ b/docs/release-notes/v0.11.0.md
@@ -1,0 +1,7 @@
+**Breaking**
+- `kolt.toml` restructured into semantic sections: `[kotlin]`, `[build]`, `[kotlin.plugins]` (#158)
+
+**Other**
+- Warn on missing `test`/`resources` source directories (#60)
+- Bump `kolt init` template Kotlin version to 2.3.20
+- Document Kotlin version support policy (ADR 0022)

--- a/docs/release-notes/v0.11.1.md
+++ b/docs/release-notes/v0.11.1.md
@@ -1,0 +1,1 @@
+- `[kotlin] compiler` field: pin kotlinc/daemon independently of `[kotlin] version` (language/API). Must be `>= version`. (#162)

--- a/docs/release-notes/v0.12.0.md
+++ b/docs/release-notes/v0.12.0.md
@@ -1,0 +1,14 @@
+**Native compiler daemon (#170, ADR 0024)**
+- konanc now runs as a warm daemon, amortizing JVM startup across native builds
+- Client backend with subprocess fallback, integrated into `doNativeBuild`
+- `kolt daemon stop` / `reap` enumerate native daemon sockets alongside JVM
+
+**Native incremental compilation (#168)**
+- Enabled via `-Xenable-incremental-compilation` on stage 2
+
+**Schema**
+- ADR 0023: `[build] target` adopts KonanTarget vocabulary (`linuxX64` etc.), reserves `kind` and `[build.targets.X]` for future multi-target (#167)
+
+**Hardening**
+- Pin native daemon heap ceiling and stderr prefix contract with regression tests
+- `kolt daemon stop` enumerates fingerprinted JVM daemon sockets (#181)

--- a/docs/release-notes/v0.13.0.md
+++ b/docs/release-notes/v0.13.0.md
@@ -1,0 +1,25 @@
+**New commands**
+- `kolt info` — project / toolchain / host snapshot with `--verbose` and `--format=json` (#26, #208, #209, #210)
+- `kolt cache clean` — purge `~/.kolt/cache` (#25)
+
+**`kolt init`**
+- Generate `.gitignore` and run `git init` on fresh projects (#192, #193)
+
+**Resolver**
+- Drop superseded transitive deps via fixpoint resolution (#56)
+- Honor Gradle `strictly` / `prefers` / `rejects` version constraints (#202)
+- Extract shared resolution kernel for JVM and native (#217)
+- Immutable `Resolution` state (#212)
+- Evaluate exclusions per BFS path (#213)
+
+**Build cache**
+- Harden cache against stale state + skip resolve on cache hit (#195)
+- Incremental test build cache for native target (#196)
+
+**Hardening**
+- Acquire `LOCK` before other `workingDir` writes (#199)
+- Fail compile fast when `LOCK` file cannot be created (#203)
+- Distinguish `kolt.toml` parse errors from missing file in `kolt info` (#210)
+
+**Cleanup**
+- Remove pre-v1 backcompat code (#197)

--- a/docs/release-notes/v0.14.0.md
+++ b/docs/release-notes/v0.14.0.md
@@ -1,0 +1,34 @@
+**Daemon self-host**
+- Close daemon self-host gap; runtime classpath manifest (#97, #228)
+- Remove shadowJar from daemon Gradle builds (#231, #232)
+- Guard daemon main-class FQN drift (#233, #235)
+- Surface corrupted libexec on bundled BTA-impl miss (#234, #236)
+- Rename daemons to kolt-\<target\>-\<role\>-daemon (#227)
+- ADR 0018 revisions (#224, #225)
+
+**Library kind**
+- Implement `kind = "lib"` build pipeline (#30, #222)
+- ADR 0025 scope fix (#223)
+
+**Main/test closure separation**
+- Foundation: Lockfile v3 + Origin + auto-inject skip (#229, #249)
+- Core 2-seed resolver and origin-split JVM outcome (#250)
+- Integrate origin filter into build / IDE / docs (#251)
+- Regenerate v3 lockfiles and pin daemon-shape manifest (#252)
+
+**LSP workspace.json**
+- Exclude build dirs + emit javaSettings + test kotlinSettings (#244, #245, #246, #253)
+- Attach -sources.jar to libraries (#242, #254)
+- Resolve user JDK and populate SDK.homePath (#243, #255)
+- Document libraries[].type choice (#247, #256)
+- Drop kls-classpath emission (#257)
+
+**Process**
+- ADR 0028: v1.0 release policy and RC window (#237)
+- ADR template + review checklist + module-naming ADR 0026
+- ktfmt applied to daemon and core sources; pre-commit hook for \`kolt fmt\`
+
+**Breaking changes (pre-v1, no migration)**
+- Lockfile v3 — old \`kolt.lock\` invalidated, auto-regenerated on next \`kolt deps install\`
+- Daemon distribution layout — \`KOLT_DAEMON_JAR\` semantics changed; recommend \`rm -rf ~/.kolt/daemon/\` before upgrade
+- \`kls-classpath\` no longer emitted — was never functionally consumed by fwcd; manually \`rm\` stale files in existing trees

--- a/docs/release-notes/v0.15.0.md
+++ b/docs/release-notes/v0.15.0.md
@@ -1,0 +1,18 @@
+**Concurrent-build safety (#239)**
+- Project-local flock + atomic `~/.kolt/cache` writes (#262)
+- Post-merge cosmetic cleanups (#264)
+
+**Reproducibility & CI cache contract**
+- Make daemon jars byte-reproducible (#259)
+- Document `~/.kolt/toolchains/` as a v1-stable CI cache contract (#260)
+
+**kolt init / kolt new**
+- Unify `init` / `new` flags (#266)
+- Interactive prompts on TTY (#267)
+
+**Toolchain pin**
+- Bump `BOOTSTRAP_JDK` 21 → 25, daemon JDK 21 → 25, Gradle 8.12 → 9.4.1 (#269, #270)
+
+**Breaking changes (pre-v1, no migration)**
+- `BOOTSTRAP_JDK` 21 → 25: building kolt from source now requires JDK 25; the prebuilt binary release is unaffected (#269, #270)
+- `kolt init` / `kolt new` flag rename: old flag names were removed without aliases (#266)

--- a/docs/release-notes/v0.16.0.md
+++ b/docs/release-notes/v0.16.0.md
@@ -1,0 +1,23 @@
+**curl | sh installer (#230)**
+- release.yml triggers on tag push and auto-publishes `kolt-<v>-linux-x64.tar.gz` + `.sha256` (#277)
+- Published `install.sh` performs SHA-256 verification + YANKED gate + extraction to `~/.local/share/kolt/<v>/` + symlink creation at `~/.local/bin/kolt` (#277)
+- self-host-smoke.yml smoke-tests the real install.sh path on every PR plus 5 negative paths (yank refuse / override / parse error / non-symlink / SHA mismatch) (#277)
+- README.ja.md Installation section synced with the curl|sh flow (#279)
+
+**Build profiles (#261)**
+- Cargo-style `kolt build [--release]` (debug default, `--release` opt-in). Native toggles `-opt` / `-g`, JVM is a declared no-op, artifacts are partitioned under `build/<profile>/` (#274)
+- Profile-naive up-to-date check now handles the release profile (#275)
+
+**Concurrent-build safety follow-up**
+- `ensureDirectoryRecursive` tolerates mkdir EEXIST (#272, TOCTOU fix)
+
+**Drift guards modernization**
+- `verifyDaemon*` drift guards moved from Gradle tasks to native tests + JDK pin guard (#273)
+
+**Installation**
+
+\`\`\`sh
+curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh
+\`\`\`
+
+Starting with this release, binaries are auto-published on tag push.

--- a/docs/release-notes/v0.16.1.md
+++ b/docs/release-notes/v0.16.1.md
@@ -1,0 +1,14 @@
+**Bugfix: clean-environment subprocess compile (#283)**
+
+On a clean Linux host (kolt binary only, no system Java), `kolt new` → `kolt build` regressed in v0.16.0 with `kotlinc: line 102: java: command not found`. The bundled kotlinc is a shell wrapper that needs `$JAVA_HOME/bin/java` or `java` on `PATH`; kolt was passing neither to subprocess forks.
+
+- `executeCommand` gains an `extraEnv` parameter — child-only setenv, parent env untouched
+- `ensureJdkBinsFromConfig` fallback (when `[build] jdk` is unset) switched to `BOOTSTRAP_JDK_VERSION` (JDK 25), so the bootstrap JDK already installed for the daemon path is shared with subprocess / `kolt fmt`
+- `JdkBins` now carries `home`; `SubprocessCompilerBackend`, `doCheck`, and `doTest` inject `JAVA_HOME` into the child
+- `BuildResult.javaHome` threaded through the test path
+
+**Installation**
+
+\`\`\`sh
+curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh
+\`\`\`

--- a/docs/release-notes/v0.16.2.md
+++ b/docs/release-notes/v0.16.2.md
@@ -1,0 +1,14 @@
+**Bugfix: JAVA_HOME injection for konanc / cinterop subprocess (#285)**
+
+v0.16.1 fixed `JAVA_HOME` for the JVM target's `kotlinc`. The Native side has the same shape — `konanc` and `cinterop` are shell wrappers that resolve `java` via `$JAVA_HOME` then `PATH` — so on a clean Linux host the Native build path failed identically: `run_konan: line 80: java: command not found`.
+
+- `NativeSubprocessBackend` accepts `javaHome` and forwards it as `executeCommand` extraEnv
+- `runCinterop` accepts `javaHome` and applies it to every cinterop invocation
+- `doNativeBuildInner` and `doNativeTest` resolve `managedJdkBins` after the up-to-date branch and thread `JAVA_HOME` into konanc + cinterop subprocess forks
+- `kolt run` / `.kexe` execution path unchanged — only the konanc / cinterop wrapper layer needs `JAVA_HOME`
+
+**Installation**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh
+```

--- a/docs/release-notes/v0.16.3.md
+++ b/docs/release-notes/v0.16.3.md
@@ -1,0 +1,21 @@
+**Bugfix: manifest reader drops alphabetical-last dep (#286)**
+
+The runtime classpath manifest is written without a trailing newline (ADR 0027 §1). `copy_manifest_deps` and `write_argfile` in `scripts/assemble-dist.sh` consumed it with vanilla `while IFS= read -r jar`, silently dropping the unterminated last line. The alphabetical-last manifest entry was missing from `libexec/<daemon>/deps/` and absent from the daemon's argfile `-cp`. On v0.16.x installs the native daemon died at `FrameCodec.<clinit>` (missing `kotlinx-serialization-json-jvm`); the JVM daemon was missing `ktoml-core-jvm`.
+
+- Both loops switched to `while IFS= read -r jar || [[ -n "$jar" ]]` to retain the unterminated last line
+- Manifest format unchanged — `RuntimeClasspathManifestTest` still pins "no trailing newline"; consumers are now tolerant
+- `self-host-post` CI guard diffs each daemon's manifest basenames against `libexec/<daemon>/deps/*.jar` and verifies every entry appears on the argfile `-cp` line
+
+**Bugfix: kotlin-stdlib + annotations missing from libexec/kolt-bta-impl/ (#287)**
+
+`SharedApiClassesClassLoader` only exposes `org.jetbrains.kotlin.buildtools.api.*` upward and falls everything else through to a JDK-only loader, so the daemon-main `kotlin-stdlib` is invisible to the BTA `-impl` child. The previous comment in `assemble-dist.sh` had this backwards and excluded `kotlin-stdlib` and `annotations` from `libexec/kolt-bta-impl/`. The impl child could not resolve `kotlin/jvm/internal/Intrinsics`, surfacing as the JVM compiler daemon failing to bind on a clean v0.16.x install.
+
+- Add `kotlin-stdlib-2.3.20.jar` and `annotations-13.0.jar` to `BTA_IMPL_JARS` (matching `kotlin-build-tools-impl-2.3.20.pom` direct deps)
+- `kotlin-build-tools-api-2.3.20` is intentionally **not** added — it IS the loader's allowlist
+- Runtime smoke step in `self-host-post` captures stderr from the fixture build and fails on `FallbackReporter`'s "falling back to subprocess" warning. `~/.kolt/daemon/` is wiped before smoke so a cold-bind regression cannot ride a warm spawn rail.
+
+**Installation**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh
+```


### PR DESCRIPTION
v0.16.2 / v0.16.3 went out with `--generate-notes` output (PR-title autoenum), which is internal-voiced and not user-facing — that prompted this change. Hand-written notes now live in `docs/release-notes/v<X>.md` and `release.yml` consumes them via `--notes-file`. The bump-version PR carries the notes file and reviews it alongside the version bump.

## Reviewer focus

- `docs/release-notes/v0.16.2.md` and `v0.16.3.md` are the only hand-written notes — please check the wording against PR #285 / #288 / #289 / #293. The other 10 are verbatim transcriptions of existing GitHub release bodies (escaped backticks in v0.16.0/v0.16.1's Installation block were preserved as-is, since "verbatim" is the policy for past notes).
- `release.yml` fails fast if `docs/release-notes/\$TAG.md` is missing, so a forgotten release note blocks publish instead of producing an empty body.
- `CLAUDE.md` gains one line under Issue & PR writing — the rule is "hand-write, no `--generate-notes`".

## Post-merge follow-up

Existing v0.16.2 / v0.16.3 GitHub release bodies are still the auto-generated ones; this PR doesn't sync them. After merge:

\`\`\`sh
gh release edit v0.16.2 --notes-file docs/release-notes/v0.16.2.md
gh release edit v0.16.3 --notes-file docs/release-notes/v0.16.3.md
\`\`\`