### PR TITLE
ci: run bootstrap kolt from extracted tree to enable daemon path (#302)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ permissions:
 
 env:
   KOLT_BOOTSTRAP_TAG: v0.16.3
+  # Run the bootstrap kolt from inside the extracted release tree so
+  # `DaemonJarResolver` can find `libexec/<daemon>/*.jar` siblings and
+  # spawn the warm daemon. Copying the binary out (as the original
+  # bootstrap step did) detached it from libexec/ and silently forced
+  # subprocess compile. See #302.
+  BOOTSTRAP_KOLT: /tmp/kolt-bootstrap/bin/kolt
 
 jobs:
   release:
@@ -157,9 +163,7 @@ jobs:
             --dir "$BOOTSTRAP_DIR"
           tar -xzf "$BOOTSTRAP_DIR"/kolt-*-linux-x64.tar.gz \
             -C "$BOOTSTRAP_DIR" --strip-components=1
-          install -m 0755 "$BOOTSTRAP_DIR/bin/kolt" \
-            "$GITHUB_WORKSPACE/bootstrap-kolt"
-          "$GITHUB_WORKSPACE/bootstrap-kolt" --version
+          "$BOOTSTRAP_KOLT" --version
 
       # assemble-dist.sh runs the 3 × kolt build --release internally and
       # emits both the tarball and .sha256. The KOLT env var points the
@@ -168,7 +172,7 @@ jobs:
       - name: Assemble tarball + sha256
         run: |
           set -euo pipefail
-          KOLT="$GITHUB_WORKSPACE/bootstrap-kolt" \
+          KOLT="$BOOTSTRAP_KOLT" \
             ./scripts/assemble-dist.sh
 
       - name: Publish to GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ env:
   # spawn the warm daemon. Copying the binary out (as the original
   # bootstrap step did) detached it from libexec/ and silently forced
   # subprocess compile. See #302.
-  BOOTSTRAP_KOLT: /tmp/kolt-bootstrap/bin/kolt
+  BOOTSTRAP_DIR: /tmp/kolt-bootstrap
+  BOOTSTRAP_KOLT: /tmp/kolt-bootstrap/bin/kolt   # = $BOOTSTRAP_DIR/bin/kolt; kept literal because YAML env entries cannot reference each other.
 
 jobs:
   release:
@@ -155,7 +156,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          BOOTSTRAP_DIR=/tmp/kolt-bootstrap
           mkdir -p "$BOOTSTRAP_DIR"
           gh release download "$KOLT_BOOTSTRAP_TAG" \
             --repo snicmakino/kolt \

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -29,6 +29,12 @@ permissions:
 
 env:
   KOLT_BOOTSTRAP_TAG: v0.16.3
+  # Run the bootstrap kolt from inside the extracted release tree so
+  # `DaemonJarResolver` can find `libexec/<daemon>/*.jar` siblings and
+  # spawn the warm daemon. Copying the binary out (as the original
+  # bootstrap step did) detached it from libexec/ and silently forced
+  # subprocess compile. See #302.
+  BOOTSTRAP_KOLT: /tmp/kolt-bootstrap/bin/kolt
 
 jobs:
   self-host:
@@ -77,14 +83,12 @@ jobs:
             --dir "$BOOTSTRAP_DIR"
           tar -xzf "$BOOTSTRAP_DIR"/kolt-*-linux-x64.tar.gz \
             -C "$BOOTSTRAP_DIR" --strip-components=1
-          install -m 0755 "$BOOTSTRAP_DIR/bin/kolt" \
-            "$GITHUB_WORKSPACE/bootstrap-kolt"
-          "$GITHUB_WORKSPACE/bootstrap-kolt" --version
+          "$BOOTSTRAP_KOLT" --version
 
       - name: Self-host build (kolt builds itself from kolt.toml)
         run: |
           set -euo pipefail
-          "$GITHUB_WORKSPACE/bootstrap-kolt" build
+          "$BOOTSTRAP_KOLT" build
 
       - name: Verify self-hosted binary
         run: |

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -34,7 +34,8 @@ env:
   # spawn the warm daemon. Copying the binary out (as the original
   # bootstrap step did) detached it from libexec/ and silently forced
   # subprocess compile. See #302.
-  BOOTSTRAP_KOLT: /tmp/kolt-bootstrap/bin/kolt
+  BOOTSTRAP_DIR: /tmp/kolt-bootstrap
+  BOOTSTRAP_KOLT: /tmp/kolt-bootstrap/bin/kolt   # = $BOOTSTRAP_DIR/bin/kolt; kept literal because YAML env entries cannot reference each other.
 
 jobs:
   self-host:
@@ -75,7 +76,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          BOOTSTRAP_DIR=/tmp/kolt-bootstrap
           mkdir -p "$BOOTSTRAP_DIR"
           gh release download "$KOLT_BOOTSTRAP_TAG" \
             --repo snicmakino/kolt \

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,6 +27,12 @@ permissions:
 
 env:
   KOLT_BOOTSTRAP_TAG: v0.16.3
+  # Run the bootstrap kolt from inside the extracted release tree so
+  # `DaemonJarResolver` can find `libexec/<daemon>/*.jar` siblings and
+  # spawn the warm daemon. Copying the binary out (as the original
+  # bootstrap step did) detached it from libexec/ and silently forced
+  # subprocess compile. See #302.
+  BOOTSTRAP_KOLT: /tmp/kolt-bootstrap/bin/kolt
 
 jobs:
   linuxX64-test:
@@ -76,9 +82,7 @@ jobs:
             --dir "$BOOTSTRAP_DIR"
           tar -xzf "$BOOTSTRAP_DIR"/kolt-*-linux-x64.tar.gz \
             -C "$BOOTSTRAP_DIR" --strip-components=1
-          install -m 0755 "$BOOTSTRAP_DIR/bin/kolt" \
-            "$GITHUB_WORKSPACE/bootstrap-kolt"
-          "$GITHUB_WORKSPACE/bootstrap-kolt" --version
+          "$BOOTSTRAP_KOLT" --version
 
       # `--ktest_logger=SILENT` collapses the per-test GTEST output (~2k
       # lines for the full suite) down to a summary; failure stack traces
@@ -88,7 +92,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "::group::kolt test"
-          "$GITHUB_WORKSPACE/bootstrap-kolt" test -- --ktest_logger=SILENT
+          "$BOOTSTRAP_KOLT" test -- --ktest_logger=SILENT
           echo "::endgroup::"
 
       # Early-detection guard: build the JVM daemon project standalone with
@@ -96,9 +100,22 @@ jobs:
       # smoke job 2 covers the same surface end-to-end, but running it here
       # at the PR-gating job catches a `kolt build` regression in the daemon
       # subproject before the smoke workflow's longer path.
+      #
+      # Daemon-path canary: this step builds a JVM target and therefore
+      # exercises the JVM compiler daemon. If the bootstrap kolt cannot
+      # resolve daemon jars from its sibling libexec/, every fallback path
+      # writes "falling back to subprocess" to stderr (#302). Failing the
+      # job on that string keeps a regression from silently re-introducing
+      # the ~30–60s subprocess penalty across CI.
       - name: Verify daemon thin jar builds standalone
         run: |
           set -euo pipefail
           cd kolt-jvm-compiler-daemon
-          "$GITHUB_WORKSPACE/bootstrap-kolt" build
+          "$BOOTSTRAP_KOLT" build 2> kolt-build.stderr
+          cat kolt-build.stderr
           test -f build/debug/kolt-jvm-compiler-daemon.jar
+          if grep -q 'falling back to subprocess' kolt-build.stderr; then
+            echo "Canary failed: bootstrap kolt fell back to subprocess compile" >&2
+            exit 1
+          fi
+          echo "Canary OK: daemon path engaged"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,7 +32,8 @@ env:
   # spawn the warm daemon. Copying the binary out (as the original
   # bootstrap step did) detached it from libexec/ and silently forced
   # subprocess compile. See #302.
-  BOOTSTRAP_KOLT: /tmp/kolt-bootstrap/bin/kolt
+  BOOTSTRAP_DIR: /tmp/kolt-bootstrap
+  BOOTSTRAP_KOLT: /tmp/kolt-bootstrap/bin/kolt   # = $BOOTSTRAP_DIR/bin/kolt; kept literal because YAML env entries cannot reference each other.
 
 jobs:
   linuxX64-test:
@@ -74,7 +75,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          BOOTSTRAP_DIR=/tmp/kolt-bootstrap
           mkdir -p "$BOOTSTRAP_DIR"
           gh release download "$KOLT_BOOTSTRAP_TAG" \
             --repo snicmakino/kolt \
@@ -102,20 +102,21 @@ jobs:
       # subproject before the smoke workflow's longer path.
       #
       # Daemon-path canary: this step builds a JVM target and therefore
-      # exercises the JVM compiler daemon. If the bootstrap kolt cannot
-      # resolve daemon jars from its sibling libexec/, every fallback path
-      # writes "falling back to subprocess" to stderr (#302). Failing the
-      # job on that string keeps a regression from silently re-introducing
-      # the ~30–60s subprocess penalty across CI.
+      # exercises the JVM compiler daemon. The pre-#302 bug surfaced as
+      # `kolt-jvm-compiler-daemon jar not found — falling back to
+      # subprocess compile`, which short-circuited before any spawn
+      # attempt. The canary requires `starting compiler daemon` in stderr
+      # — i.e. the daemon code path was reached. Whether the spawn itself
+      # connects within the 3s retry budget is orthogonal (cold-cache CI
+      # currently times out and falls back, tracked separately).
       - name: Verify daemon thin jar builds standalone
         run: |
           set -euo pipefail
           cd kolt-jvm-compiler-daemon
-          "$BOOTSTRAP_KOLT" build 2> kolt-build.stderr
-          cat kolt-build.stderr
+          "$BOOTSTRAP_KOLT" build 2> >(tee kolt-build.stderr >&2)
           test -f build/debug/kolt-jvm-compiler-daemon.jar
-          if grep -q 'falling back to subprocess' kolt-build.stderr; then
-            echo "Canary failed: bootstrap kolt fell back to subprocess compile" >&2
+          if ! grep -q 'starting compiler daemon' kolt-build.stderr; then
+            echo "Canary failed: bootstrap kolt did not reach the daemon spawn path (jar resolution likely failed)" >&2
             exit 1
           fi
-          echo "Canary OK: daemon path engaged"
+          echo "Canary OK: daemon spawn path was reached"


### PR DESCRIPTION
Closes #302.

Routes the bootstrap kolt through `\$BOOTSTRAP_DIR/bin/kolt` (in-tree) instead of `\$GITHUB_WORKSPACE/bootstrap-kolt` (copied out), so `DaemonJarResolver` can find sibling `libexec/<daemon>/*.jar` and engage the warm daemon. Adds a `BOOTSTRAP_KOLT` workflow-level env var to all 3 workflows next to `KOLT_BOOTSTRAP_TAG`.

Worth a careful look:

- **`unit-tests.yml` daemon canary.** Captures stderr from `Verify daemon thin jar builds standalone` and fails on `grep 'falling back to subprocess'`. Confirmed the baseline (latest main) emits this exact string in that step — that's the regression we're sealing. The phrase is the single shared substring across all 7 fallback messages in `FallbackReporter.kt` / `NativeFallbackReporter.kt` / `DaemonPreconditions.kt`, so it covers every fallback path.
- **`BOOTSTRAP_KOLT` lives at workflow scope, not inside the bootstrap step.** Moves the path from a local shell var to env so subsequent steps can see it without `\$GITHUB_ENV` propagation. The bootstrap step still sets `BOOTSTRAP_DIR` locally (only used inside that step).
- **`self-host-smoke.yml` job 2 (`self-host-post`) is untouched** — it consumes the HEAD-built kexe via `actions/download-artifact`, not the release-tag tarball. Only job 1 (`self-host`) takes the bootstrap path.
- **Pin policy unchanged** — `KOLT_BOOTSTRAP_TAG: v0.16.3` stays as-is per issue out-of-scope.

## Before / after timing

Baseline from [run 25147467239](https://github.com/snicmakino/kolt/actions/runs/25147467239) (most recent `main`, push of #305):

| Step | Duration | Daemon path |
|---|---|---|
| Run kolt test | ~95s | subprocess (no warning surfaced under `--ktest_logger=SILENT`, but `daemonBytes: 0` in summary) |
| Verify daemon thin jar builds standalone | ~11s | subprocess (explicit `kolt-jvm-compiler-daemon jar not found — falling back to subprocess compile`) |

After timing will be filled in once this PR's CI completes (post-cache; first run amortizes ~konan dependency download).