### PR TITLE
fix: route doNativeTest through resolveNativeCompilerBackend (#312)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -771,7 +771,7 @@ private fun doTestInner(
       return Err(it)
     }
   if (config.build.target in NATIVE_TARGETS) {
-    return doNativeTest(config, testArgs, profile)
+    return doNativeTest(config, testArgs, useDaemon, profile)
   }
   // doBuildInner (not doBuild) — the outer lock acquired by doTest
   // already covers the build; calling doBuild would attempt a second
@@ -864,6 +864,7 @@ private fun doTestInner(
 private fun doNativeTest(
   config: KoltConfig,
   testArgs: List<String>,
+  useDaemon: Boolean,
   profile: Profile,
 ): Result<Unit, Int> {
   val existingTestSources = filterExistingDirs(config.build.testSources, "test source")
@@ -906,7 +907,6 @@ private fun doNativeTest(
       ensureJdkBinsFromConfig(config, paths).getOrElse {
         return Err(it)
       }
-    val konancEnv = mapOf("JAVA_HOME" to managedJdkBins.home)
     val nativePluginArgs =
       resolvePluginArgs(config, paths, EXIT_TEST_ERROR).getOrElse {
         eprintln("error: ${it.message}")
@@ -929,6 +929,23 @@ private fun doNativeTest(
       }
     val klibs = depKlibs + cinteropKlibs
 
+    val cwd =
+      currentWorkingDirectory()
+        ?: run {
+          eprintln("error: could not determine current working directory")
+          return Err(EXIT_BUILD_ERROR)
+        }
+    val subprocessBackend =
+      NativeSubprocessBackend(konancBin = managedKonancBin, javaHome = managedJdkBins.home)
+    val backend: NativeCompilerBackend =
+      resolveNativeCompilerBackend(
+        config = config,
+        paths = paths,
+        subprocessBackend = subprocessBackend,
+        useDaemon = useDaemon,
+        absProjectPath = cwd,
+      )
+
     val libraryCmd =
       nativeTestLibraryCommand(
         testConfig,
@@ -942,8 +959,10 @@ private fun doNativeTest(
       return Err(EXIT_BUILD_ERROR)
     }
     println("compiling tests (native)...")
-    executeCommand(libraryCmd.args, konancEnv).getOrElse { error ->
-      eprintln("error: " + formatProcessError(error, "test compilation"))
+    // ADR 0024 §4: backend.compile takes konanc args *after* the binary;
+    // mirror doNativeBuildInner's drop(1).
+    backend.compile(libraryCmd.args.drop(1)).getOrElse { error ->
+      reportNativeCompileError(error, "test compilation")
       return Err(EXIT_BUILD_ERROR)
     }
 
@@ -955,8 +974,8 @@ private fun doNativeTest(
         profile = profile,
       )
     println("linking tests (native)...")
-    executeCommand(linkCmd.args, konancEnv).getOrElse { error ->
-      eprintln("error: " + formatProcessError(error, "test linking"))
+    backend.compile(linkCmd.args.drop(1)).getOrElse { error ->
+      reportNativeCompileError(error, "test linking")
       return Err(EXIT_BUILD_ERROR)
     }
 


### PR DESCRIPTION
Closes #312.

Mirrors \`doNativeBuildInner\`: thread \`useDaemon\` from \`doTestInner\`, construct \`NativeSubprocessBackend\`, resolve through \`resolveNativeCompilerBackend\`, then call \`backend.compile(args.drop(1))\` for both stages. Error reporting switches to \`reportNativeCompileError\` so daemon-side \`BackendUnavailable\` / \`InternalMisuse\` trigger the \`FallbackNativeCompilerBackend\` path correctly.

Worth a careful look:

- **No IC fallback wrapper for the test link.** \`nativeTestLinkCommand\` does not emit \`-Xenable-incremental-compilation\` / \`-Xic-cache-dir\` (unlike \`nativeLinkCommand\`), so wrapping in \`runNativeLinkWithIcFallback\` would just be dead complexity here. Plain \`backend.compile\` is the right shape.
- **\`konancEnv\` removal.** \`NativeSubprocessBackend\` injects \`JAVA_HOME\` at subprocess fallback time; the daemon JVM sets its own env at spawn. The local \`konancEnv\` map is no longer reachable.
- **Test runner step unchanged.** \`executeCommand(runCmd.args)\` runs the compiled test kexe as a process — that's the artifact, not a konanc invocation, so it stays subprocess.
- **Unit-tests.yml canary deferred.** Adding a \`starting native compiler daemon\` canary to \`Run kolt test\` only becomes meaningful once \`KOLT_BOOTSTRAP_TAG\` advances past a release that includes this fix. Filed conceptually under #312's DoD; do not block this PR on it.

Local verification: \`kolt test\` on a fresh clone with this build prints \`starting native compiler daemon...\` in stderr; the v0.16.3 bootstrap on the same path prints nothing native-daemon-related. Full unit suite (1306 tests) passes.