### PR TITLE
ci: bootstrap from prebuilt kolt.kexe instead of Gradle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ name: Release
 # defaults to true so a manual run only exercises the gates and build,
 # without publishing assets — used to validate release.yml end-to-end before
 # the first real tag.
+#
+# Bootstrap policy: KOLT_BOOTSTRAP_TAG pins the past kolt release whose
+# kolt.kexe drives `assemble-dist.sh` for the new release. The pin must
+# always trail HEAD by at least one published release. Self-bootstrap
+# means a broken pinned tag blocks releases — roll back to the previous
+# working tag in the env below (one-line PR). The tag must be reachable
+# via `gh release download` and ship `kolt-<version>-linux-x64.tar.gz`.
 
 on:
   push:
@@ -22,6 +29,9 @@ concurrency:
 
 permissions:
   contents: write
+
+env:
+  KOLT_BOOTSTRAP_TAG: v0.16.3
 
 jobs:
   release:
@@ -126,26 +136,6 @@ jobs:
       - name: Install libarchive dev headers
         run: sudo apt-get install -y --no-install-recommends libarchive-dev
 
-      # Cache keys mirror self-host-smoke.yml so both workflows share warm
-      # caches keyed per-repo, not per-workflow.
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
-
-      - name: Cache Gradle Kotlin Native
-        uses: actions/cache@v4
-        with:
-          path: ~/.konan
-          key: konan-${{ runner.os }}-${{ hashFiles('build.gradle.kts') }}
-          restore-keys: |
-            konan-${{ runner.os }}-
-
       - name: Cache kolt toolchains
         uses: actions/cache@v4
         with:
@@ -154,16 +144,31 @@ jobs:
           restore-keys: |
             kolt-${{ runner.os }}-
 
-      - name: Bootstrap kolt.kexe via Gradle
-        run: ./gradlew --no-daemon linkDebugExecutableLinuxX64
+      - name: Download bootstrap kolt.kexe
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BOOTSTRAP_DIR=/tmp/kolt-bootstrap
+          mkdir -p "$BOOTSTRAP_DIR"
+          gh release download "$KOLT_BOOTSTRAP_TAG" \
+            --repo snicmakino/kolt \
+            --pattern 'kolt-*-linux-x64.tar.gz' \
+            --dir "$BOOTSTRAP_DIR"
+          tar -xzf "$BOOTSTRAP_DIR"/kolt-*-linux-x64.tar.gz \
+            -C "$BOOTSTRAP_DIR" --strip-components=1
+          install -m 0755 "$BOOTSTRAP_DIR/bin/kolt" \
+            "$GITHUB_WORKSPACE/bootstrap-kolt"
+          "$GITHUB_WORKSPACE/bootstrap-kolt" --version
 
       # assemble-dist.sh runs the 3 × kolt build --release internally and
-      # emits both the tarball and .sha256 (PR #228 + task 1.2). The KOLT
-      # env var overrides its default releaseExecutable path so the
-      # bootstrapped debug kexe drives the 3 release builds.
+      # emits both the tarball and .sha256. The KOLT env var points the
+      # script at the prebuilt bootstrap kexe instead of its default
+      # `build/release/kolt.kexe` lookup.
       - name: Assemble tarball + sha256
         run: |
-          KOLT="$GITHUB_WORKSPACE/build/bin/linuxX64/debugExecutable/kolt.kexe" \
+          set -euo pipefail
+          KOLT="$GITHUB_WORKSPACE/bootstrap-kolt" \
             ./scripts/assemble-dist.sh
 
       - name: Publish to GitHub Release

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -2,9 +2,16 @@ name: Self-host smoke test
 
 # Builds kolt.kexe from its own kolt.toml as a smoke test against HEAD.
 # See #61 — this is the minimum signal that the self-host path stays
-# unbroken across changes. A Gradle-built kolt.kexe bootstraps itself
-# to rebuild kolt from kolt.toml, and we verify the resulting binary
-# responds to `--version`.
+# unbroken across changes. A prebuilt kolt.kexe from a past release
+# bootstraps the build, kolt rebuilds itself from kolt.toml, and we
+# verify the resulting binary responds to `--version`.
+#
+# Bootstrap policy: KOLT_BOOTSTRAP_TAG pins the past kolt release whose
+# kolt.kexe is used to build current HEAD. The pin must always trail
+# HEAD by at least one published release. If a build fails because the
+# pinned tag is broken, roll back to the previous working tag in the env
+# below (one-line PR). The tag must be reachable via `gh release
+# download` and ship `kolt-<version>-linux-x64.tar.gz`.
 
 on:
   push:
