### PR TITLE
ci: add native compiler daemon canary to self-host-smoke (#309)

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -85,10 +85,24 @@ jobs:
             -C "$BOOTSTRAP_DIR" --strip-components=1
           "$BOOTSTRAP_KOLT" --version
 
+      # Native daemon canary: `kolt build` for kolt itself is a Native
+      # target build, so it routes through `resolveNativeCompilerBackend`
+      # and the K2Native sidecar daemon (ADR 0024). Mirrors the JVM-side
+      # canary in `unit-tests.yml`: assert `starting native compiler
+      # daemon` reached stderr — i.e. the daemon code path was exercised.
+      # Spawn-to-connect timing is orthogonal (#310).
+      #
+      # `kolt test` does not engage the native daemon today (#312); use
+      # `kolt build` here instead.
       - name: Self-host build (kolt builds itself from kolt.toml)
         run: |
           set -euo pipefail
-          "$BOOTSTRAP_KOLT" build
+          "$BOOTSTRAP_KOLT" build 2> >(tee kolt-build.stderr >&2)
+          if ! grep -q 'starting native compiler daemon' kolt-build.stderr; then
+            echo "Canary failed: bootstrap kolt did not reach the native daemon spawn path" >&2
+            exit 1
+          fi
+          echo "Canary OK: native daemon spawn path was reached"
 
       - name: Verify self-hosted binary
         run: |

--- a/docs/adr/0024-native-compiler-daemon.md
+++ b/docs/adr/0024-native-compiler-daemon.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-04-19
 ---
 


### PR DESCRIPTION
Closes #309.

Mirrors the JVM canary added in #308. self-host-smoke job 1 runs \`kolt build\` against HEAD, which routes through \`resolveNativeCompilerBackend\` and the K2Native sidecar daemon (ADR 0024) — the right place to assert the native daemon path was reached. Pattern is identical to the JVM canary: \`grep -q 'starting native compiler daemon'\` on stderr captured via \`tee\`. Cold-cache 3s spawn timeout still trips on this side too (#310), so the canary asserts path-was-reached, not no-fallback.

Worth a careful look:

- **Step placement.** The canary lives on \`self-host-smoke.yml\`'s \`Self-host build\` step, not \`unit-tests.yml\`'s \`Run kolt test\`. Discovered during the work that \`doNativeTest\` (\`BuildCommands.kt:864\`) calls \`executeCommand\` directly and never engages the native daemon. Filed as #312. Once that lands, \`unit-tests.yml\` can get its own native canary alongside the JVM one.
- **ADR 0024 status drive-by.** Bumped \`proposed\` → \`accepted\` to match shipped reality (\`NativeDaemonBackend\`, \`FallbackNativeCompilerBackend\`, \`resolveNativeCompilerBackend\` all live, v0.16.3 ships the daemon jar in \`libexec/kolt-native-compiler-daemon/\`).
- **Bootstrap kolt v0.16.3 already includes the native daemon jar**, verified by inspecting the tarball — so the canary works against the current pinned bootstrap without needing a release roll.