@@ -19,6 +26,9 @@ concurrency:
 
 permissions:
   contents: read
+
+env:
+  KOLT_BOOTSTRAP_TAG: v0.16.3
 
 jobs:
   self-host:
@@ -44,28 +54,6 @@ jobs:
       - name: Install libarchive dev headers
         run: sudo apt-get install -y --no-install-recommends libarchive-dev
 
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
-
-      # Gradle's Kotlin Native plugin downloads konanc (~500 MB) into ~/.konan.
-      # Caching keeps runs under ~2 minutes after the first cold build. Keyed
-      # on build.gradle.kts because that's where the Kotlin (and therefore
-      # konanc) version lives for the Gradle path.
-      - name: Cache Gradle Kotlin Native
-        uses: actions/cache@v4
-        with:
-          path: ~/.konan
-          key: konan-${{ runner.os }}-${{ hashFiles('build.gradle.kts') }}
-          restore-keys: |
-            konan-${{ runner.os }}-
-
       # kolt downloads its own kotlinc / konanc / JDK into ~/.kolt on first
       # run. Cache keyed on the Kotlin version from kolt.toml.
       - name: Cache kolt toolchains
@@ -76,11 +64,27 @@ jobs:
           restore-keys: |
             kolt-${{ runner.os }}-
 
-      - name: Bootstrap kolt.kexe via Gradle
-        run: ./gradlew --no-daemon linkDebugExecutableLinuxX64
+      - name: Download bootstrap kolt.kexe
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BOOTSTRAP_DIR=/tmp/kolt-bootstrap
+          mkdir -p "$BOOTSTRAP_DIR"
+          gh release download "$KOLT_BOOTSTRAP_TAG" \
+            --repo snicmakino/kolt \
+            --pattern 'kolt-*-linux-x64.tar.gz' \
+            --dir "$BOOTSTRAP_DIR"
+          tar -xzf "$BOOTSTRAP_DIR"/kolt-*-linux-x64.tar.gz \
+            -C "$BOOTSTRAP_DIR" --strip-components=1
+          install -m 0755 "$BOOTSTRAP_DIR/bin/kolt" \
+            "$GITHUB_WORKSPACE/bootstrap-kolt"
+          "$GITHUB_WORKSPACE/bootstrap-kolt" --version
 
       - name: Self-host build (kolt builds itself from kolt.toml)
-        run: ./build/bin/linuxX64/debugExecutable/kolt.kexe build
+        run: |
+          set -euo pipefail
+          "$GITHUB_WORKSPACE/bootstrap-kolt" build
 
       - name: Verify self-hosted binary
         run: |
@@ -89,11 +93,14 @@ jobs:
           echo "$version"
           echo "$version" | grep -Eq '^kolt [0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'
 
+      # Upload the HEAD-built kexe so the self-host-post job exercises
+      # current HEAD (not the bootstrap tag) against the 3-daemon build +
+      # assemble-dist + install.sh chain.
       - name: Upload kolt kexe artifact
         uses: actions/upload-artifact@v4
         with:
           name: kolt-kexe
-          path: ./build/bin/linuxX64/debugExecutable/kolt.kexe
+          path: ./build/debug/kolt.kexe
           if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,9 +1,16 @@
 name: Unit tests
 
-# Runs the linuxX64Test gradle task on every push and PR. Complements the
-# self-host smoke workflow: smoke verifies the build pipeline end-to-end,
-# this job catches unit-level regressions in build / resolve / config /
-# infra logic before they reach main.
+# Runs `kolt test` on every push and PR. Complements the self-host smoke
+# workflow: smoke verifies the build pipeline end-to-end, this job catches
+# unit-level regressions in build / resolve / config / infra logic before
+# they reach main.
+#
+# Bootstrap policy: KOLT_BOOTSTRAP_TAG pins the past kolt release whose
+# kolt.kexe is used to build/test current HEAD. The pin must always
+# trail HEAD by at least one published release. If a build fails because
+# the pinned tag is broken, roll back to the previous working tag in the
+# env below (one-line PR). The tag must be reachable via `gh release
+# download` and ship `kolt-<version>-linux-x64.tar.gz`.
 
 on:
   push:
@@ -17,6 +24,9 @@ concurrency:
 
 permissions:
   contents: read
+
+env:
+  KOLT_BOOTSTRAP_TAG: v0.16.3
 
 jobs:
   linuxX64-test:
@@ -43,38 +53,46 @@ jobs:
       - name: Install libarchive dev headers
         run: sudo apt-get install -y --no-install-recommends libarchive-dev
 
-      # Cache keys deliberately mirror self-host-smoke.yml so the two
-      # workflows share underlying cache entries (keyed per repo, not per
-      # workflow). First run of either populates the caches for both.
-      - name: Cache Gradle
+      # kolt downloads its own kotlinc / konanc / JDK into ~/.kolt on first
+      # run. Cache keyed on the Kotlin version from kolt.toml.
+      - name: Cache kolt toolchains
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          path: ~/.kolt
+          key: kolt-${{ runner.os }}-${{ hashFiles('kolt.toml') }}
           restore-keys: |
-            gradle-${{ runner.os }}-
+            kolt-${{ runner.os }}-
 
-      - name: Cache Gradle Kotlin Native
-        uses: actions/cache@v4
-        with:
-          path: ~/.konan
-          key: konan-${{ runner.os }}-${{ hashFiles('build.gradle.kts') }}
-          restore-keys: |
-            konan-${{ runner.os }}-
-
-      - name: Run linuxX64Test
-        run: ./gradlew --no-daemon linuxX64Test
-
-      # Regression guard for the root `build` → `:kolt-jvm-compiler-daemon:build`
-      # wiring added in #99 (ADR 0018). If a future edit drops the `dependsOn`
-      # in build.gradle.kts, the dev-fallback path in DaemonJarResolver.kt
-      # would silently pick up a stale jar — the failure mode is invisible to
-      # self-host-smoke because the daemon falls back to subprocess compile on
-      # any error. Asserting the thin jar exists after `./gradlew build` keeps
-      # the wiring honest.
-      - name: Verify root build produces daemon thin jar
+      - name: Download bootstrap kolt.kexe
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./gradlew --no-daemon build
-          test -f kolt-jvm-compiler-daemon/build/libs/kolt-jvm-compiler-daemon.jar
+          set -euo pipefail
+          BOOTSTRAP_DIR=/tmp/kolt-bootstrap
+          mkdir -p "$BOOTSTRAP_DIR"
+          gh release download "$KOLT_BOOTSTRAP_TAG" \
+            --repo snicmakino/kolt \
+            --pattern 'kolt-*-linux-x64.tar.gz' \
+            --dir "$BOOTSTRAP_DIR"
+          tar -xzf "$BOOTSTRAP_DIR"/kolt-*-linux-x64.tar.gz \
+            -C "$BOOTSTRAP_DIR" --strip-components=1
+          install -m 0755 "$BOOTSTRAP_DIR/bin/kolt" \
+            "$GITHUB_WORKSPACE/bootstrap-kolt"
+          "$GITHUB_WORKSPACE/bootstrap-kolt" --version
+
+      - name: Run kolt test
+        run: |
+          set -euo pipefail
+          "$GITHUB_WORKSPACE/bootstrap-kolt" test
+
+      # Early-detection guard: build the JVM daemon project standalone with
+      # the bootstrap kolt and assert the thin jar materializes. self-host-
+      # smoke job 2 covers the same surface end-to-end, but running it here
+      # at the PR-gating job catches a `kolt build` regression in the daemon
+      # subproject before the smoke workflow's longer path.
+      - name: Verify daemon thin jar builds standalone
+        run: |
+          set -euo pipefail
+          cd kolt-jvm-compiler-daemon
+          "$GITHUB_WORKSPACE/bootstrap-kolt" build
+          test -f build/debug/kolt-jvm-compiler-daemon.jar

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -80,10 +80,16 @@ jobs:
             "$GITHUB_WORKSPACE/bootstrap-kolt"
           "$GITHUB_WORKSPACE/bootstrap-kolt" --version
 
+      # `--ktest_logger=SILENT` collapses the per-test GTEST output (~2k
+      # lines for the full suite) down to a summary; failure stack traces
+      # still surface on stderr. The `::group::` markers fold the step
+      # output in the GHA UI by default.
       - name: Run kolt test
         run: |
           set -euo pipefail
-          "$GITHUB_WORKSPACE/bootstrap-kolt" test
+          echo "::group::kolt test"
+          "$GITHUB_WORKSPACE/bootstrap-kolt" test -- --ktest_logger=SILENT
+          echo "::endgroup::"
 
       # Early-detection guard: build the JVM daemon project standalone with
       # the bootstrap kolt and assert the thin jar materializes. self-host-

--- a/src/nativeTest/kotlin/kolt/cli/RunLibraryRejectionTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/RunLibraryRejectionTest.kt
@@ -23,6 +23,16 @@ import platform.posix.chdir
 import platform.posix.getcwd
 import platform.posix.mkdtemp
 
+@OptIn(ExperimentalForeignApi::class)
+private fun createTempDir(prefix: String): String {
+  val template = "/tmp/${prefix}XXXXXX"
+  val buf = template.encodeToByteArray().copyOf(template.length + 1)
+  buf.usePinned { pinned ->
+    val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+    return result.toKString()
+  }
+}
+
 /**
  * R4 matrix: `kolt run` must reject library projects before any artifact resolution or build
  * invocation (ADR 0023 §1 kind schema). Coverage:
@@ -33,6 +43,32 @@ import platform.posix.mkdtemp
  */
 @OptIn(ExperimentalForeignApi::class)
 class RunLibraryRejectionTest {
+
+  // chdir to a temp dir so `doRun`'s `withProjectLock` acquires a lock
+  // against an unrelated directory rather than the kolt project root —
+  // otherwise self-host `kolt test` deadlocks against the lock its own
+  // parent invocation already holds. Tactical workaround for #303;
+  // revert once that lands.
+  private var originalCwd: String = ""
+  private var tmpDir: String = ""
+
+  @BeforeTest
+  fun setUp() {
+    originalCwd = memScoped {
+      val buf = allocArray<ByteVar>(PATH_MAX)
+      getcwd(buf, PATH_MAX.toULong())?.toKString() ?: error("getcwd failed")
+    }
+    tmpDir = createTempDir("kolt-doRun-lib-reject-")
+    check(chdir(tmpDir) == 0) { "chdir to $tmpDir failed" }
+  }
+
+  @AfterTest
+  fun tearDown() {
+    chdir(originalCwd)
+    if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
+      removeDirectoryRecursive(tmpDir)
+    }
+  }
 
   // R4.1 + R4.3: the run-guard rejects both JVM and native library
   // configs with `EXIT_CONFIG_ERROR` and emits the canonical stderr
@@ -143,15 +179,6 @@ class WatchRunLoopLibraryRejectionTest {
       stderr.any { it.contains("watching for changes") },
       "watch-run must not enter the poll loop for a library; stderr=$stderr",
     )
-  }
-
-  private fun createTempDir(prefix: String): String {
-    val template = "/tmp/${prefix}XXXXXX"
-    val buf = template.encodeToByteArray().copyOf(template.length + 1)
-    buf.usePinned { pinned ->
-      val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
-      return result.toKString()
-    }
   }
 
   companion object {


### PR DESCRIPTION
Replaces `./gradlew --no-daemon ...` in 3 workflows with `gh release download` of the kolt release pinned by `KOLT_BOOTSTRAP_TAG` (v0.16.3). First step in the #298 staged Gradle removal.

Two judgment calls to double-check:

- `unit-tests.yml`'s thin-jar guard is rewired from "Gradle root build wires daemon :build via dependsOn" to "JVM daemon project builds standalone with kolt build". The original #99 / ADR 0018 wiring concern dies with Gradle; the early-detection signal in the PR-gating job is preserved.

- `self-host-smoke.yml` now uploads the HEAD-built `./build/debug/kolt.kexe` as `kolt-kexe` instead of the Gradle-built debug kexe. Job 2 (`self-host-post`) therefore exercises the HEAD self-host kexe end-to-end — slightly stricter than before.

Known limitation, to be filed as follow-up: `bootstrap-kolt` is placed at `\$GITHUB_WORKSPACE/bootstrap-kolt` with no `libexec/` sibling, so daemons fall back to subprocess for bootstrap-driven steps. Not a regression; ~30–60s of CI overhead recoverable by running from the extracted tree.

Out of scope (deferred): root `build.gradle.kts` removal, `./gradlew` references in CLAUDE.md / steering / kolt-dev, the daemon Gradle subprojects (kept for \`stageBtaImplJars\`).

Closes #298.