### PR TITLE
315/daemon-test-via-kolt: Replace ./gradlew check with kolt-native daemon test runners

### DIFF
--- a/.kiro/specs/daemon-test-via-kolt/design.md
+++ b/.kiro/specs/daemon-test-via-kolt/design.md
@@ -1,0 +1,502 @@
+# Design Document
+
+## Overview
+
+**Purpose**: 本機能は kolt の daemon 副プロジェクト群 (`kolt-jvm-compiler-daemon` および root daemon の subdirectory `ic`、 `kolt-native-compiler-daemon`) の JUnit 5 テスト集合を `kolt test` で実行可能にし、 user-facing / developer-facing surface から `./gradlew check` 言及を撤去する。
+
+**Users**: kolt-on-kolt で kolt 自身を保守するメンテナ。 daemon 改変後の動作確認を Gradle 経由ではなく `kolt test` 1 発で完結させる。
+
+**Impact**: 統合 kolt project (root daemon + ic を 1 つの kolt.toml として運用) を採用し、 ADR 0032 で landed 済の `[classpaths.<name>]` / `[test.sys_props]` schema を消費する。 既存 `kolt test` 経路 (`doTest` → `doBuildInner` → `jvmTestArgv` → `TestRunner`) は完全に保ち、 declarative な kolt.toml 編集と invariant test 1 ファイルの追加で完結する。
+
+### Goals
+
+- `kolt-jvm-compiler-daemon/` directory での `kolt test` が root daemon test と ic test の union を Gradle 同等の verdict で実行できる (1.1, 1.4–1.6)
+- `kolt-native-compiler-daemon/` directory での `kolt test` が native daemon test を Gradle 同等の verdict で実行できる (1.3)
+- ic 単体実行は JUnit Console Launcher の filter passthrough (`kolt test -- --select-class=...`) で代替可能 (1.2)
+- ic test が必要とする 4 classpath bundle と 5 sysprop が ADR 0032 schema で表現され、 同等の jar / path が test JVM に届く (2, 3)
+- root daemon test の `kolt.daemon.coreMainSourceRoot` sysprop が `[test.sys_props]` の `project_dir` 経由で届く (4)
+- `./gradlew check` 言及を user / developer surface から撤去 (5)
+- 既存 daemon test 本体に手を入れず、 source-static invariant test 1 つで test classpath isolation の文化的代替を確保 (6)
+
+### Non-Goals
+
+- orphan な Gradle 設定ファイル (`build.gradle.kts`、 `settings.gradle.kts`、 `gradlew`、 `gradle/wrapper/`) の物理削除 — #316 で別途対応
+- `./gradlew linkDebugExecutableLinuxX64` 等価レシピの提供 — vestigial、 #316
+- multi-module project 機能 (#4) への統合 — 本 spec は ic を独立 kolt project にしないため、 path-based dep schema は導入しない
+- kolt CLI / schema の新機能追加 — 今回は ADR 0032 の適用のみ
+- daemon test 範囲拡張 — Gradle 集合と同一を保つ (新規 invariant test は ic test の import 制約 assert のみ、 source-static で flake risk なし)
+- `kolt-jvm-compiler-daemon/ic/` directory 単体での `kolt test` 実行サポート — 1.2 の filter 経路で代替
+
+## Boundary Commitments
+
+### This Spec Owns
+
+- `kolt-jvm-compiler-daemon/kolt.toml` の test 関連セクション (`[build] test_sources`、 `[test-dependencies]`、 `[classpaths.*]`、 `[test.sys_props]`)
+- `kolt-native-compiler-daemon/kolt.toml` の test 関連セクション (`[build] test_sources`、 `[test-dependencies]`)
+- 各副プロジェクトの `kolt.lock` の test / classpaths 部分 (`kolt deps install` 再生成によって更新)
+- 1 個の新規 invariant test ファイル: ic test の import 制約 (`kolt.daemon.{Main,server,reaper,...}` を ic test source が import していないこと) を source-static に assert
+- `.kiro/steering/tech.md` の `## Common Commands` にある `./gradlew check` 行とその Special-purpose 注釈の撤去
+- 本 spec の design 判断 (Option B 採用 / "from its own directory" 緩和) を PR 本文と本 design.md で明示
+
+### Out of Boundary
+
+- kolt CLI / schema の拡張 (path-based dep、 multi-module、 CLI flag 追加など)
+- Gradle 設定ファイル群の物理削除 (`build.gradle.kts`、 `settings.gradle.kts`、 `gradlew`、 `gradle/wrapper/`)
+- 既存 daemon test 本体ロジック (`kolt-jvm-compiler-daemon/**/src/test/kotlin/`、 `kolt-native-compiler-daemon/src/test/kotlin/`) の改変
+- daemon main / production logic の変更
+- CI workflow の編集 (`./gradlew check` は CI 経路に既に存在しないため触る必要なし)
+- Issue #315 本文の編集 (history value のため当時のまま保持)
+
+### Allowed Dependencies
+
+- ADR 0032 schema (`[classpaths.<name>]` / `[test.sys_props]` / `[run.sys_props]`) と関連実装 (`Config.kt` / `SysPropValue.kt` / `SysPropResolver.kt` / `DependencyResolution.kt` / `DependencyCommands.kt`)
+- 既存 `kolt test` 経路: `doTest` / `doTestInner` / `jvmTestArgv` / `TestRunner.testRunCommand`
+- `autoInjectedTestDeps` (target=jvm のとき `kotlin-test-junit5:<kotlin.version>` を auto-inject) と user-declared `[test-dependencies]` の merge
+- JUnit Platform Console Standalone 1.11.4 (`ToolManager.CONSOLE_LAUNCHER_SPEC` 経由)
+- daemon の既存 toolchain pin: Kotlin 2.3.20 / JDK 25 / kotlinx-serialization-json 1.7.3 / kotlin-result 2.3.1 / ktoml-core 0.7.1
+- Maven Central のみ (additional repository は不要)
+
+### Revalidation Triggers
+
+以下の変更が発生した場合、 本 spec の consume 側 (daemon kolt.toml / invariant test) を再検証する。
+
+- ADR 0032 schema の意味論変更 (`project_dir` の resolution 起点、 `classpath` の colon-join 順序、 sysprop key の予約)
+- `[test.sys_props]` の dotted key (例 `"kolt.daemon.coreMainSourceRoot"`) の preservation 仕様変更 — 本 spec は dotted key が `KoltConfig.testSection.sysProps` の Map key としてそのまま保たれる前提
+- `jvmTestArgv` / `TestRunner.testRunCommand` の argv 構造変更 (例えば `--scan-class-path` の固定挿入位置の変更、 sysprop の前置位置の変更)
+- JUnit Platform Console Standalone の major version bump (1.x → 2.x)
+- daemon の Kotlin / JDK pin 変更
+- `autoInjectedTestDeps` の対象 dep 変更
+- `currentWorkingDirectory()` を起点にする projectRoot の semantic 変更
+
+## Architecture
+
+### Existing Architecture Analysis
+
+- `kolt test` (target=jvm) は `doTestInner` で以下の順に走る:
+  1. `loadProjectConfig` で `kolt.toml` を parse
+  2. `doBuildInner` で main + bundle を resolve、 main classes を compile (`build/<profile>/classes`)
+  3. `testBuildCommand` で test を compile (`build/<profile>/testClasses`)
+  4. `currentWorkingDirectory()` を `projectRoot` として `jvmTestArgv` を呼び出し、 sysprop を resolve しつつ JUnit Console Launcher への argv を組む
+  5. `executeCommand` で `java -D... -jar console --class-path <cp> --scan-class-path <testArgs...>` を spawn
+- `BuildResult.bundleClasspaths: Map<String, String>` が `[classpaths.<name>]` ごとの colon-joined absolute path を保持し、 `SysPropResolver` が `{ classpath = "<name>" }` 値の resolution に使う
+- `[test-dependencies]` は `autoInjectedTestDeps` (`kotlin-test-junit5:<kotlin.version>`) と user-declared を merge して resolver に渡る
+- 既存 daemon の Gradle config (`kolt-jvm-compiler-daemon/build.gradle.kts` ほか) は本 spec の対象外、 #316 で削除予定
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+    subgraph KoltTest["kolt test (existing path)"]
+        DoTest[doTestInner]
+        DoBuild[doBuildInner]
+        JvmTestArgv[jvmTestArgv]
+        SysPropResolver[SysPropResolver]
+        TestRunner[testRunCommand]
+        ExecuteCommand[executeCommand]
+        DoTest --> DoBuild
+        DoTest --> JvmTestArgv
+        JvmTestArgv --> SysPropResolver
+        JvmTestArgv --> TestRunner
+        DoTest --> ExecuteCommand
+    end
+
+    subgraph SpecOwned["This spec owns (declarative)"]
+        JvmDaemonToml[kolt-jvm-compiler-daemon/kolt.toml]
+        NativeDaemonToml[kolt-native-compiler-daemon/kolt.toml]
+        InvariantTest[IcModuleBoundaryInvariantTest.kt]
+        DocCleanup[.kiro/steering/tech.md cleanup]
+    end
+
+    subgraph TestJvm["spawned test JVM"]
+        ConsoleLauncher[JUnit Console Launcher 1.11.4]
+        DaemonTests[Existing daemon JUnit 5 tests]
+        NewInvariant[New invariant test]
+        ConsoleLauncher --> DaemonTests
+        ConsoleLauncher --> NewInvariant
+    end
+
+    JvmDaemonToml -->|consumed by| DoTest
+    NativeDaemonToml -->|consumed by| DoTest
+    InvariantTest -->|compiled into| DaemonTests
+    ExecuteCommand -->|spawns| ConsoleLauncher
+```
+
+> `DocCleanup` は test pipeline に流れ込まない static documentation 編集のため edge を持たない。 SpecOwned 内の他 3 ノードは consumer / producer 関係で pipeline に接続している。
+
+**Architecture Integration**:
+
+- Selected pattern: **declarative consumption of existing kolt test pipeline** — 本 spec は新規 component を作らず、 既存 `kolt test` 経路を kolt.toml で driven する
+- Domain boundaries: 本 spec は kolt.toml schema の consumer 側のみ owner。 schema 自体 (ADR 0032) や test pipeline (`kolt test` 経路) は本 spec の Out of Boundary
+- Existing patterns preserved: ADR 0032 sysprop delivery、 `kolt test` 共通動作、 JUnit 5 + kotlin-test の既存 stack
+- New component rationale: invariant test 1 個のみ (`IcModuleBoundaryInvariantTest`)。 統合 classpath で失われる Gradle module isolation を source-static に補完する目的
+- Steering compliance: ADR 0001 (Result), ADR 0019 §3 (BTA fence) を維持。 本 spec は production code に触らないため、 既存 ADR への影響なし
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Build runtime | kolt 0.16.x | Test invocation host | 既存 `doTest` 経路を消費。 拡張なし |
+| JVM | JDK 25 | Test JVM | 既存 daemon pin。 kolt の `[build] jdk = "25"` を維持 |
+| Test runner | JUnit Platform Console Standalone 1.11.4 | Test discovery + execution | 既存 `ToolManager` 経由で fetch、 `testRunCommand` が argv を組む |
+| Test framework | JUnit Jupiter 5.11.3 + kotlin-test-junit5 (Kotlin 2.3.20) | Test API | Gradle 時代と同 version。 `[test-dependencies]` で明示 pin |
+| Schema | ADR 0032 (`[classpaths]` / `[test.sys_props]`) | Bundle / sysprop declaration | #318 で landed 済 |
+
+詳細な dependency rationale や transitive 確認手順は `research.md` 参照。
+
+## File Structure Plan
+
+### Modified Files
+
+- `kolt-jvm-compiler-daemon/kolt.toml`
+  - `[build] test_sources = ["src/test/kotlin", "ic/src/test/kotlin"]` 追加 (現状は `[]`)
+  - `[test-dependencies]` を新設、 `org.junit.jupiter:junit-jupiter = "5.11.3"` と `org.junit.platform:junit-platform-launcher = "1.11.3"` を pin (Gradle と同 version)
+  - `[classpaths.bta_impl]` / `[classpaths.fixture]` / `[classpaths.serialization_plugin]` / `[classpaths.serialization_runtime]` を 4 bundle 追加
+  - `[test.sys_props]` 6 個を declare (詳細は Components 節)
+- `kolt-native-compiler-daemon/kolt.toml`
+  - `[build] test_sources = ["src/test/kotlin"]` 追加
+  - `[test-dependencies]` で `org.junit.jupiter:junit-jupiter` / `org.junit.platform:junit-platform-launcher` を pin
+- `kolt-jvm-compiler-daemon/kolt.lock` — `kolt deps install` 実行で再生成 (手書き編集なし、 PR diff に含めて review)
+- `kolt-native-compiler-daemon/kolt.lock` — 同上 (PR diff に含めて review)
+- `.kiro/steering/tech.md` — `## Common Commands` の `./gradlew check` 行と `./gradlew linkDebugExecutableLinuxX64` 行、 および周辺の "Special-purpose" 注釈を削除
+
+### Created Files
+
+- `kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/IcModuleBoundaryInvariantTest.kt`
+  - 場所: 既存 `AdapterBoundaryInvariantTest` と同じ root daemon test 配下 (daemon-core の境界 invariant ファミリー)
+  - 責務: ic test source (`kolt-jvm-compiler-daemon/ic/src/test/kotlin/`) を walk し、 `import kolt.daemon.Main`、 `import kolt.daemon.server.`、 `import kolt.daemon.reaper.` のいずれかを含む行があれば fail
+  - 実装パターン: `AdapterBoundaryInvariantTest` の `Files.walk(sourceRoot)` パターンを踏襲、 sysprop `kolt.daemon.icTestSourceRoot` で source root を受ける
+
+> File Structure 観点: 本 spec は kolt の production code path に新規ファイルを追加しない。 daemon 副プロジェクトの declarative file 編集と test 1 個追加のみ。
+
+## System Flows
+
+### Test execution flow (kolt-jvm-compiler-daemon directory)
+
+```mermaid
+sequenceDiagram
+    participant Maintainer
+    participant KoltCli as kolt test
+    participant Resolver as DependencyResolver
+    participant Compiler as JVM compile
+    participant Argv as jvmTestArgv
+    participant TestJvm as JUnit Console Launcher
+
+    Maintainer->>KoltCli: kolt test (cwd=kolt-jvm-compiler-daemon)
+    KoltCli->>Resolver: resolve [dependencies] / [test-dependencies] / [classpaths.*]
+    Resolver-->>KoltCli: BuildResult.bundleClasspaths (4 bundles)
+    KoltCli->>Compiler: compile main (root + ic) + tests (root + ic)
+    Compiler-->>KoltCli: classes / testClasses dirs
+    KoltCli->>Argv: jvmTestArgv(config, projectRoot, bundleClasspaths, ...)
+    Argv->>Argv: resolveSysProps (5 sysprops)
+    Argv-->>KoltCli: argv with -D x5 + classpath + --scan-class-path + testArgs
+    KoltCli->>TestJvm: spawn java -D... -jar console --class-path <cp> --scan-class-path <passthrough>
+    TestJvm-->>Maintainer: pass/fail per test, exit code 0 or non-zero
+```
+
+主要決定:
+
+- `projectRoot = currentWorkingDirectory()` のため、 `[test.sys_props]` の `project_dir` は cwd 起点で resolve される (例: maintainer が `kolt-jvm-compiler-daemon/` で実行 → `project_dir = "src/main/kotlin"` は `kolt-jvm-compiler-daemon/src/main/kotlin` の絶対パス)
+- `testArgs` は argv の末尾に append され、 JUnit Console Launcher に passthrough されるので filter (`--select-class=...`) は `kolt test -- ...` 形式で利用可能 (1.2)
+- `[test.sys_props]` の resolve 順は ADR 0032 の declaration order に従い、 各 sysprop が `-Dkey=value` の独立フラグとして argv に並ぶ
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | root daemon dir で root + ic test 実行 | kolt-jvm-compiler-daemon/kolt.toml の test_sources / test-deps / classpaths / test.sys_props | 既存 jvmTestArgv | Test execution flow |
+| 1.2 | filter passthrough | 既存 testRunCommand の testArgs trailing | `kolt test -- <junit-args>` | passthrough は既存挙動 |
+| 1.3 | native daemon dir で test 実行 | kolt-native-compiler-daemon/kolt.toml の test_sources / test-deps | 既存 jvmTestArgv | Test execution flow |
+| 1.4 | 失敗時 non-zero exit | 既存 doTestInner の Result 経路 | 既存 ExitCode | Test execution flow |
+| 1.5 | 全 pass で zero exit | 同上 | 同上 | 同上 |
+| 1.6 | Gradle と verdict 一致 | 既存 test 本体不変 + 統合 classpath が Gradle 構造と一致 | — | Migration cross-check |
+| 2.1 | bta_impl bundle | `[classpaths.bta_impl]` | ADR 0032 resolver | — |
+| 2.2 | fixture bundle | `[classpaths.fixture]` | 同上 | — |
+| 2.3 | serialization_plugin bundle | `[classpaths.serialization_plugin]` | 同上 | — |
+| 2.4 | serialization_runtime bundle | `[classpaths.serialization_runtime]` | 同上 | — |
+| 2.5 | lockfile への bundle 反映 | `kolt deps install` 既存挙動 | 既存 `resolveBundleClasspaths` | — |
+| 2.6 | bundle 隔離 | ADR 0032 resolver の bundle isolation | 既存挙動 | — |
+| 3.1–3.4 | 4 sysprop delivery | `[test.sys_props]` 4 entries | SysPropResolver / jvmTestArgv | Test execution flow |
+| 3.5 | sysprop arrival semantics | 既存 SysPropResolver | 既存挙動 | — |
+| 4.1 | coreMainSourceRoot declare | `[test.sys_props.kolt.daemon.coreMainSourceRoot] project_dir = "src/main/kotlin"` | ADR 0032 ProjectDir | — |
+| 4.2 | sysprop の絶対 path delivery | 既存 SysPropResolver `project_dir` 解決 | 既存挙動 | — |
+| 4.3 | source root に `.kt` ファイルあり | `kolt-jvm-compiler-daemon/src/main/kotlin/` 既存 | — | — |
+| 5.1 | tech.md の `./gradlew check` 撤去 | `.kiro/steering/tech.md` 編集 | — | — |
+| 5.2 | 他の user / dev surface | 走査済み 0 件 (CI / scripts / CLAUDE.md / SKILL に該当なし) | — | — |
+| 5.3 | historical record 保持 | `.kiro/specs/`、 `docs/adr/`、 `spike/` 内の言及は触らない | — | — |
+| 5.4 | repo-wide grep 0 | 編集後の verify | — | — |
+| 6.1 | 既存 test 本体不変 | `kolt-jvm-compiler-daemon/**/src/test/kotlin/`、 `kolt-native-compiler-daemon/src/test/kotlin/` 既存ファイル不変 | — | — |
+| 6.2 | JUnit / kotlin-test / JDK pin 不変 | `[test-dependencies]` で 5.11.3、 `[kotlin] version = "2.3.20"`、 `[build] jdk = "25"` 維持 | — | — |
+| 6.3 | useJUnitPlatform 等価 | JUnit Console Launcher の `--scan-class-path` が同等 discovery | — | — |
+| 6.4 | Gradle vs kolt verdict 一致 | #316 lands 前の cross-check 期間 | manual cross-run | Migration |
+| 6.5 | invariant test 追加許容 + ic test source root sysprop | `IcModuleBoundaryInvariantTest.kt` (新規 1 ファイル)、 `[test.sys_props.kolt.daemon.icTestSourceRoot] project_dir = "ic/src/test/kotlin"` | source-static walk + ADR 0032 ProjectDir delivery | — |
+
+## Components and Interfaces
+
+### Configuration Layer (declarative)
+
+#### kolt-jvm-compiler-daemon/kolt.toml
+
+| Field | Detail |
+|-------|--------|
+| Intent | 統合 kolt project の test pipeline を declare する |
+| Requirements | 1.1, 1.2, 2.1–2.6, 3.1–3.5, 4.1–4.3, 6.2, 6.3 |
+
+**Responsibilities & Constraints**
+
+- root daemon main + ic main を `sources` に統合 (現状維持)、 `test_sources` を 2 ディレクトリに展開
+- 4 classpath bundle と 6 test sysprop (4 classpath ref + `coreMainSourceRoot` + `icTestSourceRoot`) を declare
+- `[test-dependencies]` で JUnit Jupiter と JUnit Platform Launcher を明示 pin (auto-inject の kotlin-test-junit5 transitive に頼らず、 Gradle 時代と同じ version を直接固定)
+
+**Dependencies**
+
+- Inbound: `loadProjectConfig` → `KoltConfig` (P0)
+- Outbound: ADR 0032 resolver / `jvmTestArgv` (P0)
+- External: Maven Central — JUnit / Kotlin / kotlinx.serialization の resolution (P0)
+
+**Contracts**: State [x]
+
+##### State / Schema
+
+期待される kolt.toml 抜粋 (詳細値は research.md):
+
+```toml
+[build]
+target = "jvm"
+jdk = "25"
+sources = ["src/main/kotlin", "ic/src/main/kotlin"]
+test_sources = ["src/test/kotlin", "ic/src/test/kotlin"]
+
+[test-dependencies]
+"org.junit.jupiter:junit-jupiter" = "5.11.3"
+"org.junit.platform:junit-platform-launcher" = "1.11.3"
+
+[classpaths.bta_impl]
+"org.jetbrains.kotlin:kotlin-build-tools-impl" = "2.3.20"
+
+[classpaths.fixture]
+"org.jetbrains.kotlin:kotlin-stdlib" = "2.3.20"
+
+[classpaths.serialization_plugin]
+"org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable" = "2.3.20"
+
+[classpaths.serialization_runtime]
+"org.jetbrains.kotlin:kotlin-stdlib" = "2.3.20"
+"org.jetbrains.kotlinx:kotlinx-serialization-core-jvm" = "1.7.3"
+
+[test.sys_props]
+"kolt.ic.btaImplClasspath" = { classpath = "bta_impl" }
+"kolt.ic.fixtureClasspath" = { classpath = "fixture" }
+"kolt.ic.serializationPluginClasspath" = { classpath = "serialization_plugin" }
+"kolt.ic.serializationRuntimeClasspath" = { classpath = "serialization_runtime" }
+"kolt.daemon.coreMainSourceRoot" = { project_dir = "src/main/kotlin" }
+"kolt.daemon.icTestSourceRoot" = { project_dir = "ic/src/test/kotlin" }
+```
+
+**Implementation Notes**
+
+- Integration: ADR 0032 resolver / lockfile / sysprop delivery がすべて consume 側を変更不要に組まれているため、 declarative 編集のみで動作する
+- Validation: parse OK のみでは不十分。 `kolt deps install` を回して lockfile が生成されること、 各 bundle の resolved jar が Gradle と同等であることを cross-check する (impl phase)
+- Risks: Maven transitive 解決の Gradle vs kolt 差分 (特に `kotlin-build-tools-impl` の depth)。 差分発覚時は bundle 内に explicit pin を追加、 または resolver の transitive 戦略を寄せる判断 (impl phase で確認)
+
+#### kolt-native-compiler-daemon/kolt.toml
+
+| Field | Detail |
+|-------|--------|
+| Intent | native daemon の test pipeline を declare する |
+| Requirements | 1.3, 1.4, 1.5, 6.2, 6.3 |
+
+**Responsibilities & Constraints**
+
+- `test_sources = ["src/test/kotlin"]` を追加するのみ (sources は現状の 1 ディレクトリ維持)
+- `[test-dependencies]` で JUnit Jupiter / Platform Launcher を pin
+- classpath bundle / sysprop は不要 (native daemon test は sysprop を読まない)
+
+**Dependencies**
+
+- Inbound: `loadProjectConfig` (P0)
+- Outbound: 既存 `jvmTestArgv` 経路 (P0)
+
+**Contracts**: State [x]
+
+##### State / Schema
+
+```toml
+[build]
+target = "jvm"
+jdk = "25"
+sources = ["src/main/kotlin"]
+test_sources = ["src/test/kotlin"]
+
+[test-dependencies]
+"org.junit.jupiter:junit-jupiter" = "5.11.3"
+"org.junit.platform:junit-platform-launcher" = "1.11.3"
+```
+
+**Implementation Notes**
+
+- Integration: 副プロジェクトとして独立で完結、 cross-module 依存なし
+- Validation: 既存 native daemon test 群が全 pass で kolt test 終了 code 0
+- Risks: 低 (sysprop 不要、 bundle 不要、 一直線の test 構成)
+
+### Test Layer (new)
+
+#### IcModuleBoundaryInvariantTest
+
+| Field | Detail |
+|-------|--------|
+| Intent | 統合 kolt project で失われた Gradle module isolation を、 source-static な import 制約 invariant で補完する |
+| Requirements | 6.5 |
+| Owner / Reviewers | (any kolt-on-kolt maintainer) |
+
+**Responsibilities & Constraints**
+
+- ic test source (`kolt-jvm-compiler-daemon/ic/src/test/kotlin/`) 配下の `.kt` ファイルを walk
+- `import kolt.daemon.Main`、 `import kolt.daemon.server.`、 `import kolt.daemon.reaper.` のいずれかの prefix 一致行があれば fail
+- 失敗時メッセージに違反ファイルと行番号を列挙する
+- source root は sysprop `kolt.daemon.icTestSourceRoot` で受ける
+
+**Dependencies**
+
+- Inbound: JUnit Platform discovery (root daemon test compile classpath にあれば自動 pickup) (P0)
+- Outbound: `java.nio.file.Files.walk` (P0)
+- External: なし
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+package kolt.daemon
+
+class IcModuleBoundaryInvariantTest {
+  @Test
+  fun `ic test sources do not import root daemon production packages`() {
+    // sysprop 経由で source root を受け、 walk 結果を assert
+  }
+}
+```
+
+- Preconditions: sysprop `kolt.daemon.icTestSourceRoot` が ic test source root の絶対パスに設定されている
+- Postconditions: 該当 import が 1 件もなければ pass、 1 件以上あれば assertEquals で空リスト期待値との比較で fail
+- Invariants: production code への依存ゼロ (純 source-static)、 flake risk なし
+
+**Implementation Notes**
+
+- Integration: 既存 `AdapterBoundaryInvariantTest` と同 package (`kolt.daemon`) に置く。 Files.walk pattern を踏襲し、 import prefix 配列を変えただけのほぼ同型コード
+- Source root resolution: sysprop `kolt.daemon.icTestSourceRoot` 経由で受ける。 `AdapterBoundaryInvariantTest` が既に sysprop 経由 (`kolt.daemon.coreMainSourceRoot`) で source root を受ける pattern を採用しており、 本 invariant も同 pattern に揃える。 cwd-relative 解決 (例 `Paths.get("ic/src/test/kotlin")`) は `AdapterBoundaryInvariantTest` 側を本 spec で書き換えることになり scope 膨張のため不採用。 invariant test が `[test.sys_props]` delivery 経路に self-referentially 依存する trade-off は既存 invariant test と同じ
+- Validation: 自身が新規追加されることで pass することを確認 (現状 ic test は root daemon production package を import していないことを research.md で確認済)
+- Risks: prefix リストの過不足。 `kolt.daemon` 配下で ic 以外の package が増えたら invariant の prefix も追従が必要
+
+### Documentation Layer
+
+#### tech.md cleanup
+
+| Field | Detail |
+|-------|--------|
+| Intent | `./gradlew check` 言及を user / developer surface から撤去する |
+| Requirements | 5.1, 5.2, 5.3, 5.4 |
+
+**Responsibilities & Constraints**
+
+- `.kiro/steering/tech.md` の `## Common Commands` 内、 Special-purpose ブロック (3 行: `./gradlew check`、 `./gradlew linkDebugExecutableLinuxX64 \\`、 続く `&& ...kolt.kexe build`) を削除
+- ブロック前後の文脈整合 (見出しや空行) を整える
+- 他の user / developer surface には該当行が無いこと (走査済) を verify
+- 履歴 (`.kiro/specs/`、 `docs/adr/`、 `spike/`、 orphan `build.gradle.kts`) は触らない
+
+**Implementation Notes**
+
+- Integration: `tech.md` のみの局所編集
+- Validation: `grep -r "gradlew check" .` を user / dev surface 以外を除外して 0 件であることを cross-check
+- Risks: 低 (機械的な編集)
+
+## Data Models
+
+該当なし。 本 spec は新規 data model を追加せず、 既存 `KoltConfig` / `kolt.lock` schema を消費するのみ。 `kolt.lock` の更新は `kolt deps install` の既存挙動に従う。
+
+## Error Handling
+
+### Error Strategy
+
+- kolt.toml の parse / validation error は既存 `Config.kt` の `Result<KoltConfig, ConfigError>` 経路で表面化。 本 spec は新規 error path を追加しない
+- bundle resolve 失敗、 test compile 失敗、 test JVM spawn 失敗はすべて既存 `doTestInner` の `Result<Unit, Int>` exit code 経路で扱う
+- 新規 invariant test の失敗は通常の JUnit 5 failure (assertEquals が空リストを期待し、 violation list との差分で fail message を提示)
+
+### Monitoring
+
+- `kolt deps install` のログで bundle resolution の transitive 一覧を確認
+- `kolt test` の standard output が JUnit Console Launcher の出力をそのまま流すため、 既存の Gradle 出力との比較が容易
+- `BtaSerializationPluginTest` 等の reflective load failure は JVM stacktrace で表面化、 sysprop 経由の classpath が空 / 不正な場合は `Path.of("")` 系の error で fail
+
+## Testing Strategy
+
+### Pre-flight Gate (impl phase 開始時)
+
+R1.2 の filter passthrough を Goals に含めている以上、 impl phase の最初に以下を gate として確認する。 動作不能と判明した場合は本 spec の前提が崩れるため、 design 側で対処方針を再確定する (Goals の 1.2 を弱めるか、 別経路を新設するか) — 確認できる前に kolt.toml 整備を進めない。
+
+- `kolt test -- --select-class=<FQCN>` 形式で JUnit Platform Console Standalone 1.11.4 が単一 class 実行に絞れることを smoke test
+- `--scan-class-path` の固定挿入と `--select-class` の併用 semantics が JUnit Console Launcher で意図通り (= 後者が前者を絞る) であることを confirm
+- 動作不能時は本 spec を一旦 stop し、 R1.2 の treatment を requirements 側で再確定 (本 spec の Out of Boundary に CLI flag 追加が含まれるため、 別 issue 化して本 spec から外す可能性あり)
+
+### Smoke Tests (manual + CI)
+
+- `cd kolt-jvm-compiler-daemon && kolt test` が root daemon test + ic test の union を全 pass で完了 (1.1, 1.4, 1.5)
+- `cd kolt-native-compiler-daemon && kolt test` が native daemon test を全 pass で完了 (1.3, 1.4, 1.5)
+- `cd kolt-jvm-compiler-daemon && kolt test -- --select-class=PluginTranslatorTest` が ic 単体 test に絞れる (1.2)
+
+### Cross-check Tests (#316 lands 前の期間限定)
+
+- 同じ source tree に対して `./gradlew :kolt-jvm-compiler-daemon:check` と `./gradlew :kolt-jvm-compiler-daemon:ic:check` の verdict union が `cd kolt-jvm-compiler-daemon && kolt test` と一致 (6.4)
+- 同じく `./gradlew :kolt-native-compiler-daemon:check` と `cd kolt-native-compiler-daemon && kolt test` が一致 (6.4)
+
+### Invariant Test (new)
+
+- `IcModuleBoundaryInvariantTest` 自身は ic test source 配下を source-static に走査、 現状 0 件で pass。 import 違反が混入したら fail (6.5)
+
+### Regression Guard
+
+- 既存 daemon test 群 (root: 8 ファイル、 ic: 16 ファイル、 native: 8 ファイル) は本 spec で body 改変なし (6.1)
+- JUnit / kotlin-test / JDK / Kotlin pin は維持 (6.2)
+- test discovery semantics (`useJUnitPlatform()` 相当) は JUnit Console Launcher の `--scan-class-path` で等価 (6.3)
+
+## Migration Strategy
+
+```mermaid
+flowchart LR
+    Now[Current state: ./gradlew check + Gradle subproject layout]
+    SpecDone[本 spec 完了: 統合 kolt.toml + invariant test + tech.md cleanup]
+    Both[Cross-check 期間: ./gradlew check と kolt test 並走]
+    OrphanRemove[#316 完了: orphan Gradle file 物理削除]
+
+    Now --> SpecDone
+    SpecDone --> Both
+    Both --> OrphanRemove
+```
+
+主要決定:
+
+- 本 spec の PR がマージされた時点では orphan Gradle config (`build.gradle.kts` / `settings.gradle.kts` / `gradlew` 等) はまだ残る (#316 待ち)
+- この期間は `./gradlew check` も `kolt test` も両方走らせて verdict 一致を verify する (R6.4)
+- #316 がマージされた時点で `./gradlew check` 経路は失われ、 `kolt test` が唯一の test runner になる
+- 本 spec の PR 本文には Issue #315 文言緩和 (filter 経路への代替) を 1 行明示し、 design.md §Goals / Boundary Commitments を参照リンクとする
+
+## Open Questions / Risks
+
+1. **filter passthrough の動作確認** (Research Item 6 from research.md)
+   - 詳細は Testing Strategy §Pre-flight Gate 参照。 impl 開始時の gate として扱う
+2. **Maven transitive 差分** (Research Item 1 from research.md)
+   - Gradle と kolt resolver で transitive jar 集合が一致するか (特に `kotlin-build-tools-impl:2.3.20` の depth)
+   - 差分発覚時は bundle に explicit pin を追加 (本 spec の対応範囲)
+3. **JVM test argv 等価性** (Research Item 2 from research.md)
+   - `jvmTestArgv` が組む argv と Gradle `tasks.test` の argv の差分 (working directory / -D 順序 / `-cp` 順序 / JDK option)
+   - 既存実装は `currentWorkingDirectory()` を `projectRoot` として使うので、 maintainer が `kolt-jvm-compiler-daemon/` で実行する限り Gradle の `:kolt-jvm-compiler-daemon:test` と同 cwd
+4. **`BtaSerializationPluginTest` の reflective load 安定性** (Research Item from earlier analysis)
+   - serialization compiler plugin を URLClassLoader で reflective load する経路が、 統合 classpath 環境下でも Gradle 時代と同じ ordering / file 位置で動作するか
+   - serialization_plugin bundle と serialization_runtime bundle の jar 位置が `[classpaths]` resolver で安定的に解決されることを確認
+
+## Supporting References
+
+- ADR 0032 — `[classpaths.<name>]` / `[test.sys_props]` schema (parser / resolver / lockfile / sysprop delivery)
+- ADR 0019 §3 — daemon-core が `kolt.buildtools.*` を import しない invariant (既存 `AdapterBoundaryInvariantTest` の根拠)
+- `research.md` — Option A vs B 判断経緯、 Maven transitive 差分のリサーチ計画、 ic sysprop / import confirmations
+- `requirements.md` — 6 Requirements、 Boundary Context (in scope / out of scope / adjacent expectations)
+- Issue #315 — DoD 文言と本 design の "from its own directory" 緩和判断の対比

--- a/.kiro/specs/daemon-test-via-kolt/design.md
+++ b/.kiro/specs/daemon-test-via-kolt/design.md
@@ -17,13 +17,14 @@
 - root daemon test の `kolt.daemon.coreMainSourceRoot` sysprop が `[test.sys_props]` の `project_dir` 経由で届く (4)
 - `./gradlew check` 言及を user / developer surface から撤去 (5)
 - 既存 daemon test 本体に手を入れず、 source-static invariant test 1 つで test classpath isolation の文化的代替を確保 (6)
+- kolt CLI の JVM test compile path に `-module-name` / `-Xfriend-paths` を forward する bug fix (7)。 impl 中に発見、 Gradle parity (R1.1 / R1.4 / R1.5 / R6.4) を満たすための前提条件で本 spec の DoD と直結する
 
 ### Non-Goals
 
 - orphan な Gradle 設定ファイル (`build.gradle.kts`、 `settings.gradle.kts`、 `gradlew`、 `gradle/wrapper/`) の物理削除 — #316 で別途対応
 - `./gradlew linkDebugExecutableLinuxX64` 等価レシピの提供 — vestigial、 #316
 - multi-module project 機能 (#4) への統合 — 本 spec は ic を独立 kolt project にしないため、 path-based dep schema は導入しない
-- kolt CLI / schema の新機能追加 — 今回は ADR 0032 の適用のみ
+- kolt CLI / schema の **新機能追加** (= 新しい API / コマンド / オプション)。 既存挙動の bug fix (R7 が代表例) は本 spec で必要に応じて含める
 - daemon test 範囲拡張 — Gradle 集合と同一を保つ (新規 invariant test は ic test の import 制約 assert のみ、 source-static で flake risk なし)
 - `kolt-jvm-compiler-daemon/ic/` directory 単体での `kolt test` 実行サポート — 1.2 の filter 経路で代替
 
@@ -35,6 +36,7 @@
 - `kolt-native-compiler-daemon/kolt.toml` の test 関連セクション (`[build] test_sources`、 `[test-dependencies]`)
 - 各副プロジェクトの `kolt.lock` の test / classpaths 部分 (`kolt deps install` 再生成によって更新)
 - 1 個の新規 invariant test ファイル: ic test の import 制約 (`kolt.daemon.{Main,server,reaper,...}` を ic test source が import していないこと) を source-static に assert
+- kolt CLI の JVM test compile bug fix (R7): `src/nativeMain/kotlin/kolt/build/TestBuilder.kt` の argv に `-module-name <project-name>` と `-Xfriend-paths=<main-classes-dir>` を追加、 `src/nativeMain/kotlin/kolt/build/SubprocessCompilerBackend.kt` の subprocess 経路で `request.moduleName` を `-module-name` として forward。 関連 native test を `src/nativeTest/kotlin/kolt/build/` に追加
 - `.kiro/steering/tech.md` の `## Common Commands` にある `./gradlew check` 行とその Special-purpose 注釈の撤去
 - 本 spec の design 判断 (Option B 採用 / "from its own directory" 緩和) を PR 本文と本 design.md で明示
 
@@ -67,6 +69,7 @@
 - daemon の Kotlin / JDK pin 変更
 - `autoInjectedTestDeps` の対象 dep 変更
 - `currentWorkingDirectory()` を起点にする projectRoot の semantic 変更
+- Kotlin compiler の `-module-name` / `-Xfriend-paths` flag の名称変更や semantics 変更 (R7 が依拠する)
 
 ## Architecture
 
@@ -158,6 +161,10 @@ graph TB
 - `kolt-jvm-compiler-daemon/kolt.lock` — `kolt deps install` 実行で再生成 (手書き編集なし、 PR diff に含めて review)
 - `kolt-native-compiler-daemon/kolt.lock` — 同上 (PR diff に含めて review)
 - `.kiro/steering/tech.md` — `## Common Commands` の `./gradlew check` 行と `./gradlew linkDebugExecutableLinuxX64` 行、 および周辺の "Special-purpose" 注釈を削除
+- `src/nativeMain/kotlin/kolt/build/TestBuilder.kt` — `testBuildCommand` の argv に `-module-name <project-name>` と `-Xfriend-paths=<classesDir>` を追加 (R7)
+- `src/nativeMain/kotlin/kolt/build/SubprocessCompilerBackend.kt` — `subprocessArgv` の argv に `-module-name <moduleName>` を forward (R7)、 line 29 の "intentionally not forwarded" コメントを更新
+- `src/nativeTest/kotlin/kolt/build/TestBuilderTest.kt` (or 既存 TestRunnerTest.kt と同階層の新 file) — argv に新 flag が含まれることを assert する unit test を追加 (R7.5)
+- `src/nativeTest/kotlin/kolt/build/` 内の subprocess argv 関連既存 test に `-module-name` forward を assert する case を追加 (R7.5)
 
 ### Created Files
 
@@ -229,6 +236,11 @@ sequenceDiagram
 | 6.3 | useJUnitPlatform 等価 | JUnit Console Launcher の `--scan-class-path` が同等 discovery | — | — |
 | 6.4 | Gradle vs kolt verdict 一致 | #316 lands 前の cross-check 期間 | manual cross-run | Migration |
 | 6.5 | invariant test 追加許容 + ic test source root sysprop | `IcModuleBoundaryInvariantTest.kt` (新規 1 ファイル)、 `[test.sys_props.kolt.daemon.icTestSourceRoot] project_dir = "ic/src/test/kotlin"` | source-static walk + ADR 0032 ProjectDir delivery | — |
+| 7.1 | test compile に `-module-name` forward | `TestBuilder.kt` の `testBuildCommand` 改修 | kotlinc CLI flag `-module-name <project-name>` | — |
+| 7.2 | test compile に `-Xfriend-paths` forward | 同上 | kotlinc CLI flag `-Xfriend-paths=<classesDir>` | — |
+| 7.3 | subprocess main compile の `-module-name` forward | `SubprocessCompilerBackend.kt` の `subprocessArgv` 改修 | kotlinc CLI flag `-module-name <moduleName>` | — |
+| 7.4 | `internal` access from test source set | 7.1-7.3 の効果として実現 | — | Test execution flow |
+| 7.5 | argv shape を assert する native unit test | `src/nativeTest/kotlin/kolt/build/` に新 / 拡張 test | kotlin.test | — |
 
 ## Components and Interfaces
 
@@ -386,6 +398,52 @@ class IcModuleBoundaryInvariantTest {
 - Source root resolution: sysprop `kolt.daemon.icTestSourceRoot` 経由で受ける。 `AdapterBoundaryInvariantTest` が既に sysprop 経由 (`kolt.daemon.coreMainSourceRoot`) で source root を受ける pattern を採用しており、 本 invariant も同 pattern に揃える。 cwd-relative 解決 (例 `Paths.get("ic/src/test/kotlin")`) は `AdapterBoundaryInvariantTest` 側を本 spec で書き換えることになり scope 膨張のため不採用。 invariant test が `[test.sys_props]` delivery 経路に self-referentially 依存する trade-off は既存 invariant test と同じ
 - Validation: 自身が新規追加されることで pass することを確認 (現状 ic test は root daemon production package を import していないことを research.md で確認済)
 - Risks: prefix リストの過不足。 `kolt.daemon` 配下で ic 以外の package が増えたら invariant の prefix も追従が必要
+
+### Foundation Layer (kolt CLI bug fix)
+
+#### CLI Test Compile Module-Name Alignment
+
+| Field | Detail |
+|-------|--------|
+| Intent | kolt CLI の JVM test compile が main と同じ Kotlin module 名で compile されるようにし、 test source set が main の `internal` symbol にアクセス可能にする (Gradle Kotlin plugin と同等の挙動) |
+| Requirements | 7.1, 7.2, 7.3, 7.4, 7.5 |
+
+**Responsibilities & Constraints**
+
+- `testBuildCommand` の kotlinc argv に `-module-name <KoltConfig.name>` と `-Xfriend-paths=<CLASSES_DIR>` を追加 (line 9-36 の `testBuildCommand` 関数 signature には既に `config` と `classesDir` がある)
+- `subprocessArgv` の kotlinc argv に `-module-name <request.moduleName>` を forward (line 29 の「moduleName intentionally not forwarded」 コメントは同時に削除)
+- daemon path (`DaemonCompilerBackend.kt:277` 周辺) は既に `moduleName` を forward しているため改修不要、 subprocess path のみ修正
+- 改修後、 daemon path / subprocess path のどちらでも main と test が同じ Kotlin module として compile される
+- Kotlin compiler の `internal` semantics 仕様 (`-module-name` 一致 + `-Xfriend-paths` で friend module 認定) に依拠
+
+**Dependencies**
+
+- Inbound: 既存 `doBuildInner` / `doTestInner` 経路 (P0)
+- Outbound: kotlinc CLI (Kotlin 2.3.20 など、 既存 toolchain) (P0)
+- External: Kotlin compiler の `-module-name` / `-Xfriend-paths` flag 仕様 (P0)
+
+**Contracts**: Service [x]
+
+##### Argv Contract
+
+`testBuildCommand` の出力 argv に以下が含まれる:
+
+```
+-module-name <config.name>
+-Xfriend-paths=<classesDir>
+```
+
+`subprocessArgv` の出力 argv に以下が含まれる (target=jvm のとき):
+
+```
+-module-name <request.moduleName>
+```
+
+**Implementation Notes**
+
+- Integration: 既存の argv builder 関数 signature を変えず、 既存 parameter (`config`、 `classesDir`、 `request.moduleName`) を消費する形で flag を追加するだけ
+- Validation: native unit test (`src/nativeTest/kotlin/kolt/build/`) で argv 内に新 flag が含まれることを assert、 さらに本 spec の task 5.1 / 5.4 で daemon test compile が `internal` access error なく成功することを e2e 確認
+- Risks: `-Xfriend-paths` は internal/private API 扱いだが Kotlin 1.x 系から安定して存在、 Gradle Kotlin plugin / IntelliJ で広く使われている。 値は **main classes 出力 dir** (例 `build/<profile>/classes`) で source dir ではない点に注意 (debug subagent 由来のメモ)。 `-Xfriend-paths` は internal flag なので将来 Kotlin major bump で名称が変わる可能性あり、 その時は `[Revalidation Triggers]` で検出される
 
 ### Documentation Layer
 

--- a/.kiro/specs/daemon-test-via-kolt/design.md
+++ b/.kiro/specs/daemon-test-via-kolt/design.md
@@ -12,7 +12,7 @@
 
 - `kolt-jvm-compiler-daemon/` directory での `kolt test` が root daemon test と ic test の union を Gradle 同等の verdict で実行できる (1.1, 1.4–1.6)
 - `kolt-native-compiler-daemon/` directory での `kolt test` が native daemon test を Gradle 同等の verdict で実行できる (1.3)
-- ic 単体実行は JUnit Console Launcher の filter passthrough (`kolt test -- --select-class=...`) で代替可能 (1.2)
+- ic 単体実行は **#323 lands まで一時的に DX 劣化を許容** (1.2 deferred)。 元案の filter passthrough 案は impl phase の Pre-flight Gate で動作不能を確認 (`testRunCommand` が `--scan-class-path` を固定挿入、 JUnit Console Launcher 1.11.4 が explicit selector との併用を reject)、 修正は kolt CLI 側のため別 issue #323 に分離
 - ic test が必要とする 4 classpath bundle と 5 sysprop が ADR 0032 schema で表現され、 同等の jar / path が test JVM に届く (2, 3)
 - root daemon test の `kolt.daemon.coreMainSourceRoot` sysprop が `[test.sys_props]` の `project_dir` 経由で届く (4)
 - `./gradlew check` 言及を user / developer surface から撤去 (5)
@@ -204,7 +204,7 @@ sequenceDiagram
 | Requirement | Summary | Components | Interfaces | Flows |
 |-------------|---------|------------|------------|-------|
 | 1.1 | root daemon dir で root + ic test 実行 | kolt-jvm-compiler-daemon/kolt.toml の test_sources / test-deps / classpaths / test.sys_props | 既存 jvmTestArgv | Test execution flow |
-| 1.2 | filter passthrough | 既存 testRunCommand の testArgs trailing | `kolt test -- <junit-args>` | passthrough は既存挙動 |
+| 1.2 | filter passthrough (deferred → #323) | — | — | Pre-flight Gate 結果に基づき本 spec から外す |
 | 1.3 | native daemon dir で test 実行 | kolt-native-compiler-daemon/kolt.toml の test_sources / test-deps | 既存 jvmTestArgv | Test execution flow |
 | 1.4 | 失敗時 non-zero exit | 既存 doTestInner の Result 経路 | 既存 ExitCode | Test execution flow |
 | 1.5 | 全 pass で zero exit | 同上 | 同上 | 同上 |
@@ -429,13 +429,11 @@ class IcModuleBoundaryInvariantTest {
 
 ## Testing Strategy
 
-### Pre-flight Gate (impl phase 開始時)
+### Pre-flight Gate (impl phase 実施結果: 動作不能 → #323 へ deferred)
 
-R1.2 の filter passthrough を Goals に含めている以上、 impl phase の最初に以下を gate として確認する。 動作不能と判明した場合は本 spec の前提が崩れるため、 design 側で対処方針を再確定する (Goals の 1.2 を弱めるか、 別経路を新設するか) — 確認できる前に kolt.toml 整備を進めない。
+実施結果 (2026-05-01): JUnit Platform Console Launcher 1.11.4 が `--scan-class-path` と explicit selector (`--select-class` 等) の併用を reject するため、 `kolt test -- --select-class=<FQCN>` 経由の filter は **動作不能**。 `testRunCommand` の `--scan-class-path` 固定挿入を抑止する条件分岐が必要だが、 これは kolt CLI 側の change で本 spec の Out of Boundary に該当するため、 follow-up issue **#323** に分離。
 
-- `kolt test -- --select-class=<FQCN>` 形式で JUnit Platform Console Standalone 1.11.4 が単一 class 実行に絞れることを smoke test
-- `--scan-class-path` の固定挿入と `--select-class` の併用 semantics が JUnit Console Launcher で意図通り (= 後者が前者を絞る) であることを confirm
-- 動作不能時は本 spec を一旦 stop し、 R1.2 の treatment を requirements 側で再確定 (本 spec の Out of Boundary に CLI flag 追加が含まれるため、 別 issue 化して本 spec から外す可能性あり)
+R1.2 を deferred 扱いとし、 本 spec では filter 経由の単体実行 DX を一時的に放棄する。 ic / root-only の試走は `kolt-jvm-compiler-daemon/` で全 test 実行する形で代替する。
 
 ### Smoke Tests (manual + CI)
 
@@ -481,8 +479,7 @@ flowchart LR
 
 ## Open Questions / Risks
 
-1. **filter passthrough の動作確認** (Research Item 6 from research.md)
-   - 詳細は Testing Strategy §Pre-flight Gate 参照。 impl 開始時の gate として扱う
+1. ~~**filter passthrough の動作確認**~~ — 解決済 (動作不能と確認、 #323 で別途対応)
 2. **Maven transitive 差分** (Research Item 1 from research.md)
    - Gradle と kolt resolver で transitive jar 集合が一致するか (特に `kotlin-build-tools-impl:2.3.20` の depth)
    - 差分発覚時は bundle に explicit pin を追加 (本 spec の対応範囲)

--- a/.kiro/specs/daemon-test-via-kolt/requirements.md
+++ b/.kiro/specs/daemon-test-via-kolt/requirements.md
@@ -1,0 +1,104 @@
+# Requirements Document
+
+## Introduction
+
+本機能は kolt の daemon 副プロジェクト 3 個 (`kolt-jvm-compiler-daemon`、 `kolt-jvm-compiler-daemon/ic`、 `kolt-native-compiler-daemon`) の JUnit 5 テスト集合を `kolt test` で実行可能にし、 user-facing / developer-facing surface から `./gradlew check` 参照を撤去する。
+
+`./gradlew check` は #298 / #302 / #306 後に残った最後の Gradle 依存レシピで、 `tech.md` に「special-purpose」として annotated されている。 本 spec の完了をもって kolt-on-kolt 開発フローから Gradle が完全に消える (orphan ファイル物理削除は #316 で別途対応)。
+
+スキーマ面の前提は #318 (PR #321) で landed 済の ADR 0032 (`[classpaths.<name>]` + `[test.sys_props]` + `[run.sys_props]`) に依拠する。
+
+## Boundary Context
+
+- **In scope**:
+  - `kolt-jvm-compiler-daemon/` および `kolt-native-compiler-daemon/` の各 directory から `kolt test` を実行することで全 daemon JUnit 5 テスト集合が走る状態の確立 (root daemon と ic は同一の kolt project として統合運用、 design phase で確定)
+  - ic テストが必要とする 4 つの classpath bundle と、 root daemon テストが必要とする 1 つの project-relative path の declaration を ADR 0032 schema で表現
+  - `[test.sys_props]` 経由で 5 個のシステムプロパティ (4 classpath + 1 project_dir) が test JVM に届くことの保証
+  - ic test と root daemon test を統合 kolt project で実行する際の test classpath isolation を補完する mechanism (例えば「ic test source が `kolt.daemon.{Main,server,reaper}` を import していない」 ことを source 解析で assert する新規 invariant test の追加) — Gradle module 境界の文化的な代替を確立する
+  - 既存 user-facing / developer-facing surface (`tech.md`、 関連 SKILL / docs) から `./gradlew check` 言及の撤去
+  - 既存 daemon テストロジックを変更せず、 同一テスト結果を保つこと
+- **Out of scope**:
+  - orphan な Gradle 設定ファイル (`build.gradle.kts`、 `settings.gradle.kts`、 `gradlew`、 `gradle/wrapper/`) の物理削除 (#316)
+  - `./gradlew linkDebugExecutableLinuxX64` 等価レシピの提供 (vestigial、 #316)
+  - multi-module project 機能 (#4) への統合 (Option B 採用により ic を独立 kolt project にしないため、 path-based dep schema は本 spec で導入しない)
+  - kolt CLI / schema の新機能追加 (今回は ADR 0032 の適用のみ)
+  - daemon 副プロジェクトの test 範囲拡張 (Gradle 集合と同一を保つ。 invariant test の新規追加は `ic test の import 制約` を assert する目的に限る)
+  - `kolt-jvm-compiler-daemon/ic/` directory 単体での `kolt test` 実行サポート (Requirement 1.2 の filter 経路で代替)
+- **Adjacent expectations**:
+  - ADR 0032 で定義された `[classpaths.<name>]` / `[test.sys_props]` の挙動 (resolver / lockfile / sysprop delivery) はそのまま流用する
+  - `kolt test` 共通の挙動 (target / kind / build profile / exit code) はそのまま流用する
+  - daemon 副プロジェクトの bootstrap / build 経路 (`kolt build`) は既存どおりで、 本 spec では変更しない
+  - CI workflow は既に `./gradlew check` を呼んでおらず、 self-host smoke も daemon test を直接走らせていないため、 CI 経路の変更はスコープ外
+
+## Requirements
+
+### Requirement 1: Daemon JUnit 5 suites run via `kolt test`
+
+**Objective:** As a kolt-on-kolt maintainer, I want every daemon's JUnit 5 test suite to be runnable via `kolt test`, so that I can verify daemon changes without invoking Gradle.
+
+#### Acceptance Criteria
+
+1. When the maintainer runs `kolt test` from the `kolt-jvm-compiler-daemon/` directory, the kolt test runner shall execute the union of every JUnit 5 test that `./gradlew :kolt-jvm-compiler-daemon:check` and `./gradlew :kolt-jvm-compiler-daemon:ic:check` exercise today (i.e. tests currently under `kolt-jvm-compiler-daemon/src/test/kotlin/` and `kolt-jvm-compiler-daemon/ic/src/test/kotlin/`).
+2. The kolt test runner shall accept a passthrough argument form (e.g. `kolt test -- <junit-console-launcher-args>`) that lets the maintainer narrow execution to a single class or package, so that the ic-only and root-daemon-only test runs `./gradlew :kolt-jvm-compiler-daemon:ic:test --tests <Class>` and `./gradlew :kolt-jvm-compiler-daemon:test --tests <Class>` previously offered have an equivalent way to be reproduced. The exact passthrough syntax is settled in design; this criterion only requires that *some* documented mechanism exists to filter to a subset of the suite from criterion 1.
+3. When the maintainer runs `kolt test` from the `kolt-native-compiler-daemon/` directory, the kolt test runner shall execute every JUnit 5 test that `./gradlew :kolt-native-compiler-daemon:check` exercises today (i.e. tests currently under `kolt-native-compiler-daemon/src/test/kotlin/`).
+4. If any test in the suites covered by criteria 1 and 3 fails, the kolt test runner shall exit with a non-zero status code.
+5. When every test in the suites covered by criteria 1 and 3 passes, the kolt test runner shall exit with status code zero.
+6. The kolt test runner shall produce the same set of pass / fail outcomes that the corresponding `./gradlew :<subproject>:check` invocations produce against the same source tree, treating the criterion-1 union as equivalent to the union of `./gradlew :kolt-jvm-compiler-daemon:check` and `./gradlew :kolt-jvm-compiler-daemon:ic:check`.
+
+### Requirement 2: Classpath bundles for ic test fixtures
+
+**Objective:** As a kolt-on-kolt maintainer, I want the ic subproject's four Gradle-resolved classpath bundles declared in `kolt.toml` using ADR 0032 schema, so that the ic test JVM receives the same jar sets it currently receives via Gradle custom configurations.
+
+#### Acceptance Criteria
+
+1. The kolt configuration that backs the ic subproject's `kolt test` shall declare a named classpath bundle resolving to the same artifact set that the Gradle `buildToolsImpl` configuration resolves today (currently `org.jetbrains.kotlin:kotlin-build-tools-impl:2.3.20` and its transitive closure under the same Maven Central resolution policy).
+2. The kolt configuration that backs the ic subproject's `kolt test` shall declare a named classpath bundle resolving to the same artifact set that the Gradle `fixtureClasspath` configuration resolves today (currently `org.jetbrains.kotlin:kotlin-stdlib:2.3.20` and its transitive closure).
+3. The kolt configuration that backs the ic subproject's `kolt test` shall declare a named classpath bundle resolving to the same artifact set that the Gradle `serializationPluginClasspath` configuration resolves today (currently `org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable:2.3.20` and its transitive closure).
+4. The kolt configuration that backs the ic subproject's `kolt test` shall declare a named classpath bundle resolving to the same artifact set that the Gradle `serializationRuntimeClasspath` configuration resolves today (currently `org.jetbrains.kotlin:kotlin-stdlib:2.3.20` plus `org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.7.3` and their transitive closure).
+5. When `kolt deps install` is run against the ic subproject's kolt project, the kolt resolver shall persist the four bundles' locked GAV+SHA into `kolt.lock` per ADR 0032 Requirement 4.
+6. The four bundles' contents shall remain isolated from `[dependencies]` and `[test-dependencies]` of the same kolt project: a transitive coming through any of the four bundles shall not silently appear on the main / test classpath unless explicitly declared there.
+
+### Requirement 3: System property delivery to ic test JVM
+
+**Objective:** As an ic test author, I want the four classpath bundles delivered to the test JVM under the same system-property keys the existing Gradle `tasks.test` block uses, so that test code reading `System.getProperty(...)` continues to function unchanged.
+
+#### Acceptance Criteria
+
+1. When `kolt test` spawns the ic test JVM, the kolt test runner shall set `-Dkolt.ic.btaImplClasspath=<value>` where `<value>` is the colon-joined sequence of absolute paths to every jar in the bundle declared per Requirement 2.1.
+2. When `kolt test` spawns the ic test JVM, the kolt test runner shall set `-Dkolt.ic.fixtureClasspath=<value>` where `<value>` is the colon-joined sequence of absolute paths to every jar in the bundle declared per Requirement 2.2.
+3. When `kolt test` spawns the ic test JVM, the kolt test runner shall set `-Dkolt.ic.serializationPluginClasspath=<value>` where `<value>` is the colon-joined sequence of absolute paths to every jar in the bundle declared per Requirement 2.3.
+4. When `kolt test` spawns the ic test JVM, the kolt test runner shall set `-Dkolt.ic.serializationRuntimeClasspath=<value>` where `<value>` is the colon-joined sequence of absolute paths to every jar in the bundle declared per Requirement 2.4.
+5. The four sysprop values shall arrive at `System.getProperty(...)` with the same semantics ic test code currently expects: each value is a non-empty colon-joined classpath string, every path resolves to an existing jar file on disk, and order matches declaration order in the bundle.
+
+### Requirement 4: Source-root system property for adapter boundary invariant
+
+**Objective:** As a daemon-core maintainer, I want `AdapterBoundaryInvariantTest` to receive the daemon-core main source root path through `kolt.toml`-declared sysprop, so that ADR 0019 §3 enforcement keeps working without Gradle's `layout.projectDirectory.dir(...)` helper.
+
+#### Acceptance Criteria
+
+1. The kolt configuration that backs the `kolt-jvm-compiler-daemon` daemon-core test shall declare an entry in `[test.sys_props]` whose key is `kolt.daemon.coreMainSourceRoot` and whose value resolves to the absolute filesystem path of `kolt-jvm-compiler-daemon/src/main/kotlin`.
+2. When `kolt test` spawns the daemon-core test JVM, the kolt test runner shall set `-Dkolt.daemon.coreMainSourceRoot=<absolute-path>` per ADR 0032 Requirement 3 `project_dir` semantics.
+3. The kolt test runner shall produce a sysprop value that points to an existing directory containing `.kt` files, such that `AdapterBoundaryInvariantTest` walks the same source root it walks today under Gradle.
+
+### Requirement 5: Removal of `./gradlew check` references from documentation surfaces
+
+**Objective:** As a contributor reading project docs, I want `./gradlew check` no longer presented as a development recipe, so that the kolt-on-kolt workflow is consistent across all guidance.
+
+#### Acceptance Criteria
+
+1. The kolt project shall remove the `./gradlew check` line and its surrounding "Special-purpose" annotation from `.kiro/steering/tech.md`.
+2. The kolt project shall remove or replace any other occurrence of `./gradlew check` in `CLAUDE.md`, `.kiro/steering/`, `.claude/skills/kolt-*/`, and `docs/` such that no user-facing or developer-facing surface continues to recommend the recipe.
+3. The kolt project shall keep `./gradlew check` references that exist purely as historical record (specs / ADRs / spike directories that document past decisions); these are not user-facing recipes.
+4. After this requirement is satisfied, a repository-wide search for `gradlew check` shall yield zero matches in user-facing or developer-facing surfaces (excluding historical record locations enumerated in 5.3 and orphan Gradle config files retained for #316).
+
+### Requirement 6: Behavioural parity with existing test suite
+
+**Objective:** As a kolt-on-kolt maintainer, I want the migration to leave existing daemon test logic untouched, so that any post-migration test failure pinpoints the runner switch and not a behavioural drift in the test code.
+
+#### Acceptance Criteria
+
+1. The kolt project shall not modify the body of any existing `kolt-jvm-compiler-daemon/**/src/test/kotlin/**/*.kt` or `kolt-native-compiler-daemon/src/test/kotlin/**/*.kt` file as part of this spec's implementation, except for changes required strictly to receive sysprop values previously injected by Gradle (Requirements 3 and 4).
+2. The kolt project shall keep the JUnit 5 platform version, kotlin-test version, and JDK toolchain (currently JDK 25) unchanged for daemon test execution.
+3. The kolt project shall keep test-discovery semantics equivalent to `useJUnitPlatform()` so that the same test classes are picked up under `kolt test` as under `./gradlew :<subproject>:test`.
+4. When run on the same source tree, `./gradlew check` (against the orphan Gradle config retained for #316) and `kolt test` against the new kolt configuration shall, until #316 lands, produce the same green / red verdict on the daemon test suites — treating the kolt-side `kolt test` invocation in `kolt-jvm-compiler-daemon/` as equivalent to the union of `./gradlew :kolt-jvm-compiler-daemon:check` and `./gradlew :kolt-jvm-compiler-daemon:ic:check`.
+5. The kolt project may add new test files under the daemon test source roots whose sole purpose is to encode the test-classpath isolation invariant lost in the merger of root daemon and ic into a single kolt project (e.g. asserting ic test sources do not import `kolt.daemon.{Main,server,reaper}` packages). Such additions are permitted only when their failure mode is statically derivable from source code (no production-code dependency, no flake risk).

--- a/.kiro/specs/daemon-test-via-kolt/requirements.md
+++ b/.kiro/specs/daemon-test-via-kolt/requirements.md
@@ -23,7 +23,7 @@
   - multi-module project 機能 (#4) への統合 (Option B 採用により ic を独立 kolt project にしないため、 path-based dep schema は本 spec で導入しない)
   - kolt CLI / schema の新機能追加 (今回は ADR 0032 の適用のみ)
   - daemon 副プロジェクトの test 範囲拡張 (Gradle 集合と同一を保つ。 invariant test の新規追加は `ic test の import 制約` を assert する目的に限る)
-  - `kolt-jvm-compiler-daemon/ic/` directory 単体での `kolt test` 実行サポート (Requirement 1.2 の filter 経路で代替)
+  - `kolt-jvm-compiler-daemon/ic/` directory 単体での `kolt test` 実行サポート (本 spec の元案では Requirement 1.2 の filter 経路で代替する想定だったが、 Pre-flight Gate で filter 経路自体も動作不能と判明、 fix を #323 へ defer。 本 spec では ic-only / root-only DX 自体を一時的に犠牲にする)
 - **Adjacent expectations**:
   - ADR 0032 で定義された `[classpaths.<name>]` / `[test.sys_props]` の挙動 (resolver / lockfile / sysprop delivery) はそのまま流用する
   - `kolt test` 共通の挙動 (target / kind / build profile / exit code) はそのまま流用する
@@ -39,7 +39,7 @@
 #### Acceptance Criteria
 
 1. When the maintainer runs `kolt test` from the `kolt-jvm-compiler-daemon/` directory, the kolt test runner shall execute the union of every JUnit 5 test that `./gradlew :kolt-jvm-compiler-daemon:check` and `./gradlew :kolt-jvm-compiler-daemon:ic:check` exercise today (i.e. tests currently under `kolt-jvm-compiler-daemon/src/test/kotlin/` and `kolt-jvm-compiler-daemon/ic/src/test/kotlin/`).
-2. The kolt test runner shall accept a passthrough argument form (e.g. `kolt test -- <junit-console-launcher-args>`) that lets the maintainer narrow execution to a single class or package, so that the ic-only and root-daemon-only test runs `./gradlew :kolt-jvm-compiler-daemon:ic:test --tests <Class>` and `./gradlew :kolt-jvm-compiler-daemon:test --tests <Class>` previously offered have an equivalent way to be reproduced. The exact passthrough syntax is settled in design; this criterion only requires that *some* documented mechanism exists to filter to a subset of the suite from criterion 1.
+2. **Deferred to #323**: The kolt test runner shall accept a passthrough argument form (e.g. `kolt test -- <junit-console-launcher-args>`) that lets the maintainer narrow execution to a single class or package. Pre-flight Gate during impl confirmed this is currently impossible because `testRunCommand` injects `--scan-class-path` unconditionally and JUnit Platform Console Launcher 1.11.4 rejects scanning together with explicit selectors. The fix lives in kolt CLI (TestRunner argv builder) and is tracked in issue #323. Until #323 lands, ic-only and root-daemon-only test runs are not supported via filter; maintainers reproduce them by running the full suite from `kolt-jvm-compiler-daemon/`.
 3. When the maintainer runs `kolt test` from the `kolt-native-compiler-daemon/` directory, the kolt test runner shall execute every JUnit 5 test that `./gradlew :kolt-native-compiler-daemon:check` exercises today (i.e. tests currently under `kolt-native-compiler-daemon/src/test/kotlin/`).
 4. If any test in the suites covered by criteria 1 and 3 fails, the kolt test runner shall exit with a non-zero status code.
 5. When every test in the suites covered by criteria 1 and 3 passes, the kolt test runner shall exit with status code zero.

--- a/.kiro/specs/daemon-test-via-kolt/requirements.md
+++ b/.kiro/specs/daemon-test-via-kolt/requirements.md
@@ -21,7 +21,7 @@
   - orphan な Gradle 設定ファイル (`build.gradle.kts`、 `settings.gradle.kts`、 `gradlew`、 `gradle/wrapper/`) の物理削除 (#316)
   - `./gradlew linkDebugExecutableLinuxX64` 等価レシピの提供 (vestigial、 #316)
   - multi-module project 機能 (#4) への統合 (Option B 採用により ic を独立 kolt project にしないため、 path-based dep schema は本 spec で導入しない)
-  - kolt CLI / schema の新機能追加 (今回は ADR 0032 の適用のみ)
+  - kolt CLI / schema の **新機能追加** (= 新しい API / コマンド / オプションの追加。 既存挙動の bug fix は本 spec で必要に応じて含める。 R7 が代表例: 既存 test compile path の `-module-name` / `-Xfriend-paths` 欠落を修正、 これは Gradle parity を満たすための bug fix で新機能ではない)
   - daemon 副プロジェクトの test 範囲拡張 (Gradle 集合と同一を保つ。 invariant test の新規追加は `ic test の import 制約` を assert する目的に限る)
   - `kolt-jvm-compiler-daemon/ic/` directory 単体での `kolt test` 実行サポート (本 spec の元案では Requirement 1.2 の filter 経路で代替する想定だったが、 Pre-flight Gate で filter 経路自体も動作不能と判明、 fix を #323 へ defer。 本 spec では ic-only / root-only DX 自体を一時的に犠牲にする)
 - **Adjacent expectations**:
@@ -102,3 +102,17 @@
 3. The kolt project shall keep test-discovery semantics equivalent to `useJUnitPlatform()` so that the same test classes are picked up under `kolt test` as under `./gradlew :<subproject>:test`.
 4. When run on the same source tree, `./gradlew check` (against the orphan Gradle config retained for #316) and `kolt test` against the new kolt configuration shall, until #316 lands, produce the same green / red verdict on the daemon test suites — treating the kolt-side `kolt test` invocation in `kolt-jvm-compiler-daemon/` as equivalent to the union of `./gradlew :kolt-jvm-compiler-daemon:check` and `./gradlew :kolt-jvm-compiler-daemon:ic:check`.
 5. The kolt project may add new test files under the daemon test source roots whose sole purpose is to encode the test-classpath isolation invariant lost in the merger of root daemon and ic into a single kolt project (e.g. asserting ic test sources do not import `kolt.daemon.{Main,server,reaper}` packages). Such additions are permitted only when their failure mode is statically derivable from source code (no production-code dependency, no flake risk).
+
+### Requirement 7: kolt CLI test compile module-name alignment
+
+**Objective:** As a kolt-on-kolt maintainer, I want the JVM test compile path to set `-module-name` and `-Xfriend-paths` so that test source sets can access `internal` symbols of the same kolt project, just as they do under Gradle's Kotlin plugin.
+
+This requirement was added during impl phase (task 4.1 hit a pre-existing kolt CLI bug where test compile uses a default `-module-name` derived from the output directory, so test sources see main as a different Kotlin module and lose `internal` visibility). The fix is in scope for this spec because without it R1.1 / R1.4 / R1.5 / R6.4 are unachievable: the daemon test suites depend on `internal` access (multiple symbols in `kolt.daemon.Main`, `SelfHealingIncrementalCompiler`, `BtaIncrementalCompiler`, `ClasspathSnapshotCache`).
+
+#### Acceptance Criteria
+
+1. When kolt's JVM test compile runs (via `testBuildCommand` or its equivalent), the kolt build pipeline shall pass `-module-name <project-name>` to kotlinc so the test source set is compiled into the same Kotlin module as main.
+2. When kolt's JVM test compile runs, the kolt build pipeline shall pass `-Xfriend-paths=<main-classes-dir>` to kotlinc so the test source set is treated as a friend module of main.
+3. When kolt's JVM main subprocess compile runs (via `subprocessArgv`), the kolt build pipeline shall forward `request.moduleName` as `-module-name <module-name>` so the daemon path and subprocess fallback produce identical Kotlin module identity.
+4. When `internal`-marked symbols are referenced from a test source file in the same kolt project, the kolt test compile shall succeed with no `internal in file` access error.
+5. The kolt project shall add unit tests under `src/nativeTest/kotlin/kolt/build/` that assert the new flags appear in the argv produced by `testBuildCommand` and `subprocessArgv` (one test per builder).

--- a/.kiro/specs/daemon-test-via-kolt/research.md
+++ b/.kiro/specs/daemon-test-via-kolt/research.md
@@ -1,0 +1,249 @@
+# Gap Analysis: daemon-test-via-kolt
+
+## 1. Current State Investigation
+
+### ADR 0032 schema は実装完了 (#318 / PR #321)
+
+- `src/nativeMain/kotlin/kolt/config/Config.kt`
+  - `KoltConfig.classpaths: Map<String, Map<String, String>>`
+  - `TestSection.sysProps: Map<String, SysPropValue>` / `RunSection.sysProps`
+  - target=native との衝突 / kind="lib" の `[run.sys_props]` 拒否、 undeclared bundle 参照拒否、 `project_dir` の絶対 / `..` escape 拒否
+- `src/nativeMain/kotlin/kolt/config/SysPropValue.kt` — `Literal` / `ClasspathRef` / `ProjectDir` の三項 sum type
+- `src/nativeMain/kotlin/kolt/build/SysPropResolver.kt` — bundle 名 → colon-joined absolute path、 `project_dir` → `<projectRoot>/<rel>` の絶対化
+- `src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt`
+  - `resolveBundleClasspaths` が `[classpaths.<name>]` ごとに resolveBundle を回し、 lockfile に書き戻し
+  - `bundleLockChanged` で classpaths キー集合の追加 / 削除 / リネームを検知
+- `src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt`
+  - `kolt deps install/tree/update` が classpaths を `[dependencies]` / `[test-dependencies]` と同じ update policy で処理
+  - `kolt deps tree` の bundle section レンダリング
+- `src/nativeMain/kotlin/kolt/cli/BuildCommands.kt`
+  - `BuildResult.bundleClasspaths` を doBuild → doTest / doRun に持ち回し
+  - `jvmTestArgv` / `jvmRunArgv` が SysPropResolver を回して `-D<key>=<value>` を JUnit Console Launcher / app JVM の argv に追加
+
+### JUnit 5 console launcher 経路は既存
+
+- `src/nativeMain/kotlin/kolt/tool/ToolManager.kt` で `junit-platform-console-standalone-1.11.4.jar` を Maven Central から fetch して `~/.kolt/tools/` にキャッシュ
+- `src/nativeMain/kotlin/kolt/build/TestRunner.kt` が argv builder を担う
+- `kolt test` の JVM target 経路はこの console launcher を使う構造 (kotlin.test との混在前提)
+
+### 既存 daemon 副プロジェクトの状態
+
+- `kolt-jvm-compiler-daemon/kolt.toml`
+  - `sources = ["src/main/kotlin", "ic/src/main/kotlin"]` で root + ic main を fat に統合
+  - `test_sources = []` (kolt 経由 test は no-op)
+  - `[classpaths]` / `[test.sys_props]` 未使用
+  - 依存: kotlin-build-tools-api / kotlinx-serialization-json / kotlin-result / ktoml-core
+- `kolt-jvm-compiler-daemon/ic/kolt.toml` — **存在しない**
+- `kolt-native-compiler-daemon/kolt.toml`
+  - `sources = ["src/main/kotlin"]`、 `test_sources = []`
+  - 依存: kotlinx-serialization-json / kotlin-result
+- 各副プロジェクトに `kolt.lock` がある (build/run path 経由で生成済)
+
+### Cross-module 依存
+
+- root daemon main (`kolt-jvm-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt`、 `server/DaemonServer.kt`、 `reaper/IcReaper.kt`) は `kolt.daemon.ic.*` を import している。 すなわち **root daemon main は ic main の symbols を必要とする**。
+- ic main は root daemon の symbol を import していない (一方向依存、 ic は leaf 側)。
+- ic test 群 (`kolt-jvm-compiler-daemon/ic/src/test/kotlin/`) も root daemon の symbol を import していない (ic 自身のみで完結)。
+- 既存 Gradle config では `kolt-jvm-compiler-daemon/build.gradle.kts` が `implementation(project(":ic"))` で ic を取り込み。
+
+### kolt config schema の制限
+
+- `[dependencies]` / `[test-dependencies]` は `"group:artifact" = "version"` の Maven coordinate のみ。 path-based / file-based / project-based 依存は **未実装**。
+- Workspace / multi-module 機能は無い (`includeBuild` 相当の概念が無い)。
+
+### `./gradlew check` 言及箇所 (要撤去)
+
+- `.kiro/steering/tech.md` `## Common Commands` Special-purpose ブロック (2 行)
+- それ以外の user / dev surface 走査結果 0 件 (CI / scripts / CLAUDE.md / SKILL に該当行なし)
+- orphan な `build.gradle.kts` / `settings.gradle.kts` 内の言及は #316 で削除予定なので本 spec 対象外
+- 履歴記録 (specs / ADR / spike) は意図的に保持
+
+## 2. Requirement-to-Asset Map
+
+| 要件 | 既存資産 | Gap タグ |
+|---|---|---|
+| R1.1: root daemon directory で `kolt test` 実行 | `doTest` / `jvmTestArgv` 経路あり、 daemon kolt.toml は `test_sources = []` | **Missing**: root daemon kolt.toml の `test_sources` / `[test-dependencies]` / `[test.sys_props]` 整備 |
+| R1.2: ic directory で `kolt test` 実行 | なし | **Missing**: `kolt-jvm-compiler-daemon/ic/kolt.toml` 新設 |
+| R1.3: native daemon directory で `kolt test` 実行 | native daemon kolt.toml は `test_sources = []` | **Missing**: native daemon kolt.toml の `test_sources` / `[test-dependencies]` 整備 |
+| R1.4–R1.6: pass/fail outcome / exit code が Gradle と一致 | `doTest` の exit code 経路は既存 | **Unknown**: Maven 解決 transitive 集合差分による classpath 揺れがテスト結果に影響しないか |
+| R2.1–R2.4: ic 4 classpath bundle | `[classpaths]` resolver / lockfile 既実装 | **Missing**: ic kolt.toml に bundle 4 個 declare、 transitive 解決の妥当性確認 |
+| R2.5: lockfile への bundle 反映 | `resolveBundleClasspaths` + `bundleLockChanged` | **Constraint**: 既存実装のまま動作 |
+| R2.6: bundle と main / test-deps の transitive 隔離 | resolver は bundle ごと独立 closure | **Constraint**: 既存実装のまま動作 |
+| R3.1–R3.5: 4 sysprop の delivery | `SysPropResolver` + `jvmTestArgv` | **Constraint**: 既存実装のまま動作、 ic kolt.toml に `[test.sys_props]` を declare すれば自動追従 |
+| R4.1–R4.3: `kolt.daemon.coreMainSourceRoot` | `SysPropValue.ProjectDir` / `SysPropResolver` | **Missing**: root daemon kolt.toml に `[test.sys_props]` declare |
+| R5.1–R5.4: doc 撤去 | 機械的編集のみ | **Constraint**: tech.md と関連サーフェスの 1 箇所 |
+| R6.1–R6.4: behavioural parity | 既存 daemon test 本体に手を入れない | **Unknown**: kolt jvmTestArgv が組む argv が Gradle `tasks.test` の argv と等価か (working dir / JDK args / env / classloader) |
+
+## 3. Implementation Approach Options
+
+### Option A: ic を独立 kolt project にする (推奨)
+
+**構造**:
+- `kolt-jvm-compiler-daemon/ic/kolt.toml` を新設、 `sources = ["src/main/kotlin"]`、 `test_sources = ["src/test/kotlin"]`
+- ic kolt.toml の `[dependencies]` は kotlin-build-tools-api / kotlin-result / ktoml-core (Gradle と同じ Maven coord)
+- ic kolt.toml の `[test-dependencies]` で junit-jupiter / junit-platform-launcher / kotlin-test
+- ic kolt.toml の `[classpaths]` に 4 bundle、 `[test.sys_props]` で sysprop 4 個
+- `kolt-jvm-compiler-daemon/kolt.toml` は **既存 sources を維持** (`["src/main/kotlin", "ic/src/main/kotlin"]`)、 `test_sources = ["src/test/kotlin"]` 追加、 `[test.sys_props]` で `kolt.daemon.coreMainSourceRoot` を declare
+- `kolt-native-compiler-daemon/kolt.toml` は `test_sources = ["src/test/kotlin"]` + `[test-dependencies]` を追加するのみ
+
+**動作**:
+- ic directory で `kolt test` → ic 単独 build + ic test (4 sysprop)
+- root daemon directory で `kolt test` → root + ic main 全 build + root daemon test (1 sysprop)
+- native daemon directory で `kolt test` → native daemon test
+- ic main を root daemon が `sources` で重複 build するが kolt 機能拡張不要
+
+**Trade-offs**:
+- ✅ Issue 本文 "from its own directory" を素直に満たす
+- ✅ kolt CLI / schema 拡張ゼロ (ADR 0032 schema のみで完結)
+- ✅ Gradle の `:ic` subproject 構造との対応関係が明瞭
+- ❌ ic main の二重 build (root daemon の `kolt build` 時に ic source が再 compile される)
+- ❌ ic kolt.toml と root daemon kolt.toml で kotlin-build-tools-api / kotlin-result バージョンを 2 箇所 pin する必要 (drift 注意)
+
+### Option B: 統合 kolt project (ic を root daemon の test 集合に統合)
+
+**構造**:
+- `kolt-jvm-compiler-daemon/kolt.toml` の `test_sources = ["src/test/kotlin", "ic/src/test/kotlin"]`
+- `[classpaths]` に 4 bundle、 `[test.sys_props]` に sysprop 5 個 (ic 4 + root 1) を統合
+- `kolt-jvm-compiler-daemon/ic/kolt.toml` は **作らない**
+- ic directory で `kolt test` → no-op (kolt.toml 不在 or test_sources empty)
+- root daemon directory で `kolt test` → root + ic test 全部実行
+
+**Trade-offs**:
+- ✅ kolt.toml が 2 箇所のみ (root daemon + native daemon)、 dep / version pin 重複なし
+- ✅ kolt 機能拡張ゼロ
+- ❌ Issue 本文 "from its own directory" を文字通り満たさない (ic 単体 directory での実行は不可)
+- ❌ root daemon の test JVM が ic test の sysprop 4 個も受け取る (実害なし、 ic test が読まなければ無視されるだけ)
+- ❌ ic test 単体実行が `kolt test --filter=PluginTranslatorTest` 等で代替する形になる
+
+### Option C: ic を独立 kolt project + path-based dep schema を新規追加
+
+**構造**:
+- ic を完全に分離、 root daemon が ic を path-based dep として消費する schema (`{ path = "../ic", target = "jar" }` 等) を kolt に新設
+- ic main の二重 build を排除
+
+**Trade-offs**:
+- ✅ ic main が真に 1 箇所でしか build されない
+- ✅ multi-module project (#4) への踏み台になる
+- ❌ 本 spec の Out of scope (kolt CLI / schema の新機能追加なし) を破る
+- ❌ Effort が大幅に膨らむ (resolver / lockfile / build orchestration まで波及)
+- ❌ multi-module ロードマップ (#4) と方針調整が必要
+
+## 4. Implementation Complexity & Risk
+
+- **Effort**: M (3–7 days)
+  - kolt.toml 設計 + 編集 (3 副プロジェクト): 1 day
+  - GAV + bundle 解決の妥当性確認 (Gradle transitive 集合との一致 cross-check): 1–2 days
+  - 各 daemon directory で `kolt test` を回して Gradle verdict と一致するまで debug: 1–2 days
+  - tech.md / 関連 doc 撤去 + commit 整理: 0.5 day
+  - 予備 / leftover: 1–2 days
+- **Risk**: Medium
+  - High-risk:
+    - Gradle module metadata の transitive 解決と kolt resolver の差分。 特に `kotlin-build-tools-impl:2.3.20` の transitive (depthが深い) で含まれる jar 集合が一致しないと、 `BtaIncrementalCompilerWarmPathTest` 系がfail し得る
+    - JVM 子プロセスの environment (working directory / JAVA_HOME / system property 順序) が Gradle `tasks.test` と等価か
+    - `BtaSerializationPluginTest` は serialization compiler plugin を URLClassLoader で reflective load するため、 classpath 順序や file 存在で fail し得る
+  - Low-risk: schema 適用そのもの (#318 で完成済)、 doc 撤去 (機械的)、 R6 parity (test 本体不変)
+
+## 5. Research Items for Design Phase
+
+1. **Maven transitive 解決差分の確認**
+   - `kolt deps tree` 結果と `./gradlew :kolt-jvm-compiler-daemon:ic:dependencies` の transitive 集合を side-by-side 比較
+   - 特に `kotlin-build-tools-impl:2.3.20`、 `kotlin-serialization-compiler-plugin-embeddable:2.3.20`、 `kotlinx-serialization-core-jvm:1.7.3` の transitive
+   - 差分があれば bundle に explicit pin を追加するか、 resolver 側を寄せるか判断
+2. **JVM test argv の等価性確認**
+   - `jvmTestArgv` の出力と `./gradlew :ic:test` の Gradle が組む `java ...` argv (working dir / -D / -cp 順序 / `--module-path` 有無 / JDK toolchain option) を比較
+   - working directory が project root か classes dir かで `AdapterBoundaryInvariantTest` の `Paths.get(...)` 解釈が変わる可能性
+3. **`[test-dependencies]` でどう JUnit 5 platform を declare するか**
+   - 既存 daemon kolt.toml は test-deps を持たないので、 daemon 側で junit-jupiter / junit-platform-launcher を test-dep に追加する例を design に含める
+   - kotlin.test と JUnit 5 の test discovery が混在するか、 kotlin.test に頼らず JUnit 5 単独で動かすか
+4. **ic main を root daemon が再 build することの cost / 副作用**
+   - debug / release 両 profile で ic main classes が `build/<profile>/classes` に重複出力されることの影響
+   - lockfile 2 ファイル化による `kolt deps install` 実行回数 (ic で 1 回、 root で 1 回) — 開発フローで許容できるか
+5. **#316 lands 前の cross-check 戦略**
+   - R6.4 で `./gradlew check` と `kolt test` を両方走らせる時期があるが、 orphan Gradle config を一時的に保持しておく必要がある
+   - PR の書き方 (本 spec 完了 PR vs #316 PR の 2 段階) を design 内で確定
+
+## 6. Recommendation for Design Phase
+
+- **採用候補: Option A (ic を独立 kolt project)**。 Issue 文言 "from its own directory" を素直に満たし、 kolt 機能拡張なし、 Effort M / Risk Medium で完結。
+- Option C (path-based dep schema) は multi-module support (#4) と統合する大きな決定になるので、 本 spec ではなく将来別 spec として切る。
+- Option B (統合 project) は Option A の代替として残し、 Option A の二重 build cost が許容できないと判明した場合のフォールバックにする。
+
+## 7. Out-of-Scope (Deferred to Design)
+
+- 厳密な kolt.toml の構文 (どのキーをどのテーブルに置くか、 explicit pin 候補) は design phase で確定
+- `[test-dependencies]` の選定 (JUnit 5 / kotlin-test の declare 方針) は design phase で確定
+- Native daemon kolt.toml の test 構成 (sysprop 不要、 単純な `[test-dependencies]` のみ) も design phase で記述
+
+---
+
+## 追記 (2026-04-30): Option A → Option B 逆転、 推奨更新
+
+### Option B が Gradle parity を満たすという主軸
+
+Option B (統合 kolt project) は、 Gradle 時代の test classpath 構造と一致する ことが確認された。 これが本 spec の中心的な判断根拠になる。
+
+**Gradle 時代の classpath 構造** (`kolt-jvm-compiler-daemon/build.gradle.kts` の `implementation(project(":ic"))` 経由):
+
+- root daemon test classpath = root daemon main + ic main + test-deps (JUnit 5 / kotlin-test)
+- ic test classpath = ic main + test-deps
+
+**Option B 採用後の統合 classpath**:
+
+- 統合 test classpath = root daemon main + ic main + test-deps
+
+Gradle 時代と比較した差分:
+- root daemon test 側: 完全一致 (Gradle 時代から ic main が transitive に classpath にあった)
+- ic test 側: root daemon main が classpath に追加で乗る (Gradle module isolation で除外されていた分)。 ただし ic test は `kolt.daemon.{Main,server,reaper}` を import していないため、 実行結果に影響なし
+
+つまり Option B は **production-relevant な classpath dependency を完全に保ちつつ、 module 物理境界だけを失う** 構造。 物理境界の文化的な代替は Requirement 6.5 で許容した invariant test (例: ic test source が `kolt.daemon.{Main,server,reaper}` を import していないことの source 解析 assert) で補完する。
+
+### 確定した調査結果
+
+1. **root daemon test → ic main の依存事実** (逆転の trigger)
+   - `kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/server/DaemonLifecycleTest.kt` が `kolt.daemon.ic.{IcError, IcRequest, IcResponse, IncrementalCompiler}` を import
+   - 同じく `DaemonServerTest.kt` が `kolt.daemon.ic.{IcError, IcRequest, IcResponse, IcStateLayout, IncrementalCompiler}` を import
+   - `IcReaperTest.kt` が `kolt.daemon.ic.IcMetricsSink` を import
+   - つまり root daemon test classpath に ic main が含まれていなければ Gradle 時代から compile 不能だった
+2. **ic test → root daemon main の非依存事実**
+   - `kolt-jvm-compiler-daemon/ic/src/test/kotlin/` 配下は `kolt.daemon.{Main, server, reaper}` を一切 import しない (grep 確定)
+   - Gradle module isolation で除外されていた依存関係は実態として存在しなかった
+   - 統合 classpath 化しても ic test の動作に影響しない
+3. **ic test sysprop の confirm** (Option B 採用前提の安全確認)
+   - ic test 群は `System.getProperty(...)` で `kolt.ic.{btaImplClasspath, fixtureClasspath, serializationPluginClasspath, serializationRuntimeClasspath}` のみ参照
+   - `kolt.daemon.coreMainSourceRoot` (root daemon test の sysprop) は触らない
+   - 統合 `[test.sys_props]` で 5 個全部が同じ test JVM に届いても干渉しない
+
+### 副次的便益 (Option A 比)
+
+- **ic main の二重 build 回避**: 1 つの kolt project が `sources = ["src/main/kotlin", "ic/src/main/kotlin"]` を build するだけで済む
+- **dep version pin 重複回避**: kotlin-build-tools-api / kotlin-result / ktoml-core を 1 箇所で pin
+- **lockfile 単一化**: `kolt-jvm-compiler-daemon/kolt.lock` 1 ファイルに全 dep を統合
+- **main 側の取り扱いと test 側の取り扱いの非対称性を排除**: main が既に統合されているのに test だけ別 project にすると認知負荷が大きい
+
+### 残存懸念 (Mitigation 込み)
+
+- **test classpath isolation の文化的喪失**: 統合 classpath で ic test から root daemon main が import 可能になる (Gradle 時代は不可能)
+  - Mitigation: Requirement 6.5 で許容した source-static invariant test を追加。 ic test source が `kolt.daemon.{Main,server,reaper}` を import していないことを assert。 source 解析のみで判定するため flake risk なし
+- **Issue #315 DoD の "from its own directory" 文言との乖離**
+  - Mitigation: design.md と PR 本文の双方で緩和判断を明示。 Issue 本文そのものは history value のため当時のまま保持し、 緩和の根拠は design.md を参照する形で PR が明文化する
+- **ic 単体 test の DX**: Gradle の `:ic:test --tests <Class>` 相当が `kolt test` で代替可能か
+  - Requirement 1.2 で「filter 経路の存在」 を要件化、 design phase で具体化 (有力候補は `kolt test -- --select-class=...` の passthrough)
+  - **Research Item 6 として design 入り口で確認必須**: 現状 `kolt test` の testArgs が JUnit Console Launcher にどこまで passthrough されるか、 動作確認
+
+### 残存 Research Item の更新
+
+Section 5 の Research Item 4 (ic main の二重 build cost) は **Option B 採用により消滅**。 ic main は 1 箇所でしか build されないため検討不要。
+
+新規 Research Item 6 を追加:
+
+6. **`kolt test` の filter / passthrough 経路の動作確認**
+   - 現状の `kolt test` が `testArgs` を JUnit Console Launcher にどう渡すか
+   - `kolt test -- --select-class=PluginTranslatorTest` 形式が動くか検証
+   - 動かない場合の代替経路 (CLI flag 追加は本 spec の Out of scope なので、 既存 passthrough 経路で何ができるかを確定)
+
+### 推奨更新
+
+- **採用: Option B (統合 kolt project)**。 Gradle 時代の classpath 構造と一致し、 二重 build / pin 重複を回避し、 main / test の取り扱いの対称性を保つ
+- Option A (ic を独立 kolt project) は当初推奨だったが、 Gradle 時代に ic test classpath が module isolation により root main を除外していた構造を kolt 側で再現する必要が無い (ic test がそもそも root main を import していない) ことが確定したため不採用
+- Option C (path-based dep schema) は multi-module support (#4) として将来別 spec で扱う
+

--- a/.kiro/specs/daemon-test-via-kolt/spec.json
+++ b/.kiro/specs/daemon-test-via-kolt/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "daemon-test-via-kolt",
+  "created_at": "2026-04-30T15:44:44Z",
+  "updated_at": "2026-04-30T16:50:00Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -63,7 +63,7 @@
   - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5_
   - _Boundary: src/nativeMain/kotlin/kolt/build/{TestBuilder,SubprocessCompilerBackend}.kt, src/nativeTest/kotlin/kolt/build/_
 
-- [ ] 4.2 IcModuleBoundaryInvariantTest を作成
+- [x] 4.2 IcModuleBoundaryInvariantTest を作成
   - `kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/IcModuleBoundaryInvariantTest.kt` を新設、 既存 `AdapterBoundaryInvariantTest` の `Files.walk(sourceRoot)` パターンを踏襲
   - sysprop `kolt.daemon.icTestSourceRoot` から source root を受け、 不在時は明示的な error message で fail
   - `import kolt.daemon.Main`、 `import kolt.daemon.server.`、 `import kolt.daemon.reaper.` のいずれかの prefix を含む行を violations として収集、 空でないなら fail message に違反 file / 行 / 行番号を列挙

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -54,7 +54,7 @@
   - _Boundary: kolt-native-compiler-daemon/kolt.toml, kolt-native-compiler-daemon/kolt.lock_
 
 - [ ] 4. Foundation fix + invariant test
-- [ ] 4.1 kolt CLI test compile に -module-name と -Xfriend-paths を forward
+- [x] 4.1 kolt CLI test compile に -module-name と -Xfriend-paths を forward
   - `src/nativeMain/kotlin/kolt/build/TestBuilder.kt` の `testBuildCommand` argv に `-module-name <config.name>` と `-Xfriend-paths=<classesDir>` を追加
   - `src/nativeMain/kotlin/kolt/build/SubprocessCompilerBackend.kt` の `subprocessArgv` で `request.moduleName` を `-module-name <moduleName>` として forward、 line 29 の "intentionally not forwarded" コメントは削除 / 更新
   - `src/nativeTest/kotlin/kolt/build/` に native unit test を追加 (`testBuildCommand` の argv に新 flag が含まれること、 `subprocessArgv` の argv に新 flag が含まれることを assert)

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -45,7 +45,7 @@
   - _Boundary: kolt-jvm-compiler-daemon/kolt.lock_
 
 - [ ] 3. (P) Native daemon kolt.toml 整備
-- [ ] 3.1 (P) test_sources / test-deps 追加 + lockfile 再生成
+- [x] 3.1 (P) test_sources / test-deps 追加 + lockfile 再生成
   - `kolt-native-compiler-daemon/kolt.toml` の `[build]` に `test_sources = ["src/test/kotlin"]` を追加
   - `[test-dependencies]` で `org.junit.jupiter:junit-jupiter = "5.11.3"` / `org.junit.platform:junit-platform-launcher = "1.11.3"` を pin
   - `cd kolt-native-compiler-daemon && kolt deps install` で `kolt.lock` を再生成

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -9,7 +9,7 @@
   - dogfood log (`docs/dogfood.md`) に 1 行記録
   - _Requirements: 1.2_
 
-- [ ] 2. JVM daemon kolt.toml 整備 (root + ic 統合)
+- [x] 2. JVM daemon kolt.toml 整備 (root + ic 統合)
 - [x] 2.1 test_sources と test-dependencies を追加
   - `kolt-jvm-compiler-daemon/kolt.toml` の `[build]` に `test_sources = ["src/test/kotlin", "ic/src/test/kotlin"]` を追加
   - `[test-dependencies]` を新設し `org.junit.jupiter:junit-jupiter = "5.11.3"` と `org.junit.platform:junit-platform-launcher = "1.11.3"` を pin (Gradle 時代と同 version)
@@ -44,7 +44,7 @@
   - _Requirements: 2.5, 2.6_
   - _Boundary: kolt-jvm-compiler-daemon/kolt.lock_
 
-- [ ] 3. (P) Native daemon kolt.toml 整備
+- [x] 3. (P) Native daemon kolt.toml 整備
 - [x] 3.1 (P) test_sources / test-deps 追加 + lockfile 再生成
   - `kolt-native-compiler-daemon/kolt.toml` の `[build]` に `test_sources = ["src/test/kotlin"]` を追加
   - `[test-dependencies]` で `org.junit.jupiter:junit-jupiter = "5.11.3"` / `org.junit.platform:junit-platform-launcher = "1.11.3"` を pin
@@ -53,7 +53,7 @@
   - _Requirements: 1.3, 6.2, 6.3_
   - _Boundary: kolt-native-compiler-daemon/kolt.toml, kolt-native-compiler-daemon/kolt.lock_
 
-- [ ] 4. Foundation fix + invariant test
+- [x] 4. Foundation fix + invariant test
 - [x] 4.1 kolt CLI test compile に -module-name と -Xfriend-paths を forward
   - `src/nativeMain/kotlin/kolt/build/TestBuilder.kt` の `testBuildCommand` argv に `-module-name <config.name>` と `-Xfriend-paths=<classesDir>` を追加
   - `src/nativeMain/kotlin/kolt/build/SubprocessCompilerBackend.kt` の `subprocessArgv` で `request.moduleName` を `-module-name <moduleName>` として forward、 line 29 の "intentionally not forwarded" コメントは削除 / 更新
@@ -72,7 +72,7 @@
   - _Requirements: 6.5_
   - _Boundary: IcModuleBoundaryInvariantTest_
 
-- [ ] 5. End-to-end verification と Gradle parity cross-check
+- [x] 5. End-to-end verification と Gradle parity cross-check
 - [x] 5.1 JVM daemon directory での kolt test smoke
   - `cd kolt-jvm-compiler-daemon && kolt test` を実行
   - root daemon test 群 (8 ファイル相当) と ic test 群 (16 ファイル相当) の union が全 pass、 exit code 0
@@ -102,7 +102,7 @@
   - _Depends: 5.1, 5.2_
   - _Requirements: 6.1, 6.4_
 
-- [ ] 6. Documentation cleanup
+- [x] 6. Documentation cleanup
 - [x] 6.1 tech.md から ./gradlew check 言及を撤去
   - `.kiro/steering/tech.md` の `## Common Commands` 末尾にある Special-purpose ブロック (`./gradlew check` 行 + `./gradlew linkDebugExecutableLinuxX64 \\` 行 + 続く `&& ...kolt.kexe build` 行 + 周辺の "Special-purpose" 注釈) を削除
   - 削除後の `## Common Commands` セクションが文構造として整っている (見出し / 空行 / Development for working on kolt itself のブロック整合)

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -35,7 +35,7 @@
   - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 4.1, 4.2, 4.3, 6.5_
   - _Boundary: kolt-jvm-compiler-daemon/kolt.toml_
 
-- [ ] 2.4 lockfile 再生成と Maven transitive cross-check
+- [x] 2.4 lockfile 再生成と Maven transitive cross-check
   - `cd kolt-jvm-compiler-daemon && kolt deps install` を実行し `kolt.lock` を再生成
   - `kolt deps tree` の bundle セクション出力と、 Gradle 側の `./gradlew :kolt-jvm-compiler-daemon:dependencies` / `./gradlew :ic:dependencies` の transitive を side-by-side で比較
   - 差分があれば bundle 内に explicit pin (転居 transitive を直接書き出し) を追加して再 install、 一致を確認
@@ -107,3 +107,4 @@
 
 - 2026-05-01 task 1.1: filter passthrough は JUnit Console Launcher 1.11.4 の `--scan-class-path` mutex 制約により動作不能。 #323 (`testRunCommand` の conditional `--scan-class-path` 抑止) で別途対応。 R1.2 関連 task (5.3) は deferred として close、 本 spec の DoD は filter なしの全 test 実行で完結させる。
 - 2026-05-01 task 2.1: `test_sources` を空から有効化したことで、 これまで kolt fmt の対象外だった test 配下の既存 file が ktfmt 0.54 と format 違反を持っていることが pre-commit hook で発覚。 26 ファイルを `kolt fmt` で apply して別 commit に分離。 task 3.1 (native daemon の test_sources 有効化) でも同じ現象が起きる可能性が高い、 同様に format apply を切り分ける。
+- 2026-05-01 task 2.4: PATH の `kolt` (`/home/makino/.local/bin/kolt`) は古い v3 binary で、 `kolt deps install` を実行すると lockfile を v3 に書き戻す。 v4 lockfile を生成するには dev-built `build/debug/kolt.kexe` を直接呼ぶ必要があった (bootstrap pinch、 #316 で解消予定)。 また kolt と Gradle の transitive 表示には platform-suffix の有無 (`-jvm`)、 declared vs resolved version 等の cosmetic 差があるが、 on-disk jar 集合は一致 (bundle 単位で byte-identical を確認)。 `apiguardian-api:1.1.2` は kolt が POM scope に従って `compile` として取り込み、 Gradle module metadata では `compileOnlyApi` として除外、 これは harmless な annotation jar の追加で test 動作に影響なし。

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -1,0 +1,105 @@
+# Implementation Plan
+
+- [ ] 1. Pre-flight: filter passthrough 動作確認
+- [ ] 1.1 JUnit Console Launcher の filter passthrough を smoke
+  - 任意の使い捨て kolt project (例 `spike/` 配下に簡易 JVM target project を一時的に作る) で `kolt test -- --select-class=<FQCN>` を実行
+  - JUnit Platform Console Standalone 1.11.4 が `--scan-class-path` 固定挿入と `--select-class` 併用で意図通り絞り込みできることを confirm
+  - 動作 OK なら本 spec を続行、 動作不能ならここで stop し R1.2 の treatment を再確定 (本 spec の Out of Boundary に CLI flag 追加が含まれるため follow-up issue 化を検討)
+  - 観察可能: smoke 出力で 1 クラスのみ実行され、 他クラスがスキップされた log が確認できる
+  - _Requirements: 1.2_
+
+- [ ] 2. JVM daemon kolt.toml 整備 (root + ic 統合)
+- [ ] 2.1 test_sources と test-dependencies を追加
+  - `kolt-jvm-compiler-daemon/kolt.toml` の `[build]` に `test_sources = ["src/test/kotlin", "ic/src/test/kotlin"]` を追加
+  - `[test-dependencies]` を新設し `org.junit.jupiter:junit-jupiter = "5.11.3"` と `org.junit.platform:junit-platform-launcher = "1.11.3"` を pin (Gradle 時代と同 version)
+  - `kolt info` または config parse smoke で構文 error なく読み込める
+  - 既存 `[build] sources = ["src/main/kotlin", "ic/src/main/kotlin"]` は touch しない
+  - _Requirements: 1.1, 1.6, 6.2, 6.3_
+  - _Boundary: kolt-jvm-compiler-daemon/kolt.toml_
+
+- [ ] 2.2 4 classpath bundle を declare
+  - `[classpaths.bta_impl]` に `org.jetbrains.kotlin:kotlin-build-tools-impl = "2.3.20"` を追加
+  - `[classpaths.fixture]` に `org.jetbrains.kotlin:kotlin-stdlib = "2.3.20"` を追加
+  - `[classpaths.serialization_plugin]` に `org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable = "2.3.20"` を追加
+  - `[classpaths.serialization_runtime]` に `org.jetbrains.kotlin:kotlin-stdlib = "2.3.20"` と `org.jetbrains.kotlinx:kotlinx-serialization-core-jvm = "1.7.3"` を追加
+  - 観察可能: `kolt info` で 4 bundle が一覧表示され、 parse error なし
+  - _Requirements: 2.1, 2.2, 2.3, 2.4_
+  - _Boundary: kolt-jvm-compiler-daemon/kolt.toml_
+
+- [ ] 2.3 test sysprop 6 個を declare
+  - `[test.sys_props]` に classpath ref 4 個を追加: `kolt.ic.btaImplClasspath` → `bta_impl`、 `kolt.ic.fixtureClasspath` → `fixture`、 `kolt.ic.serializationPluginClasspath` → `serialization_plugin`、 `kolt.ic.serializationRuntimeClasspath` → `serialization_runtime`
+  - `kolt.daemon.coreMainSourceRoot` を `{ project_dir = "src/main/kotlin" }` で declare
+  - `kolt.daemon.icTestSourceRoot` を `{ project_dir = "ic/src/test/kotlin" }` で declare
+  - 観察可能: `kolt info` の test sysprop 一覧に 6 entry が表示され、 dotted key (`kolt.daemon.*` / `kolt.ic.*`) が分割されずそのまま preserve されていること
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 4.1, 4.2, 4.3, 6.5_
+  - _Boundary: kolt-jvm-compiler-daemon/kolt.toml_
+
+- [ ] 2.4 lockfile 再生成と Maven transitive cross-check
+  - `cd kolt-jvm-compiler-daemon && kolt deps install` を実行し `kolt.lock` を再生成
+  - `kolt deps tree` の bundle セクション出力と、 Gradle 側の `./gradlew :kolt-jvm-compiler-daemon:dependencies` / `./gradlew :ic:dependencies` の transitive を side-by-side で比較
+  - 差分があれば bundle 内に explicit pin (転居 transitive を直接書き出し) を追加して再 install、 一致を確認
+  - 観察可能: `kolt.lock` が PR diff として review 可能、 4 bundle すべての direct + transitive jar が Gradle と同一集合
+  - _Depends: 2.2_
+  - _Requirements: 2.5, 2.6_
+  - _Boundary: kolt-jvm-compiler-daemon/kolt.lock_
+
+- [ ] 3. (P) Native daemon kolt.toml 整備
+- [ ] 3.1 (P) test_sources / test-deps 追加 + lockfile 再生成
+  - `kolt-native-compiler-daemon/kolt.toml` の `[build]` に `test_sources = ["src/test/kotlin"]` を追加
+  - `[test-dependencies]` で `org.junit.jupiter:junit-jupiter = "5.11.3"` / `org.junit.platform:junit-platform-launcher = "1.11.3"` を pin
+  - `cd kolt-native-compiler-daemon && kolt deps install` で `kolt.lock` を再生成
+  - 観察可能: `kolt info` で test 構成が表示され、 `kolt.lock` が PR diff
+  - _Requirements: 1.3, 6.2, 6.3_
+  - _Boundary: kolt-native-compiler-daemon/kolt.toml, kolt-native-compiler-daemon/kolt.lock_
+
+- [ ] 4. invariant test 実装
+- [ ] 4.1 IcModuleBoundaryInvariantTest を作成
+  - `kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/IcModuleBoundaryInvariantTest.kt` を新設、 既存 `AdapterBoundaryInvariantTest` の `Files.walk(sourceRoot)` パターンを踏襲
+  - sysprop `kolt.daemon.icTestSourceRoot` から source root を受け、 不在時は明示的な error message で fail
+  - `import kolt.daemon.Main`、 `import kolt.daemon.server.`、 `import kolt.daemon.reaper.` のいずれかの prefix を含む行を violations として収集、 空でないなら fail message に違反 file / 行 / 行番号を列挙
+  - 観察可能: `cd kolt-jvm-compiler-daemon && kolt test` で本 invariant test が discovered + green (現状 ic test 配下に違反なし)
+  - _Depends: 2.3_
+  - _Requirements: 6.5_
+  - _Boundary: IcModuleBoundaryInvariantTest_
+
+- [ ] 5. End-to-end verification と Gradle parity cross-check
+- [ ] 5.1 JVM daemon directory での kolt test smoke
+  - `cd kolt-jvm-compiler-daemon && kolt test` を実行
+  - root daemon test 群 (8 ファイル相当) と ic test 群 (16 ファイル相当) の union が全 pass、 exit code 0
+  - test 失敗時の出力を確認 (意図的に 1 test を一時 fail させて exit code が non-zero になることも cross-check)
+  - 観察可能: pass count が Gradle 時代の `./gradlew :kolt-jvm-compiler-daemon:check` + `./gradlew :ic:check` と一致 (count + class 名で confirm)
+  - _Depends: 2.4, 4.1_
+  - _Requirements: 1.1, 1.4, 1.5, 1.6_
+
+- [ ] 5.2 (P) Native daemon directory での kolt test smoke
+  - `cd kolt-native-compiler-daemon && kolt test` を実行
+  - 既存 native daemon test 群が全 pass、 exit code 0
+  - 観察可能: pass count が `./gradlew :kolt-native-compiler-daemon:check` と一致
+  - _Depends: 3.1_
+  - _Requirements: 1.3, 1.4, 1.5_
+  - _Boundary: kolt-native-compiler-daemon_
+
+- [ ] 5.3 ic 単体 test の filter 経由実行 smoke
+  - `cd kolt-jvm-compiler-daemon && kolt test -- --select-class=kolt.daemon.ic.PluginTranslatorTest`
+  - 当該 1 クラスのみが実行され、 他 test がスキップされた log を確認
+  - 観察可能: stdout / stderr で実行 test 数が 1 クラス分のみ、 ic 以外の test class が起動していない
+  - _Depends: 5.1_
+  - _Requirements: 1.2_
+
+- [ ] 5.4 Gradle vs kolt verdict 一致 cross-check と test body 不変 verify
+  - 同じ source tree で `./gradlew check` (orphan Gradle config 経由、 #316 lands 前) を実行し全 verdict を記録
+  - `cd kolt-jvm-compiler-daemon && kolt test` と `cd kolt-native-compiler-daemon && kolt test` を実行し、 両者の pass / fail set が `./gradlew check` と一致することを confirm
+  - `git diff` で `kolt-jvm-compiler-daemon/**/src/test/` と `kolt-native-compiler-daemon/src/test/` 配下の既存 file body に変更がないこと (新規 invariant test 1 ファイル追加のみ) を verify
+  - 観察可能: `git status` で test 配下の modified が `IcModuleBoundaryInvariantTest.kt` 新規追加のみ、 verdict 集合が Gradle と一致
+  - _Depends: 5.1, 5.2_
+  - _Requirements: 6.1, 6.4_
+
+- [ ] 6. Documentation cleanup
+- [ ] 6.1 tech.md から ./gradlew check 言及を撤去
+  - `.kiro/steering/tech.md` の `## Common Commands` 末尾にある Special-purpose ブロック (`./gradlew check` 行 + `./gradlew linkDebugExecutableLinuxX64 \\` 行 + 続く `&& ...kolt.kexe build` 行 + 周辺の "Special-purpose" 注釈) を削除
+  - 削除後の `## Common Commands` セクションが文構造として整っている (見出し / 空行 / Development for working on kolt itself のブロック整合)
+  - `grep -rn "gradlew check" .` を実行し、 historical record (`.kiro/specs/`、 `docs/adr/`、 `spike/`) と orphan Gradle config を除いた user / dev surface に該当が 0 件であることを confirm
+  - 観察可能: tech.md の diff が Special-purpose ブロックの削除のみ、 surface grep が 0 件
+  - _Depends: 5.4_
+  - _Requirements: 5.1, 5.2, 5.3, 5.4_
+  - _Boundary: .kiro/steering/tech.md_

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -27,7 +27,7 @@
   - _Requirements: 2.1, 2.2, 2.3, 2.4_
   - _Boundary: kolt-jvm-compiler-daemon/kolt.toml_
 
-- [ ] 2.3 test sysprop 6 個を declare
+- [x] 2.3 test sysprop 6 個を declare
   - `[test.sys_props]` に classpath ref 4 個を追加: `kolt.ic.btaImplClasspath` → `bta_impl`、 `kolt.ic.fixtureClasspath` → `fixture`、 `kolt.ic.serializationPluginClasspath` → `serialization_plugin`、 `kolt.ic.serializationRuntimeClasspath` → `serialization_runtime`
   - `kolt.daemon.coreMainSourceRoot` を `{ project_dir = "src/main/kotlin" }` で declare
   - `kolt.daemon.icTestSourceRoot` を `{ project_dir = "ic/src/test/kotlin" }` で declare
@@ -106,3 +106,4 @@
 ## Implementation Notes
 
 - 2026-05-01 task 1.1: filter passthrough は JUnit Console Launcher 1.11.4 の `--scan-class-path` mutex 制約により動作不能。 #323 (`testRunCommand` の conditional `--scan-class-path` 抑止) で別途対応。 R1.2 関連 task (5.3) は deferred として close、 本 spec の DoD は filter なしの全 test 実行で完結させる。
+- 2026-05-01 task 2.1: `test_sources` を空から有効化したことで、 これまで kolt fmt の対象外だった test 配下の既存 file が ktfmt 0.54 と format 違反を持っていることが pre-commit hook で発覚。 26 ファイルを `kolt fmt` で apply して別 commit に分離。 task 3.1 (native daemon の test_sources 有効化) でも同じ現象が起きる可能性が高い、 同様に format apply を切り分ける。

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -73,7 +73,7 @@
   - _Boundary: IcModuleBoundaryInvariantTest_
 
 - [ ] 5. End-to-end verification と Gradle parity cross-check
-- [ ] 5.1 JVM daemon directory での kolt test smoke
+- [x] 5.1 JVM daemon directory での kolt test smoke
   - `cd kolt-jvm-compiler-daemon && kolt test` を実行
   - root daemon test 群 (8 ファイル相当) と ic test 群 (16 ファイル相当) の union が全 pass、 exit code 0
   - test 失敗時の出力を確認 (意図的に 1 test を一時 fail させて exit code が non-zero になることも cross-check)
@@ -81,7 +81,7 @@
   - _Depends: 2.4, 4.1, 4.2_
   - _Requirements: 1.1, 1.4, 1.5, 1.6_
 
-- [ ] 5.2 (P) Native daemon directory での kolt test smoke
+- [x] 5.2 (P) Native daemon directory での kolt test smoke
   - `cd kolt-native-compiler-daemon && kolt test` を実行
   - 既存 native daemon test 群が全 pass、 exit code 0
   - 観察可能: pass count が `./gradlew :kolt-native-compiler-daemon:check` と一致
@@ -94,7 +94,7 @@
   - 本 spec では ic-only DX を一時的に放棄、 maintainer は `cd kolt-jvm-compiler-daemon && kolt test` で全 test を実行する
   - _Requirements: 1.2_
 
-- [ ] 5.4 Gradle vs kolt verdict 一致 cross-check と test body 不変 verify
+- [x] 5.4 Gradle vs kolt verdict 一致 cross-check と test body 不変 verify
   - 同じ source tree で `./gradlew check` (orphan Gradle config 経由、 #316 lands 前) を実行し全 verdict を記録
   - `cd kolt-jvm-compiler-daemon && kolt test` と `cd kolt-native-compiler-daemon && kolt test` を実行し、 両者の pass / fail set が `./gradlew check` と一致することを confirm
   - `git diff` で `kolt-jvm-compiler-daemon/**/src/test/` と `kolt-native-compiler-daemon/src/test/` 配下の既存 file body に変更がないこと (新規 invariant test 1 ファイル追加のみ) を verify
@@ -118,3 +118,4 @@
 - 2026-05-01 task 2.1: `test_sources` を空から有効化したことで、 これまで kolt fmt の対象外だった test 配下の既存 file が ktfmt 0.54 と format 違反を持っていることが pre-commit hook で発覚。 26 ファイルを `kolt fmt` で apply して別 commit に分離。 task 3.1 (native daemon の test_sources 有効化) でも同じ現象が起きる可能性が高い、 同様に format apply を切り分ける。
 - 2026-05-01 task 2.4: PATH の `kolt` (`/home/makino/.local/bin/kolt`) は古い v3 binary で、 `kolt deps install` を実行すると lockfile を v3 に書き戻す。 v4 lockfile を生成するには dev-built `build/debug/kolt.kexe` を直接呼ぶ必要があった (bootstrap pinch、 #316 で解消予定)。 また kolt と Gradle の transitive 表示には platform-suffix の有無 (`-jvm`)、 declared vs resolved version 等の cosmetic 差があるが、 on-disk jar 集合は一致 (bundle 単位で byte-identical を確認)。 `apiguardian-api:1.1.2` は kolt が POM scope に従って `compile` として取り込み、 Gradle module metadata では `compileOnlyApi` として除外、 これは harmless な annotation jar の追加で test 動作に影響なし。
 - 2026-05-01 task 4.1 (旧): kolt の JVM test compile が `-module-name` を渡しておらず、 main と test が別 module として compile される結果、 test source set から main の `internal` symbol が見えない bug を発見。 `MainCliArgsTest`、 `SelfHealingIncrementalCompiler.METRIC_*`、 `CapturingKotlinLogger`、 `BtaIncrementalCompiler.METRIC_LOG_ERROR`、 `ClasspathSnapshotCache.METRIC_*` など多数の test が compile fail。 元 task 4.1 (invariant test) を 4.2 に renumber、 新規 task 4.1 として CLI fix を foundation 扱いで追加。 R7 を requirements に追加。 fix 規模: `TestBuilder.kt` と `SubprocessCompilerBackend.kt` の argv builder + native unit test。 line 29 の「moduleName intentionally not forwarded」 コメントは削除予定。
+- 2026-05-01 task 5.4: kolt 経由 verdict — `kolt-jvm-compiler-daemon/` で `kolt test` 139/139 pass、 `kolt-native-compiler-daemon/` で 48/48 pass、 計 187/187。 Gradle 経由 verdict — `./gradlew check --no-parallel --max-workers=1` で root daemon 66/66 (IcModuleBoundary は assumption skip 1 含む)、 native daemon 48/48、 計 114 pass + 1 skip。 ic test (73 個) は Gradle 9.4 の strict configuration locking (`:kolt-jvm-compiler-daemon:ic:buildToolsImpl` was attempted without an exclusive lock) により直接 `:ic:test` 実行不可、 root の `./gradlew check` でも ic は集約されない。 ic test の Gradle parity は本 spec で directly verify 不能、 kolt 経由 73 個の pass で代替。 #316 で orphan Gradle 削除後はこの cross-check 自体が不要になるため、 fix 投資は見送り。 IcModuleBoundaryInvariantTest は Gradle 環境で sysprop 不在で fail するため `org.junit.jupiter.api.Assumptions.assumeTrue` で skip するよう修正、 invariant 自身は kolt 経由でのみ enforce。 既存 daemon test 本体は format apply 2 commit (`62c15a2` + `bd040c5`) 以外で touch されておらず、 R6.1 (logic 不変) は維持。

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -53,13 +53,22 @@
   - _Requirements: 1.3, 6.2, 6.3_
   - _Boundary: kolt-native-compiler-daemon/kolt.toml, kolt-native-compiler-daemon/kolt.lock_
 
-- [ ] 4. invariant test 実装
-- [ ] 4.1 IcModuleBoundaryInvariantTest を作成
+- [ ] 4. Foundation fix + invariant test
+- [ ] 4.1 kolt CLI test compile に -module-name と -Xfriend-paths を forward
+  - `src/nativeMain/kotlin/kolt/build/TestBuilder.kt` の `testBuildCommand` argv に `-module-name <config.name>` と `-Xfriend-paths=<classesDir>` を追加
+  - `src/nativeMain/kotlin/kolt/build/SubprocessCompilerBackend.kt` の `subprocessArgv` で `request.moduleName` を `-module-name <moduleName>` として forward、 line 29 の "intentionally not forwarded" コメントは削除 / 更新
+  - `src/nativeTest/kotlin/kolt/build/` に native unit test を追加 (`testBuildCommand` の argv に新 flag が含まれること、 `subprocessArgv` の argv に新 flag が含まれることを assert)
+  - 修正後 `kolt build` で kolt 自身を再 build し、 `cd kolt-jvm-compiler-daemon && build/debug/kolt.kexe test` で daemon test の compile が `internal in file` error なく成功することを smoke (full pass までは task 5.1 の責務、 ここでは compile error 解消の確認のみ)
+  - 観察可能: native unit test 追加分が `kolt test` で discovered + green、 daemon test compile が `internal` access error 0 件で進行
+  - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5_
+  - _Boundary: src/nativeMain/kotlin/kolt/build/{TestBuilder,SubprocessCompilerBackend}.kt, src/nativeTest/kotlin/kolt/build/_
+
+- [ ] 4.2 IcModuleBoundaryInvariantTest を作成
   - `kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/IcModuleBoundaryInvariantTest.kt` を新設、 既存 `AdapterBoundaryInvariantTest` の `Files.walk(sourceRoot)` パターンを踏襲
   - sysprop `kolt.daemon.icTestSourceRoot` から source root を受け、 不在時は明示的な error message で fail
   - `import kolt.daemon.Main`、 `import kolt.daemon.server.`、 `import kolt.daemon.reaper.` のいずれかの prefix を含む行を violations として収集、 空でないなら fail message に違反 file / 行 / 行番号を列挙
   - 観察可能: `cd kolt-jvm-compiler-daemon && kolt test` で本 invariant test が discovered + green (現状 ic test 配下に違反なし)
-  - _Depends: 2.3_
+  - _Depends: 2.3, 4.1_
   - _Requirements: 6.5_
   - _Boundary: IcModuleBoundaryInvariantTest_
 
@@ -69,7 +78,7 @@
   - root daemon test 群 (8 ファイル相当) と ic test 群 (16 ファイル相当) の union が全 pass、 exit code 0
   - test 失敗時の出力を確認 (意図的に 1 test を一時 fail させて exit code が non-zero になることも cross-check)
   - 観察可能: pass count が Gradle 時代の `./gradlew :kolt-jvm-compiler-daemon:check` + `./gradlew :ic:check` と一致 (count + class 名で confirm)
-  - _Depends: 2.4, 4.1_
+  - _Depends: 2.4, 4.1, 4.2_
   - _Requirements: 1.1, 1.4, 1.5, 1.6_
 
 - [ ] 5.2 (P) Native daemon directory での kolt test smoke
@@ -108,3 +117,4 @@
 - 2026-05-01 task 1.1: filter passthrough は JUnit Console Launcher 1.11.4 の `--scan-class-path` mutex 制約により動作不能。 #323 (`testRunCommand` の conditional `--scan-class-path` 抑止) で別途対応。 R1.2 関連 task (5.3) は deferred として close、 本 spec の DoD は filter なしの全 test 実行で完結させる。
 - 2026-05-01 task 2.1: `test_sources` を空から有効化したことで、 これまで kolt fmt の対象外だった test 配下の既存 file が ktfmt 0.54 と format 違反を持っていることが pre-commit hook で発覚。 26 ファイルを `kolt fmt` で apply して別 commit に分離。 task 3.1 (native daemon の test_sources 有効化) でも同じ現象が起きる可能性が高い、 同様に format apply を切り分ける。
 - 2026-05-01 task 2.4: PATH の `kolt` (`/home/makino/.local/bin/kolt`) は古い v3 binary で、 `kolt deps install` を実行すると lockfile を v3 に書き戻す。 v4 lockfile を生成するには dev-built `build/debug/kolt.kexe` を直接呼ぶ必要があった (bootstrap pinch、 #316 で解消予定)。 また kolt と Gradle の transitive 表示には platform-suffix の有無 (`-jvm`)、 declared vs resolved version 等の cosmetic 差があるが、 on-disk jar 集合は一致 (bundle 単位で byte-identical を確認)。 `apiguardian-api:1.1.2` は kolt が POM scope に従って `compile` として取り込み、 Gradle module metadata では `compileOnlyApi` として除外、 これは harmless な annotation jar の追加で test 動作に影響なし。
+- 2026-05-01 task 4.1 (旧): kolt の JVM test compile が `-module-name` を渡しておらず、 main と test が別 module として compile される結果、 test source set から main の `internal` symbol が見えない bug を発見。 `MainCliArgsTest`、 `SelfHealingIncrementalCompiler.METRIC_*`、 `CapturingKotlinLogger`、 `BtaIncrementalCompiler.METRIC_LOG_ERROR`、 `ClasspathSnapshotCache.METRIC_*` など多数の test が compile fail。 元 task 4.1 (invariant test) を 4.2 に renumber、 新規 task 4.1 として CLI fix を foundation 扱いで追加。 R7 を requirements に追加。 fix 規模: `TestBuilder.kt` と `SubprocessCompilerBackend.kt` の argv builder + native unit test。 line 29 の「moduleName intentionally not forwarded」 コメントは削除予定。

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -10,7 +10,7 @@
   - _Requirements: 1.2_
 
 - [ ] 2. JVM daemon kolt.toml 整備 (root + ic 統合)
-- [ ] 2.1 test_sources と test-dependencies を追加
+- [x] 2.1 test_sources と test-dependencies を追加
   - `kolt-jvm-compiler-daemon/kolt.toml` の `[build]` に `test_sources = ["src/test/kotlin", "ic/src/test/kotlin"]` を追加
   - `[test-dependencies]` を新設し `org.junit.jupiter:junit-jupiter = "5.11.3"` と `org.junit.platform:junit-platform-launcher = "1.11.3"` を pin (Gradle 時代と同 version)
   - `kolt info` または config parse smoke で構文 error なく読み込める

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -18,7 +18,7 @@
   - _Requirements: 1.1, 1.6, 6.2, 6.3_
   - _Boundary: kolt-jvm-compiler-daemon/kolt.toml_
 
-- [ ] 2.2 4 classpath bundle を declare
+- [x] 2.2 4 classpath bundle を declare
   - `[classpaths.bta_impl]` に `org.jetbrains.kotlin:kotlin-build-tools-impl = "2.3.20"` を追加
   - `[classpaths.fixture]` に `org.jetbrains.kotlin:kotlin-stdlib = "2.3.20"` を追加
   - `[classpaths.serialization_plugin]` に `org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable = "2.3.20"` を追加

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -1,11 +1,12 @@
 # Implementation Plan
 
-- [ ] 1. Pre-flight: filter passthrough 動作確認
-- [ ] 1.1 JUnit Console Launcher の filter passthrough を smoke
-  - 任意の使い捨て kolt project (例 `spike/` 配下に簡易 JVM target project を一時的に作る) で `kolt test -- --select-class=<FQCN>` を実行
-  - JUnit Platform Console Standalone 1.11.4 が `--scan-class-path` 固定挿入と `--select-class` 併用で意図通り絞り込みできることを confirm
-  - 動作 OK なら本 spec を続行、 動作不能ならここで stop し R1.2 の treatment を再確定 (本 spec の Out of Boundary に CLI flag 追加が含まれるため follow-up issue 化を検討)
-  - 観察可能: smoke 出力で 1 クラスのみ実行され、 他クラスがスキップされた log が確認できる
+- [x] 1. Pre-flight: filter passthrough 動作確認 (結果: 動作不能 → R1.2 を #323 へ deferred)
+- [x] 1.1 JUnit Console Launcher の filter passthrough を smoke
+  - 実施: `/tmp/filter-smoke/` に簡易 JVM kolt project (Alpha/Beta 2 test class) を作成、 `kolt test -- --select-class=filtersmoke.AlphaTest` を実行
+  - 結果: JUnit Platform Console Launcher 1.11.4 が `Scanning the classpath and using explicit selectors at the same time is not supported` で reject
+  - `testRunCommand` の `--scan-class-path` 固定挿入を抑止する fix は kolt CLI 側の change で本 spec の Out of Boundary、 follow-up issue #323 に分離
+  - R1.2 を deferred 扱い、 本 spec で R1.2 関連 task (5.3) は同様に deferred
+  - dogfood log (`docs/dogfood.md`) に 1 行記録
   - _Requirements: 1.2_
 
 - [ ] 2. JVM daemon kolt.toml 整備 (root + ic 統合)
@@ -79,11 +80,9 @@
   - _Requirements: 1.3, 1.4, 1.5_
   - _Boundary: kolt-native-compiler-daemon_
 
-- [ ] 5.3 ic 単体 test の filter 経由実行 smoke
-  - `cd kolt-jvm-compiler-daemon && kolt test -- --select-class=kolt.daemon.ic.PluginTranslatorTest`
-  - 当該 1 クラスのみが実行され、 他 test がスキップされた log を確認
-  - 観察可能: stdout / stderr で実行 test 数が 1 クラス分のみ、 ic 以外の test class が起動していない
-  - _Depends: 5.1_
+- [x] 5.3 ic 単体 test の filter 経由実行 smoke (deferred → #323)
+  - 1.1 の Pre-flight Gate 結果により skip。 filter passthrough は kolt CLI 側 fix (#323) 完了まで利用不能
+  - 本 spec では ic-only DX を一時的に放棄、 maintainer は `cd kolt-jvm-compiler-daemon && kolt test` で全 test を実行する
   - _Requirements: 1.2_
 
 - [ ] 5.4 Gradle vs kolt verdict 一致 cross-check と test body 不変 verify
@@ -103,3 +102,7 @@
   - _Depends: 5.4_
   - _Requirements: 5.1, 5.2, 5.3, 5.4_
   - _Boundary: .kiro/steering/tech.md_
+
+## Implementation Notes
+
+- 2026-05-01 task 1.1: filter passthrough は JUnit Console Launcher 1.11.4 の `--scan-class-path` mutex 制約により動作不能。 #323 (`testRunCommand` の conditional `--scan-class-path` 抑止) で別途対応。 R1.2 関連 task (5.3) は deferred として close、 本 spec の DoD は filter なしの全 test 実行で完結させる。

--- a/.kiro/specs/daemon-test-via-kolt/tasks.md
+++ b/.kiro/specs/daemon-test-via-kolt/tasks.md
@@ -103,7 +103,7 @@
   - _Requirements: 6.1, 6.4_
 
 - [ ] 6. Documentation cleanup
-- [ ] 6.1 tech.md から ./gradlew check 言及を撤去
+- [x] 6.1 tech.md から ./gradlew check 言及を撤去
   - `.kiro/steering/tech.md` の `## Common Commands` 末尾にある Special-purpose ブロック (`./gradlew check` 行 + `./gradlew linkDebugExecutableLinuxX64 \\` 行 + 続く `&& ...kolt.kexe build` 行 + 周辺の "Special-purpose" 注釈) を削除
   - 削除後の `## Common Commands` セクションが文構造として整っている (見出し / 空行 / Development for working on kolt itself のブロック整合)
   - `grep -rn "gradlew check" .` を実行し、 historical record (`.kiro/specs/`、 `docs/adr/`、 `spike/`) と orphan Gradle config を除いた user / dev surface に該当が 0 件であることを confirm

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -106,12 +106,9 @@ Development (for working on kolt itself):
 kolt build                                                  # native binary
 kolt test                                                   # unit tests
 cd kolt-jvm-compiler-daemon && kolt build                   # JVM daemon thin jar
+cd kolt-jvm-compiler-daemon && kolt test                    # JVM daemon + ic JUnit 5 suite
 cd kolt-native-compiler-daemon && kolt build                # Native daemon thin jar
-
-# Special-purpose (kept until kolt-native equivalents land):
-./gradlew check                                             # tests + daemon version verification
-./gradlew linkDebugExecutableLinuxX64 \
-  && ./build/bin/linuxX64/debugExecutable/kolt.kexe build   # CI bootstrap self-host smoke
+cd kolt-native-compiler-daemon && kolt test                 # Native daemon JUnit 5 suite
 ```
 
 ## Key Technical Decisions

--- a/docs/dogfood.md
+++ b/docs/dogfood.md
@@ -23,3 +23,7 @@ distinguishable from external-user reports.
 - 2026-04-30 `KOLT_BOOTSTRAP_TAG` self-bootstrap means a broken pinned tag blocks the next release — pin must always trail HEAD by ≥ 1 published release → policy noted in workflow headers, no issue.
 - 2026-04-30 JVM daemon's 3s spawn-to-connect retry budget is too short for cold JVM startup on CI; first build after a fresh boot falls back to subprocess even though the daemon spawn itself succeeds. Surfaced via #302's canary expecting "no fallback at all" — instead the canary had to be relaxed to "daemon code path was reached" → #310.
 - 2026-04-30 `kolt.lock` v3 → v4 migration on the jvm-sys-props branch (#318): `kolt deps install` printed the warning and overwrote cleanly in both daemon subprojects. Root project has no `kolt.lock` (native target, deps via cinterop / native resolver), so only two files moved. Diff is just the `"version"` line — `classpath_bundles` defaults to empty and is omitted by the serializer. Builds and tests stayed green post-migration; the Option B "deps install only" policy from design.md held.
+
+## 2026-05
+
+- 2026-05-01 `kolt test -- --select-class=<FQCN>` fails: JUnit Platform Console Launcher 1.11.4 rejects `--scan-class-path` together with explicit selectors (`Scanning the classpath and using explicit selectors at the same time is not supported`). `testRunCommand` always inserts `--scan-class-path`, so trailing-arg passthrough cannot be used to narrow execution to a single class or package. Surfaced during the daemon-test-via-kolt (#315) Pre-flight Gate → #323.

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalAbiCascadeTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalAbiCascadeTest.kt
@@ -41,148 +41,162 @@ import kotlin.test.fail
 // full".
 class BtaIncrementalAbiCascadeTest {
 
-    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
-    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+  private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+  private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
 
-    @Test
-    fun `signature change on mid chain function cascades to caller but stops short of full`() {
-        val workRoot = Files.createTempDirectory("bta-abi-cascade-")
-        val sourcesDir = workRoot.resolve("src").apply { createDirectories() }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic-state")
+  @Test
+  fun `signature change on mid chain function cascades to caller but stops short of full`() {
+    val workRoot = Files.createTempDirectory("bta-abi-cascade-")
+    val sourcesDir = workRoot.resolve("src").apply { createDirectories() }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic-state")
 
-        // Each file owns exactly one top-level `fun` so .class files map
-        // 1:1 to source files (modulo synthetic artefacts BTA may emit).
-        // F3 is mid-chain; it is the one we mutate.
-        val f1 = sourcesDir.resolve("F1.kt").also {
-            it.writeText(
-                """
+    // Each file owns exactly one top-level `fun` so .class files map
+    // 1:1 to source files (modulo synthetic artefacts BTA may emit).
+    // F3 is mid-chain; it is the one we mutate.
+    val f1 =
+      sourcesDir.resolve("F1.kt").also {
+        it.writeText(
+          """
                 package fixture
                 fun f1(): Int = f2() + 1
-                """.trimIndent(),
-            )
-        }
-        val f2 = sourcesDir.resolve("F2.kt").also {
-            it.writeText(
                 """
+            .trimIndent()
+        )
+      }
+    val f2 =
+      sourcesDir.resolve("F2.kt").also {
+        it.writeText(
+          """
                 package fixture
                 fun f2(): Int = f3() + 2
-                """.trimIndent(),
-            )
-        }
-        val f3 = sourcesDir.resolve("F3.kt").also {
-            it.writeText(
                 """
+            .trimIndent()
+        )
+      }
+    val f3 =
+      sourcesDir.resolve("F3.kt").also {
+        it.writeText(
+          """
                 package fixture
                 fun f3(): Int = f4() + 3
-                """.trimIndent(),
-            )
-        }
-        val f4 = sourcesDir.resolve("F4.kt").also {
-            it.writeText(
                 """
+            .trimIndent()
+        )
+      }
+    val f4 =
+      sourcesDir.resolve("F4.kt").also {
+        it.writeText(
+          """
                 package fixture
                 fun f4(): Int = f5() + 4
-                """.trimIndent(),
-            )
-        }
-        val f5 = sourcesDir.resolve("F5.kt").also {
-            it.writeText(
                 """
+            .trimIndent()
+        )
+      }
+    val f5 =
+      sourcesDir.resolve("F5.kt").also {
+        it.writeText(
+          """
                 package fixture
                 fun f5(): Int = 5
-                """.trimIndent(),
-            )
-        }
-        val files = listOf(f1, f2, f3, f4, f5)
-
-        val compiler = BtaIncrementalCompiler.create(btaImplJars).getOrElse {
-            fail("failed to load BTA toolchain: $it")
-        }
-
-        val request = IcRequest(
-            projectId = "abi-cascade-smoke",
-            projectRoot = workRoot,
-            sources = files,
-            classpath = fixtureClasspath,
-            outputDir = outputDir,
-            workingDir = workingDir,
+                """
+            .trimIndent()
         )
+      }
+    val files = listOf(f1, f2, f3, f4, f5)
 
-        // --- cold ---
-        compiler.compile(request).getOrElse { fail("cold compile failed: $it") }
-        val coldHashes = hashClassFiles(outputDir)
-        val coldCount = coldHashes.size
-        assertTrue(
-            coldCount >= 5,
-            "expected at least 5 class files after cold compile of the 5-file chain, got: $coldCount",
-        )
+    val compiler =
+      BtaIncrementalCompiler.create(btaImplJars).getOrElse {
+        fail("failed to load BTA toolchain: $it")
+      }
 
-        // --- ABI-affecting signature change on f3 + matching f2 call site ---
-        Files.writeString(
-            f3,
-            """
+    val request =
+      IcRequest(
+        projectId = "abi-cascade-smoke",
+        projectRoot = workRoot,
+        sources = files,
+        classpath = fixtureClasspath,
+        outputDir = outputDir,
+        workingDir = workingDir,
+      )
+
+    // --- cold ---
+    compiler.compile(request).getOrElse { fail("cold compile failed: $it") }
+    val coldHashes = hashClassFiles(outputDir)
+    val coldCount = coldHashes.size
+    assertTrue(
+      coldCount >= 5,
+      "expected at least 5 class files after cold compile of the 5-file chain, got: $coldCount",
+    )
+
+    // --- ABI-affecting signature change on f3 + matching f2 call site ---
+    Files.writeString(
+      f3,
+      """
             package fixture
             fun f3(bonus: Int): Int = f4() + 3 + bonus
-            """.trimIndent(),
-        )
-        Files.writeString(
-            f2,
             """
+        .trimIndent(),
+    )
+    Files.writeString(
+      f2,
+      """
             package fixture
             fun f2(): Int = f3(10) + 2
-            """.trimIndent(),
-        )
+            """
+        .trimIndent(),
+    )
 
-        // --- warm ---
-        compiler.compile(request).getOrElse { fail("warm compile failed: $it") }
-        val warmHashes = hashClassFiles(outputDir)
+    // --- warm ---
+    compiler.compile(request).getOrElse { fail("warm compile failed: $it") }
+    val warmHashes = hashClassFiles(outputDir)
 
-        val changed = warmHashes.filter { (path, hash) -> coldHashes[path] != hash }
+    val changed = warmHashes.filter { (path, hash) -> coldHashes[path] != hash }
 
-        // Cascade happened: f3 changed its ABI, f2 had to re-link against
-        // the new signature, so at minimum two .class files differ between
-        // cold and warm. A single-file change here would mean BTA did not
-        // observe the call-site edit, which the test is specifically
-        // guarding against.
-        assertTrue(
-            changed.size >= 2,
-            "expected signature change to cascade to at least the caller " +
-                "(f3 + f2 = 2 class files), got changed=${changed.size} " +
-                "(${changed.keys.sorted()})",
-        )
+    // Cascade happened: f3 changed its ABI, f2 had to re-link against
+    // the new signature, so at minimum two .class files differ between
+    // cold and warm. A single-file change here would mean BTA did not
+    // observe the call-site edit, which the test is specifically
+    // guarding against.
+    assertTrue(
+      changed.size >= 2,
+      "expected signature change to cascade to at least the caller " +
+        "(f3 + f2 = 2 class files), got changed=${changed.size} " +
+        "(${changed.keys.sorted()})",
+    )
 
-        // Cascade stopped short of full: IC is still smarter than "recompile
-        // everything". A regression producing `changed.size == coldCount`
-        // would mean the ABI snapshot failed to spare f1 / f4 / f5 from
-        // recompilation — the inverse of the bimodal floor, and the
-        // signal that the #103 ceiling has been hit.
-        assertTrue(
-            changed.size < coldCount,
-            "expected ABI cascade to stop short of full recompile, " +
-                "got changed=${changed.size} of $coldCount " +
-                "(${changed.keys.sorted()})",
-        )
-    }
+    // Cascade stopped short of full: IC is still smarter than "recompile
+    // everything". A regression producing `changed.size == coldCount`
+    // would mean the ABI snapshot failed to spare f1 / f4 / f5 from
+    // recompilation — the inverse of the bimodal floor, and the
+    // signal that the #103 ceiling has been hit.
+    assertTrue(
+      changed.size < coldCount,
+      "expected ABI cascade to stop short of full recompile, " +
+        "got changed=${changed.size} of $coldCount " +
+        "(${changed.keys.sorted()})",
+    )
+  }
 
-    private fun hashClassFiles(classesDir: Path): Map<String, String> {
-        if (!Files.isDirectory(classesDir)) return emptyMap()
-        val md = MessageDigest.getInstance("SHA-256")
-        return classesDir.walk()
-            .filter { it.extension == "class" }
-            .associate { p ->
-                val rel = p.relativeTo(classesDir).toString()
-                md.reset()
-                md.update(Files.readAllBytes(p))
-                rel to md.digest().joinToString("") { "%02x".format(it) }
-            }
-    }
+  private fun hashClassFiles(classesDir: Path): Map<String, String> {
+    if (!Files.isDirectory(classesDir)) return emptyMap()
+    val md = MessageDigest.getInstance("SHA-256")
+    return classesDir
+      .walk()
+      .filter { it.extension == "class" }
+      .associate { p ->
+        val rel = p.relativeTo(classesDir).toString()
+        md.reset()
+        md.update(Files.readAllBytes(p))
+        rel to md.digest().joinToString("") { "%02x".format(it) }
+      }
+  }
 
-    private fun systemClasspath(key: String): List<Path> {
-        val raw = System.getProperty(key)
-            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
-        return raw.split(File.pathSeparator)
-            .filter { it.isNotBlank() }
-            .map { Path.of(it) }
-    }
+  private fun systemClasspath(key: String): List<Path> {
+    val raw =
+      System.getProperty(key)
+        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+    return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
@@ -31,145 +31,160 @@ import kotlin.test.fail
 //   kolt.ic.fixtureClasspath  — kotlin-stdlib:2.3.20 (compile classpath for the fixture)
 class BtaIncrementalCompilerColdPathTest {
 
-    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
-    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+  private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+  private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
 
-    @Test
-    fun `cold compile of a single-file fixture produces a class file`() {
-        val workRoot = Files.createTempDirectory("bta-cold-")
-        val sourceFile = workRoot.resolve("Main.kt").also {
-            it.writeText(
-                """
+  @Test
+  fun `cold compile of a single-file fixture produces a class file`() {
+    val workRoot = Files.createTempDirectory("bta-cold-")
+    val sourceFile =
+      workRoot.resolve("Main.kt").also {
+        it.writeText(
+          """
                 package fixture
                 object Main {
                     fun greeting(): String = "hello"
                 }
-                """.trimIndent(),
-            )
-        }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic").apply { createDirectories() }
-
-        val compiler = BtaIncrementalCompiler.create(btaImplJars).getOrElse {
-            fail("failed to load BTA toolchain: $it")
-        }
-
-        compiler.compile(
-            IcRequest(
-                projectId = "cold-path-smoke",
-                projectRoot = workRoot,
-                sources = listOf(sourceFile),
-                classpath = fixtureClasspath,
-                outputDir = outputDir,
-                workingDir = workingDir,
-            ),
-        ).getOrElse { err ->
-            fail("expected success, got Err($err)")
-        }
-
-        val classFiles = outputDir.walk().filter { it.extension == "class" }.toList()
-        assertTrue(classFiles.isNotEmpty(), "expected at least one .class under $outputDir")
-        assertTrue(classFiles.any { it.fileName.toString() == "Main.class" }, "expected fixture.Main.class in output: $classFiles")
-
-        // ADR 0019 §Negative follow-up — IC reaper coordination: the
-        // cold path must drop a `project.path` breadcrumb inside
-        // workingDir pointing at the request's projectRoot, so the
-        // reaper can distinguish live projectId dirs from stale ones
-        // after a project is moved or deleted.
-        val breadcrumb = workingDir.resolve("project.path")
-        assertTrue(breadcrumb.exists(), "expected project.path breadcrumb at $breadcrumb")
-        assertEquals(workRoot.toString(), breadcrumb.readText().trim())
-
-        // #199: LOCK must exist under workingDir after compile and its
-        // mtime must be no later than the breadcrumb's — a literal
-        // swap of the write order back to breadcrumb-first would flip
-        // this. Strict `<` would be flaky on WSL2 9p (1s mtime
-        // granularity); `<=` catches the swap without false positives
-        // on fast filesystems.
-        val lock = workingDir.resolve("LOCK")
-        assertTrue(lock.exists(), "expected LOCK at $lock")
-        val lockMtime = Files.getLastModifiedTime(lock)
-        val breadcrumbMtime = Files.getLastModifiedTime(breadcrumb)
-        assertTrue(
-            lockMtime <= breadcrumbMtime,
-            "expected LOCK mtime ($lockMtime) <= breadcrumb mtime ($breadcrumbMtime) — ordering regressed",
-        )
-    }
-
-    // A user type error is the only BTA outcome that maps to CompilationFailed.
-    // COMPILER_INTERNAL_ERROR and COMPILATION_OOM_ERROR are compiler-infrastructure
-    // failures and map to InternalError so B-2b's self-heal retry path can fire on
-    // them; see BtaIncrementalCompiler.executeCompile and ADR 0019 §7.
-    @Test
-    fun `user type error is reported as CompilationFailed not InternalError`() {
-        val workRoot = Files.createTempDirectory("bta-err-")
-        val sourceFile = workRoot.resolve("Broken.kt").also {
-            it.writeText(
                 """
+            .trimIndent()
+        )
+      }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic").apply { createDirectories() }
+
+    val compiler =
+      BtaIncrementalCompiler.create(btaImplJars).getOrElse {
+        fail("failed to load BTA toolchain: $it")
+      }
+
+    compiler
+      .compile(
+        IcRequest(
+          projectId = "cold-path-smoke",
+          projectRoot = workRoot,
+          sources = listOf(sourceFile),
+          classpath = fixtureClasspath,
+          outputDir = outputDir,
+          workingDir = workingDir,
+        )
+      )
+      .getOrElse { err -> fail("expected success, got Err($err)") }
+
+    val classFiles = outputDir.walk().filter { it.extension == "class" }.toList()
+    assertTrue(classFiles.isNotEmpty(), "expected at least one .class under $outputDir")
+    assertTrue(
+      classFiles.any { it.fileName.toString() == "Main.class" },
+      "expected fixture.Main.class in output: $classFiles",
+    )
+
+    // ADR 0019 §Negative follow-up — IC reaper coordination: the
+    // cold path must drop a `project.path` breadcrumb inside
+    // workingDir pointing at the request's projectRoot, so the
+    // reaper can distinguish live projectId dirs from stale ones
+    // after a project is moved or deleted.
+    val breadcrumb = workingDir.resolve("project.path")
+    assertTrue(breadcrumb.exists(), "expected project.path breadcrumb at $breadcrumb")
+    assertEquals(workRoot.toString(), breadcrumb.readText().trim())
+
+    // #199: LOCK must exist under workingDir after compile and its
+    // mtime must be no later than the breadcrumb's — a literal
+    // swap of the write order back to breadcrumb-first would flip
+    // this. Strict `<` would be flaky on WSL2 9p (1s mtime
+    // granularity); `<=` catches the swap without false positives
+    // on fast filesystems.
+    val lock = workingDir.resolve("LOCK")
+    assertTrue(lock.exists(), "expected LOCK at $lock")
+    val lockMtime = Files.getLastModifiedTime(lock)
+    val breadcrumbMtime = Files.getLastModifiedTime(breadcrumb)
+    assertTrue(
+      lockMtime <= breadcrumbMtime,
+      "expected LOCK mtime ($lockMtime) <= breadcrumb mtime ($breadcrumbMtime) — ordering regressed",
+    )
+  }
+
+  // A user type error is the only BTA outcome that maps to CompilationFailed.
+  // COMPILER_INTERNAL_ERROR and COMPILATION_OOM_ERROR are compiler-infrastructure
+  // failures and map to InternalError so B-2b's self-heal retry path can fire on
+  // them; see BtaIncrementalCompiler.executeCompile and ADR 0019 §7.
+  @Test
+  fun `user type error is reported as CompilationFailed not InternalError`() {
+    val workRoot = Files.createTempDirectory("bta-err-")
+    val sourceFile =
+      workRoot.resolve("Broken.kt").also {
+        it.writeText(
+          """
                 package fixture
                 fun broken(): Int = "not an int"
-                """.trimIndent(),
-            )
-        }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic").apply { createDirectories() }
-
-        val compiler = BtaIncrementalCompiler.create(btaImplJars).getOrElse {
-            fail("failed to load BTA toolchain: $it")
-        }
-
-        val err = compiler.compile(
-            IcRequest(
-                projectId = "cold-path-err",
-                projectRoot = workRoot,
-                sources = listOf(sourceFile),
-                classpath = fixtureClasspath,
-                outputDir = outputDir,
-                workingDir = workingDir,
-            ),
-        ).getError() ?: fail("expected Err for broken source")
-
-        assertTrue(err is IcError.CompilationFailed, "expected CompilationFailed, got $err")
-        // ADR 0019 §7 diagnostics: the captured KotlinLogger error lines
-        // must surface the actual kotlinc message (source file + error
-        // text), not the synthetic "kotlinc reported COMPILATION_ERROR"
-        // stub. The stub is a last-resort fallback for the pathological
-        // case where BTA returns COMPILATION_ERROR without emitting any
-        // logger line; in practice a real type error produces at least
-        // one. A regression on this assertion would take dogfood users
-        // back to the "what did I break?" experience.
-        assertTrue(
-            err.messages.isNotEmpty(),
-            "expected at least one captured diagnostic, got: ${err.messages}",
+                """
+            .trimIndent()
         )
-        val joined = err.messages.joinToString("\n")
-        assertTrue(
-            joined.contains("Broken.kt", ignoreCase = true) || joined.contains("type mismatch", ignoreCase = true),
-            "expected the captured message to reference the broken source or the type error, got:\n$joined",
-        )
-        assertTrue(
-            !joined.contains("kotlinc reported COMPILATION_ERROR"),
-            "stub fallback must not fire when real diagnostics were captured, got:\n$joined",
-        )
-    }
+      }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic").apply { createDirectories() }
 
-    // Acceptance criterion 4 of issue #112: a kolt.toml with one enabled plugin
-    // entry must drive the translation path all the way through to the BTA layer,
-    // even if the actual plugin jars cannot be resolved or the compile fails at
-    // plugin load. This test proves that (a) the injected resolver is consulted,
-    // and (b) the adapter still reaches BtaIncrementalCompiler.executeCompile's
-    // session.executeOperation() call — i.e. the translation is wired through
-    // to the compile operation, not short-circuited before BTA sees it.
-    //
-    // A fake plugin alias is used so the test stays independent of whether a
-    // real kotlinx-serialization-compiler-plugin jar is resolvable in the Gradle
-    // test task's environment. Real plugin validation (actually compiling a
-    // @Serializable class) is B-2c's scope.
-    @Test
-    fun `kotlin_plugins section in kolt_toml reaches the compile path via the resolver`() {
-        val workRoot = Files.createTempDirectory("bta-plugins-")
-        workRoot.resolve("kolt.toml").writeText(
-            """
+    val compiler =
+      BtaIncrementalCompiler.create(btaImplJars).getOrElse {
+        fail("failed to load BTA toolchain: $it")
+      }
+
+    val err =
+      compiler
+        .compile(
+          IcRequest(
+            projectId = "cold-path-err",
+            projectRoot = workRoot,
+            sources = listOf(sourceFile),
+            classpath = fixtureClasspath,
+            outputDir = outputDir,
+            workingDir = workingDir,
+          )
+        )
+        .getError() ?: fail("expected Err for broken source")
+
+    assertTrue(err is IcError.CompilationFailed, "expected CompilationFailed, got $err")
+    // ADR 0019 §7 diagnostics: the captured KotlinLogger error lines
+    // must surface the actual kotlinc message (source file + error
+    // text), not the synthetic "kotlinc reported COMPILATION_ERROR"
+    // stub. The stub is a last-resort fallback for the pathological
+    // case where BTA returns COMPILATION_ERROR without emitting any
+    // logger line; in practice a real type error produces at least
+    // one. A regression on this assertion would take dogfood users
+    // back to the "what did I break?" experience.
+    assertTrue(
+      err.messages.isNotEmpty(),
+      "expected at least one captured diagnostic, got: ${err.messages}",
+    )
+    val joined = err.messages.joinToString("\n")
+    assertTrue(
+      joined.contains("Broken.kt", ignoreCase = true) ||
+        joined.contains("type mismatch", ignoreCase = true),
+      "expected the captured message to reference the broken source or the type error, got:\n$joined",
+    )
+    assertTrue(
+      !joined.contains("kotlinc reported COMPILATION_ERROR"),
+      "stub fallback must not fire when real diagnostics were captured, got:\n$joined",
+    )
+  }
+
+  // Acceptance criterion 4 of issue #112: a kolt.toml with one enabled plugin
+  // entry must drive the translation path all the way through to the BTA layer,
+  // even if the actual plugin jars cannot be resolved or the compile fails at
+  // plugin load. This test proves that (a) the injected resolver is consulted,
+  // and (b) the adapter still reaches BtaIncrementalCompiler.executeCompile's
+  // session.executeOperation() call — i.e. the translation is wired through
+  // to the compile operation, not short-circuited before BTA sees it.
+  //
+  // A fake plugin alias is used so the test stays independent of whether a
+  // real kotlinx-serialization-compiler-plugin jar is resolvable in the Gradle
+  // test task's environment. Real plugin validation (actually compiling a
+  // @Serializable class) is B-2c's scope.
+  @Test
+  fun `kotlin_plugins section in kolt_toml reaches the compile path via the resolver`() {
+    val workRoot = Files.createTempDirectory("bta-plugins-")
+    workRoot
+      .resolve("kolt.toml")
+      .writeText(
+        """
             name = "demo"
             version = "0.1.0"
 
@@ -183,78 +198,82 @@ class BtaIncrementalCompilerColdPathTest {
             target = "jvm"
             main = "fixture.Main"
             sources = ["."]
-            """.trimIndent(),
-        )
-        workRoot.resolve("Main.kt").writeText(
             """
+          .trimIndent()
+      )
+    workRoot
+      .resolve("Main.kt")
+      .writeText(
+        """
             package fixture
             object Main {
                 fun greeting(): String = "hi"
             }
-            """.trimIndent(),
-        )
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic").apply { createDirectories() }
+            """
+          .trimIndent()
+      )
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic").apply { createDirectories() }
 
-        val resolverCalls = mutableListOf<String>()
-        val compiler = BtaIncrementalCompiler.create(
-            btaImplJars = btaImplJars,
-            pluginJarResolver = { alias ->
-                resolverCalls += alias
-                // Return an empty classpath on purpose: the point of this test is
-                // to prove the translation path is reached, not to successfully
-                // load a real plugin. Post-#148 the translator collapses an
-                // empty resolution to zero `-Xplugin=` freeArgs, so the compile
-                // simply proceeds without the plugin attached. The assertion
-                // that matters here is that the resolver was consulted at all.
-                emptyList()
-            },
-        ).getOrElse { fail("failed to load BTA toolchain: $it") }
-
-        val result = compiler.compile(
-            IcRequest(
-                projectId = "plugin-path-smoke",
-                projectRoot = workRoot,
-                sources = listOf(workRoot.resolve("Main.kt")),
-                classpath = fixtureClasspath,
-                outputDir = outputDir,
-                workingDir = workingDir,
-            ),
+    val resolverCalls = mutableListOf<String>()
+    val compiler =
+      BtaIncrementalCompiler.create(
+          btaImplJars = btaImplJars,
+          pluginJarResolver = { alias ->
+            resolverCalls += alias
+            // Return an empty classpath on purpose: the point of this test is
+            // to prove the translation path is reached, not to successfully
+            // load a real plugin. Post-#148 the translator collapses an
+            // empty resolution to zero `-Xplugin=` freeArgs, so the compile
+            // simply proceeds without the plugin attached. The assertion
+            // that matters here is that the resolver was consulted at all.
+            emptyList()
+          },
         )
+        .getOrElse { fail("failed to load BTA toolchain: $it") }
 
-        // Primary assertion: the injected resolver was consulted for the
-        // `serialization` alias. Without this, the translation path never
-        // reached BTA; the compile outcome is a secondary signal.
-        assertEquals(
-            listOf("serialization"),
-            resolverCalls,
-            "expected PluginTranslator to consult the resolver for the `serialization` alias",
+    val result =
+      compiler.compile(
+        IcRequest(
+          projectId = "plugin-path-smoke",
+          projectRoot = workRoot,
+          sources = listOf(workRoot.resolve("Main.kt")),
+          classpath = fixtureClasspath,
+          outputDir = outputDir,
+          workingDir = workingDir,
         )
+      )
 
-        // Secondary assertion: the compile reaches a well-formed Result<,>
-        // (Ok or Err) — i.e., the adapter did not crash on a thrown exception
-        // when handed an empty-classpath plugin. Either outcome is acceptable
-        // because B-2a only requires that the translation path is exercised.
-        val outcome = result.mapBoth(
-            success = { "SUCCESS" },
-            failure = { err -> "Err(${err::class.simpleName})" },
-        )
-        // This assert is documentation for a future reader: both outcomes are
-        // legal. A test failure would mean `compile` threw past the adapter,
-        // which IS an ADR 0019 §7 invariant violation.
-        assertTrue(
-            outcome == "SUCCESS" ||
-                outcome == "Err(CompilationFailed)" ||
-                outcome == "Err(InternalError)",
-            "unexpected compile outcome: $outcome",
-        )
-    }
+    // Primary assertion: the injected resolver was consulted for the
+    // `serialization` alias. Without this, the translation path never
+    // reached BTA; the compile outcome is a secondary signal.
+    assertEquals(
+      listOf("serialization"),
+      resolverCalls,
+      "expected PluginTranslator to consult the resolver for the `serialization` alias",
+    )
 
-    private fun systemClasspath(key: String): List<Path> {
-        val raw = System.getProperty(key)
-            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
-        return raw.split(File.pathSeparator)
-            .filter { it.isNotBlank() }
-            .map { Path.of(it) }
-    }
+    // Secondary assertion: the compile reaches a well-formed Result<,>
+    // (Ok or Err) — i.e., the adapter did not crash on a thrown exception
+    // when handed an empty-classpath plugin. Either outcome is acceptable
+    // because B-2a only requires that the translation path is exercised.
+    val outcome =
+      result.mapBoth(success = { "SUCCESS" }, failure = { err -> "Err(${err::class.simpleName})" })
+    // This assert is documentation for a future reader: both outcomes are
+    // legal. A test failure would mean `compile` threw past the adapter,
+    // which IS an ADR 0019 §7 invariant violation.
+    assertTrue(
+      outcome == "SUCCESS" ||
+        outcome == "Err(CompilationFailed)" ||
+        outcome == "Err(InternalError)",
+      "unexpected compile outcome: $outcome",
+    )
+  }
+
+  private fun systemClasspath(key: String): List<Path> {
+    val raw =
+      System.getProperty(key)
+        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+    return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerWarmPathTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerWarmPathTest.kt
@@ -31,201 +31,216 @@ import kotlin.test.fail
 // spike fixtures into the daemon module's test classpath.
 class BtaIncrementalCompilerWarmPathTest {
 
-    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
-    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+  private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+  private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
 
-    @Test
-    fun `workingDir is created lazily if it does not exist when compile is called`() {
-        val workRoot = Files.createTempDirectory("bta-warm-lazy-")
-        val sourceFile = workRoot.resolve("Main.kt").also {
-            it.writeText(
-                """
+  @Test
+  fun `workingDir is created lazily if it does not exist when compile is called`() {
+    val workRoot = Files.createTempDirectory("bta-warm-lazy-")
+    val sourceFile =
+      workRoot.resolve("Main.kt").also {
+        it.writeText(
+          """
                 package fixture
                 object Main { fun greeting(): String = "hello" }
-                """.trimIndent(),
-            )
-        }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        // Intentionally NOT created — the adapter must materialise it.
-        val workingDir = workRoot.resolve("ic-state")
-        assertTrue(!Files.exists(workingDir), "precondition: workingDir must not exist")
-
-        val compiler = BtaIncrementalCompiler.create(btaImplJars).getOrElse {
-            fail("failed to load BTA toolchain: $it")
-        }
-
-        compiler.compile(
-            IcRequest(
-                projectId = "warm-lazy-mkdir",
-                projectRoot = workRoot,
-                sources = listOf(sourceFile),
-                classpath = fixtureClasspath,
-                outputDir = outputDir,
-                workingDir = workingDir,
-            ),
-        ).getOrElse { fail("expected success, got Err($it)") }
-
-        assertTrue(Files.isDirectory(workingDir), "adapter must mkdir workingDir on first compile")
-    }
-
-    @Test
-    fun `cold compile populates workingDir with IC state and warm compile reuses it`() {
-        val workRoot = Files.createTempDirectory("bta-warm-")
-        val sourceFile = workRoot.resolve("Main.kt").also {
-            it.writeText(
                 """
+            .trimIndent()
+        )
+      }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    // Intentionally NOT created — the adapter must materialise it.
+    val workingDir = workRoot.resolve("ic-state")
+    assertTrue(!Files.exists(workingDir), "precondition: workingDir must not exist")
+
+    val compiler =
+      BtaIncrementalCompiler.create(btaImplJars).getOrElse {
+        fail("failed to load BTA toolchain: $it")
+      }
+
+    compiler
+      .compile(
+        IcRequest(
+          projectId = "warm-lazy-mkdir",
+          projectRoot = workRoot,
+          sources = listOf(sourceFile),
+          classpath = fixtureClasspath,
+          outputDir = outputDir,
+          workingDir = workingDir,
+        )
+      )
+      .getOrElse { fail("expected success, got Err($it)") }
+
+    assertTrue(Files.isDirectory(workingDir), "adapter must mkdir workingDir on first compile")
+  }
+
+  @Test
+  fun `cold compile populates workingDir with IC state and warm compile reuses it`() {
+    val workRoot = Files.createTempDirectory("bta-warm-")
+    val sourceFile =
+      workRoot.resolve("Main.kt").also {
+        it.writeText(
+          """
                 package fixture
                 object Main {
                     fun greeting(): String = "hello"
                 }
-                """.trimIndent(),
-            )
-        }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic-state")
-
-        val compiler = BtaIncrementalCompiler.create(btaImplJars).getOrElse {
-            fail("failed to load BTA toolchain: $it")
-        }
-
-        val request = IcRequest(
-            projectId = "warm-path-smoke",
-            projectRoot = workRoot,
-            sources = listOf(sourceFile),
-            classpath = fixtureClasspath,
-            outputDir = outputDir,
-            workingDir = workingDir,
-        )
-
-        // --- cold ---
-        compiler.compile(request).getOrElse { fail("cold compile failed: $it") }
-
-        val coldStateFileCount = workingDir.walk().filter { Files.isRegularFile(it) }.count()
-        assertTrue(
-            coldStateFileCount > 0,
-            "BTA must write IC state under workingDir after cold compile (found $coldStateFileCount files)",
-        )
-
-        // --- touch ---
-        // Append a uniquely-named top-level function so the resulting
-        // .class bytes actually differ cold vs warm. A comment-only edit
-        // would be byte-identical and defeat the intent of the test.
-        val uniq = System.nanoTime()
-        Files.writeString(
-            sourceFile,
-            "\nfun warmTouch$uniq(): Long = $uniq\n",
-            StandardOpenOption.APPEND,
-        )
-
-        // --- warm ---
-        compiler.compile(request).getOrElse { fail("warm compile failed: $it") }
-
-        val classFiles = outputDir.walk().filter { it.extension == "class" }.toList()
-        assertTrue(
-            classFiles.any { it.fileName.toString() == "MainKt.class" || it.fileName.toString() == "Main.class" },
-            "expected at least one fixture class file after warm compile: $classFiles",
-        )
-
-        // IC state on disk must survive the warm compile. If it were
-        // wiped between requests, we would have a regression against the
-        // "daemon-owned state across requests" invariant (ADR 0019 §5).
-        val warmStateFileCount = workingDir.walk().filter { Files.isRegularFile(it) }.count()
-        assertTrue(
-            warmStateFileCount > 0,
-            "IC state must still be present after warm compile (found $warmStateFileCount files)",
-        )
-    }
-
-    @Test
-    fun `cold run emits ic_success + ic_fallback_to_full and warm run emits only ic_success`() {
-        val workRoot = Files.createTempDirectory("bta-metrics-")
-        val sourceFile = workRoot.resolve("Main.kt").also {
-            it.writeText(
                 """
+            .trimIndent()
+        )
+      }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic-state")
+
+    val compiler =
+      BtaIncrementalCompiler.create(btaImplJars).getOrElse {
+        fail("failed to load BTA toolchain: $it")
+      }
+
+    val request =
+      IcRequest(
+        projectId = "warm-path-smoke",
+        projectRoot = workRoot,
+        sources = listOf(sourceFile),
+        classpath = fixtureClasspath,
+        outputDir = outputDir,
+        workingDir = workingDir,
+      )
+
+    // --- cold ---
+    compiler.compile(request).getOrElse { fail("cold compile failed: $it") }
+
+    val coldStateFileCount = workingDir.walk().filter { Files.isRegularFile(it) }.count()
+    assertTrue(
+      coldStateFileCount > 0,
+      "BTA must write IC state under workingDir after cold compile (found $coldStateFileCount files)",
+    )
+
+    // --- touch ---
+    // Append a uniquely-named top-level function so the resulting
+    // .class bytes actually differ cold vs warm. A comment-only edit
+    // would be byte-identical and defeat the intent of the test.
+    val uniq = System.nanoTime()
+    Files.writeString(
+      sourceFile,
+      "\nfun warmTouch$uniq(): Long = $uniq\n",
+      StandardOpenOption.APPEND,
+    )
+
+    // --- warm ---
+    compiler.compile(request).getOrElse { fail("warm compile failed: $it") }
+
+    val classFiles = outputDir.walk().filter { it.extension == "class" }.toList()
+    assertTrue(
+      classFiles.any {
+        it.fileName.toString() == "MainKt.class" || it.fileName.toString() == "Main.class"
+      },
+      "expected at least one fixture class file after warm compile: $classFiles",
+    )
+
+    // IC state on disk must survive the warm compile. If it were
+    // wiped between requests, we would have a regression against the
+    // "daemon-owned state across requests" invariant (ADR 0019 §5).
+    val warmStateFileCount = workingDir.walk().filter { Files.isRegularFile(it) }.count()
+    assertTrue(
+      warmStateFileCount > 0,
+      "IC state must still be present after warm compile (found $warmStateFileCount files)",
+    )
+  }
+
+  @Test
+  fun `cold run emits ic_success + ic_fallback_to_full and warm run emits only ic_success`() {
+    val workRoot = Files.createTempDirectory("bta-metrics-")
+    val sourceFile =
+      workRoot.resolve("Main.kt").also {
+        it.writeText(
+          """
                 package fixture
                 object Main { fun greeting(): String = "hi" }
-                """.trimIndent(),
-            )
-        }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic-state")
+                """
+            .trimIndent()
+        )
+      }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic-state")
 
-        val metrics = RecordingMetricsSink()
-        val compiler = BtaIncrementalCompiler.create(
-            btaImplJars = btaImplJars,
-            metrics = metrics,
-        ).getOrElse { fail("failed to load BTA toolchain: $it") }
+    val metrics = RecordingMetricsSink()
+    val compiler =
+      BtaIncrementalCompiler.create(btaImplJars = btaImplJars, metrics = metrics).getOrElse {
+        fail("failed to load BTA toolchain: $it")
+      }
 
-        val request = IcRequest(
-            projectId = "metrics-smoke",
-            projectRoot = workRoot,
-            sources = listOf(sourceFile),
-            classpath = fixtureClasspath,
-            outputDir = outputDir,
-            workingDir = workingDir,
-        )
+    val request =
+      IcRequest(
+        projectId = "metrics-smoke",
+        projectRoot = workRoot,
+        sources = listOf(sourceFile),
+        classpath = fixtureClasspath,
+        outputDir = outputDir,
+        workingDir = workingDir,
+      )
 
-        // --- cold ---
-        compiler.compile(request).getOrElse { fail("cold compile failed: $it") }
-        val coldEvents = metrics.snapshotAndReset()
-        val coldCounterNames = coldEvents.map { it.first }.toSet()
-        assertTrue(
-            "ic.success" in coldCounterNames,
-            "cold run must emit ic.success, got: $coldCounterNames",
-        )
-        assertTrue(
-            "ic.fallback_to_full" in coldCounterNames,
-            "cold run (empty workingDir) must emit ic.fallback_to_full, got: $coldCounterNames",
-        )
-        assertTrue(
-            "ic.wall_ms" in coldCounterNames,
-            "cold run must emit ic.wall_ms, got: $coldCounterNames",
-        )
-        // BTA metrics are forwarded with `ic.bta.` prefix; at least one is
-        // expected from a real compile. This is the observability guard
-        // that the BuildMetricsCollector hook is wired up to sink.
-        assertTrue(
-            coldCounterNames.any { it.startsWith("ic.bta.") },
-            "cold run must forward at least one BTA metric with ic.bta. prefix, got: $coldCounterNames",
-        )
+    // --- cold ---
+    compiler.compile(request).getOrElse { fail("cold compile failed: $it") }
+    val coldEvents = metrics.snapshotAndReset()
+    val coldCounterNames = coldEvents.map { it.first }.toSet()
+    assertTrue(
+      "ic.success" in coldCounterNames,
+      "cold run must emit ic.success, got: $coldCounterNames",
+    )
+    assertTrue(
+      "ic.fallback_to_full" in coldCounterNames,
+      "cold run (empty workingDir) must emit ic.fallback_to_full, got: $coldCounterNames",
+    )
+    assertTrue(
+      "ic.wall_ms" in coldCounterNames,
+      "cold run must emit ic.wall_ms, got: $coldCounterNames",
+    )
+    // BTA metrics are forwarded with `ic.bta.` prefix; at least one is
+    // expected from a real compile. This is the observability guard
+    // that the BuildMetricsCollector hook is wired up to sink.
+    assertTrue(
+      coldCounterNames.any { it.startsWith("ic.bta.") },
+      "cold run must forward at least one BTA metric with ic.bta. prefix, got: $coldCounterNames",
+    )
 
-        // --- warm ---
-        Files.writeString(
-            sourceFile,
-            "\nfun warmMetricsTouch${System.nanoTime()}(): Int = 0\n",
-            StandardOpenOption.APPEND,
-        )
-        compiler.compile(request).getOrElse { fail("warm compile failed: $it") }
-        val warmEvents = metrics.snapshotAndReset()
-        val warmCounterNames = warmEvents.map { it.first }.toSet()
-        assertTrue(
-            "ic.success" in warmCounterNames,
-            "warm run must emit ic.success, got: $warmCounterNames",
-        )
-        assertEquals(
-            false,
-            "ic.fallback_to_full" in warmCounterNames,
-            "warm run (non-empty workingDir) must NOT emit ic.fallback_to_full, got: $warmCounterNames",
-        )
+    // --- warm ---
+    Files.writeString(
+      sourceFile,
+      "\nfun warmMetricsTouch${System.nanoTime()}(): Int = 0\n",
+      StandardOpenOption.APPEND,
+    )
+    compiler.compile(request).getOrElse { fail("warm compile failed: $it") }
+    val warmEvents = metrics.snapshotAndReset()
+    val warmCounterNames = warmEvents.map { it.first }.toSet()
+    assertTrue(
+      "ic.success" in warmCounterNames,
+      "warm run must emit ic.success, got: $warmCounterNames",
+    )
+    assertEquals(
+      false,
+      "ic.fallback_to_full" in warmCounterNames,
+      "warm run (non-empty workingDir) must NOT emit ic.fallback_to_full, got: $warmCounterNames",
+    )
+  }
+
+  private class RecordingMetricsSink : IcMetricsSink {
+    private val events: MutableList<Pair<String, Long>> = mutableListOf()
+
+    override fun record(name: String, value: Long) {
+      events += name to value
     }
 
-    private class RecordingMetricsSink : IcMetricsSink {
-        private val events: MutableList<Pair<String, Long>> = mutableListOf()
-        override fun record(name: String, value: Long) {
-            events += name to value
-        }
-        fun snapshotAndReset(): List<Pair<String, Long>> {
-            val snap = events.toList()
-            events.clear()
-            return snap
-        }
+    fun snapshotAndReset(): List<Pair<String, Long>> {
+      val snap = events.toList()
+      events.clear()
+      return snap
     }
+  }
 
-    private fun systemClasspath(key: String): List<Path> {
-        val raw = System.getProperty(key)
-            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
-        return raw.split(File.pathSeparator)
-            .filter { it.isNotBlank() }
-            .map { Path.of(it) }
-    }
+  private fun systemClasspath(key: String): List<Path> {
+    val raw =
+      System.getProperty(key)
+        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+    return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCorruptionSmokeTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCorruptionSmokeTest.kt
@@ -38,97 +38,97 @@ import kotlin.test.fail
 // observe the event.
 class BtaIncrementalCorruptionSmokeTest {
 
-    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
-    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+  private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+  private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
 
-    @Test
-    fun `truncated working dir triggers self-heal and second compile succeeds`() {
-        val workRoot = Files.createTempDirectory("bta-corrupt-")
-        val sourceFile = workRoot.resolve("Main.kt").also {
-            it.writeText(
-                """
+  @Test
+  fun `truncated working dir triggers self-heal and second compile succeeds`() {
+    val workRoot = Files.createTempDirectory("bta-corrupt-")
+    val sourceFile =
+      workRoot.resolve("Main.kt").also {
+        it.writeText(
+          """
                 package fixture
                 object Main { fun ping(): String = "pong" }
-                """.trimIndent(),
-            )
-        }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic-state")
-
-        val metrics = RecordingMetricsSink()
-        val adapter = BtaIncrementalCompiler.create(btaImplJars, metrics = metrics)
-            .getOrElse { fail("adapter construction failed: $it") }
-        val composed: IncrementalCompiler = SelfHealingIncrementalCompiler(
-            delegate = adapter,
-            metrics = metrics,
+                """
+            .trimIndent()
         )
+      }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic-state")
 
-        val request = IcRequest(
-            projectId = "corruption-smoke",
-            projectRoot = workRoot,
-            sources = listOf(sourceFile),
-            classpath = fixtureClasspath,
-            outputDir = outputDir,
-            workingDir = workingDir,
-        )
+    val metrics = RecordingMetricsSink()
+    val adapter =
+      BtaIncrementalCompiler.create(btaImplJars, metrics = metrics).getOrElse {
+        fail("adapter construction failed: $it")
+      }
+    val composed: IncrementalCompiler =
+      SelfHealingIncrementalCompiler(delegate = adapter, metrics = metrics)
 
-        // Cold compile — establishes BTA state under workingDir.
-        composed.compile(request).get()
-            ?: fail("expected Ok from initial cold compile")
-        assertTrue(
-            Files.exists(workingDir) && workingDir.toFile().listFiles()?.isNotEmpty() == true,
-            "cold compile should have populated workingDir: $workingDir",
-        )
+    val request =
+      IcRequest(
+        projectId = "corruption-smoke",
+        projectRoot = workRoot,
+        sources = listOf(sourceFile),
+        classpath = fixtureClasspath,
+        outputDir = outputDir,
+        workingDir = workingDir,
+      )
 
-        // Corrupt every regular file under workingDir. Directory structure
-        // is preserved so the retry path can still enumerate entries;
-        // BTA's on-disk deserialisation either throws or yields a
-        // non-SUCCESS CompilationResult against zero-byte state files.
-        val truncated = mutableListOf<Path>()
-        workingDir.walk().filter { it.isRegularFile() }.forEach { path ->
-            Files.newByteChannel(
-                path,
-                StandardOpenOption.WRITE,
-                StandardOpenOption.TRUNCATE_EXISTING,
-            ).close()
-            truncated.add(path)
-        }
-        assertTrue(
-            truncated.isNotEmpty(),
-            "expected BTA to have written at least one state file under $workingDir",
-        )
+    // Cold compile — establishes BTA state under workingDir.
+    composed.compile(request).get() ?: fail("expected Ok from initial cold compile")
+    assertTrue(
+      Files.exists(workingDir) && workingDir.toFile().listFiles()?.isNotEmpty() == true,
+      "cold compile should have populated workingDir: $workingDir",
+    )
 
-        // Clear pre-corruption events so the assertion below only sees
-        // what the second compile emits.
-        metrics.events.clear()
+    // Corrupt every regular file under workingDir. Directory structure
+    // is preserved so the retry path can still enumerate entries;
+    // BTA's on-disk deserialisation either throws or yields a
+    // non-SUCCESS CompilationResult against zero-byte state files.
+    val truncated = mutableListOf<Path>()
+    workingDir
+      .walk()
+      .filter { it.isRegularFile() }
+      .forEach { path ->
+        Files.newByteChannel(path, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)
+          .close()
+        truncated.add(path)
+      }
+    assertTrue(
+      truncated.isNotEmpty(),
+      "expected BTA to have written at least one state file under $workingDir",
+    )
 
-        // Warm compile — self-heal must fire, wipe, retry, and ultimately
-        // return Ok because the retry is a clean cold recompile.
-        val response = composed.compile(request).get()
-            ?: fail(
-                "expected self-heal to recover the second compile, " +
-                    "metrics=${metrics.events}",
-            )
-        assertTrue(response.wallMillis >= 0)
+    // Clear pre-corruption events so the assertion below only sees
+    // what the second compile emits.
+    metrics.events.clear()
 
-        assertTrue(
-            metrics.events.any { it.first == SelfHealingIncrementalCompiler.METRIC_SELF_HEAL },
-            "ic.self_heal must have fired; metrics=${metrics.events}",
-        )
+    // Warm compile — self-heal must fire, wipe, retry, and ultimately
+    // return Ok because the retry is a clean cold recompile.
+    val response =
+      composed.compile(request).get()
+        ?: fail("expected self-heal to recover the second compile, " + "metrics=${metrics.events}")
+    assertTrue(response.wallMillis >= 0)
+
+    assertTrue(
+      metrics.events.any { it.first == SelfHealingIncrementalCompiler.METRIC_SELF_HEAL },
+      "ic.self_heal must have fired; metrics=${metrics.events}",
+    )
+  }
+
+  private class RecordingMetricsSink : IcMetricsSink {
+    val events: MutableList<Pair<String, Long>> = mutableListOf()
+
+    override fun record(name: String, value: Long) {
+      events += name to value
     }
+  }
 
-    private class RecordingMetricsSink : IcMetricsSink {
-        val events: MutableList<Pair<String, Long>> = mutableListOf()
-        override fun record(name: String, value: Long) {
-            events += name to value
-        }
-    }
-
-    private fun systemClasspath(key: String): List<Path> {
-        val raw = System.getProperty(key)
-            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
-        return raw.split(File.pathSeparator)
-            .filter { it.isNotBlank() }
-            .map { Path.of(it) }
-    }
+  private fun systemClasspath(key: String): List<Path> {
+    val raw =
+      System.getProperty(key)
+        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+    return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalLockFailureTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalLockFailureTest.kt
@@ -18,127 +18,137 @@ import kotlin.test.fail
 
 class BtaIncrementalLockFailureTest {
 
-    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
-    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+  private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+  private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
 
-    @Test
-    fun `LOCK file creation failure fails compile with InternalError and skips subsequent writes`() {
-        val workRoot = Files.createTempDirectory("bta-lock-fail-")
-        val sourceFile = workRoot.resolve("Main.kt").also {
-            it.writeText(
-                """
+  @Test
+  fun `LOCK file creation failure fails compile with InternalError and skips subsequent writes`() {
+    val workRoot = Files.createTempDirectory("bta-lock-fail-")
+    val sourceFile =
+      workRoot.resolve("Main.kt").also {
+        it.writeText(
+          """
                 package fixture
                 object Main { fun greeting(): String = "hi" }
-                """.trimIndent(),
-            )
-        }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic").apply { createDirectories() }
-        // Precreate LOCK as a directory so `FileChannel.open(lockPath,
-        // CREATE, READ, WRITE)` cannot open it — EISDIR on Linux surfaces
-        // as `FileSystemException` from the JDK.
-        workingDir.resolve("LOCK").createDirectories()
+                """
+            .trimIndent()
+        )
+      }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic").apply { createDirectories() }
+    // Precreate LOCK as a directory so `FileChannel.open(lockPath,
+    // CREATE, READ, WRITE)` cannot open it — EISDIR on Linux surfaces
+    // as `FileSystemException` from the JDK.
+    workingDir.resolve("LOCK").createDirectories()
 
-        val metrics = RecordingMetricsSink()
-        val compiler = BtaIncrementalCompiler.create(
-            btaImplJars = btaImplJars,
-            metrics = metrics,
-        ).getOrElse { fail("failed to load BTA toolchain: $it") }
+    val metrics = RecordingMetricsSink()
+    val compiler =
+      BtaIncrementalCompiler.create(btaImplJars = btaImplJars, metrics = metrics).getOrElse {
+        fail("failed to load BTA toolchain: $it")
+      }
 
-        val err = compiler.compile(
-            IcRequest(
-                projectId = "lock-failure-smoke",
+    val err =
+      compiler
+        .compile(
+          IcRequest(
+            projectId = "lock-failure-smoke",
+            projectRoot = workRoot,
+            sources = listOf(sourceFile),
+            classpath = fixtureClasspath,
+            outputDir = outputDir,
+            workingDir = workingDir,
+          )
+        )
+        .getError() ?: fail("expected Err when LOCK file cannot be created")
+
+    assertTrue(err is IcError.InternalError, "expected InternalError, got $err")
+    val counterNames = metrics.events.map { it.first }.toSet()
+    assertTrue(
+      "reaper.lock_failed" in counterNames,
+      "expected reaper.lock_failed metric, got: $counterNames",
+    )
+    // If ensureLock failed but compile continued, breadcrumb would leak here.
+    assertTrue(
+      !Files.exists(workingDir.resolve("project.path")),
+      "breadcrumb must not be written when ensureLock failed",
+    )
+  }
+
+  @Test
+  fun `LOCK held by another owner lets compile proceed and records lock_conflict`() {
+    val workRoot = Files.createTempDirectory("bta-lock-conflict-")
+    val sourceFile =
+      workRoot.resolve("Main.kt").also {
+        it.writeText(
+          """
+                package fixture
+                object Main { fun greeting(): String = "hi" }
+                """
+            .trimIndent()
+        )
+      }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic").apply { createDirectories() }
+    val lockPath = workingDir.resolve("LOCK")
+
+    // Holding an exclusive FileLock from another channel in the same JVM
+    // makes the adapter's subsequent `tryLock` raise
+    // `OverlappingFileLockException` (a different process would instead
+    // get `null`). Both converge at `if (lock == null)`, so this one
+    // fixture covers both the same-JVM and cross-process paths.
+    FileChannel.open(
+        lockPath,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.READ,
+        StandardOpenOption.WRITE,
+      )
+      .use { holder ->
+        holder.lock().use {
+          val metrics = RecordingMetricsSink()
+          val compiler =
+            BtaIncrementalCompiler.create(btaImplJars = btaImplJars, metrics = metrics).getOrElse {
+              fail("failed to load BTA toolchain: $it")
+            }
+
+          compiler
+            .compile(
+              IcRequest(
+                projectId = "lock-conflict-smoke",
                 projectRoot = workRoot,
                 sources = listOf(sourceFile),
                 classpath = fixtureClasspath,
                 outputDir = outputDir,
                 workingDir = workingDir,
-            ),
-        ).getError() ?: fail("expected Err when LOCK file cannot be created")
-
-        assertTrue(err is IcError.InternalError, "expected InternalError, got $err")
-        val counterNames = metrics.events.map { it.first }.toSet()
-        assertTrue(
-            "reaper.lock_failed" in counterNames,
-            "expected reaper.lock_failed metric, got: $counterNames",
-        )
-        // If ensureLock failed but compile continued, breadcrumb would leak here.
-        assertTrue(
-            !Files.exists(workingDir.resolve("project.path")),
-            "breadcrumb must not be written when ensureLock failed",
-        )
-    }
-
-    @Test
-    fun `LOCK held by another owner lets compile proceed and records lock_conflict`() {
-        val workRoot = Files.createTempDirectory("bta-lock-conflict-")
-        val sourceFile = workRoot.resolve("Main.kt").also {
-            it.writeText(
-                """
-                package fixture
-                object Main { fun greeting(): String = "hi" }
-                """.trimIndent(),
+              )
             )
+            .getOrElse { fail("expected success despite lock conflict, got Err($it)") }
+
+          val counterNames = metrics.events.map { it.first }.toSet()
+          assertTrue(
+            "reaper.lock_conflict" in counterNames,
+            "expected reaper.lock_conflict metric, got: $counterNames",
+          )
+          assertEquals(
+            false,
+            "reaper.lock_failed" in counterNames,
+            "must not record lock_failed when LOCK file already exists, got: $counterNames",
+          )
         }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic").apply { createDirectories() }
-        val lockPath = workingDir.resolve("LOCK")
+      }
+  }
 
-        // Holding an exclusive FileLock from another channel in the same JVM
-        // makes the adapter's subsequent `tryLock` raise
-        // `OverlappingFileLockException` (a different process would instead
-        // get `null`). Both converge at `if (lock == null)`, so this one
-        // fixture covers both the same-JVM and cross-process paths.
-        FileChannel.open(
-            lockPath,
-            StandardOpenOption.CREATE,
-            StandardOpenOption.READ,
-            StandardOpenOption.WRITE,
-        ).use { holder ->
-            holder.lock().use {
-                val metrics = RecordingMetricsSink()
-                val compiler = BtaIncrementalCompiler.create(
-                    btaImplJars = btaImplJars,
-                    metrics = metrics,
-                ).getOrElse { fail("failed to load BTA toolchain: $it") }
+  private class RecordingMetricsSink : IcMetricsSink {
+    val events: MutableList<Pair<String, Long>> = mutableListOf()
 
-                compiler.compile(
-                    IcRequest(
-                        projectId = "lock-conflict-smoke",
-                        projectRoot = workRoot,
-                        sources = listOf(sourceFile),
-                        classpath = fixtureClasspath,
-                        outputDir = outputDir,
-                        workingDir = workingDir,
-                    ),
-                ).getOrElse { fail("expected success despite lock conflict, got Err($it)") }
-
-                val counterNames = metrics.events.map { it.first }.toSet()
-                assertTrue(
-                    "reaper.lock_conflict" in counterNames,
-                    "expected reaper.lock_conflict metric, got: $counterNames",
-                )
-                assertEquals(
-                    false,
-                    "reaper.lock_failed" in counterNames,
-                    "must not record lock_failed when LOCK file already exists, got: $counterNames",
-                )
-            }
-        }
+    override fun record(name: String, value: Long) {
+      events += name to value
     }
+  }
 
-    private class RecordingMetricsSink : IcMetricsSink {
-        val events: MutableList<Pair<String, Long>> = mutableListOf()
-        override fun record(name: String, value: Long) {
-            events += name to value
-        }
-    }
-
-    private fun systemClasspath(key: String): List<Path> {
-        val raw = System.getProperty(key)
-            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
-        return raw.split(File.pathSeparator)
-            .filter { it.isNotBlank() }
-            .map { Path.of(it) }
-    }
+  private fun systemClasspath(key: String): List<Path> {
+    val raw =
+      System.getProperty(key)
+        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+    return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalRecompileSetTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalRecompileSetTest.kt
@@ -42,127 +42,136 @@ import kotlin.test.fail
 // floor.
 class BtaIncrementalRecompileSetTest {
 
-    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
-    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+  private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+  private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
 
-    @Test
-    fun `warm compile after leaf body literal change recompiles at most 2 class files`() {
-        val workRoot = Files.createTempDirectory("bta-recompile-set-")
-        val sourcesDir = workRoot.resolve("src").apply { createDirectories() }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic-state")
+  @Test
+  fun `warm compile after leaf body literal change recompiles at most 2 class files`() {
+    val workRoot = Files.createTempDirectory("bta-recompile-set-")
+    val sourcesDir = workRoot.resolve("src").apply { createDirectories() }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic-state")
 
-        // Linear chain: F1 calls F2 calls F3 calls F4 calls F5. Each file
-        // holds one top-level function. F5 is the leaf whose body we
-        // touch in the ABI-neutral edit below.
-        val files = (1..5).map { i ->
-            val path = sourcesDir.resolve("F$i.kt")
-            path.writeText(
-                if (i == 5) {
-                    """
+    // Linear chain: F1 calls F2 calls F3 calls F4 calls F5. Each file
+    // holds one top-level function. F5 is the leaf whose body we
+    // touch in the ABI-neutral edit below.
+    val files =
+      (1..5).map { i ->
+        val path = sourcesDir.resolve("F$i.kt")
+        path.writeText(
+          if (i == 5) {
+            """
                     package fixture
                     fun f5(): Int {
                         val x = 1
                         return x
                     }
-                    """.trimIndent()
-                } else {
                     """
+              .trimIndent()
+          } else {
+            """
                     package fixture
                     fun f$i(): Int = f${i + 1}() + $i
-                    """.trimIndent()
-                },
-            )
-            path
-        }
-
-        val compiler = BtaIncrementalCompiler.create(btaImplJars).getOrElse {
-            fail("failed to load BTA toolchain: $it")
-        }
-
-        val request = IcRequest(
-            projectId = "recompile-set-smoke",
-            projectRoot = workRoot,
-            sources = files,
-            classpath = fixtureClasspath,
-            outputDir = outputDir,
-            workingDir = workingDir,
+                    """
+              .trimIndent()
+          }
         )
+        path
+      }
 
-        // --- cold ---
-        compiler.compile(request).getOrElse { fail("cold compile failed: $it") }
-        val coldHashes = hashClassFiles(outputDir)
-        val coldCount = coldHashes.size
-        assertTrue(
-            coldCount >= 5,
-            "expected at least 5 class files after cold compile of the 5-file chain, got: $coldCount",
-        )
+    val compiler =
+      BtaIncrementalCompiler.create(btaImplJars).getOrElse {
+        fail("failed to load BTA toolchain: $it")
+      }
 
-        // --- ABI-neutral body literal edit on the leaf ---
-        // `1` → `2` inside the body of `f5`. No signature change, no
-        // visibility change, no new symbol. BTA must recognise this as
-        // a body-only edit and avoid recompiling f1..f4.
-        val leafSource = files.last()
-        val originalText = Files.readString(leafSource)
-        val touchedText = originalText.replace("val x = 1", "val x = 2")
-        assertTrue(
-            touchedText != originalText,
-            "precondition: the leaf fixture must contain `val x = 1` so the touch below is observable",
-        )
-        Files.writeString(leafSource, touchedText)
+    val request =
+      IcRequest(
+        projectId = "recompile-set-smoke",
+        projectRoot = workRoot,
+        sources = files,
+        classpath = fixtureClasspath,
+        outputDir = outputDir,
+        workingDir = workingDir,
+      )
 
-        // --- warm ---
-        compiler.compile(request).getOrElse { fail("warm compile failed: $it") }
-        val warmHashes = hashClassFiles(outputDir)
+    // --- cold ---
+    compiler.compile(request).getOrElse { fail("cold compile failed: $it") }
+    val coldHashes = hashClassFiles(outputDir)
+    val coldCount = coldHashes.size
+    assertTrue(
+      coldCount >= 5,
+      "expected at least 5 class files after cold compile of the 5-file chain, got: $coldCount",
+    )
 
-        val changed = warmHashes.filter { (path, hash) -> coldHashes[path] != hash }
-        val added = warmHashes.keys - coldHashes.keys
-        val removed = coldHashes.keys - warmHashes.keys
+    // --- ABI-neutral body literal edit on the leaf ---
+    // `1` → `2` inside the body of `f5`. No signature change, no
+    // visibility change, no new symbol. BTA must recognise this as
+    // a body-only edit and avoid recompiling f1..f4.
+    val leafSource = files.last()
+    val originalText = Files.readString(leafSource)
+    val touchedText = originalText.replace("val x = 1", "val x = 2")
+    assertTrue(
+      touchedText != originalText,
+      "precondition: the leaf fixture must contain `val x = 1` so the touch below is observable",
+    )
+    Files.writeString(leafSource, touchedText)
 
-        // Assert structural IC reuse: the changed-set is strictly smaller
-        // than the full file count. Without IC attached, BTA would
-        // re-emit every .class file and this check would fail.
-        assertTrue(
-            changed.size < coldCount,
-            "expected a strict subset of class files to change, " +
-                "got changed=${changed.size} of $coldCount " +
-                "(changed=${changed.keys.sorted()})",
-        )
+    // --- warm ---
+    compiler.compile(request).getOrElse { fail("warm compile failed: $it") }
+    val warmHashes = hashClassFiles(outputDir)
 
-        // Pin the spike's bimodal-1 bound. BTA in 2.3.20 may legitimately
-        // touch a second .class file (synthetic / module artefact) on
-        // body-only edits, so the tight bound is 2, not 1. A regression
-        // here would mean the IC configuration on
-        // BtaIncrementalCompiler.executeCompile has stopped reaching
-        // BTA's incremental decision engine.
-        assertTrue(
-            changed.size <= 2,
-            "ABI-neutral leaf-body edit should recompile at most 2 class files, " +
-                "got changed=${changed.size} (${changed.keys.sorted()})",
-        )
+    val changed = warmHashes.filter { (path, hash) -> coldHashes[path] != hash }
+    val added = warmHashes.keys - coldHashes.keys
+    val removed = coldHashes.keys - warmHashes.keys
 
-        assertEquals(emptySet<String>(), added, "no new class files expected from a body-only edit")
-        assertEquals(emptySet<String>(), removed, "no class files should disappear from a body-only edit")
-    }
+    // Assert structural IC reuse: the changed-set is strictly smaller
+    // than the full file count. Without IC attached, BTA would
+    // re-emit every .class file and this check would fail.
+    assertTrue(
+      changed.size < coldCount,
+      "expected a strict subset of class files to change, " +
+        "got changed=${changed.size} of $coldCount " +
+        "(changed=${changed.keys.sorted()})",
+    )
 
-    private fun hashClassFiles(classesDir: Path): Map<String, String> {
-        if (!Files.isDirectory(classesDir)) return emptyMap()
-        val md = MessageDigest.getInstance("SHA-256")
-        return classesDir.walk()
-            .filter { it.extension == "class" }
-            .associate { p ->
-                val rel = p.relativeTo(classesDir).toString()
-                md.reset()
-                md.update(Files.readAllBytes(p))
-                rel to md.digest().joinToString("") { "%02x".format(it) }
-            }
-    }
+    // Pin the spike's bimodal-1 bound. BTA in 2.3.20 may legitimately
+    // touch a second .class file (synthetic / module artefact) on
+    // body-only edits, so the tight bound is 2, not 1. A regression
+    // here would mean the IC configuration on
+    // BtaIncrementalCompiler.executeCompile has stopped reaching
+    // BTA's incremental decision engine.
+    assertTrue(
+      changed.size <= 2,
+      "ABI-neutral leaf-body edit should recompile at most 2 class files, " +
+        "got changed=${changed.size} (${changed.keys.sorted()})",
+    )
 
-    private fun systemClasspath(key: String): List<Path> {
-        val raw = System.getProperty(key)
-            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
-        return raw.split(File.pathSeparator)
-            .filter { it.isNotBlank() }
-            .map { Path.of(it) }
-    }
+    assertEquals(emptySet<String>(), added, "no new class files expected from a body-only edit")
+    assertEquals(
+      emptySet<String>(),
+      removed,
+      "no class files should disappear from a body-only edit",
+    )
+  }
+
+  private fun hashClassFiles(classesDir: Path): Map<String, String> {
+    if (!Files.isDirectory(classesDir)) return emptyMap()
+    val md = MessageDigest.getInstance("SHA-256")
+    return classesDir
+      .walk()
+      .filter { it.extension == "class" }
+      .associate { p ->
+        val rel = p.relativeTo(classesDir).toString()
+        md.reset()
+        md.update(Files.readAllBytes(p))
+        rel to md.digest().joinToString("") { "%02x".format(it) }
+      }
+  }
+
+  private fun systemClasspath(key: String): List<Path> {
+    val raw =
+      System.getProperty(key)
+        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+    return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
@@ -35,44 +35,50 @@ import kotlin.test.fail
 // symbol only exists if the plugin actually transformed the AST.
 class BtaSerializationPluginTest {
 
-    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
-    private val serializationPluginJars: List<Path> =
-        systemClasspath("kolt.ic.serializationPluginClasspath")
-    private val serializationFixtureClasspath: List<Path> =
-        systemClasspath("kolt.ic.serializationRuntimeClasspath")
+  private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+  private val serializationPluginJars: List<Path> =
+    systemClasspath("kolt.ic.serializationPluginClasspath")
+  private val serializationFixtureClasspath: List<Path> =
+    systemClasspath("kolt.ic.serializationRuntimeClasspath")
 
-    @Test
-    fun `Serializable data class compiles and the plugin generated serializer symbol`() {
-        val workRoot = Files.createTempDirectory("bta-serialization-")
-        val sourceFile = workRoot.resolve("Payload.kt").also {
-            it.writeText(
-                """
+  @Test
+  fun `Serializable data class compiles and the plugin generated serializer symbol`() {
+    val workRoot = Files.createTempDirectory("bta-serialization-")
+    val sourceFile =
+      workRoot.resolve("Payload.kt").also {
+        it.writeText(
+          """
                 package fixture
 
                 import kotlinx.serialization.Serializable
 
                 @Serializable
                 data class Payload(val name: String, val count: Int)
-                """.trimIndent(),
-            )
-        }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic-state")
+                """
+            .trimIndent()
+        )
+      }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic-state")
 
-        val resolverCalls = mutableListOf<String>()
-        val compiler = BtaIncrementalCompiler.create(
-            btaImplJars = btaImplJars,
-            pluginJarResolver = { alias ->
-                resolverCalls.add(alias)
-                if (alias == "serialization") serializationPluginJars else emptyList()
-            },
-        ).getOrElse { fail("failed to load BTA toolchain: $it") }
+    val resolverCalls = mutableListOf<String>()
+    val compiler =
+      BtaIncrementalCompiler.create(
+          btaImplJars = btaImplJars,
+          pluginJarResolver = { alias ->
+            resolverCalls.add(alias)
+            if (alias == "serialization") serializationPluginJars else emptyList()
+          },
+        )
+        .getOrElse { fail("failed to load BTA toolchain: $it") }
 
-        // kolt.toml enables the serialization plugin so PluginTranslator
-        // picks it up on its normal reading path — the test is not
-        // bypassing the translator, it is going through it.
-        workRoot.resolve("kolt.toml").writeText(
-            """
+    // kolt.toml enables the serialization plugin so PluginTranslator
+    // picks it up on its normal reading path — the test is not
+    // bypassing the translator, it is going through it.
+    workRoot
+      .resolve("kolt.toml")
+      .writeText(
+        """
             name = "demo"
             version = "0.1.0"
 
@@ -86,118 +92,127 @@ class BtaSerializationPluginTest {
             target = "jvm"
             main = "fixture.Payload"
             sources = ["."]
-            """.trimIndent(),
-        )
+            """
+          .trimIndent()
+      )
 
-        compiler.compile(
-            IcRequest(
-                projectId = "serialization-smoke",
-                projectRoot = workRoot,
-                sources = listOf(sourceFile),
-                classpath = serializationFixtureClasspath,
-                outputDir = outputDir,
-                workingDir = workingDir,
-            ),
-        ).getOrElse { fail("expected successful compile of @Serializable fixture, got: $it") }
-
-        assertTrue(
-            resolverCalls.contains("serialization"),
-            "PluginTranslator must have consulted the resolver for `serialization`, got: $resolverCalls",
+    compiler
+      .compile(
+        IcRequest(
+          projectId = "serialization-smoke",
+          projectRoot = workRoot,
+          sources = listOf(sourceFile),
+          classpath = serializationFixtureClasspath,
+          outputDir = outputDir,
+          workingDir = workingDir,
         )
+      )
+      .getOrElse { fail("expected successful compile of @Serializable fixture, got: $it") }
 
-        val classFiles = outputDir.walk().filter { it.extension == "class" }.toList()
-        assertTrue(
-            classFiles.any { it.fileName.toString() == "Payload.class" },
-            "expected fixture.Payload.class in output, got: $classFiles",
-        )
+    assertTrue(
+      resolverCalls.contains("serialization"),
+      "PluginTranslator must have consulted the resolver for `serialization`, got: $resolverCalls",
+    )
 
-        // The load-bearing signal that the plugin ran is the nested
-        // `${'$'}serializer` class — a singleton that implements
-        // `KSerializer<Payload>` and is synthesised only by the
-        // serialization compiler plugin. Plain kotlinc output of a
-        // `@Serializable data class` contains no such entry. The file
-        // name is `Payload${'$'}${'$'}serializer.class` because the
-        // first `${'$'}` is the Kotlin-to-JVM nested class separator
-        // and the second is the literal name. A future regression that
-        // silently skipped plugin attachment would leave this class
-        // absent — this assertion is the guard.
-        val serializerName = "Payload\$\$serializer.class"
-        val classFileNames = classFiles.map { it.fileName.toString() }
-        assertTrue(
-            serializerName in classFileNames,
-            "kotlinx.serialization plugin must have generated `$serializerName`; " +
-                "classFiles=$classFileNames",
-        )
-    }
+    val classFiles = outputDir.walk().filter { it.extension == "class" }.toList()
+    assertTrue(
+      classFiles.any { it.fileName.toString() == "Payload.class" },
+      "expected fixture.Payload.class in output, got: $classFiles",
+    )
 
-    @Test
-    fun `serialization plugin jars resolve from the classpath system property`() {
-        // Guard the build.gradle.kts wiring: if a future edit drops the
-        // serializationPluginClasspath configuration or misroutes the
-        // system property, we want the failure signal here rather than
-        // buried inside the compile test above.
-        assertTrue(
-            serializationPluginJars.isNotEmpty(),
-            "serialization compiler plugin classpath must be non-empty",
-        )
-        assertTrue(
-            serializationPluginJars.any { it.fileName.toString().contains("serialization") },
-            "expected a serialization-compiler-plugin jar on the resolved classpath, got: $serializationPluginJars",
-        )
-    }
+    // The load-bearing signal that the plugin ran is the nested
+    // `${'$'}serializer` class — a singleton that implements
+    // `KSerializer<Payload>` and is synthesised only by the
+    // serialization compiler plugin. Plain kotlinc output of a
+    // `@Serializable data class` contains no such entry. The file
+    // name is `Payload${'$'}${'$'}serializer.class` because the
+    // first `${'$'}` is the Kotlin-to-JVM nested class separator
+    // and the second is the literal name. A future regression that
+    // silently skipped plugin attachment would leave this class
+    // absent — this assertion is the guard.
+    val serializerName = "Payload\$\$serializer.class"
+    val classFileNames = classFiles.map { it.fileName.toString() }
+    assertTrue(
+      serializerName in classFileNames,
+      "kotlinx.serialization plugin must have generated `$serializerName`; " +
+        "classFiles=$classFileNames",
+    )
+  }
 
-    @Test
-    fun `serialization runtime classpath contains kotlinx-serialization-core`() {
-        assertTrue(
-            serializationFixtureClasspath.any {
-                it.fileName.toString().contains("kotlinx-serialization-core")
-            },
-            "expected kotlinx-serialization-core on the fixture runtime classpath, " +
-                "got: $serializationFixtureClasspath",
-        )
-    }
+  @Test
+  fun `serialization plugin jars resolve from the classpath system property`() {
+    // Guard the build.gradle.kts wiring: if a future edit drops the
+    // serializationPluginClasspath configuration or misroutes the
+    // system property, we want the failure signal here rather than
+    // buried inside the compile test above.
+    assertTrue(
+      serializationPluginJars.isNotEmpty(),
+      "serialization compiler plugin classpath must be non-empty",
+    )
+    assertTrue(
+      serializationPluginJars.any { it.fileName.toString().contains("serialization") },
+      "expected a serialization-compiler-plugin jar on the resolved classpath, got: $serializationPluginJars",
+    )
+  }
 
-    // #162 single-batch invariant guard. When both PluginTranslator and
-    // LanguageVersionTranslator return non-empty lists, BtaIncrementalCompiler
-    // must pass their concatenation to `applyArgumentStrings` in a *single*
-    // call — two sequential calls would reset the earlier batch's args back
-    // to parser defaults (see BtaIncrementalCompiler.kt header comment on
-    // ordering). A regression that splits the call into two would wipe the
-    // plugin freeArgs, silently producing non-serializable output. This test
-    // catches that: with compiler=2.3.20 / version=2.1.0 the language-version
-    // translator emits two arg pairs, and if plugin args lost the ordering
-    // race the `$$serializer.class` synthesis would disappear.
-    @Test
-    fun `plugin and language-version freeArgs coexist in a single applyArgumentStrings batch`() {
-        val workRoot = Files.createTempDirectory("bta-freeargs-batch-")
-        val sourceFile = workRoot.resolve("Payload.kt").also {
-            it.writeText(
-                """
+  @Test
+  fun `serialization runtime classpath contains kotlinx-serialization-core`() {
+    assertTrue(
+      serializationFixtureClasspath.any {
+        it.fileName.toString().contains("kotlinx-serialization-core")
+      },
+      "expected kotlinx-serialization-core on the fixture runtime classpath, " +
+        "got: $serializationFixtureClasspath",
+    )
+  }
+
+  // #162 single-batch invariant guard. When both PluginTranslator and
+  // LanguageVersionTranslator return non-empty lists, BtaIncrementalCompiler
+  // must pass their concatenation to `applyArgumentStrings` in a *single*
+  // call — two sequential calls would reset the earlier batch's args back
+  // to parser defaults (see BtaIncrementalCompiler.kt header comment on
+  // ordering). A regression that splits the call into two would wipe the
+  // plugin freeArgs, silently producing non-serializable output. This test
+  // catches that: with compiler=2.3.20 / version=2.1.0 the language-version
+  // translator emits two arg pairs, and if plugin args lost the ordering
+  // race the `$$serializer.class` synthesis would disappear.
+  @Test
+  fun `plugin and language-version freeArgs coexist in a single applyArgumentStrings batch`() {
+    val workRoot = Files.createTempDirectory("bta-freeargs-batch-")
+    val sourceFile =
+      workRoot.resolve("Payload.kt").also {
+        it.writeText(
+          """
                 package fixture
 
                 import kotlinx.serialization.Serializable
 
                 @Serializable
                 data class Payload(val name: String, val count: Int)
-                """.trimIndent(),
-            )
-        }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic-state")
+                """
+            .trimIndent()
+        )
+      }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic-state")
 
-        val compiler = BtaIncrementalCompiler.create(
-            btaImplJars = btaImplJars,
-            pluginJarResolver = { alias ->
-                if (alias == "serialization") serializationPluginJars else emptyList()
-            },
-        ).getOrElse { fail("failed to load BTA toolchain: $it") }
+    val compiler =
+      BtaIncrementalCompiler.create(
+          btaImplJars = btaImplJars,
+          pluginJarResolver = { alias ->
+            if (alias == "serialization") serializationPluginJars else emptyList()
+          },
+        )
+        .getOrElse { fail("failed to load BTA toolchain: $it") }
 
-        // version=2.1.0 with compiler=2.3.20 makes LanguageVersionTranslator
-        // emit `-language-version 2.1.0 -api-version 2.1.0`; plugin translator
-        // emits `-Xplugin=<serialization jar>`. The batch invariant is that
-        // both sets survive into the compile.
-        workRoot.resolve("kolt.toml").writeText(
-            """
+    // version=2.1.0 with compiler=2.3.20 makes LanguageVersionTranslator
+    // emit `-language-version 2.1.0 -api-version 2.1.0`; plugin translator
+    // emits `-Xplugin=<serialization jar>`. The batch invariant is that
+    // both sets survive into the compile.
+    workRoot
+      .resolve("kolt.toml")
+      .writeText(
+        """
             name = "demo"
             version = "0.1.0"
 
@@ -212,40 +227,39 @@ class BtaSerializationPluginTest {
             target = "jvm"
             main = "fixture.Payload"
             sources = ["."]
-            """.trimIndent(),
+            """
+          .trimIndent()
+      )
+
+    compiler
+      .compile(
+        IcRequest(
+          projectId = "freeargs-batch",
+          projectRoot = workRoot,
+          sources = listOf(sourceFile),
+          classpath = serializationFixtureClasspath,
+          outputDir = outputDir,
+          workingDir = workingDir,
         )
+      )
+      .getOrElse {
+        fail("expected successful compile with plugin + language-version flags, got: $it")
+      }
 
-        compiler.compile(
-            IcRequest(
-                projectId = "freeargs-batch",
-                projectRoot = workRoot,
-                sources = listOf(sourceFile),
-                classpath = serializationFixtureClasspath,
-                outputDir = outputDir,
-                workingDir = workingDir,
-            ),
-        ).getOrElse {
-            fail("expected successful compile with plugin + language-version flags, got: $it")
-        }
+    val classFileNames =
+      outputDir.walk().filter { it.extension == "class" }.map { it.fileName.toString() }.toList()
+    val serializerName = "Payload\$\$serializer.class"
+    assertTrue(
+      serializerName in classFileNames,
+      "plugin freeArgs must survive alongside language-version freeArgs in one batch; " +
+        "missing `$serializerName` signals a reset; classFiles=$classFileNames",
+    )
+  }
 
-        val classFileNames = outputDir.walk()
-            .filter { it.extension == "class" }
-            .map { it.fileName.toString() }
-            .toList()
-        val serializerName = "Payload\$\$serializer.class"
-        assertTrue(
-            serializerName in classFileNames,
-            "plugin freeArgs must survive alongside language-version freeArgs in one batch; " +
-                "missing `$serializerName` signals a reset; classFiles=$classFileNames",
-        )
-    }
-
-    private fun systemClasspath(key: String): List<Path> {
-        val raw = System.getProperty(key)
-            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
-        return raw.split(File.pathSeparator)
-            .filter { it.isNotBlank() }
-            .map { Path.of(it) }
-    }
-
+  private fun systemClasspath(key: String): List<Path> {
+    val raw =
+      System.getProperty(key)
+        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+    return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/CapturingKotlinLoggerTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/CapturingKotlinLoggerTest.kt
@@ -2,10 +2,10 @@
 
 package kolt.daemon.ic
 
-import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 
 // Pins the shape of error message capture. The B-2b implementation kept
 // only `throwable.message`, which threw away the stack frame a human
@@ -14,67 +14,62 @@ import kotlin.test.assertTrue
 // preserved even when `message` is null.
 class CapturingKotlinLoggerTest {
 
-    private class RecordingSink : IcMetricsSink {
-        val events: MutableList<Pair<String, Long>> = mutableListOf()
-        override fun record(name: String, value: Long) {
-            events.add(name to value)
-        }
+  private class RecordingSink : IcMetricsSink {
+    val events: MutableList<Pair<String, Long>> = mutableListOf()
+
+    override fun record(name: String, value: Long) {
+      events.add(name to value)
     }
+  }
 
-    @Test
-    fun errorWithoutThrowablePreservesMessage() {
-        val logger = CapturingKotlinLogger(RecordingSink())
-        logger.error("kotlinc: type mismatch", null)
-        assertEquals(listOf("kotlinc: type mismatch"), logger.errorMessages())
-    }
+  @Test
+  fun errorWithoutThrowablePreservesMessage() {
+    val logger = CapturingKotlinLogger(RecordingSink())
+    logger.error("kotlinc: type mismatch", null)
+    assertEquals(listOf("kotlinc: type mismatch"), logger.errorMessages())
+  }
 
-    @Test
-    fun errorWithThrowableIncludesClassNameAndFirstFrame() {
-        val logger = CapturingKotlinLogger(RecordingSink())
-        val boom = RuntimeException("boom")
-        logger.error("bta failed", boom)
+  @Test
+  fun errorWithThrowableIncludesClassNameAndFirstFrame() {
+    val logger = CapturingKotlinLogger(RecordingSink())
+    val boom = RuntimeException("boom")
+    logger.error("bta failed", boom)
 
-        val captured = logger.errorMessages().single()
-        assertTrue(captured.startsWith("bta failed: "), "header: $captured")
-        assertTrue(
-            "java.lang.RuntimeException" in captured,
-            "throwable class name retained: $captured",
-        )
-        assertTrue("boom" in captured, "throwable message retained: $captured")
-        assertTrue(
-            "\n\tat " in captured,
-            "first stack frame retained: $captured",
-        )
-    }
+    val captured = logger.errorMessages().single()
+    assertTrue(captured.startsWith("bta failed: "), "header: $captured")
+    assertTrue("java.lang.RuntimeException" in captured, "throwable class name retained: $captured")
+    assertTrue("boom" in captured, "throwable message retained: $captured")
+    assertTrue("\n\tat " in captured, "first stack frame retained: $captured")
+  }
 
-    @Test
-    fun errorWithThrowableWhoseMessageIsNullStillPreservesClassName() {
-        val logger = CapturingKotlinLogger(RecordingSink())
-        val boom = IllegalStateException(null as String?)
-        logger.error("bta failed", boom)
+  @Test
+  fun errorWithThrowableWhoseMessageIsNullStillPreservesClassName() {
+    val logger = CapturingKotlinLogger(RecordingSink())
+    val boom = IllegalStateException(null as String?)
+    logger.error("bta failed", boom)
 
-        val captured = logger.errorMessages().single()
-        assertTrue(
-            "java.lang.IllegalStateException" in captured,
-            "class name survives null message: $captured",
-        )
-    }
+    val captured = logger.errorMessages().single()
+    assertTrue(
+      "java.lang.IllegalStateException" in captured,
+      "class name survives null message: $captured",
+    )
+  }
 
-    @Test
-    fun errorIncrementsMetricCounter() {
-        val sink = RecordingSink()
-        val logger = CapturingKotlinLogger(sink)
-        logger.error("x", null)
-        logger.error("y", null)
-        assertEquals(2, sink.events.count { it.first == BtaIncrementalCompiler.METRIC_LOG_ERROR })
-    }
+  @Test
+  fun errorIncrementsMetricCounter() {
+    val sink = RecordingSink()
+    val logger = CapturingKotlinLogger(sink)
+    logger.error("x", null)
+    logger.error("y", null)
+    assertEquals(2, sink.events.count { it.first == BtaIncrementalCompiler.METRIC_LOG_ERROR })
+  }
 
-    @Test
-    fun warnInfoLifecycleAreNotRetainedInErrorList() {
-        val logger = CapturingKotlinLogger(RecordingSink())
-        logger.warn("w", null)
-        logger.info("i")
-        logger.lifecycle("l")
-        assertTrue(logger.errorMessages().isEmpty())
-    }
+  @Test
+  fun warnInfoLifecycleAreNotRetainedInErrorList() {
+    val logger = CapturingKotlinLogger(RecordingSink())
+    logger.warn("w", null)
+    logger.info("i")
+    logger.lifecycle("l")
+    assertTrue(logger.errorMessages().isEmpty())
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClassloaderIsolationTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClassloaderIsolationTest.kt
@@ -24,56 +24,56 @@ import kotlin.test.assertNotNull
 // exactly that line.
 class ClassloaderIsolationTest {
 
-    private val btaImplJars: List<Path> = System.getProperty("kolt.ic.btaImplClasspath")
-        .orEmpty()
-        .split(File.pathSeparator)
-        .filter { it.isNotBlank() }
-        .map { Path.of(it) }
+  private val btaImplJars: List<Path> =
+    System.getProperty("kolt.ic.btaImplClasspath")
+      .orEmpty()
+      .split(File.pathSeparator)
+      .filter { it.isNotBlank() }
+      .map { Path.of(it) }
 
-    @Test
-    fun `impl-only class is reachable from the child URLClassLoader`() {
-        val (_, implLoader) = buildTopology()
-        // Class.forName through the child loader must resolve the -impl class.
-        // Using `Class.forName(name, initialize=false, loader)` avoids running
-        // static initializers that might require a full BTA bootstrap.
-        val loaded = Class.forName(IMPL_ONLY_PROBE, false, implLoader)
-        assertNotNull(loaded, "expected $IMPL_ONLY_PROBE to be reachable from the child URLClassLoader")
-    }
+  @Test
+  fun `impl-only class is reachable from the child URLClassLoader`() {
+    val (_, implLoader) = buildTopology()
+    // Class.forName through the child loader must resolve the -impl class.
+    // Using `Class.forName(name, initialize=false, loader)` avoids running
+    // static initializers that might require a full BTA bootstrap.
+    val loaded = Class.forName(IMPL_ONLY_PROBE, false, implLoader)
+    assertNotNull(loaded, "expected $IMPL_ONLY_PROBE to be reachable from the child URLClassLoader")
+  }
 
-    @Test
-    fun `impl-only class is NOT reachable from the daemon-core-facing parent`() {
-        val (parentLoader, _) = buildTopology()
-        // SharedApiClassesClassLoader exposes only org.jetbrains.kotlin.buildtools.api.*
-        // to its parent chain. The -impl class must raise ClassNotFoundException
-        // when probed through that loader — if it resolves, -impl has leaked up
-        // past the isolation boundary and daemon core is no longer protected.
-        assertFailsWith<ClassNotFoundException>(
-            message = "$IMPL_ONLY_PROBE leaked past SharedApiClassesClassLoader — " +
-                "the ADR 0019 §3 adapter invariant is broken",
-        ) {
-            Class.forName(IMPL_ONLY_PROBE, false, parentLoader)
-        }
+  @Test
+  fun `impl-only class is NOT reachable from the daemon-core-facing parent`() {
+    val (parentLoader, _) = buildTopology()
+    // SharedApiClassesClassLoader exposes only org.jetbrains.kotlin.buildtools.api.*
+    // to its parent chain. The -impl class must raise ClassNotFoundException
+    // when probed through that loader — if it resolves, -impl has leaked up
+    // past the isolation boundary and daemon core is no longer protected.
+    assertFailsWith<ClassNotFoundException>(
+      message =
+        "$IMPL_ONLY_PROBE leaked past SharedApiClassesClassLoader — " +
+          "the ADR 0019 §3 adapter invariant is broken"
+    ) {
+      Class.forName(IMPL_ONLY_PROBE, false, parentLoader)
     }
+  }
 
-    // Builds the exact topology BtaIncrementalCompiler.create constructs, but
-    // returns both loaders so the test can probe each independently. Keeping
-    // this in the test rather than exposing it from production code avoids
-    // widening the adapter's public surface for a testability hook.
-    @OptIn(org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi::class)
-    private fun buildTopology(): Pair<ClassLoader, ClassLoader> {
-        require(btaImplJars.isNotEmpty()) {
-            "kolt.ic.btaImplClasspath system property is empty — check :ic/build.gradle.kts test task config"
-        }
-        val parent = org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader()
-        val child = java.net.URLClassLoader(
-            btaImplJars.map { it.toUri().toURL() }.toTypedArray(),
-            parent,
-        )
-        return parent to child
+  // Builds the exact topology BtaIncrementalCompiler.create constructs, but
+  // returns both loaders so the test can probe each independently. Keeping
+  // this in the test rather than exposing it from production code avoids
+  // widening the adapter's public surface for a testability hook.
+  @OptIn(org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi::class)
+  private fun buildTopology(): Pair<ClassLoader, ClassLoader> {
+    require(btaImplJars.isNotEmpty()) {
+      "kolt.ic.btaImplClasspath system property is empty — check :ic/build.gradle.kts test task config"
     }
+    val parent = org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader()
+    val child =
+      java.net.URLClassLoader(btaImplJars.map { it.toUri().toURL() }.toTypedArray(), parent)
+    return parent to child
+  }
 
-    companion object {
-        private const val IMPL_ONLY_PROBE =
-            "org.jetbrains.kotlin.buildtools.internal.jvm.JvmPlatformToolchainImpl"
-    }
+  companion object {
+    private const val IMPL_ONLY_PROBE =
+      "org.jetbrains.kotlin.buildtools.internal.jvm.JvmPlatformToolchainImpl"
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCacheTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCacheTest.kt
@@ -2,10 +2,6 @@
 
 package kolt.daemon.ic
 
-import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
-import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
-import org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader
-import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain.Companion.jvm
 import java.io.File
 import java.net.URLClassLoader
 import java.nio.file.Files
@@ -14,162 +10,171 @@ import kotlin.io.path.createDirectories
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader
 
 class ClasspathSnapshotCacheTest {
 
-    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
-    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+  private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+  private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
 
-    private fun loadToolchain(): KotlinToolchains {
-        val urls = btaImplJars.map { it.toUri().toURL() }.toTypedArray()
-        val loader = URLClassLoader(urls, SharedApiClassesClassLoader())
-        return KotlinToolchains.loadImplementation(loader)
+  private fun loadToolchain(): KotlinToolchains {
+    val urls = btaImplJars.map { it.toUri().toURL() }.toTypedArray()
+    val loader = URLClassLoader(urls, SharedApiClassesClassLoader())
+    return KotlinToolchains.loadImplementation(loader)
+  }
+
+  @Test
+  fun `second call for same classpath returns cached snapshots without recomputation`() {
+    val toolchain = loadToolchain()
+    val snapshotsDir =
+      Files.createTempDirectory("cp-cache-hit-").resolve("snapshots").apply { createDirectories() }
+
+    val metrics = RecordingMetricsSink()
+    val cache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics)
+
+    // First call: all misses
+    val first = cache.getOrComputeSnapshots(fixtureClasspath)
+    assertEquals(fixtureClasspath.size, first.size)
+    first.forEach { assertTrue(Files.exists(it), "snapshot file must exist: $it") }
+
+    val firstMetrics = metrics.snapshotAndReset()
+    val firstMisses = firstMetrics.count { it.first == ClasspathSnapshotCache.METRIC_MISS }
+    assertEquals(fixtureClasspath.size, firstMisses, "first call should miss for every entry")
+
+    // Second call: all hits
+    val second = cache.getOrComputeSnapshots(fixtureClasspath)
+    assertEquals(first, second, "cached result must equal first result")
+
+    val secondMetrics = metrics.snapshotAndReset()
+    val secondHits = secondMetrics.count { it.first == ClasspathSnapshotCache.METRIC_HIT }
+    val secondMisses = secondMetrics.count { it.first == ClasspathSnapshotCache.METRIC_MISS }
+    assertEquals(fixtureClasspath.size, secondHits, "second call should hit for every entry")
+    assertEquals(0, secondMisses, "second call should have zero misses")
+  }
+
+  @Test
+  fun `cache miss when file mtime changes`() {
+    val toolchain = loadToolchain()
+    val workDir = Files.createTempDirectory("cp-cache-mtime-")
+    val snapshotsDir = workDir.resolve("snapshots").apply { createDirectories() }
+
+    // Create a small jar to control mtime
+    val jarFile = workDir.resolve("test.jar")
+    Files.copy(fixtureClasspath.last(), jarFile)
+
+    val metrics = RecordingMetricsSink()
+    val cache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics)
+
+    val classpath = listOf(jarFile)
+
+    // First call: miss
+    cache.getOrComputeSnapshots(classpath)
+    metrics.snapshotAndReset()
+
+    // Touch mtime
+    val newMtime =
+      java.nio.file.attribute.FileTime.fromMillis(
+        Files.getLastModifiedTime(jarFile).toMillis() + 2000
+      )
+    Files.setLastModifiedTime(jarFile, newMtime)
+
+    // Second call: miss (mtime changed)
+    cache.getOrComputeSnapshots(classpath)
+    val secondMetrics = metrics.snapshotAndReset()
+    val misses = secondMetrics.count { it.first == ClasspathSnapshotCache.METRIC_MISS }
+    assertEquals(1, misses, "mtime change should cause cache miss")
+  }
+
+  @Test
+  fun `file-backed recovery after in-memory cache is lost`() {
+    val toolchain = loadToolchain()
+    val snapshotsDir =
+      Files.createTempDirectory("cp-cache-recovery-").resolve("snapshots").apply {
+        createDirectories()
+      }
+
+    val metrics1 = RecordingMetricsSink()
+    val cache1 = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics1)
+
+    // Populate cache and snapshot files
+    val first = cache1.getOrComputeSnapshots(fixtureClasspath)
+
+    // Create a NEW cache instance (simulates daemon restart), same snapshotsDir
+    val metrics2 = RecordingMetricsSink()
+    val cache2 = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics2)
+
+    val second = cache2.getOrComputeSnapshots(fixtureClasspath)
+    assertEquals(first, second, "file-backed recovery must return same paths")
+
+    val secondMetrics = metrics2.snapshotAndReset()
+    val hits = secondMetrics.count { it.first == ClasspathSnapshotCache.METRIC_HIT }
+    assertEquals(fixtureClasspath.size, hits, "file-backed recovery should count as hits")
+  }
+
+  @Test
+  fun `deleted snapshot file triggers recomputation`() {
+    val toolchain = loadToolchain()
+    val snapshotsDir =
+      Files.createTempDirectory("cp-cache-deleted-").resolve("snapshots").apply {
+        createDirectories()
+      }
+
+    val metrics = RecordingMetricsSink()
+    val cache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics)
+
+    val first = cache.getOrComputeSnapshots(fixtureClasspath)
+    metrics.snapshotAndReset()
+
+    // Delete the first snapshot file (simulates self-heal wipe)
+    Files.delete(first[0])
+
+    val second = cache.getOrComputeSnapshots(fixtureClasspath)
+    assertTrue(Files.exists(second[0]), "snapshot must be recomputed after deletion")
+
+    val postDeleteMetrics = metrics.snapshotAndReset()
+    val misses = postDeleteMetrics.count { it.first == ClasspathSnapshotCache.METRIC_MISS }
+    assertTrue(misses >= 1, "at least one miss expected after file deletion")
+  }
+
+  @Test
+  fun `non-existent classpath entry causes all-or-nothing fallback to empty list`() {
+    val toolchain = loadToolchain()
+    val snapshotsDir =
+      Files.createTempDirectory("cp-cache-aon-").resolve("snapshots").apply { createDirectories() }
+
+    val metrics = RecordingMetricsSink()
+    val cache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics)
+
+    val classpath = fixtureClasspath + Path.of("/nonexistent/bogus.jar")
+
+    val result = cache.getOrComputeSnapshots(classpath)
+    assertEquals(emptyList<Path>(), result, "any failure must fall back to empty list")
+
+    val events = metrics.snapshotAndReset()
+    val errors = events.count { it.first == ClasspathSnapshotCache.METRIC_ERROR }
+    assertEquals(0, errors, "non-existent entry returns null, not an error")
+  }
+
+  private class RecordingMetricsSink : IcMetricsSink {
+    private val events: MutableList<Pair<String, Long>> = mutableListOf()
+
+    override fun record(name: String, value: Long) {
+      events += name to value
     }
 
-    @Test
-    fun `second call for same classpath returns cached snapshots without recomputation`() {
-        val toolchain = loadToolchain()
-        val snapshotsDir = Files.createTempDirectory("cp-cache-hit-")
-            .resolve("snapshots").apply { createDirectories() }
-
-        val metrics = RecordingMetricsSink()
-        val cache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics)
-
-        // First call: all misses
-        val first = cache.getOrComputeSnapshots(fixtureClasspath)
-        assertEquals(fixtureClasspath.size, first.size)
-        first.forEach { assertTrue(Files.exists(it), "snapshot file must exist: $it") }
-
-        val firstMetrics = metrics.snapshotAndReset()
-        val firstMisses = firstMetrics.count { it.first == ClasspathSnapshotCache.METRIC_MISS }
-        assertEquals(fixtureClasspath.size, firstMisses, "first call should miss for every entry")
-
-        // Second call: all hits
-        val second = cache.getOrComputeSnapshots(fixtureClasspath)
-        assertEquals(first, second, "cached result must equal first result")
-
-        val secondMetrics = metrics.snapshotAndReset()
-        val secondHits = secondMetrics.count { it.first == ClasspathSnapshotCache.METRIC_HIT }
-        val secondMisses = secondMetrics.count { it.first == ClasspathSnapshotCache.METRIC_MISS }
-        assertEquals(fixtureClasspath.size, secondHits, "second call should hit for every entry")
-        assertEquals(0, secondMisses, "second call should have zero misses")
+    fun snapshotAndReset(): List<Pair<String, Long>> {
+      val snap = events.toList()
+      events.clear()
+      return snap
     }
+  }
 
-    @Test
-    fun `cache miss when file mtime changes`() {
-        val toolchain = loadToolchain()
-        val workDir = Files.createTempDirectory("cp-cache-mtime-")
-        val snapshotsDir = workDir.resolve("snapshots").apply { createDirectories() }
-
-        // Create a small jar to control mtime
-        val jarFile = workDir.resolve("test.jar")
-        Files.copy(fixtureClasspath.last(), jarFile)
-
-        val metrics = RecordingMetricsSink()
-        val cache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics)
-
-        val classpath = listOf(jarFile)
-
-        // First call: miss
-        cache.getOrComputeSnapshots(classpath)
-        metrics.snapshotAndReset()
-
-        // Touch mtime
-        val newMtime = java.nio.file.attribute.FileTime.fromMillis(
-            Files.getLastModifiedTime(jarFile).toMillis() + 2000,
-        )
-        Files.setLastModifiedTime(jarFile, newMtime)
-
-        // Second call: miss (mtime changed)
-        cache.getOrComputeSnapshots(classpath)
-        val secondMetrics = metrics.snapshotAndReset()
-        val misses = secondMetrics.count { it.first == ClasspathSnapshotCache.METRIC_MISS }
-        assertEquals(1, misses, "mtime change should cause cache miss")
-    }
-
-    @Test
-    fun `file-backed recovery after in-memory cache is lost`() {
-        val toolchain = loadToolchain()
-        val snapshotsDir = Files.createTempDirectory("cp-cache-recovery-")
-            .resolve("snapshots").apply { createDirectories() }
-
-        val metrics1 = RecordingMetricsSink()
-        val cache1 = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics1)
-
-        // Populate cache and snapshot files
-        val first = cache1.getOrComputeSnapshots(fixtureClasspath)
-
-        // Create a NEW cache instance (simulates daemon restart), same snapshotsDir
-        val metrics2 = RecordingMetricsSink()
-        val cache2 = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics2)
-
-        val second = cache2.getOrComputeSnapshots(fixtureClasspath)
-        assertEquals(first, second, "file-backed recovery must return same paths")
-
-        val secondMetrics = metrics2.snapshotAndReset()
-        val hits = secondMetrics.count { it.first == ClasspathSnapshotCache.METRIC_HIT }
-        assertEquals(fixtureClasspath.size, hits, "file-backed recovery should count as hits")
-    }
-
-    @Test
-    fun `deleted snapshot file triggers recomputation`() {
-        val toolchain = loadToolchain()
-        val snapshotsDir = Files.createTempDirectory("cp-cache-deleted-")
-            .resolve("snapshots").apply { createDirectories() }
-
-        val metrics = RecordingMetricsSink()
-        val cache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics)
-
-        val first = cache.getOrComputeSnapshots(fixtureClasspath)
-        metrics.snapshotAndReset()
-
-        // Delete the first snapshot file (simulates self-heal wipe)
-        Files.delete(first[0])
-
-        val second = cache.getOrComputeSnapshots(fixtureClasspath)
-        assertTrue(Files.exists(second[0]), "snapshot must be recomputed after deletion")
-
-        val postDeleteMetrics = metrics.snapshotAndReset()
-        val misses = postDeleteMetrics.count { it.first == ClasspathSnapshotCache.METRIC_MISS }
-        assertTrue(misses >= 1, "at least one miss expected after file deletion")
-    }
-
-    @Test
-    fun `non-existent classpath entry causes all-or-nothing fallback to empty list`() {
-        val toolchain = loadToolchain()
-        val snapshotsDir = Files.createTempDirectory("cp-cache-aon-")
-            .resolve("snapshots").apply { createDirectories() }
-
-        val metrics = RecordingMetricsSink()
-        val cache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics)
-
-        val classpath = fixtureClasspath + Path.of("/nonexistent/bogus.jar")
-
-        val result = cache.getOrComputeSnapshots(classpath)
-        assertEquals(emptyList<Path>(), result, "any failure must fall back to empty list")
-
-        val events = metrics.snapshotAndReset()
-        val errors = events.count { it.first == ClasspathSnapshotCache.METRIC_ERROR }
-        assertEquals(0, errors, "non-existent entry returns null, not an error")
-    }
-
-    private class RecordingMetricsSink : IcMetricsSink {
-        private val events: MutableList<Pair<String, Long>> = mutableListOf()
-        override fun record(name: String, value: Long) {
-            events += name to value
-        }
-        fun snapshotAndReset(): List<Pair<String, Long>> {
-            val snap = events.toList()
-            events.clear()
-            return snap
-        }
-    }
-
-    private fun systemClasspath(key: String): List<Path> {
-        val raw = System.getProperty(key)
-            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
-        return raw.split(File.pathSeparator)
-            .filter { it.isNotBlank() }
-            .map { Path.of(it) }
-    }
+  private fun systemClasspath(key: String): List<Path> {
+    val raw =
+      System.getProperty(key)
+        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+    return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCostTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCostTest.kt
@@ -2,10 +2,6 @@
 
 package kolt.daemon.ic
 
-import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
-import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
-import org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader
-import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain.Companion.jvm
 import java.io.File
 import java.net.URLClassLoader
 import java.nio.file.Files
@@ -15,6 +11,10 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader
+import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain.Companion.jvm
 
 // Phase 0 measurement: how expensive is ClasspathEntrySnapshot computation
 // for representative jars? This test prints wall times so we can decide
@@ -23,73 +23,76 @@ import kotlin.time.TimeSource
 // catastrophic regressions, not to pin expected performance.
 class ClasspathSnapshotCostTest {
 
-    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
-    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+  private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+  private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
 
-    @Test
-    fun `measure classpath snapshot computation cost per jar`() {
-        val implUrls = btaImplJars.map { it.toUri().toURL() }.toTypedArray()
-        val implLoader = URLClassLoader(implUrls, SharedApiClassesClassLoader())
-        val toolchain = KotlinToolchains.loadImplementation(implLoader)
+  @Test
+  fun `measure classpath snapshot computation cost per jar`() {
+    val implUrls = btaImplJars.map { it.toUri().toURL() }.toTypedArray()
+    val implLoader = URLClassLoader(implUrls, SharedApiClassesClassLoader())
+    val toolchain = KotlinToolchains.loadImplementation(implLoader)
 
-        val snapshotsDir = Files.createTempDirectory("cp-snapshot-cost-")
-            .resolve("snapshots").apply { createDirectories() }
+    val snapshotsDir =
+      Files.createTempDirectory("cp-snapshot-cost-").resolve("snapshots").apply {
+        createDirectories()
+      }
 
-        println("=== ClasspathEntrySnapshot computation cost ===")
-        println("classpath entries: ${fixtureClasspath.size}")
+    println("=== ClasspathEntrySnapshot computation cost ===")
+    println("classpath entries: ${fixtureClasspath.size}")
 
-        for (entry in fixtureClasspath) {
-            val fileSize = Files.size(entry)
-            println("  entry: ${entry.fileName} (${fileSize / 1024} KB)")
+    for (entry in fixtureClasspath) {
+      val fileSize = Files.size(entry)
+      println("  entry: ${entry.fileName} (${fileSize / 1024} KB)")
 
-            // Warm up: first call may include classloader init overhead
-            val warmupFile = snapshotsDir.resolve("warmup-${entry.fileName}.snapshot")
-            val warmupStart = TimeSource.Monotonic.markNow()
-            val warmupSnapshot = toolchain.createBuildSession().use { session ->
-                val op = toolchain.jvm.classpathSnapshottingOperationBuilder(entry).build()
-                session.executeOperation(op)
-            }
-            val warmupMs = warmupStart.elapsedNow().toLong(DurationUnit.MILLISECONDS)
-            warmupSnapshot.saveSnapshot(warmupFile)
-            val snapshotFileSize = Files.size(warmupFile)
-            println("    warmup:  ${warmupMs}ms (snapshot file: ${snapshotFileSize / 1024} KB)")
-
-            // Measured run (no classloader init overhead)
-            val measuredFile = snapshotsDir.resolve("measured-${entry.fileName}.snapshot")
-            val measuredStart = TimeSource.Monotonic.markNow()
-            val measuredSnapshot = toolchain.createBuildSession().use { session ->
-                val op = toolchain.jvm.classpathSnapshottingOperationBuilder(entry).build()
-                session.executeOperation(op)
-            }
-            val measuredMs = measuredStart.elapsedNow().toLong(DurationUnit.MILLISECONDS)
-            measuredSnapshot.saveSnapshot(measuredFile)
-            println("    steady:  ${measuredMs}ms")
-
-            // Sanity: snapshot file was actually written
-            assertTrue(Files.exists(warmupFile), "snapshot file must exist")
-            assertTrue(snapshotFileSize > 0, "snapshot file must be non-empty")
+      // Warm up: first call may include classloader init overhead
+      val warmupFile = snapshotsDir.resolve("warmup-${entry.fileName}.snapshot")
+      val warmupStart = TimeSource.Monotonic.markNow()
+      val warmupSnapshot =
+        toolchain.createBuildSession().use { session ->
+          val op = toolchain.jvm.classpathSnapshottingOperationBuilder(entry).build()
+          session.executeOperation(op)
         }
+      val warmupMs = warmupStart.elapsedNow().toLong(DurationUnit.MILLISECONDS)
+      warmupSnapshot.saveSnapshot(warmupFile)
+      val snapshotFileSize = Files.size(warmupFile)
+      println("    warmup:  ${warmupMs}ms (snapshot file: ${snapshotFileSize / 1024} KB)")
 
-        // Third run to confirm stability
-        val thirdRunTimes = mutableListOf<Long>()
-        for (entry in fixtureClasspath) {
-            val start = TimeSource.Monotonic.markNow()
-            toolchain.createBuildSession().use { session ->
-                val op = toolchain.jvm.classpathSnapshottingOperationBuilder(entry).build()
-                session.executeOperation(op)
-            }
-            thirdRunTimes.add(start.elapsedNow().toLong(DurationUnit.MILLISECONDS))
+      // Measured run (no classloader init overhead)
+      val measuredFile = snapshotsDir.resolve("measured-${entry.fileName}.snapshot")
+      val measuredStart = TimeSource.Monotonic.markNow()
+      val measuredSnapshot =
+        toolchain.createBuildSession().use { session ->
+          val op = toolchain.jvm.classpathSnapshottingOperationBuilder(entry).build()
+          session.executeOperation(op)
         }
-        val totalThirdRun = thirdRunTimes.sum()
-        println("  third-run total: ${totalThirdRun}ms (${thirdRunTimes.joinToString(", ")}ms each)")
-        println("=== end ===")
+      val measuredMs = measuredStart.elapsedNow().toLong(DurationUnit.MILLISECONDS)
+      measuredSnapshot.saveSnapshot(measuredFile)
+      println("    steady:  ${measuredMs}ms")
+
+      // Sanity: snapshot file was actually written
+      assertTrue(Files.exists(warmupFile), "snapshot file must exist")
+      assertTrue(snapshotFileSize > 0, "snapshot file must be non-empty")
     }
 
-    private fun systemClasspath(key: String): List<Path> {
-        val raw = System.getProperty(key)
-            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
-        return raw.split(File.pathSeparator)
-            .filter { it.isNotBlank() }
-            .map { Path.of(it) }
+    // Third run to confirm stability
+    val thirdRunTimes = mutableListOf<Long>()
+    for (entry in fixtureClasspath) {
+      val start = TimeSource.Monotonic.markNow()
+      toolchain.createBuildSession().use { session ->
+        val op = toolchain.jvm.classpathSnapshottingOperationBuilder(entry).build()
+        session.executeOperation(op)
+      }
+      thirdRunTimes.add(start.elapsedNow().toLong(DurationUnit.MILLISECONDS))
     }
+    val totalThirdRun = thirdRunTimes.sum()
+    println("  third-run total: ${totalThirdRun}ms (${thirdRunTimes.joinToString(", ")}ms each)")
+    println("=== end ===")
+  }
+
+  private fun systemClasspath(key: String): List<Path> {
+    val raw =
+      System.getProperty(key)
+        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+    return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/IcMetricsSinkTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/IcMetricsSinkTest.kt
@@ -12,43 +12,43 @@ import kotlin.test.assertTrue
 // daemon's other stderr noise does not collide.
 class IcMetricsSinkTest {
 
-    @Test
-    fun `NoopIcMetricsSink discards every record call`() {
-        // The point of Noop is that there is nothing to assert *on the
-        // output*; the assertion is that it does not throw and can be
-        // called freely from non-test contexts (default constructor
-        // parameter on BtaIncrementalCompiler and SelfHealingIncrementalCompiler).
-        NoopIcMetricsSink.record("ic.success")
-        NoopIcMetricsSink.record("ic.self_heal", 3)
-    }
+  @Test
+  fun `NoopIcMetricsSink discards every record call`() {
+    // The point of Noop is that there is nothing to assert *on the
+    // output*; the assertion is that it does not throw and can be
+    // called freely from non-test contexts (default constructor
+    // parameter on BtaIncrementalCompiler and SelfHealingIncrementalCompiler).
+    NoopIcMetricsSink.record("ic.success")
+    NoopIcMetricsSink.record("ic.self_heal", 3)
+  }
 
-    @Test
-    fun `StderrIcMetricsSink emits one kolt-ic-metric line per record`() {
-        val buffer = ByteArrayOutputStream()
-        val sink = StderrIcMetricsSink(PrintStream(buffer, true, Charsets.UTF_8))
+  @Test
+  fun `StderrIcMetricsSink emits one kolt-ic-metric line per record`() {
+    val buffer = ByteArrayOutputStream()
+    val sink = StderrIcMetricsSink(PrintStream(buffer, true, Charsets.UTF_8))
 
-        sink.record("ic.success")
-        sink.record("ic.self_heal", 1)
-        sink.record("ic.wall_ms", 412)
+    sink.record("ic.success")
+    sink.record("ic.self_heal", 1)
+    sink.record("ic.wall_ms", 412)
 
-        val lines = buffer.toString(Charsets.UTF_8).lineSequence().filter { it.isNotBlank() }.toList()
-        assertEquals(3, lines.size)
-        assertEquals("""kolt-ic-metric {"name":"ic.success","value":1}""", lines[0])
-        assertEquals("""kolt-ic-metric {"name":"ic.self_heal","value":1}""", lines[1])
-        assertEquals("""kolt-ic-metric {"name":"ic.wall_ms","value":412}""", lines[2])
-    }
+    val lines = buffer.toString(Charsets.UTF_8).lineSequence().filter { it.isNotBlank() }.toList()
+    assertEquals(3, lines.size)
+    assertEquals("""kolt-ic-metric {"name":"ic.success","value":1}""", lines[0])
+    assertEquals("""kolt-ic-metric {"name":"ic.self_heal","value":1}""", lines[1])
+    assertEquals("""kolt-ic-metric {"name":"ic.wall_ms","value":412}""", lines[2])
+  }
 
-    @Test
-    fun `StderrIcMetricsSink tolerates names with inner dots and underscores`() {
-        val buffer = ByteArrayOutputStream()
-        val sink = StderrIcMetricsSink(PrintStream(buffer, true, Charsets.UTF_8))
+  @Test
+  fun `StderrIcMetricsSink tolerates names with inner dots and underscores`() {
+    val buffer = ByteArrayOutputStream()
+    val sink = StderrIcMetricsSink(PrintStream(buffer, true, Charsets.UTF_8))
 
-        sink.record("ic.bta.compiled_files", 7)
+    sink.record("ic.bta.compiled_files", 7)
 
-        assertTrue(
-            buffer.toString(Charsets.UTF_8).contains(
-                """kolt-ic-metric {"name":"ic.bta.compiled_files","value":7}""",
-            ),
-        )
-    }
+    assertTrue(
+      buffer
+        .toString(Charsets.UTF_8)
+        .contains("""kolt-ic-metric {"name":"ic.bta.compiled_files","value":7}""")
+    )
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/IcStateLayoutTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/IcStateLayoutTest.kt
@@ -8,77 +8,78 @@ import kotlin.test.assertTrue
 
 class IcStateLayoutTest {
 
-    @Test
-    fun `projectIdFor returns 32 char lowercase hex`() {
-        val id = IcStateLayout.projectIdFor(Path.of("/home/alice/projects/kolt"))
+  @Test
+  fun `projectIdFor returns 32 char lowercase hex`() {
+    val id = IcStateLayout.projectIdFor(Path.of("/home/alice/projects/kolt"))
 
-        assertEquals(32, id.length)
-        assertTrue(id.all { it.isDigit() || it in 'a'..'f' }, "id must be lowercase hex, got: $id")
-    }
+    assertEquals(32, id.length)
+    assertTrue(id.all { it.isDigit() || it in 'a'..'f' }, "id must be lowercase hex, got: $id")
+  }
 
-    @Test
-    fun `projectIdFor is deterministic for the same input`() {
-        val a = IcStateLayout.projectIdFor(Path.of("/w/x/y"))
-        val b = IcStateLayout.projectIdFor(Path.of("/w/x/y"))
+  @Test
+  fun `projectIdFor is deterministic for the same input`() {
+    val a = IcStateLayout.projectIdFor(Path.of("/w/x/y"))
+    val b = IcStateLayout.projectIdFor(Path.of("/w/x/y"))
 
-        assertEquals(a, b)
-    }
+    assertEquals(a, b)
+  }
 
-    @Test
-    fun `projectIdFor distinguishes different project roots`() {
-        val a = IcStateLayout.projectIdFor(Path.of("/w/x/y"))
-        val b = IcStateLayout.projectIdFor(Path.of("/w/x/z"))
+  @Test
+  fun `projectIdFor distinguishes different project roots`() {
+    val a = IcStateLayout.projectIdFor(Path.of("/w/x/y"))
+    val b = IcStateLayout.projectIdFor(Path.of("/w/x/z"))
 
-        assertNotEquals(a, b)
-    }
+    assertNotEquals(a, b)
+  }
 
-    @Test
-    fun `projectIdFor uses the absolute path string verbatim`() {
-        // Carryover #6: IcStateLayout is the one place that defines the
-        // hash input shape. If a future refactor changes the algorithm
-        // (e.g. canonicalising symlinks), this test will pin the break.
-        val explicit = IcStateLayout.projectIdFor(Path.of("/abs/path"))
+  @Test
+  fun `projectIdFor uses the absolute path string verbatim`() {
+    // Carryover #6: IcStateLayout is the one place that defines the
+    // hash input shape. If a future refactor changes the algorithm
+    // (e.g. canonicalising symlinks), this test will pin the break.
+    val explicit = IcStateLayout.projectIdFor(Path.of("/abs/path"))
 
-        val md = java.security.MessageDigest.getInstance("SHA-256")
-        val expected = md.digest("/abs/path".toByteArray(Charsets.UTF_8))
-            .take(16)
-            .joinToString("") { "%02x".format(it) }
+    val md = java.security.MessageDigest.getInstance("SHA-256")
+    val expected =
+      md.digest("/abs/path".toByteArray(Charsets.UTF_8)).take(16).joinToString("") {
+        "%02x".format(it)
+      }
 
-        assertEquals(expected, explicit)
-    }
+    assertEquals(expected, explicit)
+  }
 
-    @Test
-    fun `workingDirFor composes icRoot kotlinVersion and projectId`() {
-        val icRoot = Path.of("/home/alice/.kolt/daemon/ic")
-        val projectRoot = Path.of("/work/proj")
-        val projectId = IcStateLayout.projectIdFor(projectRoot)
+  @Test
+  fun `workingDirFor composes icRoot kotlinVersion and projectId`() {
+    val icRoot = Path.of("/home/alice/.kolt/daemon/ic")
+    val projectRoot = Path.of("/work/proj")
+    val projectId = IcStateLayout.projectIdFor(projectRoot)
 
-        val workingDir = IcStateLayout.workingDirFor(icRoot, "2.3.20", projectRoot)
+    val workingDir = IcStateLayout.workingDirFor(icRoot, "2.3.20", projectRoot)
 
-        assertEquals(icRoot.resolve("2.3.20").resolve(projectId), workingDir)
-    }
+    assertEquals(icRoot.resolve("2.3.20").resolve(projectId), workingDir)
+  }
 
-    @Test
-    fun `workingDirFor separates by kotlin version`() {
-        val icRoot = Path.of("/ic")
-        val projectRoot = Path.of("/w")
+  @Test
+  fun `workingDirFor separates by kotlin version`() {
+    val icRoot = Path.of("/ic")
+    val projectRoot = Path.of("/w")
 
-        val v1 = IcStateLayout.workingDirFor(icRoot, "2.3.20", projectRoot)
-        val v2 = IcStateLayout.workingDirFor(icRoot, "2.4.0", projectRoot)
+    val v1 = IcStateLayout.workingDirFor(icRoot, "2.3.20", projectRoot)
+    val v2 = IcStateLayout.workingDirFor(icRoot, "2.4.0", projectRoot)
 
-        assertNotEquals(v1, v2)
-        assertEquals(icRoot.resolve("2.3.20"), v1.parent)
-        assertEquals(icRoot.resolve("2.4.0"), v2.parent)
-    }
+    assertNotEquals(v1, v2)
+    assertEquals(icRoot.resolve("2.3.20"), v1.parent)
+    assertEquals(icRoot.resolve("2.4.0"), v2.parent)
+  }
 
-    @Test
-    fun `workingDirFor separates by project root`() {
-        val icRoot = Path.of("/ic")
+  @Test
+  fun `workingDirFor separates by project root`() {
+    val icRoot = Path.of("/ic")
 
-        val a = IcStateLayout.workingDirFor(icRoot, "2.3.20", Path.of("/w/a"))
-        val b = IcStateLayout.workingDirFor(icRoot, "2.3.20", Path.of("/w/b"))
+    val a = IcStateLayout.workingDirFor(icRoot, "2.3.20", Path.of("/w/a"))
+    val b = IcStateLayout.workingDirFor(icRoot, "2.3.20", Path.of("/w/b"))
 
-        assertNotEquals(a, b)
-        assertEquals(a.parent, b.parent, "same kotlinVersion directory hosts both")
-    }
+    assertNotEquals(a, b)
+    assertEquals(a.parent, b.parent, "same kotlinVersion directory hosts both")
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/IncrementalCompilerContractTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/IncrementalCompilerContractTest.kt
@@ -19,61 +19,62 @@ import kotlin.test.assertTrue
 // forcing daemon-core call sites to change.
 class IncrementalCompilerContractTest {
 
-    private fun sampleRequest(): IcRequest = IcRequest(
-        projectId = "abc123",
-        projectRoot = Path.of("/tmp/fixture"),
-        sources = listOf(Path.of("/tmp/fixture/Main.kt")),
-        classpath = listOf(Path.of("/tmp/kotlin-stdlib.jar")),
-        outputDir = Path.of("/tmp/fixture/out"),
-        workingDir = Path.of("/tmp/fixture/ic"),
+  private fun sampleRequest(): IcRequest =
+    IcRequest(
+      projectId = "abc123",
+      projectRoot = Path.of("/tmp/fixture"),
+      sources = listOf(Path.of("/tmp/fixture/Main.kt")),
+      classpath = listOf(Path.of("/tmp/kotlin-stdlib.jar")),
+      outputDir = Path.of("/tmp/fixture/out"),
+      workingDir = Path.of("/tmp/fixture/ic"),
     )
 
-    @Test
-    fun `success path returns Ok IcResponse`() {
-        val compiler = object : IncrementalCompiler {
-            override fun compile(request: IcRequest): Result<IcResponse, IcError> =
-                Ok(IcResponse(wallMillis = 42, compiledFileCount = 1))
-        }
+  @Test
+  fun `success path returns Ok IcResponse`() {
+    val compiler =
+      object : IncrementalCompiler {
+        override fun compile(request: IcRequest): Result<IcResponse, IcError> =
+          Ok(IcResponse(wallMillis = 42, compiledFileCount = 1))
+      }
 
-        val response = compiler.compile(sampleRequest()).getOrElse {
-            error("expected Ok, got Err($it)")
-        }
+    val response =
+      compiler.compile(sampleRequest()).getOrElse { error("expected Ok, got Err($it)") }
 
-        assertEquals(42L, response.wallMillis)
-        assertEquals(1, response.compiledFileCount)
-    }
+    assertEquals(42L, response.wallMillis)
+    assertEquals(1, response.compiledFileCount)
+  }
 
-    @Test
-    fun `compiledFileCount is nullable when metrics unavailable`() {
-        val response = IcResponse(wallMillis = 1, compiledFileCount = null)
-        assertNull(response.compiledFileCount)
-    }
+  @Test
+  fun `compiledFileCount is nullable when metrics unavailable`() {
+    val response = IcResponse(wallMillis = 1, compiledFileCount = null)
+    assertNull(response.compiledFileCount)
+  }
 
-    @Test
-    fun `CompilationFailed carries diagnostic messages`() {
-        val compiler = object : IncrementalCompiler {
-            override fun compile(request: IcRequest): Result<IcResponse, IcError> =
-                Err(IcError.CompilationFailed(listOf("Main.kt:1: error: unresolved reference")))
-        }
+  @Test
+  fun `CompilationFailed carries diagnostic messages`() {
+    val compiler =
+      object : IncrementalCompiler {
+        override fun compile(request: IcRequest): Result<IcResponse, IcError> =
+          Err(IcError.CompilationFailed(listOf("Main.kt:1: error: unresolved reference")))
+      }
 
-        val err = compiler.compile(sampleRequest()).getError()
-            ?: error("expected Err")
-        val compilationFailed = assertIs<IcError.CompilationFailed>(err)
-        assertEquals(1, compilationFailed.messages.size)
-        assertTrue(compilationFailed.messages.single().contains("unresolved reference"))
-    }
+    val err = compiler.compile(sampleRequest()).getError() ?: error("expected Err")
+    val compilationFailed = assertIs<IcError.CompilationFailed>(err)
+    assertEquals(1, compilationFailed.messages.size)
+    assertTrue(compilationFailed.messages.single().contains("unresolved reference"))
+  }
 
-    @Test
-    fun `InternalError carries original cause`() {
-        val cause = IllegalStateException("bta boom")
-        val compiler = object : IncrementalCompiler {
-            override fun compile(request: IcRequest): Result<IcResponse, IcError> =
-                Err(IcError.InternalError(cause))
-        }
+  @Test
+  fun `InternalError carries original cause`() {
+    val cause = IllegalStateException("bta boom")
+    val compiler =
+      object : IncrementalCompiler {
+        override fun compile(request: IcRequest): Result<IcResponse, IcError> =
+          Err(IcError.InternalError(cause))
+      }
 
-        val err = compiler.compile(sampleRequest()).getError()
-            ?: error("expected Err")
-        val internal = assertIs<IcError.InternalError>(err)
-        assertEquals(cause, internal.cause)
-    }
+    val err = compiler.compile(sampleRequest()).getError() ?: error("expected Err")
+    val internal = assertIs<IcError.InternalError>(err)
+    assertEquals(cause, internal.cause)
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/LanguageVersionTranslatorTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/LanguageVersionTranslatorTest.kt
@@ -8,7 +8,8 @@ import kotlin.test.assertTrue
 
 class LanguageVersionTranslatorTest {
 
-    private val baseToml = """
+  private val baseToml =
+    """
         name = "demo"
         version = "0.1.0"
 
@@ -16,58 +17,68 @@ class LanguageVersionTranslatorTest {
         target = "jvm"
         main = "demo.Main"
         sources = ["src/main/kotlin"]
-    """.trimIndent()
+    """
+      .trimIndent()
 
-    @Test
-    fun `missing kolt_toml yields no args`() {
-        val projectRoot = Files.createTempDirectory("lang-translator-empty-")
-        assertTrue(LanguageVersionTranslator.translate(projectRoot).isEmpty())
-    }
+  @Test
+  fun `missing kolt_toml yields no args`() {
+    val projectRoot = Files.createTempDirectory("lang-translator-empty-")
+    assertTrue(LanguageVersionTranslator.translate(projectRoot).isEmpty())
+  }
 
-    @Test
-    fun `compiler unset yields no args`() {
-        val projectRoot = Files.createTempDirectory("lang-translator-unset-")
-        projectRoot.resolve("kolt.toml").writeText(
-            """
+  @Test
+  fun `compiler unset yields no args`() {
+    val projectRoot = Files.createTempDirectory("lang-translator-unset-")
+    projectRoot
+      .resolve("kolt.toml")
+      .writeText(
+        """
             $baseToml
 
             [kotlin]
             version = "2.1.0"
-            """.trimIndent(),
-        )
-        assertTrue(LanguageVersionTranslator.translate(projectRoot).isEmpty())
-    }
-
-    @Test
-    fun `compiler equal to version yields no args`() {
-        val projectRoot = Files.createTempDirectory("lang-translator-equal-")
-        projectRoot.resolve("kolt.toml").writeText(
             """
+          .trimIndent()
+      )
+    assertTrue(LanguageVersionTranslator.translate(projectRoot).isEmpty())
+  }
+
+  @Test
+  fun `compiler equal to version yields no args`() {
+    val projectRoot = Files.createTempDirectory("lang-translator-equal-")
+    projectRoot
+      .resolve("kolt.toml")
+      .writeText(
+        """
             $baseToml
 
             [kotlin]
             version = "2.3.20"
             compiler = "2.3.20"
-            """.trimIndent(),
-        )
-        assertTrue(LanguageVersionTranslator.translate(projectRoot).isEmpty())
-    }
-
-    @Test
-    fun `compiler higher than version emits language and api flags pinned to version`() {
-        val projectRoot = Files.createTempDirectory("lang-translator-higher-")
-        projectRoot.resolve("kolt.toml").writeText(
             """
+          .trimIndent()
+      )
+    assertTrue(LanguageVersionTranslator.translate(projectRoot).isEmpty())
+  }
+
+  @Test
+  fun `compiler higher than version emits language and api flags pinned to version`() {
+    val projectRoot = Files.createTempDirectory("lang-translator-higher-")
+    projectRoot
+      .resolve("kolt.toml")
+      .writeText(
+        """
             $baseToml
 
             [kotlin]
             version = "2.1.0"
             compiler = "2.3.20"
-            """.trimIndent(),
-        )
-        assertEquals(
-            listOf("-language-version", "2.1", "-api-version", "2.1"),
-            LanguageVersionTranslator.translate(projectRoot),
-        )
-    }
+            """
+          .trimIndent()
+      )
+    assertEquals(
+      listOf("-language-version", "2.1", "-api-version", "2.1"),
+      LanguageVersionTranslator.translate(projectRoot),
+    )
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/PluginTranslatorTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/PluginTranslatorTest.kt
@@ -19,7 +19,8 @@ import kotlin.test.assertTrue
 // descriptor, so the translator just passes through resolved jar paths.
 class PluginTranslatorTest {
 
-    private val baseToml = """
+  private val baseToml =
+    """
         name = "demo"
         version = "0.1.0"
 
@@ -30,152 +31,183 @@ class PluginTranslatorTest {
         target = "jvm"
         main = "demo.Main"
         sources = ["src/main/kotlin"]
-    """.trimIndent()
+    """
+      .trimIndent()
 
-    @Test
-    fun `missing kolt_toml yields an empty plugin list`() {
-        val projectRoot = Files.createTempDirectory("plugin-translator-empty-")
-        val args = PluginTranslator.translate(
-            projectRoot = projectRoot,
-            jarResolver = { _ -> error("resolver must not be called when no plugins section") },
-        )
-        assertTrue(args.isEmpty(), "no kolt.toml → no plugin args, got $args")
-    }
+  @Test
+  fun `missing kolt_toml yields an empty plugin list`() {
+    val projectRoot = Files.createTempDirectory("plugin-translator-empty-")
+    val args =
+      PluginTranslator.translate(
+        projectRoot = projectRoot,
+        jarResolver = { _ -> error("resolver must not be called when no plugins section") },
+      )
+    assertTrue(args.isEmpty(), "no kolt.toml → no plugin args, got $args")
+  }
 
-    @Test
-    fun `kolt_toml with no plugins section yields an empty list`() {
-        val projectRoot = Files.createTempDirectory("plugin-translator-no-section-")
-        projectRoot.resolve("kolt.toml").writeText(baseToml)
-        val args = PluginTranslator.translate(
-            projectRoot = projectRoot,
-            jarResolver = { _ -> error("resolver must not be called when plugins map is empty") },
-        )
-        assertTrue(args.isEmpty())
-    }
+  @Test
+  fun `kolt_toml with no plugins section yields an empty list`() {
+    val projectRoot = Files.createTempDirectory("plugin-translator-no-section-")
+    projectRoot.resolve("kolt.toml").writeText(baseToml)
+    val args =
+      PluginTranslator.translate(
+        projectRoot = projectRoot,
+        jarResolver = { _ -> error("resolver must not be called when plugins map is empty") },
+      )
+    assertTrue(args.isEmpty())
+  }
 
-    @Test
-    fun `serialization plugin entry emits one -Xplugin= arg per resolved jar`() {
-        val projectRoot = Files.createTempDirectory("plugin-translator-serialization-")
-        projectRoot.resolve("kolt.toml").writeText(
-            baseToml + """
+  @Test
+  fun `serialization plugin entry emits one -Xplugin= arg per resolved jar`() {
+    val projectRoot = Files.createTempDirectory("plugin-translator-serialization-")
+    projectRoot
+      .resolve("kolt.toml")
+      .writeText(
+        baseToml +
+          """
 
                 [kotlin.plugins]
                 serialization = true
-            """.trimIndent(),
-        )
-        val fakeJar = Path.of("/fake/kotlinx-serialization-compiler-plugin.jar")
-        val resolved = mutableListOf<String>()
+            """
+            .trimIndent()
+      )
+    val fakeJar = Path.of("/fake/kotlinx-serialization-compiler-plugin.jar")
+    val resolved = mutableListOf<String>()
 
-        val args = PluginTranslator.translate(
-            projectRoot = projectRoot,
-            jarResolver = { name ->
-                resolved += name
-                if (name == "serialization") listOf(fakeJar) else emptyList()
-            },
-        )
+    val args =
+      PluginTranslator.translate(
+        projectRoot = projectRoot,
+        jarResolver = { name ->
+          resolved += name
+          if (name == "serialization") listOf(fakeJar) else emptyList()
+        },
+      )
 
-        assertEquals(listOf("serialization"), resolved, "resolver should be asked once for the serialization plugin")
-        assertEquals(listOf("-Xplugin=$fakeJar"), args)
-    }
+    assertEquals(
+      listOf("serialization"),
+      resolved,
+      "resolver should be asked once for the serialization plugin",
+    )
+    assertEquals(listOf("-Xplugin=$fakeJar"), args)
+  }
 
-    @Test
-    fun `disabled plugin entry is skipped entirely`() {
-        val projectRoot = Files.createTempDirectory("plugin-translator-disabled-")
-        projectRoot.resolve("kolt.toml").writeText(
-            baseToml + """
+  @Test
+  fun `disabled plugin entry is skipped entirely`() {
+    val projectRoot = Files.createTempDirectory("plugin-translator-disabled-")
+    projectRoot
+      .resolve("kolt.toml")
+      .writeText(
+        baseToml +
+          """
 
                 [kotlin.plugins]
                 serialization = false
-            """.trimIndent(),
-        )
-        val args = PluginTranslator.translate(
-            projectRoot = projectRoot,
-            jarResolver = { _ -> error("resolver must not be called for disabled plugin") },
-        )
-        assertTrue(args.isEmpty())
-    }
+            """
+            .trimIndent()
+      )
+    val args =
+      PluginTranslator.translate(
+        projectRoot = projectRoot,
+        jarResolver = { _ -> error("resolver must not be called for disabled plugin") },
+      )
+    assertTrue(args.isEmpty())
+  }
 
-    // #65 native client wiring: allopen / noarg must also translate through
-    // the same passthrough path. The translator is alias-agnostic now — it
-    // only trusts the resolver — so this test pins the "resolver gets asked"
-    // behaviour for all three known aliases.
-    @Test
-    fun `allopen plugin entry emits -Xplugin= passthrough args`() {
-        val projectRoot = Files.createTempDirectory("plugin-translator-allopen-")
-        projectRoot.resolve("kolt.toml").writeText(
-            baseToml + """
+  // #65 native client wiring: allopen / noarg must also translate through
+  // the same passthrough path. The translator is alias-agnostic now — it
+  // only trusts the resolver — so this test pins the "resolver gets asked"
+  // behaviour for all three known aliases.
+  @Test
+  fun `allopen plugin entry emits -Xplugin= passthrough args`() {
+    val projectRoot = Files.createTempDirectory("plugin-translator-allopen-")
+    projectRoot
+      .resolve("kolt.toml")
+      .writeText(
+        baseToml +
+          """
 
                 [kotlin.plugins]
                 allopen = true
-            """.trimIndent(),
-        )
-        val fakeJar = Path.of("/fake/allopen-compiler-plugin.jar")
-        val args = PluginTranslator.translate(
-            projectRoot = projectRoot,
-            jarResolver = { name -> if (name == "allopen") listOf(fakeJar) else emptyList() },
-        )
-        assertEquals(listOf("-Xplugin=$fakeJar"), args)
-    }
+            """
+            .trimIndent()
+      )
+    val fakeJar = Path.of("/fake/allopen-compiler-plugin.jar")
+    val args =
+      PluginTranslator.translate(
+        projectRoot = projectRoot,
+        jarResolver = { name -> if (name == "allopen") listOf(fakeJar) else emptyList() },
+      )
+    assertEquals(listOf("-Xplugin=$fakeJar"), args)
+  }
 
-    @Test
-    fun `noarg plugin entry emits -Xplugin= passthrough args`() {
-        val projectRoot = Files.createTempDirectory("plugin-translator-noarg-")
-        projectRoot.resolve("kolt.toml").writeText(
-            baseToml + """
+  @Test
+  fun `noarg plugin entry emits -Xplugin= passthrough args`() {
+    val projectRoot = Files.createTempDirectory("plugin-translator-noarg-")
+    projectRoot
+      .resolve("kolt.toml")
+      .writeText(
+        baseToml +
+          """
 
                 [kotlin.plugins]
                 noarg = true
-            """.trimIndent(),
-        )
-        val fakeJar = Path.of("/fake/noarg-compiler-plugin.jar")
-        val args = PluginTranslator.translate(
-            projectRoot = projectRoot,
-            jarResolver = { name -> if (name == "noarg") listOf(fakeJar) else emptyList() },
-        )
-        assertEquals(listOf("-Xplugin=$fakeJar"), args)
-    }
+            """
+            .trimIndent()
+      )
+    val fakeJar = Path.of("/fake/noarg-compiler-plugin.jar")
+    val args =
+      PluginTranslator.translate(
+        projectRoot = projectRoot,
+        jarResolver = { name -> if (name == "noarg") listOf(fakeJar) else emptyList() },
+      )
+    assertEquals(listOf("-Xplugin=$fakeJar"), args)
+  }
 
-    @Test
-    fun `multi-jar resolution emits one arg per jar preserving resolver order`() {
-        val projectRoot = Files.createTempDirectory("plugin-translator-multijar-")
-        projectRoot.resolve("kolt.toml").writeText(
-            baseToml + """
-
-                [kotlin.plugins]
-                serialization = true
-            """.trimIndent(),
-        )
-        val jars = listOf(
-            Path.of("/fake/kotlinx-serialization-compiler-plugin.jar"),
-            Path.of("/fake/kotlinx-serialization-compiler-plugin-embeddable.jar"),
-        )
-        val args = PluginTranslator.translate(
-            projectRoot = projectRoot,
-            jarResolver = { _ -> jars },
-        )
-        assertEquals(jars.map { "-Xplugin=$it" }, args)
-    }
-
-    @Test
-    fun `empty resolver result for an enabled plugin produces no args`() {
-        // Production upstream (`PluginJarFetcher` in the CLI) fails before the
-        // daemon request is built if a plugin jar cannot be fetched, so the
-        // resolver never returns an empty list for an enabled alias in
-        // practice. This test pins the boundary case: if it does happen
-        // (test mocks, future resolver rewiring) the translator emits no
-        // `-Xplugin=` entries rather than a malformed one.
-        val projectRoot = Files.createTempDirectory("plugin-translator-unresolved-")
-        projectRoot.resolve("kolt.toml").writeText(
-            baseToml + """
+  @Test
+  fun `multi-jar resolution emits one arg per jar preserving resolver order`() {
+    val projectRoot = Files.createTempDirectory("plugin-translator-multijar-")
+    projectRoot
+      .resolve("kolt.toml")
+      .writeText(
+        baseToml +
+          """
 
                 [kotlin.plugins]
                 serialization = true
-            """.trimIndent(),
-        )
-        val args = PluginTranslator.translate(
-            projectRoot = projectRoot,
-            jarResolver = { _ -> emptyList() },
-        )
-        assertTrue(args.isEmpty())
-    }
+            """
+            .trimIndent()
+      )
+    val jars =
+      listOf(
+        Path.of("/fake/kotlinx-serialization-compiler-plugin.jar"),
+        Path.of("/fake/kotlinx-serialization-compiler-plugin-embeddable.jar"),
+      )
+    val args = PluginTranslator.translate(projectRoot = projectRoot, jarResolver = { _ -> jars })
+    assertEquals(jars.map { "-Xplugin=$it" }, args)
+  }
+
+  @Test
+  fun `empty resolver result for an enabled plugin produces no args`() {
+    // Production upstream (`PluginJarFetcher` in the CLI) fails before the
+    // daemon request is built if a plugin jar cannot be fetched, so the
+    // resolver never returns an empty list for an enabled alias in
+    // practice. This test pins the boundary case: if it does happen
+    // (test mocks, future resolver rewiring) the translator emits no
+    // `-Xplugin=` entries rather than a malformed one.
+    val projectRoot = Files.createTempDirectory("plugin-translator-unresolved-")
+    projectRoot
+      .resolve("kolt.toml")
+      .writeText(
+        baseToml +
+          """
+
+                [kotlin.plugins]
+                serialization = true
+            """
+            .trimIndent()
+      )
+    val args =
+      PluginTranslator.translate(projectRoot = projectRoot, jarResolver = { _ -> emptyList() })
+    assertTrue(args.isEmpty())
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingBtaCompositionTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingBtaCompositionTest.kt
@@ -30,115 +30,126 @@ import kotlin.test.fail
 // the new KotlinLogger diagnostic plumbing surviving the wrap.
 class SelfHealingBtaCompositionTest {
 
-    private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
-    private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+  private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+  private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
 
-    @Test
-    fun `composed stack returns Ok for a healthy compile`() {
-        val workRoot = Files.createTempDirectory("composition-ok-")
-        val sourceFile = workRoot.resolve("Main.kt").also {
-            it.writeText(
-                """
+  @Test
+  fun `composed stack returns Ok for a healthy compile`() {
+    val workRoot = Files.createTempDirectory("composition-ok-")
+    val sourceFile =
+      workRoot.resolve("Main.kt").also {
+        it.writeText(
+          """
                 package fixture
                 object Main { fun ping(): String = "pong" }
-                """.trimIndent(),
-            )
-        }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic-state")
-
-        val metrics = RecordingMetricsSink()
-        val adapter = BtaIncrementalCompiler.create(btaImplJars, metrics = metrics)
-            .getOrElse { fail("adapter construction failed: $it") }
-        val composed: IncrementalCompiler = SelfHealingIncrementalCompiler(
-            delegate = adapter,
-            metrics = metrics,
-        )
-
-        val response = composed.compile(
-            IcRequest(
-                projectId = "composition-ok",
-                projectRoot = workRoot,
-                sources = listOf(sourceFile),
-                classpath = fixtureClasspath,
-                outputDir = outputDir,
-                workingDir = workingDir,
-            ),
-        ).get() ?: fail("expected Ok from the composed stack")
-
-        assertTrue(response.wallMillis >= 0)
-        // No self-heal event should fire on a healthy first compile.
-        assertTrue(
-            metrics.events.none { it.first == "ic.self_heal" },
-            "healthy compile must not fire ic.self_heal, got: ${metrics.events}",
-        )
-    }
-
-    @Test
-    fun `composed stack returns CompilationFailed with real kotlinc diagnostic`() {
-        val workRoot = Files.createTempDirectory("composition-err-")
-        val sourceFile = workRoot.resolve("Broken.kt").also {
-            it.writeText(
                 """
+            .trimIndent()
+        )
+      }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic-state")
+
+    val metrics = RecordingMetricsSink()
+    val adapter =
+      BtaIncrementalCompiler.create(btaImplJars, metrics = metrics).getOrElse {
+        fail("adapter construction failed: $it")
+      }
+    val composed: IncrementalCompiler =
+      SelfHealingIncrementalCompiler(delegate = adapter, metrics = metrics)
+
+    val response =
+      composed
+        .compile(
+          IcRequest(
+            projectId = "composition-ok",
+            projectRoot = workRoot,
+            sources = listOf(sourceFile),
+            classpath = fixtureClasspath,
+            outputDir = outputDir,
+            workingDir = workingDir,
+          )
+        )
+        .get() ?: fail("expected Ok from the composed stack")
+
+    assertTrue(response.wallMillis >= 0)
+    // No self-heal event should fire on a healthy first compile.
+    assertTrue(
+      metrics.events.none { it.first == "ic.self_heal" },
+      "healthy compile must not fire ic.self_heal, got: ${metrics.events}",
+    )
+  }
+
+  @Test
+  fun `composed stack returns CompilationFailed with real kotlinc diagnostic`() {
+    val workRoot = Files.createTempDirectory("composition-err-")
+    val sourceFile =
+      workRoot.resolve("Broken.kt").also {
+        it.writeText(
+          """
                 package fixture
                 fun broken(): Int = "not an int"
-                """.trimIndent(),
-            )
-        }
-        val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-        val workingDir = workRoot.resolve("ic-state")
-
-        val metrics = RecordingMetricsSink()
-        val adapter = BtaIncrementalCompiler.create(btaImplJars, metrics = metrics)
-            .getOrElse { fail("adapter construction failed: $it") }
-        val composed: IncrementalCompiler = SelfHealingIncrementalCompiler(
-            delegate = adapter,
-            metrics = metrics,
+                """
+            .trimIndent()
         )
+      }
+    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val workingDir = workRoot.resolve("ic-state")
 
-        val err = composed.compile(
-            IcRequest(
-                projectId = "composition-err",
-                projectRoot = workRoot,
-                sources = listOf(sourceFile),
-                classpath = fixtureClasspath,
-                outputDir = outputDir,
-                workingDir = workingDir,
-            ),
-        ).getError() ?: fail("expected Err from the composed stack")
+    val metrics = RecordingMetricsSink()
+    val adapter =
+      BtaIncrementalCompiler.create(btaImplJars, metrics = metrics).getOrElse {
+        fail("adapter construction failed: $it")
+      }
+    val composed: IncrementalCompiler =
+      SelfHealingIncrementalCompiler(delegate = adapter, metrics = metrics)
 
-        assertTrue(
-            err is IcError.CompilationFailed,
-            "CompilationFailed must pass through the self-heal wrapper unchanged, got: $err",
+    val err =
+      composed
+        .compile(
+          IcRequest(
+            projectId = "composition-err",
+            projectRoot = workRoot,
+            sources = listOf(sourceFile),
+            classpath = fixtureClasspath,
+            outputDir = outputDir,
+            workingDir = workingDir,
+          )
         )
-        assertTrue(err.messages.isNotEmpty(), "diagnostic capture must survive the composition")
-        val joined = err.messages.joinToString("\n")
-        assertTrue(
-            joined.contains("Broken.kt", ignoreCase = true) || joined.contains("type mismatch", ignoreCase = true),
-            "composed stack must surface real kotlinc diagnostic, got:\n$joined",
-        )
+        .getError() ?: fail("expected Err from the composed stack")
 
-        // The wrapper must NOT fire self-heal on a CompilationFailed —
-        // that would loop on every type error.
-        assertEquals(
-            0,
-            metrics.events.count { it.first == "ic.self_heal" },
-            "CompilationFailed path must not fire ic.self_heal",
-        )
+    assertTrue(
+      err is IcError.CompilationFailed,
+      "CompilationFailed must pass through the self-heal wrapper unchanged, got: $err",
+    )
+    assertTrue(err.messages.isNotEmpty(), "diagnostic capture must survive the composition")
+    val joined = err.messages.joinToString("\n")
+    assertTrue(
+      joined.contains("Broken.kt", ignoreCase = true) ||
+        joined.contains("type mismatch", ignoreCase = true),
+      "composed stack must surface real kotlinc diagnostic, got:\n$joined",
+    )
+
+    // The wrapper must NOT fire self-heal on a CompilationFailed —
+    // that would loop on every type error.
+    assertEquals(
+      0,
+      metrics.events.count { it.first == "ic.self_heal" },
+      "CompilationFailed path must not fire ic.self_heal",
+    )
+  }
+
+  private class RecordingMetricsSink : IcMetricsSink {
+    val events: MutableList<Pair<String, Long>> = mutableListOf()
+
+    override fun record(name: String, value: Long) {
+      events += name to value
     }
+  }
 
-    private class RecordingMetricsSink : IcMetricsSink {
-        val events: MutableList<Pair<String, Long>> = mutableListOf()
-        override fun record(name: String, value: Long) {
-            events += name to value
-        }
-    }
-
-    private fun systemClasspath(key: String): List<Path> {
-        val raw = System.getProperty(key)
-            ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
-        return raw.split(File.pathSeparator)
-            .filter { it.isNotBlank() }
-            .map { Path.of(it) }
-    }
+  private fun systemClasspath(key: String): List<Path> {
+    val raw =
+      System.getProperty(key)
+        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+    return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
+  }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingIncrementalCompilerTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingIncrementalCompilerTest.kt
@@ -18,495 +18,531 @@ import kotlin.test.assertTrue
 
 class SelfHealingIncrementalCompilerTest {
 
-    private lateinit var tmpRoot: Path
-    private lateinit var workingDir: Path
+  private lateinit var tmpRoot: Path
+  private lateinit var workingDir: Path
 
-    @BeforeTest
-    fun setUp() {
-        tmpRoot = Files.createTempDirectory("kolt-ic-selfheal-")
-        workingDir = tmpRoot.resolve("ic-state").also { Files.createDirectories(it) }
-        Files.writeString(workingDir.resolve("marker.txt"), "stale")
+  @BeforeTest
+  fun setUp() {
+    tmpRoot = Files.createTempDirectory("kolt-ic-selfheal-")
+    workingDir = tmpRoot.resolve("ic-state").also { Files.createDirectories(it) }
+    Files.writeString(workingDir.resolve("marker.txt"), "stale")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    runCatching { tmpRoot.toFile().deleteRecursively() }
+  }
+
+  private fun request(): IcRequest =
+    IcRequest(
+      projectId = "deadbeef",
+      projectRoot = tmpRoot,
+      sources = emptyList(),
+      classpath = emptyList(),
+      outputDir = tmpRoot.resolve("out"),
+      workingDir = workingDir,
+    )
+
+  @Test
+  fun `success on first attempt passes through without retry or wipe`() {
+    val calls = AtomicInteger(0)
+    val wipes = AtomicInteger(0)
+    val delegate = FakeCompiler { _ ->
+      calls.incrementAndGet()
+      Ok(IcResponse(wallMillis = 5, compiledFileCount = 3))
     }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = {
+          wipes.incrementAndGet()
+          emptyList()
+        },
+      )
 
-    @AfterTest
-    fun tearDown() {
-        runCatching { tmpRoot.toFile().deleteRecursively() }
+    val result = wrapper.compile(request())
+
+    val response = result.get() ?: error("expected Ok, got ${result.getError()}")
+    assertEquals(5, response.wallMillis)
+    assertEquals(1, calls.get())
+    assertEquals(0, wipes.get())
+    assertTrue(
+      Files.exists(workingDir.resolve("marker.txt")),
+      "marker.txt must survive when no wipe fires",
+    )
+  }
+
+  @Test
+  fun `CompilationFailed is surfaced without retry or wipe`() {
+    val calls = AtomicInteger(0)
+    val wipes = AtomicInteger(0)
+    val delegate = FakeCompiler { _ ->
+      calls.incrementAndGet()
+      Err(IcError.CompilationFailed(listOf("Main.kt: error: unresolved reference")))
     }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = {
+          wipes.incrementAndGet()
+          emptyList()
+        },
+      )
 
-    private fun request(): IcRequest = IcRequest(
-        projectId = "deadbeef",
+    val result = wrapper.compile(request())
+
+    val error = result.getError() ?: error("expected Err, got ${result.get()}")
+    assertTrue(error is IcError.CompilationFailed)
+    assertEquals(1, calls.get(), "CompilationFailed is a user error — no retry")
+    assertEquals(0, wipes.get(), "CompilationFailed must not wipe the workingDir")
+    assertTrue(Files.exists(workingDir.resolve("marker.txt")))
+  }
+
+  @Test
+  fun `InternalError then SUCCESS wipes workingDir and retries transparently`() {
+    val calls = AtomicInteger(0)
+    val wipedPaths = mutableListOf<Path>()
+    val delegate = FakeCompiler { _ ->
+      when (calls.incrementAndGet()) {
+        1 -> Err(IcError.InternalError(RuntimeException("corrupt cache")))
+        else -> Ok(IcResponse(wallMillis = 42, compiledFileCount = 7))
+      }
+    }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = { path ->
+          wipedPaths.add(path)
+          emptyList()
+        },
+      )
+
+    val result = wrapper.compile(request())
+
+    val response = result.getOrElse { error("expected Ok, got $it") }
+    assertEquals(42, response.wallMillis)
+    assertEquals(2, calls.get())
+    assertEquals(listOf(workingDir), wipedPaths)
+  }
+
+  @Test
+  fun `InternalError twice surfaces the retry's error, not the original`() {
+    val calls = AtomicInteger(0)
+    val wipes = AtomicInteger(0)
+    val delegate = FakeCompiler { _ ->
+      val n = calls.incrementAndGet()
+      Err(IcError.InternalError(RuntimeException("attempt-$n")))
+    }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = {
+          wipes.incrementAndGet()
+          emptyList()
+        },
+      )
+
+    val result = wrapper.compile(request())
+
+    val error = result.getError() ?: error("expected Err, got ${result.get()}")
+    assertTrue(error is IcError.InternalError)
+    assertEquals(
+      "attempt-2",
+      error.cause.message,
+      "retry's error must overwrite the first attempt's error",
+    )
+    assertEquals(2, calls.get())
+    assertEquals(1, wipes.get(), "wipe fires exactly once regardless of retry outcome")
+  }
+
+  @Test
+  fun `InternalError then CompilationFailed surfaces the retry's CompilationFailed`() {
+    val calls = AtomicInteger(0)
+    val delegate = FakeCompiler { _ ->
+      when (calls.incrementAndGet()) {
+        1 -> Err(IcError.InternalError(RuntimeException("cache corrupt")))
+        else -> Err(IcError.CompilationFailed(listOf("Retry.kt: error: type mismatch")))
+      }
+    }
+    val wrapper = SelfHealingIncrementalCompiler(delegate = delegate, wipe = { emptyList() })
+
+    val result = wrapper.compile(request())
+
+    val error = result.getError() ?: error("expected Err, got ${result.get()}")
+    assertTrue(error is IcError.CompilationFailed)
+    assertTrue(error.messages.single().contains("type mismatch"))
+    assertEquals(2, calls.get())
+  }
+
+  @Test
+  fun `VirtualMachineError from the delegate propagates without wipe or retry`() {
+    val calls = AtomicInteger(0)
+    val wipes = AtomicInteger(0)
+    val delegate = FakeCompiler { _ ->
+      calls.incrementAndGet()
+      throw OutOfMemoryError("synthetic OOM")
+    }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = {
+          wipes.incrementAndGet()
+          emptyList()
+        },
+      )
+
+    val thrown = assertFailsWith<OutOfMemoryError> { wrapper.compile(request()) }
+    assertEquals("synthetic OOM", thrown.message)
+    assertEquals(1, calls.get(), "VirtualMachineError must not trigger retry")
+    assertEquals(0, wipes.get(), "VirtualMachineError must not trigger wipe")
+  }
+
+  @Test
+  fun `default filesystem wipe deletes the workingDir tree`() {
+    val nested = workingDir.resolve("sub/nested")
+    Files.createDirectories(nested)
+    Files.writeString(nested.resolve("file.txt"), "junk")
+
+    val calls = AtomicInteger(0)
+    val delegate = FakeCompiler { _ ->
+      when (calls.incrementAndGet()) {
+        1 -> Err(IcError.InternalError(RuntimeException("boom")))
+        else -> Ok(IcResponse(wallMillis = 1, compiledFileCount = null))
+      }
+    }
+    val wrapper = SelfHealingIncrementalCompiler(delegate)
+
+    val result = wrapper.compile(request())
+
+    val response = result.get() ?: error("expected Ok, got ${result.getError()}")
+    assertEquals(1, response.wallMillis)
+    assertEquals(2, calls.get())
+    assertTrue(!Files.exists(workingDir.resolve("marker.txt")), "default wipe must delete the tree")
+    assertTrue(!Files.exists(nested.resolve("file.txt")))
+  }
+
+  @Test
+  fun `self-heal emits ic_self_heal metric and a single stderr warning`() {
+    val metrics = RecordingMetricsSink()
+    val warnings = mutableListOf<String>()
+    val calls = AtomicInteger(0)
+    val delegate = FakeCompiler { _ ->
+      when (calls.incrementAndGet()) {
+        1 ->
+          com.github.michaelbull.result.Err(
+            IcError.InternalError(RuntimeException("corrupt ic state"))
+          )
+        else -> Ok(IcResponse(wallMillis = 1, compiledFileCount = 1))
+      }
+    }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = { emptyList() },
+        metrics = metrics,
+        stderrWarn = { warnings.add(it) },
+      )
+
+    wrapper.compile(request()).get() ?: error("expected success")
+
+    assertEquals(listOf("ic.self_heal" to 1L), metrics.events)
+    assertEquals(1, warnings.size, "self-heal must emit exactly one stderr warning")
+    assertTrue(warnings.single().contains("self-heal fired"))
+    assertTrue(
+      warnings.single().contains("corrupt ic state"),
+      "warning must surface the underlying cause so a dogfood user can correlate it",
+    )
+  }
+
+  @Test
+  fun `no self-heal events when the first attempt succeeds`() {
+    val metrics = RecordingMetricsSink()
+    val warnings = mutableListOf<String>()
+    val delegate = FakeCompiler { _ -> Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)) }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        metrics = metrics,
+        stderrWarn = { warnings.add(it) },
+      )
+
+    wrapper.compile(request()).get() ?: error("expected success")
+
+    assertTrue(metrics.events.isEmpty(), "no retry → no ic.self_heal metric")
+    assertTrue(warnings.isEmpty(), "no retry → no stderr warning")
+  }
+
+  @Test
+  fun `partial wipe records ic_self_heal_wipe_failed but still runs the retry`() {
+    val metrics = RecordingMetricsSink()
+    val calls = AtomicInteger(0)
+    val delegate = FakeCompiler { _ ->
+      when (calls.incrementAndGet()) {
+        1 -> com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt")))
+        else -> Ok(IcResponse(wallMillis = 1, compiledFileCount = 0))
+      }
+    }
+    val stuckPaths = listOf(workingDir.resolve("locked-1.bin"), workingDir.resolve("locked-2.bin"))
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = { stuckPaths }, // simulate two files that could not be deleted
+        metrics = metrics,
+        stderrWarn = {},
+      )
+
+    // Retry still runs and succeeds even though the wipe reported leftovers.
+    wrapper.compile(request()).get() ?: error("expected success after partial-wipe retry")
+
+    assertEquals(2, calls.get(), "delegate must still be retried after a partial wipe")
+    val selfHealCount = metrics.events.count { it.first == "ic.self_heal" }
+    val wipeFailedCount = metrics.events.count { it.first == "ic.self_heal_wipe_failed" }
+    assertEquals(1, selfHealCount, "ic.self_heal still fires once per retry cycle")
+    assertEquals(1, wipeFailedCount, "ic.self_heal_wipe_failed is emitted once per partial wipe")
+    // The value of the `ic.self_heal_wipe_failed` metric is the
+    // leftover count so `kolt doctor` can distinguish "one stuck
+    // file" from "wipe was completely ineffective".
+    val wipeFailedEvent = metrics.events.single { it.first == "ic.self_heal_wipe_failed" }
+    assertEquals(stuckPaths.size.toLong(), wipeFailedEvent.second)
+  }
+
+  @Test
+  fun `thrown wipe is absorbed into ic_self_heal_wipe_failed and retry still runs`() {
+    val metrics = RecordingMetricsSink()
+    val calls = AtomicInteger(0)
+    val delegate = FakeCompiler { _ ->
+      when (calls.incrementAndGet()) {
+        1 -> com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt")))
+        else -> Ok(IcResponse(wallMillis = 1, compiledFileCount = 0))
+      }
+    }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = { throw java.io.UncheckedIOException(java.io.IOException("wipe blew up")) },
+        metrics = metrics,
+        stderrWarn = {},
+      )
+
+    wrapper.compile(request()).get() ?: error("expected success after wipe-throw retry")
+
+    assertEquals(2, calls.get(), "retry must still run even when the wipe throws")
+    val wipeFailedEvent = metrics.events.single { it.first == "ic.self_heal_wipe_failed" }
+    assertEquals(
+      1L,
+      wipeFailedEvent.second,
+      "a thrown wipe is recorded as a single leftover (the workingDir root)",
+    )
+  }
+
+  @Test
+  fun `VirtualMachineError thrown by wipe still propagates past the self-heal path`() {
+    val delegate = FakeCompiler { _ ->
+      com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt")))
+    }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = { throw OutOfMemoryError("synthetic OOM during wipe") },
+        metrics = RecordingMetricsSink(),
+        stderrWarn = {},
+      )
+
+    val thrown = kotlin.test.assertFailsWith<OutOfMemoryError> { wrapper.compile(request()) }
+    assertEquals("synthetic OOM during wipe", thrown.message)
+  }
+
+  @Test
+  fun `consecutive InternalError on the same project skips the retry and emits skipped metric`() {
+    // Regression guard for issue #117 part 2: when the underlying
+    // bug is persistent (e.g. a client-side source-path mistake),
+    // every request to the same project should NOT burn a fresh
+    // wipe+retry cycle. The first request pays the self-heal; the
+    // second surfaces the error directly without touching the
+    // workingDir.
+    val metrics = RecordingMetricsSink()
+    val calls = AtomicInteger(0)
+    val wipeCalls = AtomicInteger(0)
+    val delegate = FakeCompiler { _ ->
+      calls.incrementAndGet()
+      com.github.michaelbull.result.Err(
+        IcError.InternalError(RuntimeException("persistent failure"))
+      )
+    }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = {
+          wipeCalls.incrementAndGet()
+          emptyList()
+        },
+        metrics = metrics,
+        stderrWarn = {},
+      )
+    val req = request()
+
+    // Request 1: first failure fires a self-heal (wipe + retry).
+    wrapper.compile(req)
+    assertEquals(2, calls.get(), "first request: one initial attempt + one retry")
+    assertEquals(1, wipeCalls.get())
+    assertEquals(1, metrics.events.count { it.first == "ic.self_heal" })
+    assertEquals(0, metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" })
+
+    // Request 2: same project, same error. The latch is set from
+    // request 1, so no wipe, no retry, no ic.self_heal — just the
+    // skipped counter.
+    wrapper.compile(req)
+    assertEquals(3, calls.get(), "second request: one attempt, no retry")
+    assertEquals(1, wipeCalls.get(), "wipe must NOT fire on the consecutive failure")
+    assertEquals(1, metrics.events.count { it.first == "ic.self_heal" })
+    assertEquals(1, metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" })
+
+    // Request 3: same project, same error. Latch stays set, skip again.
+    wrapper.compile(req)
+    assertEquals(4, calls.get())
+    assertEquals(1, wipeCalls.get())
+    assertEquals(2, metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" })
+  }
+
+  @Test
+  fun `a successful compile clears the self-heal latch so a later InternalError still self-heals`() {
+    val metrics = RecordingMetricsSink()
+    val sequence =
+      listOf<Result<IcResponse, IcError>>(
+        com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt 1"))),
+        // retry of request 1 — succeeds
+        Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),
+        // request 2 — healthy
+        Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),
+        // request 3 — InternalError again; latch was cleared by
+        // the prior success so this one should self-heal again
+        com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt 2"))),
+        // retry of request 3 — succeeds
+        Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),
+      )
+    val idx = AtomicInteger(0)
+    val delegate = FakeCompiler { _ -> sequence[idx.getAndIncrement()] }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = { emptyList() },
+        metrics = metrics,
+        stderrWarn = {},
+      )
+    val req = request()
+
+    wrapper.compile(req) // request 1 — self-heal fires
+    wrapper.compile(req) // request 2 — success, clears latch
+    wrapper.compile(req) // request 3 — self-heal fires again
+
+    assertEquals(2, metrics.events.count { it.first == "ic.self_heal" })
+    assertEquals(
+      0,
+      metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" },
+      "a successful compile between the two failures must reset the latch",
+    )
+  }
+
+  @Test
+  fun `CompilationFailed between two InternalErrors also clears the latch`() {
+    // User type errors are unrelated to cache corruption, so a
+    // CompilationFailed should not keep the latch set from a
+    // prior self-heal. Otherwise a developer who hits an
+    // InternalError, then a syntax error, then another
+    // InternalError (e.g. intermittent BTA bug) would lose the
+    // self-heal on the third request.
+    val metrics = RecordingMetricsSink()
+    val sequence =
+      listOf<Result<IcResponse, IcError>>(
+        com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt 1"))),
+        Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)), // retry succeeds
+        com.github.michaelbull.result.Err(IcError.CompilationFailed(listOf("Main.kt: error"))),
+        com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt 2"))),
+        Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)), // retry succeeds
+      )
+    val idx = AtomicInteger(0)
+    val delegate = FakeCompiler { _ -> sequence[idx.getAndIncrement()] }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = { emptyList() },
+        metrics = metrics,
+        stderrWarn = {},
+      )
+    val req = request()
+
+    wrapper.compile(req) // InternalError → self-heal → SUCCESS
+    wrapper.compile(req) // CompilationFailed — clears latch
+    wrapper.compile(req) // InternalError → self-heal fires again
+
+    assertEquals(2, metrics.events.count { it.first == "ic.self_heal" })
+    assertEquals(0, metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" })
+  }
+
+  @Test
+  fun `different projects keep independent self-heal latches`() {
+    val metrics = RecordingMetricsSink()
+    val delegate = FakeCompiler { _ ->
+      com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt")))
+    }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = { emptyList() },
+        metrics = metrics,
+        stderrWarn = {},
+      )
+    val projectA =
+      IcRequest(
+        projectId = "project-a",
         projectRoot = tmpRoot,
         sources = emptyList(),
         classpath = emptyList(),
-        outputDir = tmpRoot.resolve("out"),
+        outputDir = tmpRoot.resolve("out-a"),
         workingDir = workingDir,
+      )
+    val projectB = projectA.copy(projectId = "project-b")
+
+    wrapper.compile(projectA) // A self-heals
+    wrapper.compile(projectB) // B independently self-heals
+    wrapper.compile(projectA) // A skipped
+    wrapper.compile(projectB) // B skipped
+
+    assertEquals(
+      2,
+      metrics.events.count { it.first == "ic.self_heal" },
+      "each project gets exactly one self-heal on first InternalError",
     )
+    assertEquals(
+      2,
+      metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" },
+      "consecutive failure on each project is skipped independently",
+    )
+  }
 
-    @Test
-    fun `success on first attempt passes through without retry or wipe`() {
-        val calls = AtomicInteger(0)
-        val wipes = AtomicInteger(0)
-        val delegate = FakeCompiler { _ ->
-            calls.incrementAndGet()
-            Ok(IcResponse(wallMillis = 5, compiledFileCount = 3))
-        }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { wipes.incrementAndGet(); emptyList() },
-        )
-
-        val result = wrapper.compile(request())
-
-        val response = result.get() ?: error("expected Ok, got ${result.getError()}")
-        assertEquals(5, response.wallMillis)
-        assertEquals(1, calls.get())
-        assertEquals(0, wipes.get())
-        assertTrue(Files.exists(workingDir.resolve("marker.txt")), "marker.txt must survive when no wipe fires")
+  @Test
+  fun `no self-heal events when the failure is a CompilationFailed`() {
+    val metrics = RecordingMetricsSink()
+    val delegate = FakeCompiler { _ ->
+      com.github.michaelbull.result.Err(IcError.CompilationFailed(listOf("Main.kt: error")))
     }
+    val wrapper = SelfHealingIncrementalCompiler(delegate = delegate, metrics = metrics)
 
-    @Test
-    fun `CompilationFailed is surfaced without retry or wipe`() {
-        val calls = AtomicInteger(0)
-        val wipes = AtomicInteger(0)
-        val delegate = FakeCompiler { _ ->
-            calls.incrementAndGet()
-            Err(IcError.CompilationFailed(listOf("Main.kt: error: unresolved reference")))
-        }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { wipes.incrementAndGet(); emptyList() },
-        )
+    wrapper.compile(request())
 
-        val result = wrapper.compile(request())
+    assertTrue(metrics.events.isEmpty(), "CompilationFailed is a user error — no self-heal")
+  }
 
-        val error = result.getError() ?: error("expected Err, got ${result.get()}")
-        assertTrue(error is IcError.CompilationFailed)
-        assertEquals(1, calls.get(), "CompilationFailed is a user error — no retry")
-        assertEquals(0, wipes.get(), "CompilationFailed must not wipe the workingDir")
-        assertTrue(Files.exists(workingDir.resolve("marker.txt")))
+  private class FakeCompiler(private val onCompile: (IcRequest) -> Result<IcResponse, IcError>) :
+    IncrementalCompiler {
+    override fun compile(request: IcRequest): Result<IcResponse, IcError> = onCompile(request)
+  }
+
+  private class RecordingMetricsSink : IcMetricsSink {
+    val events: MutableList<Pair<String, Long>> = mutableListOf()
+
+    override fun record(name: String, value: Long) {
+      events += name to value
     }
-
-    @Test
-    fun `InternalError then SUCCESS wipes workingDir and retries transparently`() {
-        val calls = AtomicInteger(0)
-        val wipedPaths = mutableListOf<Path>()
-        val delegate = FakeCompiler { _ ->
-            when (calls.incrementAndGet()) {
-                1 -> Err(IcError.InternalError(RuntimeException("corrupt cache")))
-                else -> Ok(IcResponse(wallMillis = 42, compiledFileCount = 7))
-            }
-        }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { path -> wipedPaths.add(path); emptyList() },
-        )
-
-        val result = wrapper.compile(request())
-
-        val response = result.getOrElse { error("expected Ok, got $it") }
-        assertEquals(42, response.wallMillis)
-        assertEquals(2, calls.get())
-        assertEquals(listOf(workingDir), wipedPaths)
-    }
-
-    @Test
-    fun `InternalError twice surfaces the retry's error, not the original`() {
-        val calls = AtomicInteger(0)
-        val wipes = AtomicInteger(0)
-        val delegate = FakeCompiler { _ ->
-            val n = calls.incrementAndGet()
-            Err(IcError.InternalError(RuntimeException("attempt-$n")))
-        }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { wipes.incrementAndGet(); emptyList() },
-        )
-
-        val result = wrapper.compile(request())
-
-        val error = result.getError() ?: error("expected Err, got ${result.get()}")
-        assertTrue(error is IcError.InternalError)
-        assertEquals("attempt-2", error.cause.message, "retry's error must overwrite the first attempt's error")
-        assertEquals(2, calls.get())
-        assertEquals(1, wipes.get(), "wipe fires exactly once regardless of retry outcome")
-    }
-
-    @Test
-    fun `InternalError then CompilationFailed surfaces the retry's CompilationFailed`() {
-        val calls = AtomicInteger(0)
-        val delegate = FakeCompiler { _ ->
-            when (calls.incrementAndGet()) {
-                1 -> Err(IcError.InternalError(RuntimeException("cache corrupt")))
-                else -> Err(IcError.CompilationFailed(listOf("Retry.kt: error: type mismatch")))
-            }
-        }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { emptyList() },
-        )
-
-        val result = wrapper.compile(request())
-
-        val error = result.getError() ?: error("expected Err, got ${result.get()}")
-        assertTrue(error is IcError.CompilationFailed)
-        assertTrue(error.messages.single().contains("type mismatch"))
-        assertEquals(2, calls.get())
-    }
-
-    @Test
-    fun `VirtualMachineError from the delegate propagates without wipe or retry`() {
-        val calls = AtomicInteger(0)
-        val wipes = AtomicInteger(0)
-        val delegate = FakeCompiler { _ ->
-            calls.incrementAndGet()
-            throw OutOfMemoryError("synthetic OOM")
-        }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { wipes.incrementAndGet(); emptyList() },
-        )
-
-        val thrown = assertFailsWith<OutOfMemoryError> { wrapper.compile(request()) }
-        assertEquals("synthetic OOM", thrown.message)
-        assertEquals(1, calls.get(), "VirtualMachineError must not trigger retry")
-        assertEquals(0, wipes.get(), "VirtualMachineError must not trigger wipe")
-    }
-
-    @Test
-    fun `default filesystem wipe deletes the workingDir tree`() {
-        val nested = workingDir.resolve("sub/nested")
-        Files.createDirectories(nested)
-        Files.writeString(nested.resolve("file.txt"), "junk")
-
-        val calls = AtomicInteger(0)
-        val delegate = FakeCompiler { _ ->
-            when (calls.incrementAndGet()) {
-                1 -> Err(IcError.InternalError(RuntimeException("boom")))
-                else -> Ok(IcResponse(wallMillis = 1, compiledFileCount = null))
-            }
-        }
-        val wrapper = SelfHealingIncrementalCompiler(delegate)
-
-        val result = wrapper.compile(request())
-
-        val response = result.get() ?: error("expected Ok, got ${result.getError()}")
-        assertEquals(1, response.wallMillis)
-        assertEquals(2, calls.get())
-        assertTrue(!Files.exists(workingDir.resolve("marker.txt")), "default wipe must delete the tree")
-        assertTrue(!Files.exists(nested.resolve("file.txt")))
-    }
-
-    @Test
-    fun `self-heal emits ic_self_heal metric and a single stderr warning`() {
-        val metrics = RecordingMetricsSink()
-        val warnings = mutableListOf<String>()
-        val calls = AtomicInteger(0)
-        val delegate = FakeCompiler { _ ->
-            when (calls.incrementAndGet()) {
-                1 -> com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt ic state")))
-                else -> Ok(IcResponse(wallMillis = 1, compiledFileCount = 1))
-            }
-        }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { emptyList() },
-            metrics = metrics,
-            stderrWarn = { warnings.add(it) },
-        )
-
-        wrapper.compile(request()).get() ?: error("expected success")
-
-        assertEquals(listOf("ic.self_heal" to 1L), metrics.events)
-        assertEquals(1, warnings.size, "self-heal must emit exactly one stderr warning")
-        assertTrue(warnings.single().contains("self-heal fired"))
-        assertTrue(
-            warnings.single().contains("corrupt ic state"),
-            "warning must surface the underlying cause so a dogfood user can correlate it",
-        )
-    }
-
-    @Test
-    fun `no self-heal events when the first attempt succeeds`() {
-        val metrics = RecordingMetricsSink()
-        val warnings = mutableListOf<String>()
-        val delegate = FakeCompiler { _ -> Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)) }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            metrics = metrics,
-            stderrWarn = { warnings.add(it) },
-        )
-
-        wrapper.compile(request()).get() ?: error("expected success")
-
-        assertTrue(metrics.events.isEmpty(), "no retry → no ic.self_heal metric")
-        assertTrue(warnings.isEmpty(), "no retry → no stderr warning")
-    }
-
-    @Test
-    fun `partial wipe records ic_self_heal_wipe_failed but still runs the retry`() {
-        val metrics = RecordingMetricsSink()
-        val calls = AtomicInteger(0)
-        val delegate = FakeCompiler { _ ->
-            when (calls.incrementAndGet()) {
-                1 -> com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt")))
-                else -> Ok(IcResponse(wallMillis = 1, compiledFileCount = 0))
-            }
-        }
-        val stuckPaths = listOf(
-            workingDir.resolve("locked-1.bin"),
-            workingDir.resolve("locked-2.bin"),
-        )
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { stuckPaths },  // simulate two files that could not be deleted
-            metrics = metrics,
-            stderrWarn = { },
-        )
-
-        // Retry still runs and succeeds even though the wipe reported leftovers.
-        wrapper.compile(request()).get() ?: error("expected success after partial-wipe retry")
-
-        assertEquals(2, calls.get(), "delegate must still be retried after a partial wipe")
-        val selfHealCount = metrics.events.count { it.first == "ic.self_heal" }
-        val wipeFailedCount = metrics.events.count { it.first == "ic.self_heal_wipe_failed" }
-        assertEquals(1, selfHealCount, "ic.self_heal still fires once per retry cycle")
-        assertEquals(1, wipeFailedCount, "ic.self_heal_wipe_failed is emitted once per partial wipe")
-        // The value of the `ic.self_heal_wipe_failed` metric is the
-        // leftover count so `kolt doctor` can distinguish "one stuck
-        // file" from "wipe was completely ineffective".
-        val wipeFailedEvent = metrics.events.single { it.first == "ic.self_heal_wipe_failed" }
-        assertEquals(stuckPaths.size.toLong(), wipeFailedEvent.second)
-    }
-
-    @Test
-    fun `thrown wipe is absorbed into ic_self_heal_wipe_failed and retry still runs`() {
-        val metrics = RecordingMetricsSink()
-        val calls = AtomicInteger(0)
-        val delegate = FakeCompiler { _ ->
-            when (calls.incrementAndGet()) {
-                1 -> com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt")))
-                else -> Ok(IcResponse(wallMillis = 1, compiledFileCount = 0))
-            }
-        }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { throw java.io.UncheckedIOException(java.io.IOException("wipe blew up")) },
-            metrics = metrics,
-            stderrWarn = { },
-        )
-
-        wrapper.compile(request()).get() ?: error("expected success after wipe-throw retry")
-
-        assertEquals(2, calls.get(), "retry must still run even when the wipe throws")
-        val wipeFailedEvent = metrics.events.single { it.first == "ic.self_heal_wipe_failed" }
-        assertEquals(
-            1L,
-            wipeFailedEvent.second,
-            "a thrown wipe is recorded as a single leftover (the workingDir root)",
-        )
-    }
-
-    @Test
-    fun `VirtualMachineError thrown by wipe still propagates past the self-heal path`() {
-        val delegate = FakeCompiler { _ ->
-            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt")))
-        }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { throw OutOfMemoryError("synthetic OOM during wipe") },
-            metrics = RecordingMetricsSink(),
-            stderrWarn = { },
-        )
-
-        val thrown = kotlin.test.assertFailsWith<OutOfMemoryError> { wrapper.compile(request()) }
-        assertEquals("synthetic OOM during wipe", thrown.message)
-    }
-
-    @Test
-    fun `consecutive InternalError on the same project skips the retry and emits skipped metric`() {
-        // Regression guard for issue #117 part 2: when the underlying
-        // bug is persistent (e.g. a client-side source-path mistake),
-        // every request to the same project should NOT burn a fresh
-        // wipe+retry cycle. The first request pays the self-heal; the
-        // second surfaces the error directly without touching the
-        // workingDir.
-        val metrics = RecordingMetricsSink()
-        val calls = AtomicInteger(0)
-        val wipeCalls = AtomicInteger(0)
-        val delegate = FakeCompiler { _ ->
-            calls.incrementAndGet()
-            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("persistent failure")))
-        }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { wipeCalls.incrementAndGet(); emptyList() },
-            metrics = metrics,
-            stderrWarn = { },
-        )
-        val req = request()
-
-        // Request 1: first failure fires a self-heal (wipe + retry).
-        wrapper.compile(req)
-        assertEquals(2, calls.get(), "first request: one initial attempt + one retry")
-        assertEquals(1, wipeCalls.get())
-        assertEquals(1, metrics.events.count { it.first == "ic.self_heal" })
-        assertEquals(0, metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" })
-
-        // Request 2: same project, same error. The latch is set from
-        // request 1, so no wipe, no retry, no ic.self_heal — just the
-        // skipped counter.
-        wrapper.compile(req)
-        assertEquals(3, calls.get(), "second request: one attempt, no retry")
-        assertEquals(1, wipeCalls.get(), "wipe must NOT fire on the consecutive failure")
-        assertEquals(1, metrics.events.count { it.first == "ic.self_heal" })
-        assertEquals(1, metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" })
-
-        // Request 3: same project, same error. Latch stays set, skip again.
-        wrapper.compile(req)
-        assertEquals(4, calls.get())
-        assertEquals(1, wipeCalls.get())
-        assertEquals(2, metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" })
-    }
-
-    @Test
-    fun `a successful compile clears the self-heal latch so a later InternalError still self-heals`() {
-        val metrics = RecordingMetricsSink()
-        val sequence = listOf<Result<IcResponse, IcError>>(
-            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt 1"))),
-            // retry of request 1 — succeeds
-            Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),
-            // request 2 — healthy
-            Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),
-            // request 3 — InternalError again; latch was cleared by
-            // the prior success so this one should self-heal again
-            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt 2"))),
-            // retry of request 3 — succeeds
-            Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),
-        )
-        val idx = AtomicInteger(0)
-        val delegate = FakeCompiler { _ -> sequence[idx.getAndIncrement()] }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { emptyList() },
-            metrics = metrics,
-            stderrWarn = { },
-        )
-        val req = request()
-
-        wrapper.compile(req)  // request 1 — self-heal fires
-        wrapper.compile(req)  // request 2 — success, clears latch
-        wrapper.compile(req)  // request 3 — self-heal fires again
-
-        assertEquals(2, metrics.events.count { it.first == "ic.self_heal" })
-        assertEquals(
-            0,
-            metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" },
-            "a successful compile between the two failures must reset the latch",
-        )
-    }
-
-    @Test
-    fun `CompilationFailed between two InternalErrors also clears the latch`() {
-        // User type errors are unrelated to cache corruption, so a
-        // CompilationFailed should not keep the latch set from a
-        // prior self-heal. Otherwise a developer who hits an
-        // InternalError, then a syntax error, then another
-        // InternalError (e.g. intermittent BTA bug) would lose the
-        // self-heal on the third request.
-        val metrics = RecordingMetricsSink()
-        val sequence = listOf<Result<IcResponse, IcError>>(
-            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt 1"))),
-            Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),  // retry succeeds
-            com.github.michaelbull.result.Err(IcError.CompilationFailed(listOf("Main.kt: error"))),
-            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt 2"))),
-            Ok(IcResponse(wallMillis = 1, compiledFileCount = 0)),  // retry succeeds
-        )
-        val idx = AtomicInteger(0)
-        val delegate = FakeCompiler { _ -> sequence[idx.getAndIncrement()] }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { emptyList() },
-            metrics = metrics,
-            stderrWarn = { },
-        )
-        val req = request()
-
-        wrapper.compile(req)  // InternalError → self-heal → SUCCESS
-        wrapper.compile(req)  // CompilationFailed — clears latch
-        wrapper.compile(req)  // InternalError → self-heal fires again
-
-        assertEquals(2, metrics.events.count { it.first == "ic.self_heal" })
-        assertEquals(
-            0,
-            metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" },
-        )
-    }
-
-    @Test
-    fun `different projects keep independent self-heal latches`() {
-        val metrics = RecordingMetricsSink()
-        val delegate = FakeCompiler { _ ->
-            com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt")))
-        }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            wipe = { emptyList() },
-            metrics = metrics,
-            stderrWarn = { },
-        )
-        val projectA = IcRequest(
-            projectId = "project-a",
-            projectRoot = tmpRoot,
-            sources = emptyList(),
-            classpath = emptyList(),
-            outputDir = tmpRoot.resolve("out-a"),
-            workingDir = workingDir,
-        )
-        val projectB = projectA.copy(projectId = "project-b")
-
-        wrapper.compile(projectA)  // A self-heals
-        wrapper.compile(projectB)  // B independently self-heals
-        wrapper.compile(projectA)  // A skipped
-        wrapper.compile(projectB)  // B skipped
-
-        assertEquals(
-            2,
-            metrics.events.count { it.first == "ic.self_heal" },
-            "each project gets exactly one self-heal on first InternalError",
-        )
-        assertEquals(
-            2,
-            metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" },
-            "consecutive failure on each project is skipped independently",
-        )
-    }
-
-    @Test
-    fun `no self-heal events when the failure is a CompilationFailed`() {
-        val metrics = RecordingMetricsSink()
-        val delegate = FakeCompiler { _ ->
-            com.github.michaelbull.result.Err(IcError.CompilationFailed(listOf("Main.kt: error")))
-        }
-        val wrapper = SelfHealingIncrementalCompiler(
-            delegate = delegate,
-            metrics = metrics,
-        )
-
-        wrapper.compile(request())
-
-        assertTrue(metrics.events.isEmpty(), "CompilationFailed is a user error — no self-heal")
-    }
-
-    private class FakeCompiler(
-        private val onCompile: (IcRequest) -> Result<IcResponse, IcError>,
-    ) : IncrementalCompiler {
-        override fun compile(request: IcRequest): Result<IcResponse, IcError> = onCompile(request)
-    }
-
-    private class RecordingMetricsSink : IcMetricsSink {
-        val events: MutableList<Pair<String, Long>> = mutableListOf()
-        override fun record(name: String, value: Long) {
-            events += name to value
-        }
-    }
+  }
 }

--- a/kolt-jvm-compiler-daemon/kolt.lock
+++ b/kolt-jvm-compiler-daemon/kolt.lock
@@ -11,6 +11,12 @@
       "version": "2.3.1",
       "sha256": "96289c225b06d20156a0695432afc104f187ab68c84e9b8bed7af573e5194c83"
     },
+    "org.apiguardian:apiguardian-api": {
+      "version": "1.1.2",
+      "sha256": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
+      "transitive": true,
+      "test": true
+    },
     "org.jetbrains.kotlin:kotlin-build-tools-api": {
       "version": "2.3.20",
       "sha256": "22f1ab223854b949099f6b259cef541d5b58a3643df9a49c4577c63c416e843b"
@@ -18,6 +24,17 @@
     "org.jetbrains.kotlin:kotlin-stdlib": {
       "version": "2.3.20",
       "sha256": "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e"
+    },
+    "org.jetbrains.kotlin:kotlin-test": {
+      "version": "2.3.20",
+      "sha256": "d6c9ccf82f67e6cf7fdaf9e0cea419dac4dfa58620a1653d3dba45f544a289ac",
+      "transitive": true,
+      "test": true
+    },
+    "org.jetbrains.kotlin:kotlin-test-junit5": {
+      "version": "2.3.20",
+      "sha256": "90c554e254623cc49de7ae4c7c932a86287795e45875c47e1937c29c297eff02",
+      "test": true
     },
     "org.jetbrains.kotlinx:kotlinx-datetime-jvm": {
       "version": "0.7.1-0.6.x-compat",
@@ -37,6 +54,147 @@
       "version": "13.0",
       "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
       "transitive": true
+    },
+    "org.junit.jupiter:junit-jupiter": {
+      "version": "5.11.3",
+      "sha256": "ac7578efed162367c3ddc006338e07d4571510fd9866642ea93d5b9e4ed2f665",
+      "test": true
+    },
+    "org.junit.jupiter:junit-jupiter-api": {
+      "version": "5.11.3",
+      "sha256": "5d8147a60f49453973e250ed68701b7ff055964fe2462fc2cb1ec1d6d44889ba",
+      "transitive": true,
+      "test": true
+    },
+    "org.junit.jupiter:junit-jupiter-engine": {
+      "version": "5.11.3",
+      "sha256": "e62420c99f7c0d59a2159a2ef63e61877e9c80bd722c03ca8bf3bdcea050a589",
+      "transitive": true,
+      "test": true
+    },
+    "org.junit.jupiter:junit-jupiter-params": {
+      "version": "5.11.3",
+      "sha256": "0f798ebec744c4e6605fd4f2072f41a8e989e2d469e21db5aa67cf799c0b51ec",
+      "transitive": true,
+      "test": true
+    },
+    "org.junit.platform:junit-platform-commons": {
+      "version": "1.11.3",
+      "sha256": "be262964b0b6b48de977c61d4f931df8cf61e80e750cc3f3a0a39cdd21c1008c",
+      "transitive": true,
+      "test": true
+    },
+    "org.junit.platform:junit-platform-engine": {
+      "version": "1.11.3",
+      "sha256": "0043f72f611664735da8dc9a308bf12ecd2236b05339351c4741edb4d8fab0da",
+      "transitive": true,
+      "test": true
+    },
+    "org.junit.platform:junit-platform-launcher": {
+      "version": "1.11.3",
+      "sha256": "b4727459201b0011beb0742bd807421a1fc8426b116193031ed87825bc2d4f04",
+      "test": true
+    },
+    "org.opentest4j:opentest4j": {
+      "version": "1.3.0",
+      "sha256": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+      "transitive": true,
+      "test": true
+    }
+  },
+  "classpath_bundles": {
+    "bta_impl": {
+      "org.jetbrains.kotlin:kotlin-build-tools-api": {
+        "version": "2.3.20",
+        "sha256": "22f1ab223854b949099f6b259cef541d5b58a3643df9a49c4577c63c416e843b",
+        "transitive": true
+      },
+      "org.jetbrains.kotlin:kotlin-build-tools-cri-impl": {
+        "version": "2.3.20",
+        "sha256": "54eced630f28124ccfe2e464e6cacc281e528a8a50a89725721554c9693548fe",
+        "transitive": true
+      },
+      "org.jetbrains.kotlin:kotlin-build-tools-impl": {
+        "version": "2.3.20",
+        "sha256": "9681bc2164a8bd9f6ddf4c085cf4a836b92d27506667d73bab9f6d855336c910"
+      },
+      "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+        "version": "2.3.20",
+        "sha256": "976f989d0b5f5d80e8e8a8ad4b73da0bfc27fdd965b9fa38362b2be79ecc1337",
+        "transitive": true
+      },
+      "org.jetbrains.kotlin:kotlin-compiler-runner": {
+        "version": "2.3.20",
+        "sha256": "c069f30a403be70c8152f8aa9f25eccba188eead54263ae02af14421437a2208",
+        "transitive": true
+      },
+      "org.jetbrains.kotlin:kotlin-daemon-client": {
+        "version": "2.3.20",
+        "sha256": "c71a7c1be8fbff04e0af45c9ee8cb7a61d8953bca6b8bf225a5719c725a90b44",
+        "transitive": true
+      },
+      "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+        "version": "2.3.20",
+        "sha256": "8870bab840b8087c96c4ddc06088b4aedf5131c408af3674306304f1f96af3f4",
+        "transitive": true
+      },
+      "org.jetbrains.kotlin:kotlin-reflect": {
+        "version": "1.6.10",
+        "sha256": "3277ac102ae17aad10a55abec75ff5696c8d109790396434b496e75087854203",
+        "transitive": true
+      },
+      "org.jetbrains.kotlin:kotlin-script-runtime": {
+        "version": "2.3.20",
+        "sha256": "6fcdb7da6e65cf8cc43e5aabab94bdcc48825e7933686f8a1bf694eb88f8e00e",
+        "transitive": true
+      },
+      "org.jetbrains.kotlin:kotlin-stdlib": {
+        "version": "2.3.20",
+        "sha256": "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e",
+        "transitive": true
+      },
+      "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+        "version": "1.8.0",
+        "sha256": "9860906a1937490bf5f3b06d2f0e10ef451e65b95b269f22daf68a3d1f5065c5",
+        "transitive": true
+      },
+      "org.jetbrains:annotations": {
+        "version": "13.0",
+        "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
+        "transitive": true
+      }
+    },
+    "fixture": {
+      "org.jetbrains.kotlin:kotlin-stdlib": {
+        "version": "2.3.20",
+        "sha256": "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e"
+      },
+      "org.jetbrains:annotations": {
+        "version": "13.0",
+        "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
+        "transitive": true
+      }
+    },
+    "serialization_plugin": {
+      "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable": {
+        "version": "2.3.20",
+        "sha256": "178edb62cda3e255fc80e270656f2848b6e0752f7b4b4c27e4a88cc537bea674"
+      }
+    },
+    "serialization_runtime": {
+      "org.jetbrains.kotlin:kotlin-stdlib": {
+        "version": "2.3.20",
+        "sha256": "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e"
+      },
+      "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm": {
+        "version": "1.7.3",
+        "sha256": "f0adde45864144475385cf4aa7e0b7feb27f61fcf9472665ed98cc971b06b1eb"
+      },
+      "org.jetbrains:annotations": {
+        "version": "13.0",
+        "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
+        "transitive": true
+      }
     }
   }
 }

--- a/kolt-jvm-compiler-daemon/kolt.toml
+++ b/kolt-jvm-compiler-daemon/kolt.toml
@@ -38,3 +38,11 @@ test_sources = ["src/test/kotlin", "ic/src/test/kotlin"]
 [classpaths.serialization_runtime]
 "org.jetbrains.kotlin:kotlin-stdlib" = "2.3.20"
 "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm" = "1.7.3"
+
+[test.sys_props]
+"kolt.ic.btaImplClasspath" = { classpath = "bta_impl" }
+"kolt.ic.fixtureClasspath" = { classpath = "fixture" }
+"kolt.ic.serializationPluginClasspath" = { classpath = "serialization_plugin" }
+"kolt.ic.serializationRuntimeClasspath" = { classpath = "serialization_runtime" }
+"kolt.daemon.coreMainSourceRoot" = { project_dir = "src/main/kotlin" }
+"kolt.daemon.icTestSourceRoot" = { project_dir = "ic/src/test/kotlin" }

--- a/kolt-jvm-compiler-daemon/kolt.toml
+++ b/kolt-jvm-compiler-daemon/kolt.toml
@@ -25,3 +25,16 @@ test_sources = ["src/test/kotlin", "ic/src/test/kotlin"]
 [test-dependencies]
 "org.junit.jupiter:junit-jupiter" = "5.11.3"
 "org.junit.platform:junit-platform-launcher" = "1.11.3"
+
+[classpaths.bta_impl]
+"org.jetbrains.kotlin:kotlin-build-tools-impl" = "2.3.20"
+
+[classpaths.fixture]
+"org.jetbrains.kotlin:kotlin-stdlib" = "2.3.20"
+
+[classpaths.serialization_plugin]
+"org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable" = "2.3.20"
+
+[classpaths.serialization_runtime]
+"org.jetbrains.kotlin:kotlin-stdlib" = "2.3.20"
+"org.jetbrains.kotlinx:kotlinx-serialization-core-jvm" = "1.7.3"

--- a/kolt-jvm-compiler-daemon/kolt.toml
+++ b/kolt-jvm-compiler-daemon/kolt.toml
@@ -14,10 +14,14 @@ jvm_target = "25"
 jdk = "25"
 main = "kolt.daemon.main"
 sources = ["src/main/kotlin", "ic/src/main/kotlin"]
-test_sources = []
+test_sources = ["src/test/kotlin", "ic/src/test/kotlin"]
 
 [dependencies]
 "org.jetbrains.kotlin:kotlin-build-tools-api" = "2.3.20"
 "org.jetbrains.kotlinx:kotlinx-serialization-json" = "1.7.3"
 "com.michael-bull.kotlin-result:kotlin-result" = "2.3.1"
 "com.akuleshov7:ktoml-core" = "0.7.1"
+
+[test-dependencies]
+"org.junit.jupiter:junit-jupiter" = "5.11.3"
+"org.junit.platform:junit-platform-launcher" = "1.11.3"

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/AdapterBoundaryInvariantTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/AdapterBoundaryInvariantTest.kt
@@ -24,44 +24,43 @@ import kotlin.test.assertTrue
 // other regressions, and is easy to run in IDE.
 class AdapterBoundaryInvariantTest {
 
-    @Test
-    fun `no daemon core file imports kotlin buildtools types`() {
-        val sourceRoot = Path.of(
-            System.getProperty("kolt.daemon.coreMainSourceRoot")
-                ?: error(
-                    "kolt.daemon.coreMainSourceRoot system property not set — " +
-                        "check :kolt-jvm-compiler-daemon/build.gradle.kts `tasks.test`",
-                ),
-        )
-        assertTrue(
-            Files.isDirectory(sourceRoot),
-            "expected daemon core source root at $sourceRoot",
-        )
+  @Test
+  fun `no daemon core file imports kotlin buildtools types`() {
+    val sourceRoot =
+      Path.of(
+        System.getProperty("kolt.daemon.coreMainSourceRoot")
+          ?: error(
+            "kolt.daemon.coreMainSourceRoot system property not set — " +
+              "check :kolt-jvm-compiler-daemon/build.gradle.kts `tasks.test`"
+          )
+      )
+    assertTrue(Files.isDirectory(sourceRoot), "expected daemon core source root at $sourceRoot")
 
-        val offenders = mutableListOf<Pair<Path, String>>()
-        Files.walk(sourceRoot).use { stream ->
-            stream.asSequence()
-                .filter { it.toString().endsWith(".kt") }
-                .forEach { file ->
-                    Files.readAllLines(file).forEachIndexed { idx, line ->
-                        // `import org.jetbrains.kotlin.buildtools.` is
-                        // the shape we are forbidding. Substring match
-                        // is sufficient — there is no legitimate alias
-                        // form in kolt's style (stdlib wildcards are
-                        // not permitted by IntelliJ's formatter).
-                        if (line.contains("import org.jetbrains.kotlin.buildtools.")) {
-                            offenders += file to "${idx + 1}: $line"
-                        }
-                    }
-                }
+    val offenders = mutableListOf<Pair<Path, String>>()
+    Files.walk(sourceRoot).use { stream ->
+      stream
+        .asSequence()
+        .filter { it.toString().endsWith(".kt") }
+        .forEach { file ->
+          Files.readAllLines(file).forEachIndexed { idx, line ->
+            // `import org.jetbrains.kotlin.buildtools.` is
+            // the shape we are forbidding. Substring match
+            // is sufficient — there is no legitimate alias
+            // form in kolt's style (stdlib wildcards are
+            // not permitted by IntelliJ's formatter).
+            if (line.contains("import org.jetbrains.kotlin.buildtools.")) {
+              offenders += file to "${idx + 1}: $line"
+            }
+          }
         }
-
-        assertEquals(
-            emptyList<Pair<Path, String>>(),
-            offenders,
-            "ADR 0019 §3 violation: daemon core must not import kotlin.buildtools.* " +
-                "— see the :ic subproject for the adapter layer. Offenders:\n" +
-                offenders.joinToString("\n") { (p, l) -> "  $p:$l" },
-        )
     }
+
+    assertEquals(
+      emptyList<Pair<Path, String>>(),
+      offenders,
+      "ADR 0019 §3 violation: daemon core must not import kotlin.buildtools.* " +
+        "— see the :ic subproject for the adapter layer. Offenders:\n" +
+        offenders.joinToString("\n") { (p, l) -> "  $p:$l" },
+    )
+  }
 }

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/IcModuleBoundaryInvariantTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/IcModuleBoundaryInvariantTest.kt
@@ -1,0 +1,60 @@
+package kolt.daemon
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.streams.asSequence
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// kolt-jvm-compiler-daemon now compiles root daemon and ic into the
+// same kolt project, so the Gradle module boundary that previously
+// kept ic test code from importing root daemon production packages
+// is gone. With both source sets sharing one test compile classpath,
+// nothing at compile time stops an ic test from reaching into
+// `kolt.daemon.Main`, `kolt.daemon.server.*`, or `kolt.daemon.reaper.*`.
+// This test re-encodes that boundary statically by walking ic test
+// sources and failing on any forbidden import — pure source scan,
+// no production dependency, no flake surface.
+class IcModuleBoundaryInvariantTest {
+
+  @Test
+  fun `ic test sources do not import root daemon production packages`() {
+    val sourceRoot =
+      Path.of(
+        System.getProperty("kolt.daemon.icTestSourceRoot")
+          ?: error(
+            "kolt.daemon.icTestSourceRoot system property not set — " +
+              "declare it in kolt-jvm-compiler-daemon/kolt.toml under [test.sys_props] " +
+              "as `\"kolt.daemon.icTestSourceRoot\" = { project_dir = \"ic/src/test/kotlin\" }`"
+          )
+      )
+    assertTrue(Files.isDirectory(sourceRoot), "expected ic test source root at $sourceRoot")
+
+    val forbiddenPrefixes =
+      listOf("import kolt.daemon.Main", "import kolt.daemon.server.", "import kolt.daemon.reaper.")
+
+    val offenders = mutableListOf<Pair<Path, String>>()
+    Files.walk(sourceRoot).use { stream ->
+      stream
+        .asSequence()
+        .filter { it.toString().endsWith(".kt") }
+        .forEach { file ->
+          Files.readAllLines(file).forEachIndexed { idx, line ->
+            if (forbiddenPrefixes.any { line.contains(it) }) {
+              offenders += file to "${idx + 1}: $line"
+            }
+          }
+        }
+    }
+
+    assertEquals(
+      emptyList<Pair<Path, String>>(),
+      offenders,
+      "ic test sources must not import kolt.daemon.{Main,server.*,reaper.*} — " +
+        "those are root daemon production packages and the merged kolt project " +
+        "no longer enforces this via Gradle module isolation. Offenders:\n" +
+        offenders.joinToString("\n") { (p, l) -> "  $p:$l" },
+    )
+  }
+}

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/IcModuleBoundaryInvariantTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/IcModuleBoundaryInvariantTest.kt
@@ -6,6 +6,7 @@ import kotlin.streams.asSequence
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
 
 // kolt-jvm-compiler-daemon now compiles root daemon and ic into the
 // same kolt project, so the Gradle module boundary that previously
@@ -20,15 +21,17 @@ class IcModuleBoundaryInvariantTest {
 
   @Test
   fun `ic test sources do not import root daemon production packages`() {
-    val sourceRoot =
-      Path.of(
-        System.getProperty("kolt.daemon.icTestSourceRoot")
-          ?: error(
-            "kolt.daemon.icTestSourceRoot system property not set — " +
-              "declare it in kolt-jvm-compiler-daemon/kolt.toml under [test.sys_props] " +
-              "as `\"kolt.daemon.icTestSourceRoot\" = { project_dir = \"ic/src/test/kotlin\" }`"
-          )
-      )
+    // Skip when run outside kolt (e.g. cross-check via `./gradlew check` while
+    // the orphan Gradle config is still around): the Gradle test task does not
+    // declare this sysprop, and adding it would mean editing config that #316
+    // is about to delete. The kolt path always sets the sysprop via
+    // [test.sys_props.kolt.daemon.icTestSourceRoot] in kolt.toml.
+    val sourceRootProp = System.getProperty("kolt.daemon.icTestSourceRoot")
+    assumeTrue(
+      sourceRootProp != null,
+      "kolt.daemon.icTestSourceRoot not set — invariant only enforced under `kolt test`",
+    )
+    val sourceRoot = Path.of(sourceRootProp!!)
     assertTrue(Files.isDirectory(sourceRoot), "expected ic test source root at $sourceRoot")
 
     val forbiddenPrefixes =

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/MainCliArgsTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/MainCliArgsTest.kt
@@ -24,210 +24,242 @@ import kotlin.test.assertNotNull
 // of that intent.
 class MainCliArgsTest {
 
-    @Test
-    fun parseArgsAcceptsAllThreeRequiredFlags() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/kolt-daemon.sock",
-                "--compiler-jars", "/kt/lib/a.jar:/kt/lib/b.jar",
-                "--bta-impl-jars", "/bta/impl/kotlin-build-tools-impl.jar",
-            ),
+  @Test
+  fun parseArgsAcceptsAllThreeRequiredFlags() {
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/kolt-daemon.sock",
+          "--compiler-jars",
+          "/kt/lib/a.jar:/kt/lib/b.jar",
+          "--bta-impl-jars",
+          "/bta/impl/kotlin-build-tools-impl.jar",
         )
-        val cli = assertNotNull(result.get())
-        assertEquals("/tmp/kolt-daemon.sock", cli.socketPath.toString())
-        assertEquals(2, cli.compilerJars.size)
-        assertEquals(1, cli.btaImplJars.size)
-    }
+      )
+    val cli = assertNotNull(result.get())
+    assertEquals("/tmp/kolt-daemon.sock", cli.socketPath.toString())
+    assertEquals(2, cli.compilerJars.size)
+    assertEquals(1, cli.btaImplJars.size)
+  }
 
-    @Test
-    fun compilerJarsFlagIsRequiredEvenThoughDaemonDoesNotLoadItDirectly() {
-        // Regression guard for the "drop --compiler-jars because it is dead"
-        // temptation. The field is dead inside daemon core after ad05de8 but
-        // the flag must stay on the wire so the native client does not break.
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/kolt-daemon.sock",
-                "--bta-impl-jars", "/bta/impl/x.jar",
-            ),
-        )
-        assertEquals(CliError.MissingCompilerJars, result.getError())
-    }
+  @Test
+  fun compilerJarsFlagIsRequiredEvenThoughDaemonDoesNotLoadItDirectly() {
+    // Regression guard for the "drop --compiler-jars because it is dead"
+    // temptation. The field is dead inside daemon core after ad05de8 but
+    // the flag must stay on the wire so the native client does not break.
+    val result =
+      parseArgs(arrayOf("--socket", "/tmp/kolt-daemon.sock", "--bta-impl-jars", "/bta/impl/x.jar"))
+    assertEquals(CliError.MissingCompilerJars, result.getError())
+  }
 
-    @Test
-    fun btaImplJarsFlagIsRequired() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/kolt-daemon.sock",
-                "--compiler-jars", "/kt/lib/a.jar",
-            ),
-        )
-        assertEquals(CliError.MissingBtaImplJars, result.getError())
-    }
+  @Test
+  fun btaImplJarsFlagIsRequired() {
+    val result =
+      parseArgs(arrayOf("--socket", "/tmp/kolt-daemon.sock", "--compiler-jars", "/kt/lib/a.jar"))
+    assertEquals(CliError.MissingBtaImplJars, result.getError())
+  }
 
-    @Test
-    fun emptyCompilerJarsValueRejected() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/kolt-daemon.sock",
-                "--compiler-jars", "",
-                "--bta-impl-jars", "/bta/impl/x.jar",
-            ),
+  @Test
+  fun emptyCompilerJarsValueRejected() {
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/kolt-daemon.sock",
+          "--compiler-jars",
+          "",
+          "--bta-impl-jars",
+          "/bta/impl/x.jar",
         )
-        assertEquals(CliError.EmptyCompilerJars, result.getError())
-    }
+      )
+    assertEquals(CliError.EmptyCompilerJars, result.getError())
+  }
 
-    @Test
-    fun emptyBtaImplJarsValueRejected() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/kolt-daemon.sock",
-                "--compiler-jars", "/kt/lib/a.jar",
-                "--bta-impl-jars", "",
-            ),
+  @Test
+  fun emptyBtaImplJarsValueRejected() {
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/kolt-daemon.sock",
+          "--compiler-jars",
+          "/kt/lib/a.jar",
+          "--bta-impl-jars",
+          "",
         )
-        assertEquals(CliError.EmptyBtaImplJars, result.getError())
-    }
+      )
+    assertEquals(CliError.EmptyBtaImplJars, result.getError())
+  }
 
-    @Test
-    fun icRootDefaultsToUserHomeKoltDaemonIc() {
-        // ADR 0019 §5: when `--ic-root` is omitted the daemon defaults to
-        // `$HOME/.kolt/daemon/ic`. Tests and integration harnesses override
-        // via `--ic-root <path>`.
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--compiler-jars", "/a.jar",
-                "--bta-impl-jars", "/b.jar",
-            ),
-        )
-        val cli = assertNotNull(result.get())
-        assertEquals(Path.of(System.getProperty("user.home"), ".kolt", "daemon", "ic"), cli.icRoot)
-    }
+  @Test
+  fun icRootDefaultsToUserHomeKoltDaemonIc() {
+    // ADR 0019 §5: when `--ic-root` is omitted the daemon defaults to
+    // `$HOME/.kolt/daemon/ic`. Tests and integration harnesses override
+    // via `--ic-root <path>`.
+    val result =
+      parseArgs(
+        arrayOf("--socket", "/tmp/s", "--compiler-jars", "/a.jar", "--bta-impl-jars", "/b.jar")
+      )
+    val cli = assertNotNull(result.get())
+    assertEquals(Path.of(System.getProperty("user.home"), ".kolt", "daemon", "ic"), cli.icRoot)
+  }
 
-    @Test
-    fun icRootFlagOverridesDefault() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--compiler-jars", "/a.jar",
-                "--bta-impl-jars", "/b.jar",
-                "--ic-root", "/tmp/custom-ic",
-            ),
+  @Test
+  fun icRootFlagOverridesDefault() {
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/s",
+          "--compiler-jars",
+          "/a.jar",
+          "--bta-impl-jars",
+          "/b.jar",
+          "--ic-root",
+          "/tmp/custom-ic",
         )
-        val cli = assertNotNull(result.get())
-        assertEquals(Path.of("/tmp/custom-ic"), cli.icRoot)
-    }
+      )
+    val cli = assertNotNull(result.get())
+    assertEquals(Path.of("/tmp/custom-ic"), cli.icRoot)
+  }
 
-    @Test
-    fun pluginJarsOptionalDefaultsToEmptyMap() {
-        // ADR 0019 §9 + B-2c: `--plugin-jars` is optional. A project that uses
-        // no compiler plugins (kolt.toml has no `[kotlin.plugins]` section or all
-        // entries are `false`) must not be forced to pass the flag.
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--compiler-jars", "/a.jar",
-                "--bta-impl-jars", "/b.jar",
-            ),
-        )
-        val cli = assertNotNull(result.get())
-        assertEquals(emptyMap(), cli.pluginJars)
-    }
+  @Test
+  fun pluginJarsOptionalDefaultsToEmptyMap() {
+    // ADR 0019 §9 + B-2c: `--plugin-jars` is optional. A project that uses
+    // no compiler plugins (kolt.toml has no `[kotlin.plugins]` section or all
+    // entries are `false`) must not be forced to pass the flag.
+    val result =
+      parseArgs(
+        arrayOf("--socket", "/tmp/s", "--compiler-jars", "/a.jar", "--bta-impl-jars", "/b.jar")
+      )
+    val cli = assertNotNull(result.get())
+    assertEquals(emptyMap(), cli.pluginJars)
+  }
 
-    @Test
-    fun pluginJarsParsesAliasToClasspath() {
-        // Format: `<alias>=<cp>[;<alias>=<cp>...]`. Inside each `<cp>` the
-        // usual File.pathSeparator splits entries. The `;` outer separator
-        // avoids colliding with `:` (pathSeparator) on Linux.
-        val sep = java.io.File.pathSeparator
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--compiler-jars", "/a.jar",
-                "--bta-impl-jars", "/b.jar",
-                "--plugin-jars", "serialization=/plugins/ser1.jar${sep}/plugins/ser2.jar",
-            ),
+  @Test
+  fun pluginJarsParsesAliasToClasspath() {
+    // Format: `<alias>=<cp>[;<alias>=<cp>...]`. Inside each `<cp>` the
+    // usual File.pathSeparator splits entries. The `;` outer separator
+    // avoids colliding with `:` (pathSeparator) on Linux.
+    val sep = java.io.File.pathSeparator
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/s",
+          "--compiler-jars",
+          "/a.jar",
+          "--bta-impl-jars",
+          "/b.jar",
+          "--plugin-jars",
+          "serialization=/plugins/ser1.jar${sep}/plugins/ser2.jar",
         )
-        val cli = assertNotNull(result.get())
-        assertEquals(
-            mapOf("serialization" to listOf(Path.of("/plugins/ser1.jar"), Path.of("/plugins/ser2.jar"))),
-            cli.pluginJars,
-        )
-    }
+      )
+    val cli = assertNotNull(result.get())
+    assertEquals(
+      mapOf("serialization" to listOf(Path.of("/plugins/ser1.jar"), Path.of("/plugins/ser2.jar"))),
+      cli.pluginJars,
+    )
+  }
 
-    @Test
-    fun pluginJarsParsesMultipleAliases() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--compiler-jars", "/a.jar",
-                "--bta-impl-jars", "/b.jar",
-                "--plugin-jars", "serialization=/p/ser.jar;allopen=/p/open.jar",
-            ),
+  @Test
+  fun pluginJarsParsesMultipleAliases() {
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/s",
+          "--compiler-jars",
+          "/a.jar",
+          "--bta-impl-jars",
+          "/b.jar",
+          "--plugin-jars",
+          "serialization=/p/ser.jar;allopen=/p/open.jar",
         )
-        val cli = assertNotNull(result.get())
-        assertEquals(
-            mapOf(
-                "serialization" to listOf(Path.of("/p/ser.jar")),
-                "allopen" to listOf(Path.of("/p/open.jar")),
-            ),
-            cli.pluginJars,
-        )
-    }
+      )
+    val cli = assertNotNull(result.get())
+    assertEquals(
+      mapOf(
+        "serialization" to listOf(Path.of("/p/ser.jar")),
+        "allopen" to listOf(Path.of("/p/open.jar")),
+      ),
+      cli.pluginJars,
+    )
+  }
 
-    @Test
-    fun pluginJarsMalformedEntryRejected() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--compiler-jars", "/a.jar",
-                "--bta-impl-jars", "/b.jar",
-                "--plugin-jars", "serialization",
-            ),
+  @Test
+  fun pluginJarsMalformedEntryRejected() {
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/s",
+          "--compiler-jars",
+          "/a.jar",
+          "--bta-impl-jars",
+          "/b.jar",
+          "--plugin-jars",
+          "serialization",
         )
-        assertEquals(CliError.MalformedPluginJars("serialization"), result.getError())
-    }
+      )
+    assertEquals(CliError.MalformedPluginJars("serialization"), result.getError())
+  }
 
-    @Test
-    fun pluginJarsEmptyAliasRejected() {
-        // `=foo.jar` has no alias; `eq <= 0` catches it inside parsePluginJars.
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--compiler-jars", "/a.jar",
-                "--bta-impl-jars", "/b.jar",
-                "--plugin-jars", "=foo.jar",
-            ),
+  @Test
+  fun pluginJarsEmptyAliasRejected() {
+    // `=foo.jar` has no alias; `eq <= 0` catches it inside parsePluginJars.
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/s",
+          "--compiler-jars",
+          "/a.jar",
+          "--bta-impl-jars",
+          "/b.jar",
+          "--plugin-jars",
+          "=foo.jar",
         )
-        assertEquals(CliError.MalformedPluginJars("=foo.jar"), result.getError())
-    }
+      )
+    assertEquals(CliError.MalformedPluginJars("=foo.jar"), result.getError())
+  }
 
-    @Test
-    fun pluginJarsEmptyClasspathRejected() {
-        // `alias=` has a trailing `=` with no classpath; `eq == entry.length - 1`
-        // catches it before the pathSeparator split even runs.
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--compiler-jars", "/a.jar",
-                "--bta-impl-jars", "/b.jar",
-                "--plugin-jars", "serialization=",
-            ),
+  @Test
+  fun pluginJarsEmptyClasspathRejected() {
+    // `alias=` has a trailing `=` with no classpath; `eq == entry.length - 1`
+    // catches it before the pathSeparator split even runs.
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/s",
+          "--compiler-jars",
+          "/a.jar",
+          "--bta-impl-jars",
+          "/b.jar",
+          "--plugin-jars",
+          "serialization=",
         )
-        assertEquals(CliError.MalformedPluginJars("serialization="), result.getError())
-    }
+      )
+    assertEquals(CliError.MalformedPluginJars("serialization="), result.getError())
+  }
 
-    @Test
-    fun unknownFlagRejected() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--compiler-jars", "/a.jar",
-                "--bta-impl-jars", "/b.jar",
-                "--frobnicate",
-            ),
+  @Test
+  fun unknownFlagRejected() {
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/s",
+          "--compiler-jars",
+          "/a.jar",
+          "--bta-impl-jars",
+          "/b.jar",
+          "--frobnicate",
         )
-        val err = assertNotNull(result.getError()) as CliError.UnknownFlag
-        assertEquals("--frobnicate", err.flag)
-    }
+      )
+    val err = assertNotNull(result.getError()) as CliError.UnknownFlag
+    assertEquals("--frobnicate", err.flag)
+  }
 }

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/DiagnosticParserTest.kt
@@ -12,164 +12,150 @@ import kotlin.test.assertNull
 // caller keeps the original string).
 class DiagnosticParserTest {
 
-    @Test
-    fun parsesErrorLineWithAbsolutePath() {
-        val parsed = DiagnosticParser.parseLine(
-            "/tmp/kolt/Main.kt:12:7: error: unresolved reference: foo",
-        )
-        assertEquals(
-            Diagnostic(
-                severity = Severity.Error,
-                file = "/tmp/kolt/Main.kt",
-                line = 12,
-                column = 7,
-                message = "unresolved reference: foo",
-            ),
-            parsed,
-        )
-    }
+  @Test
+  fun parsesErrorLineWithAbsolutePath() {
+    val parsed =
+      DiagnosticParser.parseLine("/tmp/kolt/Main.kt:12:7: error: unresolved reference: foo")
+    assertEquals(
+      Diagnostic(
+        severity = Severity.Error,
+        file = "/tmp/kolt/Main.kt",
+        line = 12,
+        column = 7,
+        message = "unresolved reference: foo",
+      ),
+      parsed,
+    )
+  }
 
-    @Test
-    fun parsesWarningLine() {
-        val parsed = DiagnosticParser.parseLine(
-            "/src/a/B.kt:3:1: warning: parameter 'x' is never used",
-        )
-        assertEquals(Severity.Warning, parsed?.severity)
-        assertEquals("parameter 'x' is never used", parsed?.message)
-    }
+  @Test
+  fun parsesWarningLine() {
+    val parsed = DiagnosticParser.parseLine("/src/a/B.kt:3:1: warning: parameter 'x' is never used")
+    assertEquals(Severity.Warning, parsed?.severity)
+    assertEquals("parameter 'x' is never used", parsed?.message)
+  }
 
-    @Test
-    fun parsesInfoLine() {
-        val parsed = DiagnosticParser.parseLine("/p/Q.kt:1:1: info: note text")
-        assertEquals(Severity.Info, parsed?.severity)
-    }
+  @Test
+  fun parsesInfoLine() {
+    val parsed = DiagnosticParser.parseLine("/p/Q.kt:1:1: info: note text")
+    assertEquals(Severity.Info, parsed?.severity)
+  }
 
-    @Test
-    fun returnsNullForNonDiagnosticLine() {
-        assertNull(DiagnosticParser.parseLine("just some random kotlinc chatter"))
-    }
+  @Test
+  fun returnsNullForNonDiagnosticLine() {
+    assertNull(DiagnosticParser.parseLine("just some random kotlinc chatter"))
+  }
 
-    @Test
-    fun returnsNullForMissingSeverity() {
-        assertNull(DiagnosticParser.parseLine("/x/Y.kt:1:1: nope: whatever"))
-    }
+  @Test
+  fun returnsNullForMissingSeverity() {
+    assertNull(DiagnosticParser.parseLine("/x/Y.kt:1:1: nope: whatever"))
+  }
 
-    @Test
-    fun parseMessagesSplitsParsedAndUnparsedLines() {
-        val input = listOf(
-            "/tmp/A.kt:5:3: error: bad",
-            "something else",
-            "/tmp/B.kt:1:1: warning: stylistic",
-        )
-        val (diagnostics, plain) = DiagnosticParser.parseMessages(input)
-        assertEquals(
-            listOf(
-                Diagnostic(Severity.Error, "/tmp/A.kt", 5, 3, "bad"),
-                Diagnostic(Severity.Warning, "/tmp/B.kt", 1, 1, "stylistic"),
-            ),
-            diagnostics,
-        )
-        assertEquals(listOf("something else"), plain)
-    }
+  @Test
+  fun parseMessagesSplitsParsedAndUnparsedLines() {
+    val input =
+      listOf("/tmp/A.kt:5:3: error: bad", "something else", "/tmp/B.kt:1:1: warning: stylistic")
+    val (diagnostics, plain) = DiagnosticParser.parseMessages(input)
+    assertEquals(
+      listOf(
+        Diagnostic(Severity.Error, "/tmp/A.kt", 5, 3, "bad"),
+        Diagnostic(Severity.Warning, "/tmp/B.kt", 1, 1, "stylistic"),
+      ),
+      diagnostics,
+    )
+    assertEquals(listOf("something else"), plain)
+  }
 
-    @Test
-    fun parsesLineWithExtraSpacesAroundSeverity() {
-        val parsed = DiagnosticParser.parseLine(
-            "/a/B.kt:2:4:   error:   msg with padding",
-        )
-        assertEquals("msg with padding", parsed?.message)
-    }
+  @Test
+  fun parsesLineWithExtraSpacesAroundSeverity() {
+    val parsed = DiagnosticParser.parseLine("/a/B.kt:2:4:   error:   msg with padding")
+    assertEquals("msg with padding", parsed?.message)
+  }
 
-    @Test
-    fun strongWarningCollapsesToWarning() {
-        // kotlinc emits `strong_warning` for opt-in-required and a few
-        // other cases; the parser must recognise it (not drop the line
-        // into plain-text stderr) and the IDE-rendered severity must be
-        // the regular Warning bucket.
-        val parsed = DiagnosticParser.parseLine(
-            "/tmp/A.kt:1:1: strong_warning: opt-in required for foo",
-        )
-        assertEquals(Severity.Warning, parsed?.severity)
-        assertEquals("opt-in required for foo", parsed?.message)
-    }
+  @Test
+  fun strongWarningCollapsesToWarning() {
+    // kotlinc emits `strong_warning` for opt-in-required and a few
+    // other cases; the parser must recognise it (not drop the line
+    // into plain-text stderr) and the IDE-rendered severity must be
+    // the regular Warning bucket.
+    val parsed =
+      DiagnosticParser.parseLine("/tmp/A.kt:1:1: strong_warning: opt-in required for foo")
+    assertEquals(Severity.Warning, parsed?.severity)
+    assertEquals("opt-in required for foo", parsed?.message)
+  }
 
-    @Test
-    fun parsesBtaInlineShapeWithFileUriAndNoSeverityWord() {
-        // BTA 2.3.20 `KotlinLogger.error` emits this shape on a real
-        // compile error; verified against dogfood output on the B-2c
-        // merge. The `file://` prefix must be stripped and the
-        // severity defaults to `Error` because only error-level lines
-        // reach `CapturingKotlinLogger.errors`.
-        val parsed = DiagnosticParser.parseLine(
-            "file:///tmp/kolt/File12.kt:3:17 Initializer type mismatch: expected 'Int', actual 'String'.",
-        )
-        assertEquals(
-            Diagnostic(
-                severity = Severity.Error,
-                file = "/tmp/kolt/File12.kt",
-                line = 3,
-                column = 17,
-                message = "Initializer type mismatch: expected 'Int', actual 'String'.",
-            ),
-            parsed,
-        )
-    }
+  @Test
+  fun parsesBtaInlineShapeWithFileUriAndNoSeverityWord() {
+    // BTA 2.3.20 `KotlinLogger.error` emits this shape on a real
+    // compile error; verified against dogfood output on the B-2c
+    // merge. The `file://` prefix must be stripped and the
+    // severity defaults to `Error` because only error-level lines
+    // reach `CapturingKotlinLogger.errors`.
+    val parsed =
+      DiagnosticParser.parseLine(
+        "file:///tmp/kolt/File12.kt:3:17 Initializer type mismatch: expected 'Int', actual 'String'."
+      )
+    assertEquals(
+      Diagnostic(
+        severity = Severity.Error,
+        file = "/tmp/kolt/File12.kt",
+        line = 3,
+        column = 17,
+        message = "Initializer type mismatch: expected 'Int', actual 'String'.",
+      ),
+      parsed,
+    )
+  }
 
-    @Test
-    fun nonAbsolutePathFallsThroughInsteadOfFalsePositiveOnBtaInline() {
-        // The BTA-inline regex must not match arbitrary error-level
-        // log lines that happen to contain `word:digits:digits word`.
-        // Real diagnostics always start with an absolute path or
-        // `file://` URI; anything else is unstructured chatter and
-        // should land in plain-text stderr instead of being lifted
-        // into a fake Diagnostic with a path like `Cannot resolve`.
-        assertNull(
-            DiagnosticParser.parseLine("Cannot resolve coordinate org.foo:1:2 from repo"),
-        )
-        assertNull(DiagnosticParser.parseLine("foo:1:2 bar"))
-    }
+  @Test
+  fun nonAbsolutePathFallsThroughInsteadOfFalsePositiveOnBtaInline() {
+    // The BTA-inline regex must not match arbitrary error-level
+    // log lines that happen to contain `word:digits:digits word`.
+    // Real diagnostics always start with an absolute path or
+    // `file://` URI; anything else is unstructured chatter and
+    // should land in plain-text stderr instead of being lifted
+    // into a fake Diagnostic with a path like `Cannot resolve`.
+    assertNull(DiagnosticParser.parseLine("Cannot resolve coordinate org.foo:1:2 from repo"))
+    assertNull(DiagnosticParser.parseLine("foo:1:2 bar"))
+  }
 
-    @Test
-    fun subprocessShapeWinsOverBtaInlineShapeOnLinesThatMatchBoth() {
-        // `/foo:1:2: error: bar` is a legal subprocess shape AND would
-        // also match the BTA-inline regex if reached (path=`/foo`,
-        // line=1, col=2, msg=`error: bar`). The parser must try the
-        // subprocess regex first so the severity word is honoured and
-        // the message body is correct. A refactor that swapped the
-        // order would silently produce wrong diagnostics.
-        val parsed = DiagnosticParser.parseLine("/foo:1:2: error: bar")
-        assertEquals(Severity.Error, parsed?.severity)
-        assertEquals("/foo", parsed?.file)
-        assertEquals("bar", parsed?.message)
-    }
+  @Test
+  fun subprocessShapeWinsOverBtaInlineShapeOnLinesThatMatchBoth() {
+    // `/foo:1:2: error: bar` is a legal subprocess shape AND would
+    // also match the BTA-inline regex if reached (path=`/foo`,
+    // line=1, col=2, msg=`error: bar`). The parser must try the
+    // subprocess regex first so the severity word is honoured and
+    // the message body is correct. A refactor that swapped the
+    // order would silently produce wrong diagnostics.
+    val parsed = DiagnosticParser.parseLine("/foo:1:2: error: bar")
+    assertEquals(Severity.Error, parsed?.severity)
+    assertEquals("/foo", parsed?.file)
+    assertEquals("bar", parsed?.message)
+  }
 
-    @Test
-    fun trailingNewlineIsStripped() {
-        // BTA may or may not terminate captured strings; defend
-        // against a future bump by trimming `\n` / `\r` before the
-        // regex tries matchEntire (which does not consume `\n`).
-        val parsed = DiagnosticParser.parseLine(
-            "file:///tmp/A.kt:1:1 boom\n",
-        )
-        assertEquals("/tmp/A.kt", parsed?.file)
-        assertEquals("boom", parsed?.message)
-    }
+  @Test
+  fun trailingNewlineIsStripped() {
+    // BTA may or may not terminate captured strings; defend
+    // against a future bump by trimming `\n` / `\r` before the
+    // regex tries matchEntire (which does not consume `\n`).
+    val parsed = DiagnosticParser.parseLine("file:///tmp/A.kt:1:1 boom\n")
+    assertEquals("/tmp/A.kt", parsed?.file)
+    assertEquals("boom", parsed?.message)
+  }
 
-    @Test
-    fun btaInlineShapeWithoutFileUriPrefixStillParses() {
-        // A future BTA release may drop the `file://` prefix. Matching
-        // the shape without it keeps us forward-compatible.
-        val parsed = DiagnosticParser.parseLine(
-            "/tmp/kolt/File12.kt:3:17 Initializer type mismatch",
-        )
-        assertEquals("/tmp/kolt/File12.kt", parsed?.file)
-        assertEquals(Severity.Error, parsed?.severity)
-    }
+  @Test
+  fun btaInlineShapeWithoutFileUriPrefixStillParses() {
+    // A future BTA release may drop the `file://` prefix. Matching
+    // the shape without it keeps us forward-compatible.
+    val parsed = DiagnosticParser.parseLine("/tmp/kolt/File12.kt:3:17 Initializer type mismatch")
+    assertEquals("/tmp/kolt/File12.kt", parsed?.file)
+    assertEquals(Severity.Error, parsed?.severity)
+  }
 
-    @Test
-    fun trailingStackFrameLinesStayUnparsed() {
-        // CapturingKotlinLogger appends `\n\tat Foo.bar(...)` for throwables.
-        // That trailing frame must not masquerade as a diagnostic.
-        assertNull(DiagnosticParser.parseLine("\tat foo.Bar.baz(Bar.kt:42)"))
-    }
+  @Test
+  fun trailingStackFrameLinesStayUnparsed() {
+    // CapturingKotlinLogger appends `\n\tat Foo.bar(...)` for throwables.
+    // That trailing frame must not masquerade as a diagnostic.
+    assertNull(DiagnosticParser.parseLine("\tat foo.Bar.baz(Bar.kt:42)"))
+  }
 }

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/FrameCodecTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/FrameCodecTest.kt
@@ -13,96 +13,100 @@ import kotlin.test.assertNotNull
 
 class FrameCodecTest {
 
-    @Test
-    fun `round-trips a Ping frame`() {
-        val out = ByteArrayOutputStream()
-        FrameCodec.writeFrame(out, Message.Ping)
+  @Test
+  fun `round-trips a Ping frame`() {
+    val out = ByteArrayOutputStream()
+    FrameCodec.writeFrame(out, Message.Ping)
 
-        val decoded = FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get()
-        assertEquals(Message.Ping, decoded)
-    }
+    val decoded = FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get()
+    assertEquals(Message.Ping, decoded)
+  }
 
-    @Test
-    fun `round-trips a Compile frame`() {
-        val msg: Message = Message.Compile(
-            workingDir = "/w",
-            classpath = listOf("a.jar"),
-            sources = listOf("A.kt"),
-            outputPath = "out.jar",
-            moduleName = "main",
-            extraArgs = emptyList(),
-        )
-        val out = ByteArrayOutputStream()
-        FrameCodec.writeFrame(out, msg)
+  @Test
+  fun `round-trips a Compile frame`() {
+    val msg: Message =
+      Message.Compile(
+        workingDir = "/w",
+        classpath = listOf("a.jar"),
+        sources = listOf("A.kt"),
+        outputPath = "out.jar",
+        moduleName = "main",
+        extraArgs = emptyList(),
+      )
+    val out = ByteArrayOutputStream()
+    FrameCodec.writeFrame(out, msg)
 
-        assertEquals(msg, FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get())
-    }
+    assertEquals(msg, FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get())
+  }
 
-    @Test
-    fun `reads multiple frames back to back`() {
-        val out = ByteArrayOutputStream()
-        FrameCodec.writeFrame(out, Message.Ping)
-        FrameCodec.writeFrame(out, Message.Pong)
-        FrameCodec.writeFrame(out, Message.Shutdown)
+  @Test
+  fun `reads multiple frames back to back`() {
+    val out = ByteArrayOutputStream()
+    FrameCodec.writeFrame(out, Message.Ping)
+    FrameCodec.writeFrame(out, Message.Pong)
+    FrameCodec.writeFrame(out, Message.Shutdown)
 
-        val input = ByteArrayInputStream(out.toByteArray())
-        assertEquals(Message.Ping, FrameCodec.readFrame(input).get())
-        assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
-        assertEquals(Message.Shutdown, FrameCodec.readFrame(input).get())
-    }
+    val input = ByteArrayInputStream(out.toByteArray())
+    assertEquals(Message.Ping, FrameCodec.readFrame(input).get())
+    assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
+    assertEquals(Message.Shutdown, FrameCodec.readFrame(input).get())
+  }
 
-    @Test
-    fun `empty stream returns Eof`() {
-        val err = FrameCodec.readFrame(ByteArrayInputStream(ByteArray(0))).getError()
-        assertEquals(FrameError.Eof, err)
-    }
+  @Test
+  fun `empty stream returns Eof`() {
+    val err = FrameCodec.readFrame(ByteArrayInputStream(ByteArray(0))).getError()
+    assertEquals(FrameError.Eof, err)
+  }
 
-    @Test
-    fun `truncated length prefix returns Truncated`() {
-        val err = FrameCodec.readFrame(ByteArrayInputStream(byteArrayOf(0, 0))).getError()
-        assertNotNull(err)
-        assertIs<FrameError.Truncated>(err)
-    }
+  @Test
+  fun `truncated length prefix returns Truncated`() {
+    val err = FrameCodec.readFrame(ByteArrayInputStream(byteArrayOf(0, 0))).getError()
+    assertNotNull(err)
+    assertIs<FrameError.Truncated>(err)
+  }
 
-    @Test
-    fun `truncated body returns Truncated`() {
-        val out = ByteArrayOutputStream()
-        FrameCodec.writeFrame(out, Message.Ping)
-        val full = out.toByteArray()
-        val cut = full.copyOf(full.size - 2)
+  @Test
+  fun `truncated body returns Truncated`() {
+    val out = ByteArrayOutputStream()
+    FrameCodec.writeFrame(out, Message.Ping)
+    val full = out.toByteArray()
+    val cut = full.copyOf(full.size - 2)
 
-        val err = FrameCodec.readFrame(ByteArrayInputStream(cut)).getError()
-        assertNotNull(err)
-        assertIs<FrameError.Truncated>(err)
-    }
+    val err = FrameCodec.readFrame(ByteArrayInputStream(cut)).getError()
+    assertNotNull(err)
+    assertIs<FrameError.Truncated>(err)
+  }
 
-    @Test
-    fun `malformed JSON body returns Malformed`() {
-        val body = "not json".toByteArray(Charsets.UTF_8)
-        val out = ByteArrayOutputStream()
-        out.write(byteArrayOf(0, 0, 0, body.size.toByte()))
-        out.write(body)
+  @Test
+  fun `malformed JSON body returns Malformed`() {
+    val body = "not json".toByteArray(Charsets.UTF_8)
+    val out = ByteArrayOutputStream()
+    out.write(byteArrayOf(0, 0, 0, body.size.toByte()))
+    out.write(body)
 
-        val err = FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).getError()
-        assertNotNull(err)
-        assertIs<FrameError.Malformed>(err)
-    }
+    val err = FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).getError()
+    assertNotNull(err)
+    assertIs<FrameError.Malformed>(err)
+  }
 
-    @Test
-    fun `writeFrame returns Io error when the stream throws`() {
-        val failing = object : OutputStream() {
-            override fun write(b: Int) { throw IOException("broken pipe") }
+  @Test
+  fun `writeFrame returns Io error when the stream throws`() {
+    val failing =
+      object : OutputStream() {
+        override fun write(b: Int) {
+          throw IOException("broken pipe")
         }
-        val err = FrameCodec.writeFrame(failing, Message.Ping).getError()
-        assertNotNull(err)
-        assertIs<FrameError.Io>(err)
-    }
+      }
+    val err = FrameCodec.writeFrame(failing, Message.Ping).getError()
+    assertNotNull(err)
+    assertIs<FrameError.Io>(err)
+  }
 
-    @Test
-    fun `negative length returns Malformed`() {
-        val bytes = byteArrayOf(-1, -1, -1, -1)
-        val err = FrameCodec.readFrame(ByteArrayInputStream(bytes)).getError()
-        assertNotNull(err)
-        assertIs<FrameError.Malformed>(err)
-    }
+  @Test
+  fun `negative length returns Malformed`() {
+    val bytes = byteArrayOf(-1, -1, -1, -1)
+    val err = FrameCodec.readFrame(ByteArrayInputStream(bytes)).getError()
+    assertNotNull(err)
+    assertIs<FrameError.Malformed>(err)
+  }
 }

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/MessageSerializationTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/protocol/MessageSerializationTest.kt
@@ -1,94 +1,93 @@
 package kolt.daemon.protocol
 
-import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlinx.serialization.json.Json
 
 class MessageSerializationTest {
 
-    private val json = Json { classDiscriminator = "type" }
+  private val json = Json { classDiscriminator = "type" }
 
-    @Test
-    fun `Compile round-trips through JSON`() {
-        val original: Message = Message.Compile(
-            workingDir = "/tmp/project",
-            classpath = listOf("/lib/a.jar", "/lib/b.jar"),
-            sources = listOf("src/Main.kt", "src/Util.kt"),
-            outputPath = "build/out.jar",
-            moduleName = "main",
-            extraArgs = listOf("-Xjsr305=strict"),
-        )
+  @Test
+  fun `Compile round-trips through JSON`() {
+    val original: Message =
+      Message.Compile(
+        workingDir = "/tmp/project",
+        classpath = listOf("/lib/a.jar", "/lib/b.jar"),
+        sources = listOf("src/Main.kt", "src/Util.kt"),
+        outputPath = "build/out.jar",
+        moduleName = "main",
+        extraArgs = listOf("-Xjsr305=strict"),
+      )
 
-        val encoded = json.encodeToString(Message.serializer(), original)
-        val decoded = json.decodeFromString(Message.serializer(), encoded)
+    val encoded = json.encodeToString(Message.serializer(), original)
+    val decoded = json.decodeFromString(Message.serializer(), encoded)
 
-        assertEquals(original, decoded)
-        assertIs<Message.Compile>(decoded)
-    }
+    assertEquals(original, decoded)
+    assertIs<Message.Compile>(decoded)
+  }
 
-    @Test
-    fun `Ping round-trips through JSON`() {
-        val original: Message = Message.Ping
-        val encoded = json.encodeToString(Message.serializer(), original)
-        val decoded = json.decodeFromString(Message.serializer(), encoded)
-        assertEquals(Message.Ping, decoded)
-    }
+  @Test
+  fun `Ping round-trips through JSON`() {
+    val original: Message = Message.Ping
+    val encoded = json.encodeToString(Message.serializer(), original)
+    val decoded = json.decodeFromString(Message.serializer(), encoded)
+    assertEquals(Message.Ping, decoded)
+  }
 
-    @Test
-    fun `Shutdown round-trips through JSON`() {
-        val original: Message = Message.Shutdown
-        val encoded = json.encodeToString(Message.serializer(), original)
-        val decoded = json.decodeFromString(Message.serializer(), encoded)
-        assertEquals(Message.Shutdown, decoded)
-    }
+  @Test
+  fun `Shutdown round-trips through JSON`() {
+    val original: Message = Message.Shutdown
+    val encoded = json.encodeToString(Message.serializer(), original)
+    val decoded = json.decodeFromString(Message.serializer(), encoded)
+    assertEquals(Message.Shutdown, decoded)
+  }
 
-    @Test
-    fun `CompileResult success round-trips through JSON`() {
-        val original: Message = Message.CompileResult(
-            exitCode = 0,
-            diagnostics = emptyList(),
-            stdout = "",
-            stderr = "",
-        )
-        val encoded = json.encodeToString(Message.serializer(), original)
-        val decoded = json.decodeFromString(Message.serializer(), encoded)
-        assertEquals(original, decoded)
-    }
+  @Test
+  fun `CompileResult success round-trips through JSON`() {
+    val original: Message =
+      Message.CompileResult(exitCode = 0, diagnostics = emptyList(), stdout = "", stderr = "")
+    val encoded = json.encodeToString(Message.serializer(), original)
+    val decoded = json.decodeFromString(Message.serializer(), encoded)
+    assertEquals(original, decoded)
+  }
 
-    @Test
-    fun `CompileResult with diagnostics round-trips through JSON`() {
-        val original: Message = Message.CompileResult(
-            exitCode = 1,
-            diagnostics = listOf(
-                Diagnostic(
-                    severity = Severity.Error,
-                    file = "src/Main.kt",
-                    line = 12,
-                    column = 5,
-                    message = "unresolved reference: foo",
-                ),
-                Diagnostic(
-                    severity = Severity.Warning,
-                    file = null,
-                    line = null,
-                    column = null,
-                    message = "unused parameter",
-                ),
+  @Test
+  fun `CompileResult with diagnostics round-trips through JSON`() {
+    val original: Message =
+      Message.CompileResult(
+        exitCode = 1,
+        diagnostics =
+          listOf(
+            Diagnostic(
+              severity = Severity.Error,
+              file = "src/Main.kt",
+              line = 12,
+              column = 5,
+              message = "unresolved reference: foo",
             ),
-            stdout = "",
-            stderr = "error: 1 error",
-        )
-        val encoded = json.encodeToString(Message.serializer(), original)
-        val decoded = json.decodeFromString(Message.serializer(), encoded)
-        assertEquals(original, decoded)
-    }
+            Diagnostic(
+              severity = Severity.Warning,
+              file = null,
+              line = null,
+              column = null,
+              message = "unused parameter",
+            ),
+          ),
+        stdout = "",
+        stderr = "error: 1 error",
+      )
+    val encoded = json.encodeToString(Message.serializer(), original)
+    val decoded = json.decodeFromString(Message.serializer(), encoded)
+    assertEquals(original, decoded)
+  }
 
-    @Test
-    fun `Pong round-trips through JSON`() {
-        val original: Message = Message.Pong
-        val encoded = json.encodeToString(Message.serializer(), original)
-        val decoded = json.decodeFromString(Message.serializer(), encoded)
-        assertEquals(Message.Pong, decoded)
-    }
+  @Test
+  fun `Pong round-trips through JSON`() {
+    val original: Message = Message.Pong
+    val encoded = json.encodeToString(Message.serializer(), original)
+    val decoded = json.decodeFromString(Message.serializer(), encoded)
+    assertEquals(Message.Pong, decoded)
+  }
 }

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/reaper/IcReaperTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/reaper/IcReaperTest.kt
@@ -1,10 +1,10 @@
 package kolt.daemon.reaper
 
-import kolt.daemon.ic.IcMetricsSink
 import java.nio.channels.FileChannel
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
+import kolt.daemon.ic.IcMetricsSink
 import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
 import kotlin.test.AfterTest
@@ -16,185 +16,191 @@ import kotlin.test.assertTrue
 
 class IcReaperTest {
 
-    private lateinit var icRoot: Path
-    private lateinit var otherTmp: Path
-    private lateinit var metrics: RecordingMetricsSink
+  private lateinit var icRoot: Path
+  private lateinit var otherTmp: Path
+  private lateinit var metrics: RecordingMetricsSink
 
-    @BeforeTest
-    fun setUp() {
-        icRoot = Files.createTempDirectory("kolt-ic-reaper-root-")
-        otherTmp = Files.createTempDirectory("kolt-ic-reaper-project-")
-        metrics = RecordingMetricsSink()
+  @BeforeTest
+  fun setUp() {
+    icRoot = Files.createTempDirectory("kolt-ic-reaper-root-")
+    otherTmp = Files.createTempDirectory("kolt-ic-reaper-project-")
+    metrics = RecordingMetricsSink()
+  }
+
+  @AfterTest
+  fun tearDown() {
+    runCatching { icRoot.toFile().deleteRecursively() }
+    runCatching { otherTmp.toFile().deleteRecursively() }
+  }
+
+  @Test
+  fun `empty icRoot returns an empty report`() {
+    val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+    assertEquals(0, report.scanned)
+    assertEquals(0, report.removed)
+    assertEquals(0, report.skippedLocked)
+    assertTrue(report.errors.isEmpty())
+  }
+
+  @Test
+  fun `missing icRoot returns an empty report`() {
+    val nonexistent = icRoot.resolve("does-not-exist")
+    val report = IcReaper.run(nonexistent, "2.3.20", metrics)
+
+    assertEquals(0, report.scanned)
+    assertEquals(0, report.removed)
+  }
+
+  @Test
+  fun `Rule A removes stale version segments wholesale`() {
+    val stale = icRoot.resolve("2.3.19").resolve("aaaaaaaaaaaaaaaa").createDirectories()
+    stale.resolve("state.bin").writeText("garbage")
+    val current = icRoot.resolve("2.3.20").resolve("bbbbbbbbbbbbbbbb").createDirectories()
+    current.resolve("project.path").writeText(otherTmp.toString())
+
+    val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+    assertFalse(Files.exists(icRoot.resolve("2.3.19")), "stale version segment must be gone")
+    assertTrue(Files.exists(current), "current-version projectId dir must survive")
+    assertEquals(1, report.removed)
+  }
+
+  @Test
+  fun `Rule B removes projectId when breadcrumb points to a missing path`() {
+    val missing = otherTmp.resolve("deleted-project")
+    val projectId = icRoot.resolve("2.3.20").resolve("cccccccccccccccc").createDirectories()
+    projectId.resolve("project.path").writeText(missing.toString())
+    projectId.resolve("state.bin").writeText("garbage")
+
+    val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+    assertFalse(Files.exists(projectId), "projectId with dangling breadcrumb must be removed")
+    assertEquals(1, report.removed)
+  }
+
+  @Test
+  fun `Rule B keeps projectId when breadcrumb points to an existing path`() {
+    val projectId = icRoot.resolve("2.3.20").resolve("dddddddddddddddd").createDirectories()
+    projectId.resolve("project.path").writeText(otherTmp.toString())
+
+    val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+    assertTrue(Files.exists(projectId), "projectId with live breadcrumb must survive")
+    assertEquals(0, report.removed)
+  }
+
+  @Test
+  fun `Rule B removes projectId when breadcrumb is missing entirely`() {
+    val orphan = icRoot.resolve("2.3.20").resolve("eeeeeeeeeeeeeeee").createDirectories()
+    orphan.resolve("state.bin").writeText("orphan")
+
+    val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+    assertFalse(Files.exists(orphan), "projectId without breadcrumb must be removed")
+    assertEquals(1, report.removed)
+  }
+
+  @Test
+  fun `Rule B removes projectId when breadcrumb content is empty`() {
+    val corrupt = icRoot.resolve("2.3.20").resolve("7777777777777777").createDirectories()
+    corrupt.resolve("project.path").writeText("")
+
+    val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+    assertFalse(Files.exists(corrupt), "projectId with empty breadcrumb must be removed")
+    assertEquals(1, report.removed)
+  }
+
+  @Test
+  fun `Rule B skips projectId when LOCK is held by another channel`() {
+    val missing = otherTmp.resolve("deleted-project")
+    val projectId = icRoot.resolve("2.3.20").resolve("ffffffffffffffff").createDirectories()
+    projectId.resolve("project.path").writeText(missing.toString())
+    val lockPath = projectId.resolve("LOCK")
+    Files.createFile(lockPath)
+
+    val channel = FileChannel.open(lockPath, StandardOpenOption.READ, StandardOpenOption.WRITE)
+    val lock = channel.tryLock() ?: error("test could not acquire LOCK on $lockPath")
+    try {
+      val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+      assertTrue(Files.exists(projectId), "locked projectId must not be removed")
+      assertEquals(1, report.skippedLocked)
+      assertEquals(0, report.removed)
+    } finally {
+      lock.release()
+      channel.close()
     }
+  }
 
-    @AfterTest
-    fun tearDown() {
-        runCatching { icRoot.toFile().deleteRecursively() }
-        runCatching { otherTmp.toFile().deleteRecursively() }
+  @Test
+  fun `regular files directly under icRoot are ignored without crashing the scan`() {
+    Files.writeString(icRoot.resolve("README.txt"), "accidentally placed here")
+    icRoot
+      .resolve("2.3.20")
+      .resolve("aaaaaaaaaaaaaaaa")
+      .createDirectories()
+      .resolve("project.path")
+      .writeText(otherTmp.toString())
+
+    val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+    assertTrue(Files.exists(icRoot.resolve("README.txt")), "stray file must survive")
+    assertEquals(1, report.scanned)
+    assertEquals(0, report.removed)
+  }
+
+  @Test
+  fun `run emits all counter names through the metrics sink on a mixed fixture`() {
+    val stale = icRoot.resolve("2.3.19").resolve("1111111111111111").createDirectories()
+    stale.resolve("state.bin").writeText("x")
+
+    val keep = icRoot.resolve("2.3.20").resolve("2222222222222222").createDirectories()
+    keep.resolve("project.path").writeText(otherTmp.toString())
+
+    val drop = icRoot.resolve("2.3.20").resolve("3333333333333333").createDirectories()
+    drop.resolve("project.path").writeText(otherTmp.resolve("gone").toString())
+
+    val noBreadcrumb = icRoot.resolve("2.3.20").resolve("4444444444444444").createDirectories()
+    noBreadcrumb.resolve("state.bin").writeText("orphan")
+
+    val lockedDangling = icRoot.resolve("2.3.20").resolve("5555555555555555").createDirectories()
+    lockedDangling.resolve("project.path").writeText(otherTmp.resolve("also-gone").toString())
+    val lockedFile = lockedDangling.resolve("LOCK")
+    Files.createFile(lockedFile)
+    val lockChannel =
+      FileChannel.open(lockedFile, StandardOpenOption.READ, StandardOpenOption.WRITE)
+    val heldLock = lockChannel.tryLock() ?: error("test setup: failed to hold LOCK on $lockedFile")
+    try {
+      val report = IcReaper.run(icRoot, "2.3.20", metrics)
+
+      assertEquals(3, report.removed, "stale version + dangling breadcrumb + missing breadcrumb")
+      assertEquals(1, report.skippedLocked, "locked dangling projectId must stay")
+      assertTrue(Files.exists(keep))
+      assertFalse(Files.exists(noBreadcrumb), "projectId without breadcrumb must be removed")
+      assertTrue(
+        Files.exists(lockedDangling),
+        "locked projectId must not be removed even when breadcrumb is stale",
+      )
+      assertFalse(Files.exists(stale.parent))
+
+      assertTrue(metrics.records.any { it.name == "reaper.scanned" })
+      assertTrue(metrics.records.any { it.name == "reaper.removed" && it.value == 3L })
+      assertTrue(metrics.records.any { it.name == "reaper.skipped_locked" && it.value == 1L })
+    } finally {
+      heldLock.release()
+      lockChannel.close()
     }
+  }
 
-    @Test
-    fun `empty icRoot returns an empty report`() {
-        val report = IcReaper.run(icRoot, "2.3.20", metrics)
+  private class RecordingMetricsSink : IcMetricsSink {
+    data class Record(val name: String, val value: Long)
 
-        assertEquals(0, report.scanned)
-        assertEquals(0, report.removed)
-        assertEquals(0, report.skippedLocked)
-        assertTrue(report.errors.isEmpty())
+    val records = mutableListOf<Record>()
+
+    override fun record(name: String, value: Long) {
+      records += Record(name, value)
     }
-
-    @Test
-    fun `missing icRoot returns an empty report`() {
-        val nonexistent = icRoot.resolve("does-not-exist")
-        val report = IcReaper.run(nonexistent, "2.3.20", metrics)
-
-        assertEquals(0, report.scanned)
-        assertEquals(0, report.removed)
-    }
-
-    @Test
-    fun `Rule A removes stale version segments wholesale`() {
-        val stale = icRoot.resolve("2.3.19").resolve("aaaaaaaaaaaaaaaa").createDirectories()
-        stale.resolve("state.bin").writeText("garbage")
-        val current = icRoot.resolve("2.3.20").resolve("bbbbbbbbbbbbbbbb").createDirectories()
-        current.resolve("project.path").writeText(otherTmp.toString())
-
-        val report = IcReaper.run(icRoot, "2.3.20", metrics)
-
-        assertFalse(Files.exists(icRoot.resolve("2.3.19")), "stale version segment must be gone")
-        assertTrue(Files.exists(current), "current-version projectId dir must survive")
-        assertEquals(1, report.removed)
-    }
-
-    @Test
-    fun `Rule B removes projectId when breadcrumb points to a missing path`() {
-        val missing = otherTmp.resolve("deleted-project")
-        val projectId = icRoot.resolve("2.3.20").resolve("cccccccccccccccc").createDirectories()
-        projectId.resolve("project.path").writeText(missing.toString())
-        projectId.resolve("state.bin").writeText("garbage")
-
-        val report = IcReaper.run(icRoot, "2.3.20", metrics)
-
-        assertFalse(Files.exists(projectId), "projectId with dangling breadcrumb must be removed")
-        assertEquals(1, report.removed)
-    }
-
-    @Test
-    fun `Rule B keeps projectId when breadcrumb points to an existing path`() {
-        val projectId = icRoot.resolve("2.3.20").resolve("dddddddddddddddd").createDirectories()
-        projectId.resolve("project.path").writeText(otherTmp.toString())
-
-        val report = IcReaper.run(icRoot, "2.3.20", metrics)
-
-        assertTrue(Files.exists(projectId), "projectId with live breadcrumb must survive")
-        assertEquals(0, report.removed)
-    }
-
-    @Test
-    fun `Rule B removes projectId when breadcrumb is missing entirely`() {
-        val orphan = icRoot.resolve("2.3.20").resolve("eeeeeeeeeeeeeeee").createDirectories()
-        orphan.resolve("state.bin").writeText("orphan")
-
-        val report = IcReaper.run(icRoot, "2.3.20", metrics)
-
-        assertFalse(Files.exists(orphan), "projectId without breadcrumb must be removed")
-        assertEquals(1, report.removed)
-    }
-
-    @Test
-    fun `Rule B removes projectId when breadcrumb content is empty`() {
-        val corrupt = icRoot.resolve("2.3.20").resolve("7777777777777777").createDirectories()
-        corrupt.resolve("project.path").writeText("")
-
-        val report = IcReaper.run(icRoot, "2.3.20", metrics)
-
-        assertFalse(Files.exists(corrupt), "projectId with empty breadcrumb must be removed")
-        assertEquals(1, report.removed)
-    }
-
-    @Test
-    fun `Rule B skips projectId when LOCK is held by another channel`() {
-        val missing = otherTmp.resolve("deleted-project")
-        val projectId = icRoot.resolve("2.3.20").resolve("ffffffffffffffff").createDirectories()
-        projectId.resolve("project.path").writeText(missing.toString())
-        val lockPath = projectId.resolve("LOCK")
-        Files.createFile(lockPath)
-
-        val channel = FileChannel.open(
-            lockPath,
-            StandardOpenOption.READ,
-            StandardOpenOption.WRITE,
-        )
-        val lock = channel.tryLock() ?: error("test could not acquire LOCK on $lockPath")
-        try {
-            val report = IcReaper.run(icRoot, "2.3.20", metrics)
-
-            assertTrue(Files.exists(projectId), "locked projectId must not be removed")
-            assertEquals(1, report.skippedLocked)
-            assertEquals(0, report.removed)
-        } finally {
-            lock.release()
-            channel.close()
-        }
-    }
-
-    @Test
-    fun `regular files directly under icRoot are ignored without crashing the scan`() {
-        Files.writeString(icRoot.resolve("README.txt"), "accidentally placed here")
-        icRoot.resolve("2.3.20").resolve("aaaaaaaaaaaaaaaa").createDirectories()
-            .resolve("project.path").writeText(otherTmp.toString())
-
-        val report = IcReaper.run(icRoot, "2.3.20", metrics)
-
-        assertTrue(Files.exists(icRoot.resolve("README.txt")), "stray file must survive")
-        assertEquals(1, report.scanned)
-        assertEquals(0, report.removed)
-    }
-
-    @Test
-    fun `run emits all counter names through the metrics sink on a mixed fixture`() {
-        val stale = icRoot.resolve("2.3.19").resolve("1111111111111111").createDirectories()
-        stale.resolve("state.bin").writeText("x")
-
-        val keep = icRoot.resolve("2.3.20").resolve("2222222222222222").createDirectories()
-        keep.resolve("project.path").writeText(otherTmp.toString())
-
-        val drop = icRoot.resolve("2.3.20").resolve("3333333333333333").createDirectories()
-        drop.resolve("project.path").writeText(otherTmp.resolve("gone").toString())
-
-        val noBreadcrumb = icRoot.resolve("2.3.20").resolve("4444444444444444").createDirectories()
-        noBreadcrumb.resolve("state.bin").writeText("orphan")
-
-        val lockedDangling = icRoot.resolve("2.3.20").resolve("5555555555555555").createDirectories()
-        lockedDangling.resolve("project.path").writeText(otherTmp.resolve("also-gone").toString())
-        val lockedFile = lockedDangling.resolve("LOCK")
-        Files.createFile(lockedFile)
-        val lockChannel = FileChannel.open(lockedFile, StandardOpenOption.READ, StandardOpenOption.WRITE)
-        val heldLock = lockChannel.tryLock() ?: error("test setup: failed to hold LOCK on $lockedFile")
-        try {
-            val report = IcReaper.run(icRoot, "2.3.20", metrics)
-
-            assertEquals(3, report.removed, "stale version + dangling breadcrumb + missing breadcrumb")
-            assertEquals(1, report.skippedLocked, "locked dangling projectId must stay")
-            assertTrue(Files.exists(keep))
-            assertFalse(Files.exists(noBreadcrumb), "projectId without breadcrumb must be removed")
-            assertTrue(Files.exists(lockedDangling), "locked projectId must not be removed even when breadcrumb is stale")
-            assertFalse(Files.exists(stale.parent))
-
-            assertTrue(metrics.records.any { it.name == "reaper.scanned" })
-            assertTrue(metrics.records.any { it.name == "reaper.removed" && it.value == 3L })
-            assertTrue(metrics.records.any { it.name == "reaper.skipped_locked" && it.value == 1L })
-        } finally {
-            heldLock.release()
-            lockChannel.close()
-        }
-    }
-
-    private class RecordingMetricsSink : IcMetricsSink {
-        data class Record(val name: String, val value: Long)
-        val records = mutableListOf<Record>()
-        override fun record(name: String, value: Long) {
-            records += Record(name, value)
-        }
-    }
+  }
 }

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/server/DaemonLifecycleTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/server/DaemonLifecycleTest.kt
@@ -3,12 +3,6 @@ package kolt.daemon.server
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
-import kolt.daemon.ic.IcError
-import kolt.daemon.ic.IcRequest
-import kolt.daemon.ic.IcResponse
-import kolt.daemon.ic.IncrementalCompiler
-import kolt.daemon.protocol.FrameCodec
-import kolt.daemon.protocol.Message
 import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
@@ -16,6 +10,12 @@ import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
+import kolt.daemon.ic.IcError
+import kolt.daemon.ic.IcRequest
+import kolt.daemon.ic.IcResponse
+import kolt.daemon.ic.IncrementalCompiler
+import kolt.daemon.protocol.FrameCodec
+import kolt.daemon.protocol.Message
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -27,197 +27,215 @@ import kotlin.test.assertTrue
 
 class DaemonLifecycleTest {
 
-    private lateinit var socketDir: Path
-    private lateinit var socketPath: Path
-    private lateinit var icRoot: Path
-    private lateinit var serverThread: Thread
-    private lateinit var server: DaemonServer
+  private lateinit var socketDir: Path
+  private lateinit var socketPath: Path
+  private lateinit var icRoot: Path
+  private lateinit var serverThread: Thread
+  private lateinit var server: DaemonServer
 
-    @BeforeTest
-    fun setUp() {
-        socketDir = Files.createTempDirectory("kolt-daemon-lifecycle-")
-        socketPath = socketDir.resolve("jvm-compiler-daemon.sock")
-        icRoot = Files.createTempDirectory("kolt-daemon-lifecycle-ic-")
-    }
+  @BeforeTest
+  fun setUp() {
+    socketDir = Files.createTempDirectory("kolt-daemon-lifecycle-")
+    socketPath = socketDir.resolve("jvm-compiler-daemon.sock")
+    icRoot = Files.createTempDirectory("kolt-daemon-lifecycle-ic-")
+  }
 
-    @AfterTest
-    fun tearDown() {
-        runCatching { server.stop() }
-        runCatching { serverThread.join(2_000) }
-        runCatching { Files.deleteIfExists(socketPath) }
-        runCatching { Files.deleteIfExists(socketDir) }
-        runCatching { icRoot.toFile().deleteRecursively() }
-    }
+  @AfterTest
+  fun tearDown() {
+    runCatching { server.stop() }
+    runCatching { serverThread.join(2_000) }
+    runCatching { Files.deleteIfExists(socketPath) }
+    runCatching { Files.deleteIfExists(socketDir) }
+    runCatching { icRoot.toFile().deleteRecursively() }
+  }
 
-    @Test
-    fun `server exits after serving maxCompiles compiles`() {
-        val compiler = alwaysSuccess()
-        server = DaemonServer(
-            socketPath = socketPath,
-            compiler = compiler,
-            icRoot = icRoot,
-            kotlinVersion = "2.3.20",
-            config = DaemonConfig(
-                idleTimeoutMillis = 60_000,
-                maxCompiles = 2,
-                heapWatermarkBytes = Long.MAX_VALUE,
-            ),
+  @Test
+  fun `server exits after serving maxCompiles compiles`() {
+    val compiler = alwaysSuccess()
+    server =
+      DaemonServer(
+        socketPath = socketPath,
+        compiler = compiler,
+        icRoot = icRoot,
+        kotlinVersion = "2.3.20",
+        config =
+          DaemonConfig(
+            idleTimeoutMillis = 60_000,
+            maxCompiles = 2,
+            heapWatermarkBytes = Long.MAX_VALUE,
+          ),
+      )
+    serverThread =
+      Thread({ server.serve() }, "daemon-lifecycle").apply {
+        isDaemon = true
+        start()
+      }
+    waitForSocket()
+
+    SocketChannel.open(StandardProtocolFamily.UNIX).use { ch ->
+      ch.connect(UnixDomainSocketAddress.of(socketPath))
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      repeat(2) {
+        FrameCodec.writeFrame(
+          output,
+          Message.Compile(
+            workingDir = "/w",
+            classpath = emptyList(),
+            sources = listOf("A.kt"),
+            outputPath = "build/classes",
+            moduleName = "m",
+          ),
         )
-        serverThread = Thread({ server.serve() }, "daemon-lifecycle").apply {
-            isDaemon = true
-            start()
-        }
-        waitForSocket()
-
-        SocketChannel.open(StandardProtocolFamily.UNIX).use { ch ->
-            ch.connect(UnixDomainSocketAddress.of(socketPath))
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            repeat(2) {
-                FrameCodec.writeFrame(
-                    output,
-                    Message.Compile(
-                        workingDir = "/w",
-                        classpath = emptyList(),
-                        sources = listOf("A.kt"),
-                        outputPath = "build/classes",
-                        moduleName = "m",
-                    ),
-                )
-                FrameCodec.readFrame(input)
-            }
-        }
-
-        serverThread.join(2_000)
-        assertFalse(serverThread.isAlive, "server should have exited after maxCompiles")
+        FrameCodec.readFrame(input)
+      }
     }
 
-    @Test
-    fun `idle timeout stops server when no connection arrives`() {
-        server = DaemonServer(
-            socketPath = socketPath,
-            compiler = alwaysSuccess(),
-            icRoot = icRoot,
-            kotlinVersion = "2.3.20",
-            config = DaemonConfig(
-                idleTimeoutMillis = 1_000,
-                maxCompiles = Int.MAX_VALUE,
-                heapWatermarkBytes = Long.MAX_VALUE,
-            ),
-        )
-        serverThread = Thread({ server.serve() }, "daemon-idle").apply {
-            isDaemon = true
-            start()
-        }
-        waitForSocket()
+    serverThread.join(2_000)
+    assertFalse(serverThread.isAlive, "server should have exited after maxCompiles")
+  }
 
-        serverThread.join(5_000)
-        assertEquals(false, serverThread.isAlive, "server should have exited after idle timeout")
+  @Test
+  fun `idle timeout stops server when no connection arrives`() {
+    server =
+      DaemonServer(
+        socketPath = socketPath,
+        compiler = alwaysSuccess(),
+        icRoot = icRoot,
+        kotlinVersion = "2.3.20",
+        config =
+          DaemonConfig(
+            idleTimeoutMillis = 1_000,
+            maxCompiles = Int.MAX_VALUE,
+            heapWatermarkBytes = Long.MAX_VALUE,
+          ),
+      )
+    serverThread =
+      Thread({ server.serve() }, "daemon-idle").apply {
+        isDaemon = true
+        start()
+      }
+    waitForSocket()
+
+    serverThread.join(5_000)
+    assertEquals(false, serverThread.isAlive, "server should have exited after idle timeout")
+  }
+
+  @Test
+  fun `preServeHook fires exactly once after bind and before accept loop`() {
+    val hookCalls = AtomicInteger(0)
+    server =
+      DaemonServer(
+        socketPath = socketPath,
+        compiler = alwaysSuccess(),
+        icRoot = icRoot,
+        kotlinVersion = "2.3.20",
+        config =
+          DaemonConfig(
+            idleTimeoutMillis = 500,
+            maxCompiles = Int.MAX_VALUE,
+            heapWatermarkBytes = Long.MAX_VALUE,
+          ),
+        preServeHook = {
+          // Socket must already exist when the hook fires — this
+          // is the ordering ADR 0019 §Negative relies on so that
+          // the IC reaper never races with a client connection
+          // attempt.
+          assertTrue(Files.exists(socketPath), "socket must be bound before hook fires")
+          hookCalls.incrementAndGet()
+        },
+      )
+    serverThread =
+      Thread({ server.serve() }, "daemon-pre-serve-hook").apply {
+        isDaemon = true
+        start()
+      }
+    waitForSocket()
+    // Hook must fire synchronously between bind and accept loop, so
+    // the socket existing already proves the hook ran exactly once.
+    // Asserting here (before idle-driven shutdown) keeps the test
+    // independent of watchdog timing.
+    assertEquals(1, hookCalls.get(), "preServeHook must fire exactly once per serve()")
+  }
+
+  @Test
+  fun `serve swallows preServeHook failures and keeps serving`() {
+    val compiler = alwaysSuccess()
+    server =
+      DaemonServer(
+        socketPath = socketPath,
+        compiler = compiler,
+        icRoot = icRoot,
+        kotlinVersion = "2.3.20",
+        config =
+          DaemonConfig(
+            idleTimeoutMillis = 60_000,
+            maxCompiles = 1,
+            heapWatermarkBytes = Long.MAX_VALUE,
+          ),
+        preServeHook = { throw RuntimeException("reaper blew up") },
+      )
+    serverThread =
+      Thread({ server.serve() }, "daemon-hook-failure").apply {
+        isDaemon = true
+        start()
+      }
+    waitForSocket()
+
+    SocketChannel.open(StandardProtocolFamily.UNIX).use { ch ->
+      ch.connect(UnixDomainSocketAddress.of(socketPath))
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      FrameCodec.writeFrame(
+        output,
+        Message.Compile(
+          workingDir = "/w",
+          classpath = emptyList(),
+          sources = listOf("A.kt"),
+          outputPath = "build/classes",
+          moduleName = "m",
+        ),
+      )
+      FrameCodec.readFrame(input)
     }
 
-    @Test
-    fun `preServeHook fires exactly once after bind and before accept loop`() {
-        val hookCalls = AtomicInteger(0)
-        server = DaemonServer(
-            socketPath = socketPath,
-            compiler = alwaysSuccess(),
-            icRoot = icRoot,
-            kotlinVersion = "2.3.20",
-            config = DaemonConfig(
-                idleTimeoutMillis = 500,
-                maxCompiles = Int.MAX_VALUE,
-                heapWatermarkBytes = Long.MAX_VALUE,
-            ),
-            preServeHook = {
-                // Socket must already exist when the hook fires — this
-                // is the ordering ADR 0019 §Negative relies on so that
-                // the IC reaper never races with a client connection
-                // attempt.
-                assertTrue(Files.exists(socketPath), "socket must be bound before hook fires")
-                hookCalls.incrementAndGet()
-            },
-        )
-        serverThread = Thread({ server.serve() }, "daemon-pre-serve-hook").apply {
-            isDaemon = true
-            start()
-        }
-        waitForSocket()
-        // Hook must fire synchronously between bind and accept loop, so
-        // the socket existing already proves the hook ran exactly once.
-        // Asserting here (before idle-driven shutdown) keeps the test
-        // independent of watchdog timing.
-        assertEquals(1, hookCalls.get(), "preServeHook must fire exactly once per serve()")
+    serverThread.join(2_000)
+    assertFalse(serverThread.isAlive, "server should have served the compile despite hook failure")
+  }
+
+  @Test
+  fun `serve returns BindFailed when the parent directory cannot be created`() {
+    val impossible = Path.of("/dev/null/kolt-daemon-impossible/jvm-compiler-daemon.sock")
+    server =
+      DaemonServer(
+        socketPath = impossible,
+        compiler = alwaysSuccess(),
+        icRoot = icRoot,
+        kotlinVersion = "2.3.20",
+        config = DaemonConfig(),
+      )
+    serverThread =
+      Thread({}, "noop").apply {
+        start()
+        join()
+      }
+
+    val result = server.serve()
+    val err = result.getError()
+    assertNotNull(err)
+    assertIs<DaemonError.BindFailed>(err)
+  }
+
+  private fun alwaysSuccess(): IncrementalCompiler =
+    object : IncrementalCompiler {
+      override fun compile(request: IcRequest): Result<IcResponse, IcError> =
+        Ok(IcResponse(wallMillis = 0, compiledFileCount = 0))
     }
 
-    @Test
-    fun `serve swallows preServeHook failures and keeps serving`() {
-        val compiler = alwaysSuccess()
-        server = DaemonServer(
-            socketPath = socketPath,
-            compiler = compiler,
-            icRoot = icRoot,
-            kotlinVersion = "2.3.20",
-            config = DaemonConfig(
-                idleTimeoutMillis = 60_000,
-                maxCompiles = 1,
-                heapWatermarkBytes = Long.MAX_VALUE,
-            ),
-            preServeHook = { throw RuntimeException("reaper blew up") },
-        )
-        serverThread = Thread({ server.serve() }, "daemon-hook-failure").apply {
-            isDaemon = true
-            start()
-        }
-        waitForSocket()
-
-        SocketChannel.open(StandardProtocolFamily.UNIX).use { ch ->
-            ch.connect(UnixDomainSocketAddress.of(socketPath))
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            FrameCodec.writeFrame(
-                output,
-                Message.Compile(
-                    workingDir = "/w",
-                    classpath = emptyList(),
-                    sources = listOf("A.kt"),
-                    outputPath = "build/classes",
-                    moduleName = "m",
-                ),
-            )
-            FrameCodec.readFrame(input)
-        }
-
-        serverThread.join(2_000)
-        assertFalse(serverThread.isAlive, "server should have served the compile despite hook failure")
+  private fun waitForSocket() {
+    val deadline = System.currentTimeMillis() + 2_000
+    while (!Files.exists(socketPath) && System.currentTimeMillis() < deadline) {
+      Thread.sleep(10)
     }
-
-    @Test
-    fun `serve returns BindFailed when the parent directory cannot be created`() {
-        val impossible = Path.of("/dev/null/kolt-daemon-impossible/jvm-compiler-daemon.sock")
-        server = DaemonServer(
-            socketPath = impossible,
-            compiler = alwaysSuccess(),
-            icRoot = icRoot,
-            kotlinVersion = "2.3.20",
-            config = DaemonConfig(),
-        )
-        serverThread = Thread({}, "noop").apply { start(); join() }
-
-        val result = server.serve()
-        val err = result.getError()
-        assertNotNull(err)
-        assertIs<DaemonError.BindFailed>(err)
-    }
-
-    private fun alwaysSuccess(): IncrementalCompiler = object : IncrementalCompiler {
-        override fun compile(request: IcRequest): Result<IcResponse, IcError> =
-            Ok(IcResponse(wallMillis = 0, compiledFileCount = 0))
-    }
-
-    private fun waitForSocket() {
-        val deadline = System.currentTimeMillis() + 2_000
-        while (!Files.exists(socketPath) && System.currentTimeMillis() < deadline) {
-            Thread.sleep(10)
-        }
-    }
+  }
 }

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/server/DaemonServerTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/server/DaemonServerTest.kt
@@ -3,13 +3,6 @@ package kolt.daemon.server
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
-import kolt.daemon.ic.IcError
-import kolt.daemon.ic.IcRequest
-import kolt.daemon.ic.IcResponse
-import kolt.daemon.ic.IcStateLayout
-import kolt.daemon.ic.IncrementalCompiler
-import kolt.daemon.protocol.FrameCodec
-import kolt.daemon.protocol.Message
 import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
@@ -17,6 +10,13 @@ import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
+import kolt.daemon.ic.IcError
+import kolt.daemon.ic.IcRequest
+import kolt.daemon.ic.IcResponse
+import kolt.daemon.ic.IcStateLayout
+import kolt.daemon.ic.IncrementalCompiler
+import kolt.daemon.protocol.FrameCodec
+import kolt.daemon.protocol.Message
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -25,184 +25,188 @@ import kotlin.test.assertNotNull
 
 class DaemonServerTest {
 
-    private lateinit var socketDir: Path
-    private lateinit var socketPath: Path
-    private lateinit var icRoot: Path
-    private lateinit var server: DaemonServer
-    private lateinit var serverThread: Thread
+  private lateinit var socketDir: Path
+  private lateinit var socketPath: Path
+  private lateinit var icRoot: Path
+  private lateinit var server: DaemonServer
+  private lateinit var serverThread: Thread
 
-    @BeforeTest
-    fun setUp() {
-        socketDir = Files.createTempDirectory("kolt-daemon-server-")
-        socketPath = socketDir.resolve("jvm-compiler-daemon.sock")
-        icRoot = Files.createTempDirectory("kolt-daemon-server-ic-")
+  @BeforeTest
+  fun setUp() {
+    socketDir = Files.createTempDirectory("kolt-daemon-server-")
+    socketPath = socketDir.resolve("jvm-compiler-daemon.sock")
+    icRoot = Files.createTempDirectory("kolt-daemon-server-ic-")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    runCatching { server.stop() }
+    runCatching { serverThread.join(2_000) }
+    runCatching { Files.deleteIfExists(socketPath) }
+    runCatching { Files.deleteIfExists(socketDir) }
+    runCatching { icRoot.toFile().deleteRecursively() }
+  }
+
+  private fun startServer(compiler: IncrementalCompiler) {
+    server =
+      DaemonServer(
+        socketPath = socketPath,
+        compiler = compiler,
+        icRoot = icRoot,
+        kotlinVersion = "2.3.20",
+      )
+    serverThread =
+      Thread({ server.serve() }, "daemon-server-test").apply {
+        isDaemon = true
+        start()
+      }
+    val deadline = System.currentTimeMillis() + 2_000
+    while (!Files.exists(socketPath) && System.currentTimeMillis() < deadline) {
+      Thread.sleep(10)
+    }
+  }
+
+  private fun connect(): SocketChannel =
+    SocketChannel.open(StandardProtocolFamily.UNIX).also {
+      it.connect(UnixDomainSocketAddress.of(socketPath))
     }
 
-    @AfterTest
-    fun tearDown() {
-        runCatching { server.stop() }
-        runCatching { serverThread.join(2_000) }
-        runCatching { Files.deleteIfExists(socketPath) }
-        runCatching { Files.deleteIfExists(socketDir) }
-        runCatching { icRoot.toFile().deleteRecursively() }
+  @Test
+  fun `responds to Ping with Pong`() {
+    startServer(FakeCompiler())
+    connect().use { ch ->
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      FrameCodec.writeFrame(output, Message.Ping)
+      val response = FrameCodec.readFrame(input).get()
+      assertEquals(Message.Pong, response)
     }
+  }
 
-    private fun startServer(compiler: IncrementalCompiler) {
-        server = DaemonServer(
-            socketPath = socketPath,
-            compiler = compiler,
-            icRoot = icRoot,
-            kotlinVersion = "2.3.20",
-        )
-        serverThread = Thread({ server.serve() }, "daemon-server-test").apply {
-            isDaemon = true
-            start()
+  @Test
+  fun `delegates Compile to the incremental compiler and returns CompileResult`() {
+    val calls = AtomicInteger(0)
+    val observedRequests = mutableListOf<IcRequest>()
+    val compiler =
+      FakeCompiler(
+        onCompile = { req ->
+          calls.incrementAndGet()
+          observedRequests += req
+          Ok(IcResponse(wallMillis = 7, compiledFileCount = 1))
         }
-        val deadline = System.currentTimeMillis() + 2_000
-        while (!Files.exists(socketPath) && System.currentTimeMillis() < deadline) {
-            Thread.sleep(10)
-        }
+      )
+    startServer(compiler)
+
+    connect().use { ch ->
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      FrameCodec.writeFrame(
+        output,
+        Message.Compile(
+          workingDir = "/w",
+          classpath = emptyList(),
+          sources = listOf("A.kt"),
+          outputPath = "build/classes",
+          moduleName = "mod-a",
+          extraArgs = emptyList(),
+        ),
+      )
+      val response = FrameCodec.readFrame(input).get()
+      assertNotNull(response)
+      val result = response as Message.CompileResult
+      assertEquals(0, result.exitCode)
+      assertEquals(1, calls.get())
+      val observed = observedRequests.single()
+      assertEquals(Path.of("/w"), observed.projectRoot)
+      assertEquals(listOf(Path.of("A.kt")), observed.sources)
+      assertEquals(Path.of("build/classes"), observed.outputDir)
+      // ADR 0019 §5 / B-2a carryover #5 + #6: workingDir must be
+      // daemon-owned IC state under `icRoot / kotlinVersion /
+      // projectIdFor(projectRoot)`, not a projectRoot placeholder.
+      // projectId must be produced by `IcStateLayout` so the two
+      // call sites cannot drift apart.
+      assertEquals(IcStateLayout.projectIdFor(Path.of("/w")), observed.projectId)
+      assertEquals(
+        IcStateLayout.workingDirFor(icRoot, "2.3.20", Path.of("/w")),
+        observed.workingDir,
+      )
     }
+  }
 
-    private fun connect(): SocketChannel =
-        SocketChannel.open(StandardProtocolFamily.UNIX).also {
-            it.connect(UnixDomainSocketAddress.of(socketPath))
+  @Test
+  fun `CompilationFailed from the adapter becomes a non-zero CompileResult`() {
+    val compiler =
+      FakeCompiler(
+        onCompile = { _ ->
+          com.github.michaelbull.result.Err(
+            IcError.CompilationFailed(listOf("Main.kt: error: unresolved reference"))
+          )
         }
+      )
+    startServer(compiler)
 
-    @Test
-    fun `responds to Ping with Pong`() {
-        startServer(FakeCompiler())
-        connect().use { ch ->
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            FrameCodec.writeFrame(output, Message.Ping)
-            val response = FrameCodec.readFrame(input).get()
-            assertEquals(Message.Pong, response)
-        }
+    connect().use { ch ->
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      FrameCodec.writeFrame(
+        output,
+        Message.Compile(
+          workingDir = "/w",
+          classpath = emptyList(),
+          sources = listOf("Main.kt"),
+          outputPath = "build/classes",
+          moduleName = "m",
+        ),
+      )
+      val result = FrameCodec.readFrame(input).get() as Message.CompileResult
+      assertEquals(1, result.exitCode)
+      kotlin.test.assertTrue(result.stderr.contains("unresolved reference"))
     }
+  }
 
-    @Test
-    fun `delegates Compile to the incremental compiler and returns CompileResult`() {
-        val calls = AtomicInteger(0)
-        val observedRequests = mutableListOf<IcRequest>()
-        val compiler = FakeCompiler(
-            onCompile = { req ->
-                calls.incrementAndGet()
-                observedRequests += req
-                Ok(IcResponse(wallMillis = 7, compiledFileCount = 1))
-            },
-        )
-        startServer(compiler)
-
-        connect().use { ch ->
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            FrameCodec.writeFrame(
-                output,
-                Message.Compile(
-                    workingDir = "/w",
-                    classpath = emptyList(),
-                    sources = listOf("A.kt"),
-                    outputPath = "build/classes",
-                    moduleName = "mod-a",
-                    extraArgs = emptyList(),
-                ),
-            )
-            val response = FrameCodec.readFrame(input).get()
-            assertNotNull(response)
-            val result = response as Message.CompileResult
-            assertEquals(0, result.exitCode)
-            assertEquals(1, calls.get())
-            val observed = observedRequests.single()
-            assertEquals(Path.of("/w"), observed.projectRoot)
-            assertEquals(listOf(Path.of("A.kt")), observed.sources)
-            assertEquals(Path.of("build/classes"), observed.outputDir)
-            // ADR 0019 §5 / B-2a carryover #5 + #6: workingDir must be
-            // daemon-owned IC state under `icRoot / kotlinVersion /
-            // projectIdFor(projectRoot)`, not a projectRoot placeholder.
-            // projectId must be produced by `IcStateLayout` so the two
-            // call sites cannot drift apart.
-            assertEquals(IcStateLayout.projectIdFor(Path.of("/w")), observed.projectId)
-            assertEquals(
-                IcStateLayout.workingDirFor(icRoot, "2.3.20", Path.of("/w")),
-                observed.workingDir,
-            )
-        }
+  @Test
+  fun `handles multiple frames on the same connection`() {
+    startServer(FakeCompiler())
+    connect().use { ch ->
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      repeat(3) {
+        FrameCodec.writeFrame(output, Message.Ping)
+        assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
+      }
     }
+  }
 
-    @Test
-    fun `CompilationFailed from the adapter becomes a non-zero CompileResult`() {
-        val compiler = FakeCompiler(
-            onCompile = { _ ->
-                com.github.michaelbull.result.Err(IcError.CompilationFailed(listOf("Main.kt: error: unresolved reference")))
-            },
-        )
-        startServer(compiler)
+  @Test
+  fun `Shutdown message stops the server and cleans up the socket file`() {
+    startServer(FakeCompiler())
+    connect().use { ch -> FrameCodec.writeFrame(Channels.newOutputStream(ch), Message.Shutdown) }
+    serverThread.join(2_000)
+    assertEquals(false, serverThread.isAlive, "server thread should have exited")
+    assertEquals(false, Files.exists(socketPath), "socket file should have been removed on exit")
+  }
 
-        connect().use { ch ->
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            FrameCodec.writeFrame(
-                output,
-                Message.Compile(
-                    workingDir = "/w",
-                    classpath = emptyList(),
-                    sources = listOf("Main.kt"),
-                    outputPath = "build/classes",
-                    moduleName = "m",
-                ),
-            )
-            val result = FrameCodec.readFrame(input).get() as Message.CompileResult
-            assertEquals(1, result.exitCode)
-            kotlin.test.assertTrue(result.stderr.contains("unresolved reference"))
-        }
+  @Test
+  fun `rejects server-only messages with a protocol error reply`() {
+    startServer(FakeCompiler())
+    connect().use { ch ->
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      FrameCodec.writeFrame(output, Message.Pong)
+      val response = FrameCodec.readFrame(input).get() as Message.CompileResult
+      assertEquals(2, response.exitCode)
+      kotlin.test.assertTrue(
+        response.stderr.contains("protocol error"),
+        "expected protocol error in stderr, got: ${response.stderr}",
+      )
     }
+  }
 
-    @Test
-    fun `handles multiple frames on the same connection`() {
-        startServer(FakeCompiler())
-        connect().use { ch ->
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            repeat(3) {
-                FrameCodec.writeFrame(output, Message.Ping)
-                assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
-            }
-        }
+  private class FakeCompiler(
+    private val onCompile: (IcRequest) -> Result<IcResponse, IcError> = { _ ->
+      Ok(IcResponse(wallMillis = 0, compiledFileCount = 0))
     }
-
-    @Test
-    fun `Shutdown message stops the server and cleans up the socket file`() {
-        startServer(FakeCompiler())
-        connect().use { ch ->
-            FrameCodec.writeFrame(Channels.newOutputStream(ch), Message.Shutdown)
-        }
-        serverThread.join(2_000)
-        assertEquals(false, serverThread.isAlive, "server thread should have exited")
-        assertEquals(false, Files.exists(socketPath), "socket file should have been removed on exit")
-    }
-
-    @Test
-    fun `rejects server-only messages with a protocol error reply`() {
-        startServer(FakeCompiler())
-        connect().use { ch ->
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            FrameCodec.writeFrame(output, Message.Pong)
-            val response = FrameCodec.readFrame(input).get() as Message.CompileResult
-            assertEquals(2, response.exitCode)
-            kotlin.test.assertTrue(
-                response.stderr.contains("protocol error"),
-                "expected protocol error in stderr, got: ${response.stderr}",
-            )
-        }
-    }
-
-    private class FakeCompiler(
-        private val onCompile: (IcRequest) -> Result<IcResponse, IcError> = { _ ->
-            Ok(IcResponse(wallMillis = 0, compiledFileCount = 0))
-        },
-    ) : IncrementalCompiler {
-        override fun compile(request: IcRequest): Result<IcResponse, IcError> = onCompile(request)
-    }
+  ) : IncrementalCompiler {
+    override fun compile(request: IcRequest): Result<IcResponse, IcError> = onCompile(request)
+  }
 }

--- a/kolt-native-compiler-daemon/kolt.lock
+++ b/kolt-native-compiler-daemon/kolt.lock
@@ -7,9 +7,26 @@
       "version": "2.3.1",
       "sha256": "96289c225b06d20156a0695432afc104f187ab68c84e9b8bed7af573e5194c83"
     },
+    "org.apiguardian:apiguardian-api": {
+      "version": "1.1.2",
+      "sha256": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
+      "transitive": true,
+      "test": true
+    },
     "org.jetbrains.kotlin:kotlin-stdlib": {
       "version": "2.3.20",
       "sha256": "0ae12504a5040ebaf37703908483420d1a5624dd1d93f357665f8c77c848a01e"
+    },
+    "org.jetbrains.kotlin:kotlin-test": {
+      "version": "2.3.20",
+      "sha256": "d6c9ccf82f67e6cf7fdaf9e0cea419dac4dfa58620a1653d3dba45f544a289ac",
+      "transitive": true,
+      "test": true
+    },
+    "org.jetbrains.kotlin:kotlin-test-junit5": {
+      "version": "2.3.20",
+      "sha256": "90c554e254623cc49de7ae4c7c932a86287795e45875c47e1937c29c297eff02",
+      "test": true
     },
     "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm": {
       "version": "1.7.3",
@@ -24,6 +41,52 @@
       "version": "13.0",
       "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
       "transitive": true
+    },
+    "org.junit.jupiter:junit-jupiter": {
+      "version": "5.11.3",
+      "sha256": "ac7578efed162367c3ddc006338e07d4571510fd9866642ea93d5b9e4ed2f665",
+      "test": true
+    },
+    "org.junit.jupiter:junit-jupiter-api": {
+      "version": "5.11.3",
+      "sha256": "5d8147a60f49453973e250ed68701b7ff055964fe2462fc2cb1ec1d6d44889ba",
+      "transitive": true,
+      "test": true
+    },
+    "org.junit.jupiter:junit-jupiter-engine": {
+      "version": "5.11.3",
+      "sha256": "e62420c99f7c0d59a2159a2ef63e61877e9c80bd722c03ca8bf3bdcea050a589",
+      "transitive": true,
+      "test": true
+    },
+    "org.junit.jupiter:junit-jupiter-params": {
+      "version": "5.11.3",
+      "sha256": "0f798ebec744c4e6605fd4f2072f41a8e989e2d469e21db5aa67cf799c0b51ec",
+      "transitive": true,
+      "test": true
+    },
+    "org.junit.platform:junit-platform-commons": {
+      "version": "1.11.3",
+      "sha256": "be262964b0b6b48de977c61d4f931df8cf61e80e750cc3f3a0a39cdd21c1008c",
+      "transitive": true,
+      "test": true
+    },
+    "org.junit.platform:junit-platform-engine": {
+      "version": "1.11.3",
+      "sha256": "0043f72f611664735da8dc9a308bf12ecd2236b05339351c4741edb4d8fab0da",
+      "transitive": true,
+      "test": true
+    },
+    "org.junit.platform:junit-platform-launcher": {
+      "version": "1.11.3",
+      "sha256": "b4727459201b0011beb0742bd807421a1fc8426b116193031ed87825bc2d4f04",
+      "test": true
+    },
+    "org.opentest4j:opentest4j": {
+      "version": "1.3.0",
+      "sha256": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+      "transitive": true,
+      "test": true
     }
   }
 }

--- a/kolt-native-compiler-daemon/kolt.toml
+++ b/kolt-native-compiler-daemon/kolt.toml
@@ -14,8 +14,12 @@ jvm_target = "25"
 jdk = "25"
 main = "kolt.nativedaemon.main"
 sources = ["src/main/kotlin"]
-test_sources = []
+test_sources = ["src/test/kotlin"]
 
 [dependencies]
 "org.jetbrains.kotlinx:kotlinx-serialization-json" = "1.7.3"
 "com.michael-bull.kotlin-result:kotlin-result" = "2.3.1"
+
+[test-dependencies]
+"org.junit.jupiter:junit-jupiter" = "5.11.3"
+"org.junit.platform:junit-platform-launcher" = "1.11.3"

--- a/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/MainCliArgsTest.kt
+++ b/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/MainCliArgsTest.kt
@@ -15,138 +15,106 @@ import kotlin.test.assertNotNull
 // a field regression.
 class MainCliArgsTest {
 
-    @Test
-    fun parseAcceptsAllThreeRequiredFlags() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/kolt-native-compiler-daemon.sock",
-                "--konanc-jar", "/home/u/.konan/kotlin-native/konan/lib/kotlin-native-compiler-embeddable.jar",
-                "--konan-home", "/home/u/.konan/kotlin-native",
-            ),
+  @Test
+  fun parseAcceptsAllThreeRequiredFlags() {
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/kolt-native-compiler-daemon.sock",
+          "--konanc-jar",
+          "/home/u/.konan/kotlin-native/konan/lib/kotlin-native-compiler-embeddable.jar",
+          "--konan-home",
+          "/home/u/.konan/kotlin-native",
         )
+      )
 
-        val cli = assertNotNull(result.get())
-        assertEquals(Path.of("/tmp/kolt-native-compiler-daemon.sock"), cli.socketPath)
-        assertEquals(Path.of("/home/u/.konan/kotlin-native/konan/lib/kotlin-native-compiler-embeddable.jar"), cli.konancJar)
-        assertEquals(Path.of("/home/u/.konan/kotlin-native"), cli.konanHome)
-    }
+    val cli = assertNotNull(result.get())
+    assertEquals(Path.of("/tmp/kolt-native-compiler-daemon.sock"), cli.socketPath)
+    assertEquals(
+      Path.of("/home/u/.konan/kotlin-native/konan/lib/kotlin-native-compiler-embeddable.jar"),
+      cli.konancJar,
+    )
+    assertEquals(Path.of("/home/u/.konan/kotlin-native"), cli.konanHome)
+  }
 
-    @Test
-    fun socketFlagIsRequired() {
-        val result = parseArgs(
-            arrayOf(
-                "--konanc-jar", "/a.jar",
-                "--konan-home", "/k",
-            ),
+  @Test
+  fun socketFlagIsRequired() {
+    val result = parseArgs(arrayOf("--konanc-jar", "/a.jar", "--konan-home", "/k"))
+    assertEquals(CliError.MissingSocket, result.getError())
+  }
+
+  @Test
+  fun konancJarFlagIsRequired() {
+    val result = parseArgs(arrayOf("--socket", "/tmp/s", "--konan-home", "/k"))
+    assertEquals(CliError.MissingKonancJar, result.getError())
+  }
+
+  @Test
+  fun konanHomeFlagIsRequired() {
+    val result = parseArgs(arrayOf("--socket", "/tmp/s", "--konanc-jar", "/a.jar"))
+    assertEquals(CliError.MissingKonanHome, result.getError())
+  }
+
+  @Test
+  fun unknownFlagRejected() {
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/s",
+          "--konanc-jar",
+          "/a.jar",
+          "--konan-home",
+          "/k",
+          "--frobnicate",
         )
-        assertEquals(CliError.MissingSocket, result.getError())
-    }
+      )
+    val err = assertNotNull(result.getError()) as CliError.UnknownFlag
+    assertEquals("--frobnicate", err.flag)
+  }
 
-    @Test
-    fun konancJarFlagIsRequired() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--konan-home", "/k",
-            ),
-        )
-        assertEquals(CliError.MissingKonancJar, result.getError())
-    }
+  @Test
+  fun emptyValueForSocketRejected() {
+    val result = parseArgs(arrayOf("--socket", "", "--konanc-jar", "/a.jar", "--konan-home", "/k"))
+    assertEquals(CliError.EmptySocket, result.getError())
+  }
 
-    @Test
-    fun konanHomeFlagIsRequired() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--konanc-jar", "/a.jar",
-            ),
-        )
-        assertEquals(CliError.MissingKonanHome, result.getError())
-    }
+  @Test
+  fun emptyValueForKonancJarRejected() {
+    val result = parseArgs(arrayOf("--socket", "/tmp/s", "--konanc-jar", "", "--konan-home", "/k"))
+    assertEquals(CliError.EmptyKonancJar, result.getError())
+  }
 
-    @Test
-    fun unknownFlagRejected() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--konanc-jar", "/a.jar",
-                "--konan-home", "/k",
-                "--frobnicate",
-            ),
-        )
-        val err = assertNotNull(result.getError()) as CliError.UnknownFlag
-        assertEquals("--frobnicate", err.flag)
-    }
+  @Test
+  fun emptyValueForKonanHomeRejected() {
+    val result =
+      parseArgs(arrayOf("--socket", "/tmp/s", "--konanc-jar", "/a.jar", "--konan-home", ""))
+    assertEquals(CliError.EmptyKonanHome, result.getError())
+  }
 
-    @Test
-    fun emptyValueForSocketRejected() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "",
-                "--konanc-jar", "/a.jar",
-                "--konan-home", "/k",
-            ),
-        )
-        assertEquals(CliError.EmptySocket, result.getError())
-    }
+  // The three tests below pin the current behaviour where a flag at the
+  // end of argv with no following token collapses to MissingXyz (via
+  // `getOrNull(i+1)` returning null) rather than a dedicated
+  // "value-missing" variant. The JVM daemon parser has the same shape —
+  // adding these tests here prevents a future refactor from silently
+  // regressing the current diagnosability floor.
 
-    @Test
-    fun emptyValueForKonancJarRejected() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--konanc-jar", "",
-                "--konan-home", "/k",
-            ),
-        )
-        assertEquals(CliError.EmptyKonancJar, result.getError())
-    }
+  @Test
+  fun socketFlagAtEndOfArgvCollapsesToMissingSocket() {
+    val result = parseArgs(arrayOf("--socket"))
+    assertEquals(CliError.MissingSocket, result.getError())
+  }
 
-    @Test
-    fun emptyValueForKonanHomeRejected() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--konanc-jar", "/a.jar",
-                "--konan-home", "",
-            ),
-        )
-        assertEquals(CliError.EmptyKonanHome, result.getError())
-    }
+  @Test
+  fun konancJarFlagAtEndOfArgvCollapsesToMissingKonancJar() {
+    val result = parseArgs(arrayOf("--socket", "/tmp/s", "--konanc-jar"))
+    assertEquals(CliError.MissingKonancJar, result.getError())
+  }
 
-    // The three tests below pin the current behaviour where a flag at the
-    // end of argv with no following token collapses to MissingXyz (via
-    // `getOrNull(i+1)` returning null) rather than a dedicated
-    // "value-missing" variant. The JVM daemon parser has the same shape —
-    // adding these tests here prevents a future refactor from silently
-    // regressing the current diagnosability floor.
-
-    @Test
-    fun socketFlagAtEndOfArgvCollapsesToMissingSocket() {
-        val result = parseArgs(arrayOf("--socket"))
-        assertEquals(CliError.MissingSocket, result.getError())
-    }
-
-    @Test
-    fun konancJarFlagAtEndOfArgvCollapsesToMissingKonancJar() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--konanc-jar",
-            ),
-        )
-        assertEquals(CliError.MissingKonancJar, result.getError())
-    }
-
-    @Test
-    fun konanHomeFlagAtEndOfArgvCollapsesToMissingKonanHome() {
-        val result = parseArgs(
-            arrayOf(
-                "--socket", "/tmp/s",
-                "--konanc-jar", "/a.jar",
-                "--konan-home",
-            ),
-        )
-        assertEquals(CliError.MissingKonanHome, result.getError())
-    }
+  @Test
+  fun konanHomeFlagAtEndOfArgvCollapsesToMissingKonanHome() {
+    val result = parseArgs(arrayOf("--socket", "/tmp/s", "--konanc-jar", "/a.jar", "--konan-home"))
+    assertEquals(CliError.MissingKonanHome, result.getError())
+  }
 }

--- a/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/compiler/NativeCompilerTest.kt
+++ b/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/compiler/NativeCompilerTest.kt
@@ -18,51 +18,49 @@ import kotlin.test.assertNotNull
 // (e.g., reflection threw) become NativeCompileError.
 class NativeCompilerTest {
 
-    @Test
-    fun `compile returns Ok with exitCode 0 and empty stderr on success`() {
-        val compiler = FakeCompiler { args ->
-            assertEquals(listOf("-target", "linux_x64", "A.kt"), args)
-            Ok(NativeCompileOutcome(exitCode = 0, stderr = ""))
-        }
-
-        val result = compiler.compile(listOf("-target", "linux_x64", "A.kt"))
-
-        val outcome = assertNotNull(result.get())
-        assertEquals(0, outcome.exitCode)
-        assertEquals("", outcome.stderr)
+  @Test
+  fun `compile returns Ok with exitCode 0 and empty stderr on success`() {
+    val compiler = FakeCompiler { args ->
+      assertEquals(listOf("-target", "linux_x64", "A.kt"), args)
+      Ok(NativeCompileOutcome(exitCode = 0, stderr = ""))
     }
 
-    @Test
-    fun `non-zero exitCode is an Ok outcome not an error`() {
-        val compiler = FakeCompiler {
-            Ok(NativeCompileOutcome(exitCode = 1, stderr = "error: unresolved reference: foo"))
-        }
+    val result = compiler.compile(listOf("-target", "linux_x64", "A.kt"))
 
-        val result = compiler.compile(listOf("-target", "linux_x64", "A.kt"))
+    val outcome = assertNotNull(result.get())
+    assertEquals(0, outcome.exitCode)
+    assertEquals("", outcome.stderr)
+  }
 
-        val outcome = assertNotNull(result.get())
-        assertEquals(1, outcome.exitCode)
-        assertEquals("error: unresolved reference: foo", outcome.stderr)
+  @Test
+  fun `non-zero exitCode is an Ok outcome not an error`() {
+    val compiler = FakeCompiler {
+      Ok(NativeCompileOutcome(exitCode = 1, stderr = "error: unresolved reference: foo"))
     }
 
-    @Test
-    fun `reflective invocation failure surfaces as InvocationFailed`() {
-        val boom = RuntimeException("K2Native.exec threw")
-        val compiler = FakeCompiler {
-            Err(NativeCompileError.InvocationFailed(boom))
-        }
+    val result = compiler.compile(listOf("-target", "linux_x64", "A.kt"))
 
-        val err = compiler.compile(emptyList()).getError()
+    val outcome = assertNotNull(result.get())
+    assertEquals(1, outcome.exitCode)
+    assertEquals("error: unresolved reference: foo", outcome.stderr)
+  }
 
-        assertNotNull(err)
-        assertIs<NativeCompileError.InvocationFailed>(err)
-        assertEquals(boom, err.cause)
-    }
+  @Test
+  fun `reflective invocation failure surfaces as InvocationFailed`() {
+    val boom = RuntimeException("K2Native.exec threw")
+    val compiler = FakeCompiler { Err(NativeCompileError.InvocationFailed(boom)) }
 
-    private class FakeCompiler(
-        private val handler: (List<String>) -> Result<NativeCompileOutcome, NativeCompileError>,
-    ) : NativeCompiler {
-        override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> =
-            handler(args)
-    }
+    val err = compiler.compile(emptyList()).getError()
+
+    assertNotNull(err)
+    assertIs<NativeCompileError.InvocationFailed>(err)
+    assertEquals(boom, err.cause)
+  }
+
+  private class FakeCompiler(
+    private val handler: (List<String>) -> Result<NativeCompileOutcome, NativeCompileError>
+  ) : NativeCompiler {
+    override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> =
+      handler(args)
+  }
 }

--- a/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/compiler/ReflectiveK2NativeCompilerTest.kt
+++ b/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/compiler/ReflectiveK2NativeCompilerTest.kt
@@ -1,7 +1,6 @@
 package kolt.nativedaemon.compiler
 
 import com.github.michaelbull.result.getError
-import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.jar.Attributes
@@ -10,6 +9,7 @@ import java.util.jar.Manifest
 import kotlin.test.Test
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.io.TempDir
 
 // Production setup path is best validated end-to-end with a real konanc jar,
 // which is deferred to PR 6's integration test (needs KONAN_HOME / a staged
@@ -19,48 +19,48 @@ import kotlin.test.assertNotNull
 // diagnosable message.
 class ReflectiveK2NativeCompilerTest {
 
-    @Test
-    fun `create returns KonancJarNotFound when the path does not exist`(@TempDir tmp: Path) {
-        val missing = tmp.resolve("absent-konanc.jar")
+  @Test
+  fun `create returns KonancJarNotFound when the path does not exist`(@TempDir tmp: Path) {
+    val missing = tmp.resolve("absent-konanc.jar")
 
-        val err = ReflectiveK2NativeCompiler.create(missing).getError()
+    val err = ReflectiveK2NativeCompiler.create(missing).getError()
 
-        val e = assertNotNull(err)
-        assertIs<SetupError.KonancJarNotFound>(e)
+    val e = assertNotNull(err)
+    assertIs<SetupError.KonancJarNotFound>(e)
+  }
+
+  @Test
+  fun `create returns K2NativeClassNotFound when the jar lacks K2Native`(@TempDir tmp: Path) {
+    // An empty jar (valid zip with only a MANIFEST.MF) resolves into a
+    // URLClassLoader fine but has no `org.jetbrains.kotlin.cli.bc.K2Native`,
+    // so the reflective Class.forName fails. This pins the "wrong jar"
+    // diagnostic as distinct from "jar missing".
+    val emptyJar = tmp.resolve("empty.jar")
+    writeEmptyJar(emptyJar)
+
+    val err = ReflectiveK2NativeCompiler.create(emptyJar).getError()
+
+    val e = assertNotNull(err)
+    assertIs<SetupError.K2NativeClassNotFound>(e)
+  }
+
+  @Test
+  fun `create returns KonancJarUnreadable when the path is a directory`(@TempDir tmp: Path) {
+    // A directory passed as `--konanc-jar` is a plausible operator
+    // mistake; we reject it explicitly rather than letting URLClassLoader
+    // produce a confusing lazy failure downstream.
+    val dir = Files.createDirectory(tmp.resolve("not-a-jar-dir"))
+
+    val err = ReflectiveK2NativeCompiler.create(dir).getError()
+
+    val e = assertNotNull(err)
+    assertIs<SetupError.KonancJarUnreadable>(e)
+  }
+
+  private fun writeEmptyJar(path: Path) {
+    val manifest = Manifest().also { it.mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0" }
+    Files.newOutputStream(path).use { out ->
+      JarOutputStream(out, manifest).use { /* close writes the manifest + EOCD */ }
     }
-
-    @Test
-    fun `create returns K2NativeClassNotFound when the jar lacks K2Native`(@TempDir tmp: Path) {
-        // An empty jar (valid zip with only a MANIFEST.MF) resolves into a
-        // URLClassLoader fine but has no `org.jetbrains.kotlin.cli.bc.K2Native`,
-        // so the reflective Class.forName fails. This pins the "wrong jar"
-        // diagnostic as distinct from "jar missing".
-        val emptyJar = tmp.resolve("empty.jar")
-        writeEmptyJar(emptyJar)
-
-        val err = ReflectiveK2NativeCompiler.create(emptyJar).getError()
-
-        val e = assertNotNull(err)
-        assertIs<SetupError.K2NativeClassNotFound>(e)
-    }
-
-    @Test
-    fun `create returns KonancJarUnreadable when the path is a directory`(@TempDir tmp: Path) {
-        // A directory passed as `--konanc-jar` is a plausible operator
-        // mistake; we reject it explicitly rather than letting URLClassLoader
-        // produce a confusing lazy failure downstream.
-        val dir = Files.createDirectory(tmp.resolve("not-a-jar-dir"))
-
-        val err = ReflectiveK2NativeCompiler.create(dir).getError()
-
-        val e = assertNotNull(err)
-        assertIs<SetupError.KonancJarUnreadable>(e)
-    }
-
-    private fun writeEmptyJar(path: Path) {
-        val manifest = Manifest().also { it.mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0" }
-        Files.newOutputStream(path).use { out ->
-            JarOutputStream(out, manifest).use { /* close writes the manifest + EOCD */ }
-        }
-    }
+  }
 }

--- a/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/protocol/FrameCodecTest.kt
+++ b/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/protocol/FrameCodecTest.kt
@@ -13,134 +13,148 @@ import kotlin.test.assertNotNull
 
 class FrameCodecTest {
 
-    @Test
-    fun `round-trips a Ping frame`() {
-        val out = ByteArrayOutputStream()
-        FrameCodec.writeFrame(out, Message.Ping)
+  @Test
+  fun `round-trips a Ping frame`() {
+    val out = ByteArrayOutputStream()
+    FrameCodec.writeFrame(out, Message.Ping)
 
-        val decoded = FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get()
-        assertEquals(Message.Ping, decoded)
-    }
+    val decoded = FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get()
+    assertEquals(Message.Ping, decoded)
+  }
 
-    @Test
-    fun `round-trips a NativeCompile frame`() {
-        val msg: Message = Message.NativeCompile(
-            args = listOf("-target", "linux_x64", "src/Main.kt", "-p", "library", "-nopack", "-o", "build/main-klib"),
-        )
-        val out = ByteArrayOutputStream()
-        FrameCodec.writeFrame(out, msg)
+  @Test
+  fun `round-trips a NativeCompile frame`() {
+    val msg: Message =
+      Message.NativeCompile(
+        args =
+          listOf(
+            "-target",
+            "linux_x64",
+            "src/Main.kt",
+            "-p",
+            "library",
+            "-nopack",
+            "-o",
+            "build/main-klib",
+          )
+      )
+    val out = ByteArrayOutputStream()
+    FrameCodec.writeFrame(out, msg)
 
-        assertEquals(msg, FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get())
-    }
+    assertEquals(msg, FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get())
+  }
 
-    @Test
-    fun `round-trips a NativeCompileResult frame`() {
-        val msg: Message = Message.NativeCompileResult(
-            exitCode = 1,
-            stderr = "error: unresolved reference: foo",
-        )
-        val out = ByteArrayOutputStream()
-        FrameCodec.writeFrame(out, msg)
+  @Test
+  fun `round-trips a NativeCompileResult frame`() {
+    val msg: Message =
+      Message.NativeCompileResult(exitCode = 1, stderr = "error: unresolved reference: foo")
+    val out = ByteArrayOutputStream()
+    FrameCodec.writeFrame(out, msg)
 
-        assertEquals(msg, FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get())
-    }
+    assertEquals(msg, FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).get())
+  }
 
-    @Test
-    fun `reads multiple frames back to back`() {
-        val out = ByteArrayOutputStream()
-        FrameCodec.writeFrame(out, Message.Ping)
-        FrameCodec.writeFrame(out, Message.Pong)
-        FrameCodec.writeFrame(out, Message.Shutdown)
+  @Test
+  fun `reads multiple frames back to back`() {
+    val out = ByteArrayOutputStream()
+    FrameCodec.writeFrame(out, Message.Ping)
+    FrameCodec.writeFrame(out, Message.Pong)
+    FrameCodec.writeFrame(out, Message.Shutdown)
 
-        val input = ByteArrayInputStream(out.toByteArray())
-        assertEquals(Message.Ping, FrameCodec.readFrame(input).get())
-        assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
-        assertEquals(Message.Shutdown, FrameCodec.readFrame(input).get())
-    }
+    val input = ByteArrayInputStream(out.toByteArray())
+    assertEquals(Message.Ping, FrameCodec.readFrame(input).get())
+    assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
+    assertEquals(Message.Shutdown, FrameCodec.readFrame(input).get())
+  }
 
-    @Test
-    fun `empty stream returns Eof`() {
-        val err = FrameCodec.readFrame(ByteArrayInputStream(ByteArray(0))).getError()
-        assertEquals(FrameError.Eof, err)
-    }
+  @Test
+  fun `empty stream returns Eof`() {
+    val err = FrameCodec.readFrame(ByteArrayInputStream(ByteArray(0))).getError()
+    assertEquals(FrameError.Eof, err)
+  }
 
-    @Test
-    fun `truncated length prefix returns Truncated`() {
-        val err = FrameCodec.readFrame(ByteArrayInputStream(byteArrayOf(0, 0))).getError()
-        assertNotNull(err)
-        assertIs<FrameError.Truncated>(err)
-    }
+  @Test
+  fun `truncated length prefix returns Truncated`() {
+    val err = FrameCodec.readFrame(ByteArrayInputStream(byteArrayOf(0, 0))).getError()
+    assertNotNull(err)
+    assertIs<FrameError.Truncated>(err)
+  }
 
-    @Test
-    fun `truncated body returns Truncated`() {
-        val out = ByteArrayOutputStream()
-        FrameCodec.writeFrame(out, Message.Ping)
-        val full = out.toByteArray()
-        val cut = full.copyOf(full.size - 2)
+  @Test
+  fun `truncated body returns Truncated`() {
+    val out = ByteArrayOutputStream()
+    FrameCodec.writeFrame(out, Message.Ping)
+    val full = out.toByteArray()
+    val cut = full.copyOf(full.size - 2)
 
-        val err = FrameCodec.readFrame(ByteArrayInputStream(cut)).getError()
-        assertNotNull(err)
-        assertIs<FrameError.Truncated>(err)
-    }
+    val err = FrameCodec.readFrame(ByteArrayInputStream(cut)).getError()
+    assertNotNull(err)
+    assertIs<FrameError.Truncated>(err)
+  }
 
-    @Test
-    fun `malformed JSON body returns Malformed`() {
-        val body = "not json".toByteArray(Charsets.UTF_8)
-        val out = ByteArrayOutputStream()
-        out.write(byteArrayOf(0, 0, 0, body.size.toByte()))
-        out.write(body)
+  @Test
+  fun `malformed JSON body returns Malformed`() {
+    val body = "not json".toByteArray(Charsets.UTF_8)
+    val out = ByteArrayOutputStream()
+    out.write(byteArrayOf(0, 0, 0, body.size.toByte()))
+    out.write(body)
 
-        val err = FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).getError()
-        assertNotNull(err)
-        assertIs<FrameError.Malformed>(err)
-    }
+    val err = FrameCodec.readFrame(ByteArrayInputStream(out.toByteArray())).getError()
+    assertNotNull(err)
+    assertIs<FrameError.Malformed>(err)
+  }
 
-    @Test
-    fun `writeFrame returns Io error when the stream throws`() {
-        val failing = object : OutputStream() {
-            override fun write(b: Int) { throw IOException("broken pipe") }
+  @Test
+  fun `writeFrame returns Io error when the stream throws`() {
+    val failing =
+      object : OutputStream() {
+        override fun write(b: Int) {
+          throw IOException("broken pipe")
         }
-        val err = FrameCodec.writeFrame(failing, Message.Ping).getError()
-        assertNotNull(err)
-        assertIs<FrameError.Io>(err)
-    }
+      }
+    val err = FrameCodec.writeFrame(failing, Message.Ping).getError()
+    assertNotNull(err)
+    assertIs<FrameError.Io>(err)
+  }
 
-    @Test
-    fun `negative length returns Malformed`() {
-        val bytes = byteArrayOf(-1, -1, -1, -1)
-        val err = FrameCodec.readFrame(ByteArrayInputStream(bytes)).getError()
-        assertNotNull(err)
-        assertIs<FrameError.Malformed>(err)
-    }
+  @Test
+  fun `negative length returns Malformed`() {
+    val bytes = byteArrayOf(-1, -1, -1, -1)
+    val err = FrameCodec.readFrame(ByteArrayInputStream(bytes)).getError()
+    assertNotNull(err)
+    assertIs<FrameError.Malformed>(err)
+  }
 
-    @Test
-    fun `writeFrame returns Malformed when body exceeds MAX_BODY_BYTES`() {
-        // One arg whose JSON-encoded length alone overflows the cap. The actual
-        // body grows slightly past the arg size (type discriminator, field name,
-        // quotes), guaranteeing we cross the threshold.
-        val oversized = "x".repeat(FrameCodec.MAX_BODY_BYTES + 1)
-        val msg: Message = Message.NativeCompile(args = listOf(oversized))
+  @Test
+  fun `writeFrame returns Malformed when body exceeds MAX_BODY_BYTES`() {
+    // One arg whose JSON-encoded length alone overflows the cap. The actual
+    // body grows slightly past the arg size (type discriminator, field name,
+    // quotes), guaranteeing we cross the threshold.
+    val oversized = "x".repeat(FrameCodec.MAX_BODY_BYTES + 1)
+    val msg: Message = Message.NativeCompile(args = listOf(oversized))
 
-        val err = FrameCodec.writeFrame(ByteArrayOutputStream(), msg).getError()
-        assertNotNull(err)
-        assertIs<FrameError.Malformed>(err)
-    }
+    val err = FrameCodec.writeFrame(ByteArrayOutputStream(), msg).getError()
+    assertNotNull(err)
+    assertIs<FrameError.Malformed>(err)
+  }
 
-    @Test
-    fun `reads a NativeCompile NativeCompileResult pair back to back`() {
-        val request: Message = Message.NativeCompile(
-            args = listOf("-target", "linux_x64", "src/Main.kt", "-p", "library", "-nopack"),
-        )
-        val response: Message = Message.NativeCompileResult(
-            exitCode = 0,
-            stderr = "warning: deprecated API usage at src/Main.kt:3",
-        )
-        val out = ByteArrayOutputStream()
-        FrameCodec.writeFrame(out, request)
-        FrameCodec.writeFrame(out, response)
+  @Test
+  fun `reads a NativeCompile NativeCompileResult pair back to back`() {
+    val request: Message =
+      Message.NativeCompile(
+        args = listOf("-target", "linux_x64", "src/Main.kt", "-p", "library", "-nopack")
+      )
+    val response: Message =
+      Message.NativeCompileResult(
+        exitCode = 0,
+        stderr = "warning: deprecated API usage at src/Main.kt:3",
+      )
+    val out = ByteArrayOutputStream()
+    FrameCodec.writeFrame(out, request)
+    FrameCodec.writeFrame(out, response)
 
-        val input = ByteArrayInputStream(out.toByteArray())
-        assertEquals(request, FrameCodec.readFrame(input).get())
-        assertEquals(response, FrameCodec.readFrame(input).get())
-    }
+    val input = ByteArrayInputStream(out.toByteArray())
+    assertEquals(request, FrameCodec.readFrame(input).get())
+    assertEquals(response, FrameCodec.readFrame(input).get())
+  }
 }

--- a/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/protocol/MessageTest.kt
+++ b/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/protocol/MessageTest.kt
@@ -1,83 +1,90 @@
 package kolt.nativedaemon.protocol
 
-import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
 
 class MessageTest {
 
-    private val json = Json { classDiscriminator = "type" }
+  private val json = Json { classDiscriminator = "type" }
 
-    @Test
-    fun `NativeCompile carries a flat args list`() {
-        val msg: Message = Message.NativeCompile(
-            args = listOf("-target", "linux_x64", "src/Main.kt", "-p", "library", "-nopack", "-o", "build/main-klib"),
-        )
+  @Test
+  fun `NativeCompile carries a flat args list`() {
+    val msg: Message =
+      Message.NativeCompile(
+        args =
+          listOf(
+            "-target",
+            "linux_x64",
+            "src/Main.kt",
+            "-p",
+            "library",
+            "-nopack",
+            "-o",
+            "build/main-klib",
+          )
+      )
 
-        val encoded = json.encodeToString(Message.serializer(), msg)
-        val decoded = json.decodeFromString(Message.serializer(), encoded)
+    val encoded = json.encodeToString(Message.serializer(), msg)
+    val decoded = json.decodeFromString(Message.serializer(), encoded)
 
-        assertEquals(msg, decoded)
+    assertEquals(msg, decoded)
+  }
+
+  @Test
+  fun `NativeCompile serializes with type discriminator NativeCompile`() {
+    val msg: Message = Message.NativeCompile(args = listOf("-target", "linux_x64"))
+
+    val encoded = json.encodeToString(Message.serializer(), msg)
+
+    assertTrue(
+      encoded.contains("\"type\":\"NativeCompile\""),
+      "expected type discriminator, got: $encoded",
+    )
+  }
+
+  @Test
+  fun `NativeCompileResult round-trips with exitCode and stderr`() {
+    val msg: Message =
+      Message.NativeCompileResult(exitCode = 0, stderr = "warning: deprecated API usage")
+
+    val encoded = json.encodeToString(Message.serializer(), msg)
+    val decoded = json.decodeFromString(Message.serializer(), encoded)
+
+    assertEquals(msg, decoded)
+  }
+
+  @Test
+  fun `NativeCompileResult with non-zero exit code preserves stderr blob`() {
+    val msg: Message =
+      Message.NativeCompileResult(
+        exitCode = 1,
+        stderr = "error: unresolved reference: foo\n    at src/Main.kt:3",
+      )
+
+    val decoded =
+      json.decodeFromString(Message.serializer(), json.encodeToString(Message.serializer(), msg))
+
+    assertEquals(msg, decoded)
+  }
+
+  @Test
+  fun `control messages Ping Pong Shutdown round-trip`() {
+    for (msg in listOf<Message>(Message.Ping, Message.Pong, Message.Shutdown)) {
+      val decoded =
+        json.decodeFromString(Message.serializer(), json.encodeToString(Message.serializer(), msg))
+      assertEquals(msg, decoded)
     }
+  }
 
-    @Test
-    fun `NativeCompile serializes with type discriminator NativeCompile`() {
-        val msg: Message = Message.NativeCompile(args = listOf("-target", "linux_x64"))
+  @Test
+  fun `NativeCompile accepts empty args list`() {
+    val msg: Message = Message.NativeCompile(args = emptyList())
 
-        val encoded = json.encodeToString(Message.serializer(), msg)
+    val decoded =
+      json.decodeFromString(Message.serializer(), json.encodeToString(Message.serializer(), msg))
 
-        assertTrue(encoded.contains("\"type\":\"NativeCompile\""), "expected type discriminator, got: $encoded")
-    }
-
-    @Test
-    fun `NativeCompileResult round-trips with exitCode and stderr`() {
-        val msg: Message = Message.NativeCompileResult(
-            exitCode = 0,
-            stderr = "warning: deprecated API usage",
-        )
-
-        val encoded = json.encodeToString(Message.serializer(), msg)
-        val decoded = json.decodeFromString(Message.serializer(), encoded)
-
-        assertEquals(msg, decoded)
-    }
-
-    @Test
-    fun `NativeCompileResult with non-zero exit code preserves stderr blob`() {
-        val msg: Message = Message.NativeCompileResult(
-            exitCode = 1,
-            stderr = "error: unresolved reference: foo\n    at src/Main.kt:3",
-        )
-
-        val decoded = json.decodeFromString(
-            Message.serializer(),
-            json.encodeToString(Message.serializer(), msg),
-        )
-
-        assertEquals(msg, decoded)
-    }
-
-    @Test
-    fun `control messages Ping Pong Shutdown round-trip`() {
-        for (msg in listOf<Message>(Message.Ping, Message.Pong, Message.Shutdown)) {
-            val decoded = json.decodeFromString(
-                Message.serializer(),
-                json.encodeToString(Message.serializer(), msg),
-            )
-            assertEquals(msg, decoded)
-        }
-    }
-
-    @Test
-    fun `NativeCompile accepts empty args list`() {
-        val msg: Message = Message.NativeCompile(args = emptyList())
-
-        val decoded = json.decodeFromString(
-            Message.serializer(),
-            json.encodeToString(Message.serializer(), msg),
-        )
-
-        assertEquals(msg, decoded)
-    }
+    assertEquals(msg, decoded)
+  }
 }

--- a/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonConfigTest.kt
+++ b/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonConfigTest.kt
@@ -9,32 +9,41 @@ import kotlin.test.assertEquals
 // stage 2 linking uses more heap per invocation.
 class DaemonConfigTest {
 
-    @Test
-    fun `defaults match ADR 0024 section 3`() {
-        val config = DaemonConfig()
+  @Test
+  fun `defaults match ADR 0024 section 3`() {
+    val config = DaemonConfig()
 
-        assertEquals(10 * 60 * 1000L, config.idleTimeoutMillis, "idle timeout: 10 minutes per ADR 0024 §3")
-        assertEquals(500, config.maxCompiles, "max compiles: 500 per ADR 0024 §3")
-        assertEquals(2L * 1024 * 1024 * 1024, config.heapWatermarkBytes, "heap watermark: 2 GB per ADR 0024 §3")
-    }
+    assertEquals(
+      10 * 60 * 1000L,
+      config.idleTimeoutMillis,
+      "idle timeout: 10 minutes per ADR 0024 §3",
+    )
+    assertEquals(500, config.maxCompiles, "max compiles: 500 per ADR 0024 §3")
+    assertEquals(
+      2L * 1024 * 1024 * 1024,
+      config.heapWatermarkBytes,
+      "heap watermark: 2 GB per ADR 0024 §3",
+    )
+  }
 
-    @Test
-    fun `companion constants expose the defaults`() {
-        assertEquals(10 * 60 * 1000L, DaemonConfig.DEFAULT_IDLE_TIMEOUT_MILLIS)
-        assertEquals(500, DaemonConfig.DEFAULT_MAX_COMPILES)
-        assertEquals(2L * 1024 * 1024 * 1024, DaemonConfig.DEFAULT_HEAP_WATERMARK_BYTES)
-    }
+  @Test
+  fun `companion constants expose the defaults`() {
+    assertEquals(10 * 60 * 1000L, DaemonConfig.DEFAULT_IDLE_TIMEOUT_MILLIS)
+    assertEquals(500, DaemonConfig.DEFAULT_MAX_COMPILES)
+    assertEquals(2L * 1024 * 1024 * 1024, DaemonConfig.DEFAULT_HEAP_WATERMARK_BYTES)
+  }
 
-    @Test
-    fun `values can be overridden for tests`() {
-        val config = DaemonConfig(
-            idleTimeoutMillis = 1_000,
-            maxCompiles = 3,
-            heapWatermarkBytes = 128L * 1024 * 1024,
-        )
+  @Test
+  fun `values can be overridden for tests`() {
+    val config =
+      DaemonConfig(
+        idleTimeoutMillis = 1_000,
+        maxCompiles = 3,
+        heapWatermarkBytes = 128L * 1024 * 1024,
+      )
 
-        assertEquals(1_000L, config.idleTimeoutMillis)
-        assertEquals(3, config.maxCompiles)
-        assertEquals(128L * 1024 * 1024, config.heapWatermarkBytes)
-    }
+    assertEquals(1_000L, config.idleTimeoutMillis)
+    assertEquals(3, config.maxCompiles)
+    assertEquals(128L * 1024 * 1024, config.heapWatermarkBytes)
+  }
 }

--- a/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonLifecycleTest.kt
+++ b/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonLifecycleTest.kt
@@ -3,125 +3,133 @@ package kolt.nativedaemon.server
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
-import kolt.nativedaemon.compiler.NativeCompileError
-import kolt.nativedaemon.compiler.NativeCompileOutcome
-import kolt.nativedaemon.compiler.NativeCompiler
-import kolt.nativedaemon.protocol.FrameCodec
-import kolt.nativedaemon.protocol.Message
 import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
 import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
+import kolt.nativedaemon.compiler.NativeCompileError
+import kolt.nativedaemon.compiler.NativeCompileOutcome
+import kolt.nativedaemon.compiler.NativeCompiler
+import kolt.nativedaemon.protocol.FrameCodec
+import kolt.nativedaemon.protocol.Message
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 
 class DaemonLifecycleTest {
 
-    private lateinit var socketDir: Path
-    private lateinit var socketPath: Path
-    private lateinit var serverThread: Thread
-    private lateinit var server: DaemonServer
+  private lateinit var socketDir: Path
+  private lateinit var socketPath: Path
+  private lateinit var serverThread: Thread
+  private lateinit var server: DaemonServer
 
-    @BeforeTest
-    fun setUp() {
-        socketDir = Files.createTempDirectory("kolt-native-compiler-daemon-lifecycle-")
-        socketPath = socketDir.resolve("native-compiler-daemon.sock")
+  @BeforeTest
+  fun setUp() {
+    socketDir = Files.createTempDirectory("kolt-native-compiler-daemon-lifecycle-")
+    socketPath = socketDir.resolve("native-compiler-daemon.sock")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    runCatching { server.stop() }
+    runCatching { serverThread.join(2_000) }
+    runCatching { Files.deleteIfExists(socketPath) }
+    runCatching { Files.deleteIfExists(socketDir) }
+  }
+
+  @Test
+  fun `server exits after serving maxCompiles compiles`() {
+    server =
+      DaemonServer(
+        socketPath = socketPath,
+        compiler = alwaysSuccess(),
+        config =
+          DaemonConfig(
+            idleTimeoutMillis = 60_000,
+            maxCompiles = 2,
+            heapWatermarkBytes = Long.MAX_VALUE,
+          ),
+      )
+    serverThread =
+      Thread({ server.serve() }, "native-daemon-lifecycle").apply {
+        isDaemon = true
+        start()
+      }
+    waitForSocket()
+
+    SocketChannel.open(StandardProtocolFamily.UNIX).use { ch ->
+      ch.connect(UnixDomainSocketAddress.of(socketPath))
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      repeat(2) {
+        FrameCodec.writeFrame(output, Message.NativeCompile(args = listOf("-target", "linux_x64")))
+        FrameCodec.readFrame(input)
+      }
     }
 
-    @AfterTest
-    fun tearDown() {
-        runCatching { server.stop() }
-        runCatching { serverThread.join(2_000) }
-        runCatching { Files.deleteIfExists(socketPath) }
-        runCatching { Files.deleteIfExists(socketDir) }
+    serverThread.join(2_000)
+    assertFalse(serverThread.isAlive, "server should have exited after maxCompiles")
+  }
+
+  @Test
+  fun `idle timeout stops server when no connection arrives`() {
+    server =
+      DaemonServer(
+        socketPath = socketPath,
+        compiler = alwaysSuccess(),
+        config =
+          DaemonConfig(
+            idleTimeoutMillis = 1_000,
+            maxCompiles = Int.MAX_VALUE,
+            heapWatermarkBytes = Long.MAX_VALUE,
+          ),
+      )
+    serverThread =
+      Thread({ server.serve() }, "native-daemon-idle").apply {
+        isDaemon = true
+        start()
+      }
+    waitForSocket()
+
+    serverThread.join(5_000)
+    assertFalse(serverThread.isAlive, "server should have exited after idle timeout")
+  }
+
+  @Test
+  fun `serve returns BindFailed when the parent directory cannot be created`() {
+    // `/dev/null/...` cannot be a directory — `Files.createDirectories`
+    // fails here, which is the first bind-side failure mode the native
+    // client needs to distinguish from a genuine connect-refused race.
+    val impossible =
+      Path.of("/dev/null/kolt-native-compiler-daemon-impossible/native-compiler-daemon.sock")
+    server = DaemonServer(socketPath = impossible, compiler = alwaysSuccess())
+    serverThread =
+      Thread({}, "noop").apply {
+        start()
+        join()
+      }
+
+    val result = server.serve()
+    val err = result.getError()
+    assertNotNull(err)
+    assertIs<DaemonError.BindFailed>(err)
+  }
+
+  private fun alwaysSuccess(): NativeCompiler =
+    object : NativeCompiler {
+      override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> =
+        Ok(NativeCompileOutcome(exitCode = 0, stderr = ""))
     }
 
-    @Test
-    fun `server exits after serving maxCompiles compiles`() {
-        server = DaemonServer(
-            socketPath = socketPath,
-            compiler = alwaysSuccess(),
-            config = DaemonConfig(
-                idleTimeoutMillis = 60_000,
-                maxCompiles = 2,
-                heapWatermarkBytes = Long.MAX_VALUE,
-            ),
-        )
-        serverThread = Thread({ server.serve() }, "native-daemon-lifecycle").apply {
-            isDaemon = true
-            start()
-        }
-        waitForSocket()
-
-        SocketChannel.open(StandardProtocolFamily.UNIX).use { ch ->
-            ch.connect(UnixDomainSocketAddress.of(socketPath))
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            repeat(2) {
-                FrameCodec.writeFrame(output, Message.NativeCompile(args = listOf("-target", "linux_x64")))
-                FrameCodec.readFrame(input)
-            }
-        }
-
-        serverThread.join(2_000)
-        assertFalse(serverThread.isAlive, "server should have exited after maxCompiles")
+  private fun waitForSocket() {
+    val deadline = System.currentTimeMillis() + 2_000
+    while (!Files.exists(socketPath) && System.currentTimeMillis() < deadline) {
+      Thread.sleep(10)
     }
-
-    @Test
-    fun `idle timeout stops server when no connection arrives`() {
-        server = DaemonServer(
-            socketPath = socketPath,
-            compiler = alwaysSuccess(),
-            config = DaemonConfig(
-                idleTimeoutMillis = 1_000,
-                maxCompiles = Int.MAX_VALUE,
-                heapWatermarkBytes = Long.MAX_VALUE,
-            ),
-        )
-        serverThread = Thread({ server.serve() }, "native-daemon-idle").apply {
-            isDaemon = true
-            start()
-        }
-        waitForSocket()
-
-        serverThread.join(5_000)
-        assertFalse(serverThread.isAlive, "server should have exited after idle timeout")
-    }
-
-    @Test
-    fun `serve returns BindFailed when the parent directory cannot be created`() {
-        // `/dev/null/...` cannot be a directory — `Files.createDirectories`
-        // fails here, which is the first bind-side failure mode the native
-        // client needs to distinguish from a genuine connect-refused race.
-        val impossible = Path.of("/dev/null/kolt-native-compiler-daemon-impossible/native-compiler-daemon.sock")
-        server = DaemonServer(
-            socketPath = impossible,
-            compiler = alwaysSuccess(),
-        )
-        serverThread = Thread({}, "noop").apply { start(); join() }
-
-        val result = server.serve()
-        val err = result.getError()
-        assertNotNull(err)
-        assertIs<DaemonError.BindFailed>(err)
-    }
-
-    private fun alwaysSuccess(): NativeCompiler = object : NativeCompiler {
-        override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> =
-            Ok(NativeCompileOutcome(exitCode = 0, stderr = ""))
-    }
-
-    private fun waitForSocket() {
-        val deadline = System.currentTimeMillis() + 2_000
-        while (!Files.exists(socketPath) && System.currentTimeMillis() < deadline) {
-            Thread.sleep(10)
-        }
-    }
+  }
 }

--- a/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonServerTest.kt
+++ b/kolt-native-compiler-daemon/src/test/kotlin/kolt/nativedaemon/server/DaemonServerTest.kt
@@ -4,195 +4,210 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
-import kolt.nativedaemon.compiler.NativeCompileError
-import kolt.nativedaemon.compiler.NativeCompileOutcome
-import kolt.nativedaemon.compiler.NativeCompiler
-import kolt.nativedaemon.protocol.FrameCodec
-import kolt.nativedaemon.protocol.Message
 import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
 import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
+import kolt.nativedaemon.compiler.NativeCompileError
+import kolt.nativedaemon.compiler.NativeCompileOutcome
+import kolt.nativedaemon.compiler.NativeCompiler
+import kolt.nativedaemon.protocol.FrameCodec
+import kolt.nativedaemon.protocol.Message
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class DaemonServerTest {
 
-    private lateinit var socketDir: Path
-    private lateinit var socketPath: Path
-    private lateinit var server: DaemonServer
-    private lateinit var serverThread: Thread
+  private lateinit var socketDir: Path
+  private lateinit var socketPath: Path
+  private lateinit var server: DaemonServer
+  private lateinit var serverThread: Thread
 
-    @BeforeTest
-    fun setUp() {
-        socketDir = Files.createTempDirectory("kolt-native-compiler-daemon-server-")
-        socketPath = socketDir.resolve("native-compiler-daemon.sock")
+  @BeforeTest
+  fun setUp() {
+    socketDir = Files.createTempDirectory("kolt-native-compiler-daemon-server-")
+    socketPath = socketDir.resolve("native-compiler-daemon.sock")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    runCatching { server.stop() }
+    runCatching { serverThread.join(2_000) }
+    runCatching { Files.deleteIfExists(socketPath) }
+    runCatching { Files.deleteIfExists(socketDir) }
+  }
+
+  private fun startServer(compiler: NativeCompiler) {
+    server = DaemonServer(socketPath = socketPath, compiler = compiler)
+    serverThread =
+      Thread({ server.serve() }, "native-daemon-server-test").apply {
+        isDaemon = true
+        start()
+      }
+    val deadline = System.currentTimeMillis() + 2_000
+    while (!Files.exists(socketPath) && System.currentTimeMillis() < deadline) {
+      Thread.sleep(10)
+    }
+  }
+
+  private fun connect(): SocketChannel =
+    SocketChannel.open(StandardProtocolFamily.UNIX).also {
+      it.connect(UnixDomainSocketAddress.of(socketPath))
     }
 
-    @AfterTest
-    fun tearDown() {
-        runCatching { server.stop() }
-        runCatching { serverThread.join(2_000) }
-        runCatching { Files.deleteIfExists(socketPath) }
-        runCatching { Files.deleteIfExists(socketDir) }
+  @Test
+  fun `responds to Ping with Pong`() {
+    startServer(FakeCompiler())
+    connect().use { ch ->
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      FrameCodec.writeFrame(output, Message.Ping)
+      assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
     }
+  }
 
-    private fun startServer(compiler: NativeCompiler) {
-        server = DaemonServer(socketPath = socketPath, compiler = compiler)
-        serverThread = Thread({ server.serve() }, "native-daemon-server-test").apply {
-            isDaemon = true
-            start()
-        }
-        val deadline = System.currentTimeMillis() + 2_000
-        while (!Files.exists(socketPath) && System.currentTimeMillis() < deadline) {
-            Thread.sleep(10)
-        }
+  @Test
+  fun `delegates NativeCompile to the compiler and returns NativeCompileResult`() {
+    val observedArgs = mutableListOf<List<String>>()
+    val compiler = FakeCompiler { args ->
+      observedArgs += args
+      Ok(NativeCompileOutcome(exitCode = 0, stderr = ""))
     }
+    startServer(compiler)
 
-    private fun connect(): SocketChannel =
-        SocketChannel.open(StandardProtocolFamily.UNIX).also {
-            it.connect(UnixDomainSocketAddress.of(socketPath))
-        }
-
-    @Test
-    fun `responds to Ping with Pong`() {
-        startServer(FakeCompiler())
-        connect().use { ch ->
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            FrameCodec.writeFrame(output, Message.Ping)
-            assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
-        }
+    connect().use { ch ->
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      val argv =
+        listOf(
+          "-target",
+          "linux_x64",
+          "src/Main.kt",
+          "-p",
+          "library",
+          "-nopack",
+          "-o",
+          "build/m-klib",
+        )
+      FrameCodec.writeFrame(output, Message.NativeCompile(args = argv))
+      val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
+      assertEquals(0, response.exitCode)
+      assertEquals("", response.stderr)
+      assertEquals(argv, observedArgs.single())
     }
+  }
 
-    @Test
-    fun `delegates NativeCompile to the compiler and returns NativeCompileResult`() {
-        val observedArgs = mutableListOf<List<String>>()
-        val compiler = FakeCompiler { args ->
-            observedArgs += args
-            Ok(NativeCompileOutcome(exitCode = 0, stderr = ""))
-        }
-        startServer(compiler)
-
-        connect().use { ch ->
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            val argv = listOf("-target", "linux_x64", "src/Main.kt", "-p", "library", "-nopack", "-o", "build/m-klib")
-            FrameCodec.writeFrame(output, Message.NativeCompile(args = argv))
-            val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
-            assertEquals(0, response.exitCode)
-            assertEquals("", response.stderr)
-            assertEquals(argv, observedArgs.single())
-        }
+  @Test
+  fun `non-zero exit code from compiler passes through to client`() {
+    val compiler = FakeCompiler {
+      Ok(NativeCompileOutcome(exitCode = 1, stderr = "error: unresolved reference: foo"))
     }
+    startServer(compiler)
 
-    @Test
-    fun `non-zero exit code from compiler passes through to client`() {
-        val compiler = FakeCompiler {
-            Ok(NativeCompileOutcome(exitCode = 1, stderr = "error: unresolved reference: foo"))
-        }
-        startServer(compiler)
-
-        connect().use { ch ->
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            FrameCodec.writeFrame(output, Message.NativeCompile(args = listOf("-target", "linux_x64", "Bad.kt")))
-            val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
-            assertEquals(1, response.exitCode)
-            assertTrue(response.stderr.contains("unresolved reference"))
-        }
+    connect().use { ch ->
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      FrameCodec.writeFrame(
+        output,
+        Message.NativeCompile(args = listOf("-target", "linux_x64", "Bad.kt")),
+      )
+      val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
+      assertEquals(1, response.exitCode)
+      assertTrue(response.stderr.contains("unresolved reference"))
     }
+  }
 
-    @Test
-    fun `InvocationFailed from the compiler becomes exitCode 2 with stderr`() {
-        val compiler = FakeCompiler {
-            Err(NativeCompileError.InvocationFailed(RuntimeException("K2Native.exec threw: classloader broken")))
-        }
-        startServer(compiler)
-
-        connect().use { ch ->
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            FrameCodec.writeFrame(output, Message.NativeCompile(args = listOf("-target", "linux_x64")))
-            val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
-            assertEquals(2, response.exitCode)
-            // LOAD-BEARING prefix — mirrored in the native client's
-            // `NativeDaemonBackend.isDaemonSideFailure` (and its mock-reply
-            // test in src/nativeTest/.../NativeDaemonBackendTest.kt). Rename
-            // without updating the client side turns reflective-invocation
-            // failures into silently-routed konanc errors and loses fallback.
-            assertTrue(
-                response.stderr.startsWith(INVOCATION_FAILED_PREFIX),
-                "expected stderr to start with '$INVOCATION_FAILED_PREFIX', got: ${response.stderr}",
-            )
-            assertTrue(response.stderr.contains("K2Native.exec threw"))
-        }
+  @Test
+  fun `InvocationFailed from the compiler becomes exitCode 2 with stderr`() {
+    val compiler = FakeCompiler {
+      Err(
+        NativeCompileError.InvocationFailed(
+          RuntimeException("K2Native.exec threw: classloader broken")
+        )
+      )
     }
+    startServer(compiler)
 
-    @Test
-    fun `handles multiple frames on the same connection`() {
-        startServer(FakeCompiler())
-        connect().use { ch ->
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            repeat(3) {
-                FrameCodec.writeFrame(output, Message.Ping)
-                assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
-            }
-        }
+    connect().use { ch ->
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      FrameCodec.writeFrame(output, Message.NativeCompile(args = listOf("-target", "linux_x64")))
+      val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
+      assertEquals(2, response.exitCode)
+      // LOAD-BEARING prefix — mirrored in the native client's
+      // `NativeDaemonBackend.isDaemonSideFailure` (and its mock-reply
+      // test in src/nativeTest/.../NativeDaemonBackendTest.kt). Rename
+      // without updating the client side turns reflective-invocation
+      // failures into silently-routed konanc errors and loses fallback.
+      assertTrue(
+        response.stderr.startsWith(INVOCATION_FAILED_PREFIX),
+        "expected stderr to start with '$INVOCATION_FAILED_PREFIX', got: ${response.stderr}",
+      )
+      assertTrue(response.stderr.contains("K2Native.exec threw"))
     }
+  }
 
-    @Test
-    fun `Shutdown message stops the server and cleans up the socket file`() {
-        startServer(FakeCompiler())
-        connect().use { ch ->
-            FrameCodec.writeFrame(Channels.newOutputStream(ch), Message.Shutdown)
-        }
-        serverThread.join(2_000)
-        assertEquals(false, serverThread.isAlive, "server thread should have exited")
-        assertEquals(false, Files.exists(socketPath), "socket file should have been removed on exit")
+  @Test
+  fun `handles multiple frames on the same connection`() {
+    startServer(FakeCompiler())
+    connect().use { ch ->
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      repeat(3) {
+        FrameCodec.writeFrame(output, Message.Ping)
+        assertEquals(Message.Pong, FrameCodec.readFrame(input).get())
+      }
     }
+  }
 
-    @Test
-    fun `rejects server-only messages with a protocol error reply`() {
-        startServer(FakeCompiler())
-        connect().use { ch ->
-            val input = Channels.newInputStream(ch)
-            val output = Channels.newOutputStream(ch)
-            FrameCodec.writeFrame(output, Message.Pong)
-            val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
-            assertEquals(2, response.exitCode)
-            // LOAD-BEARING prefix — paired with the client side same as the
-            // InvocationFailed test above. See the comment there.
-            assertTrue(
-                response.stderr.startsWith(PROTOCOL_ERROR_PREFIX),
-                "expected stderr to start with '$PROTOCOL_ERROR_PREFIX', got: ${response.stderr}",
-            )
-        }
-    }
+  @Test
+  fun `Shutdown message stops the server and cleans up the socket file`() {
+    startServer(FakeCompiler())
+    connect().use { ch -> FrameCodec.writeFrame(Channels.newOutputStream(ch), Message.Shutdown) }
+    serverThread.join(2_000)
+    assertEquals(false, serverThread.isAlive, "server thread should have exited")
+    assertEquals(false, Files.exists(socketPath), "socket file should have been removed on exit")
+  }
 
-    companion object {
-        // These must match the prefixes the client matches on in
-        // `kolt.build.nativedaemon.NativeDaemonBackend.isDaemonSideFailure`.
-        // Hardcoding the literals on both sides is the contract; the two
-        // sibling tests (here + client-side NativeDaemonBackendTest mock
-        // replies) catch a drift on whichever side renames first.
-        private const val PROTOCOL_ERROR_PREFIX = "protocol error: "
-        private const val INVOCATION_FAILED_PREFIX = "native compiler invocation failed: "
+  @Test
+  fun `rejects server-only messages with a protocol error reply`() {
+    startServer(FakeCompiler())
+    connect().use { ch ->
+      val input = Channels.newInputStream(ch)
+      val output = Channels.newOutputStream(ch)
+      FrameCodec.writeFrame(output, Message.Pong)
+      val response = FrameCodec.readFrame(input).get() as Message.NativeCompileResult
+      assertEquals(2, response.exitCode)
+      // LOAD-BEARING prefix — paired with the client side same as the
+      // InvocationFailed test above. See the comment there.
+      assertTrue(
+        response.stderr.startsWith(PROTOCOL_ERROR_PREFIX),
+        "expected stderr to start with '$PROTOCOL_ERROR_PREFIX', got: ${response.stderr}",
+      )
     }
+  }
 
-    private class FakeCompiler(
-        private val handler: (List<String>) -> Result<NativeCompileOutcome, NativeCompileError> = { _ ->
-            Ok(NativeCompileOutcome(exitCode = 0, stderr = ""))
-        },
-    ) : NativeCompiler {
-        override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> =
-            handler(args)
+  companion object {
+    // These must match the prefixes the client matches on in
+    // `kolt.build.nativedaemon.NativeDaemonBackend.isDaemonSideFailure`.
+    // Hardcoding the literals on both sides is the contract; the two
+    // sibling tests (here + client-side NativeDaemonBackendTest mock
+    // replies) catch a drift on whichever side renames first.
+    private const val PROTOCOL_ERROR_PREFIX = "protocol error: "
+    private const val INVOCATION_FAILED_PREFIX = "native compiler invocation failed: "
+  }
+
+  private class FakeCompiler(
+    private val handler: (List<String>) -> Result<NativeCompileOutcome, NativeCompileError> = { _ ->
+      Ok(NativeCompileOutcome(exitCode = 0, stderr = ""))
     }
+  ) : NativeCompiler {
+    override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> =
+      handler(args)
+  }
 }

--- a/src/nativeMain/kotlin/kolt/build/SubprocessCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/SubprocessCompilerBackend.kt
@@ -26,7 +26,6 @@ class SubprocessCompilerBackend(
   }
 }
 
-// moduleName intentionally not forwarded — subprocess path never set -module-name.
 internal fun subprocessArgv(kotlincBin: String, request: CompileRequest): List<String> = buildList {
   add(kotlincBin)
   if (request.classpath.isNotEmpty()) {
@@ -35,6 +34,11 @@ internal fun subprocessArgv(kotlincBin: String, request: CompileRequest): List<S
   }
   addAll(request.sources)
   addAll(request.extraArgs)
+  // Forward moduleName so the subprocess path produces the same Kotlin module
+  // identity as the daemon path; required for `internal` access from the test
+  // source set in `testBuildCommand`.
+  add("-module-name")
+  add(request.moduleName)
   add("-d")
   add(request.outputPath)
 }

--- a/src/nativeMain/kotlin/kolt/build/TestBuilder.kt
+++ b/src/nativeMain/kotlin/kolt/build/TestBuilder.kt
@@ -29,6 +29,11 @@ fun testBuildCommand(
     add(config.build.jvmTarget)
     addAll(languageVersionArgs(config))
     addAll(pluginArgs)
+    // Match Gradle Kotlin plugin: test source set shares the main module's
+    // identity so `internal` symbols are visible across the boundary.
+    add("-module-name")
+    add(config.name)
+    add("-Xfriend-paths=$classesDir")
     add("-d")
     add(TEST_CLASSES_DIR)
   }

--- a/src/nativeTest/kotlin/kolt/build/SubprocessCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/SubprocessCompilerBackendTest.kt
@@ -70,6 +70,14 @@ class SubprocessCompilerBackendArgvTest {
   }
 
   @Test
+  fun argvForwardsModuleName() {
+    val argv = subprocessArgv("kotlinc", request(moduleName = "my-app"))
+    val idx = argv.indexOf("-module-name")
+    assertTrue(idx >= 0, "expected -module-name flag in argv but got: $argv")
+    assertEquals("my-app", argv[idx + 1])
+  }
+
+  @Test
   fun argvIncludesExtraArgs() {
     val argv =
       subprocessArgv(

--- a/src/nativeTest/kotlin/kolt/build/TestBuilderTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/TestBuilderTest.kt
@@ -19,6 +19,9 @@ class TestBuilderTest {
         "test",
         "-jvm-target",
         "17",
+        "-module-name",
+        "my-app",
+        "-Xfriend-paths=build/classes",
         "-d",
         "build/test-classes",
       ),
@@ -44,6 +47,9 @@ class TestBuilderTest {
         "test",
         "-jvm-target",
         "17",
+        "-module-name",
+        "my-app",
+        "-Xfriend-paths=build/classes",
         "-d",
         "build/test-classes",
       ),
@@ -68,6 +74,9 @@ class TestBuilderTest {
         "integration-test",
         "-jvm-target",
         "17",
+        "-module-name",
+        "my-app",
+        "-Xfriend-paths=build/classes",
         "-d",
         "build/test-classes",
       ),
@@ -87,6 +96,9 @@ class TestBuilderTest {
         "test",
         "-jvm-target",
         "21",
+        "-module-name",
+        "my-app",
+        "-Xfriend-paths=build/classes",
         "-d",
         "build/test-classes",
       ),
@@ -126,6 +138,9 @@ class TestBuilderTest {
         "-jvm-target",
         "17",
         "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
+        "-module-name",
+        "my-app",
+        "-Xfriend-paths=build/classes",
         "-d",
         "build/test-classes",
       ),
@@ -154,6 +169,9 @@ class TestBuilderTest {
         "17",
         "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
         "-Xplugin=/usr/local/kotlinc/lib/allopen-compiler-plugin.jar",
+        "-module-name",
+        "my-app",
+        "-Xfriend-paths=build/classes",
         "-d",
         "build/test-classes",
       ),
@@ -178,6 +196,9 @@ class TestBuilderTest {
         "test",
         "-jvm-target",
         "17",
+        "-module-name",
+        "my-app",
+        "-Xfriend-paths=build/classes",
         "-d",
         "build/test-classes",
       ),
@@ -204,6 +225,9 @@ class TestBuilderTest {
         "test",
         "-jvm-target",
         "17",
+        "-module-name",
+        "my-app",
+        "-Xfriend-paths=build/classes",
         "-d",
         "build/test-classes",
       ),
@@ -239,6 +263,9 @@ class TestBuilderTest {
         "test",
         "-jvm-target",
         "17",
+        "-module-name",
+        "my-app",
+        "-Xfriend-paths=build/classes",
         "-d",
         "build/test-classes",
       ),
@@ -268,6 +295,9 @@ class TestBuilderTest {
         "-jvm-target",
         "17",
         "-Xplugin=/usr/local/kotlinc/lib/kotlinx-serialization-compiler-plugin.jar",
+        "-module-name",
+        "my-app",
+        "-Xfriend-paths=build/classes",
         "-d",
         "build/test-classes",
       ),
@@ -296,6 +326,30 @@ class TestBuilderTest {
     kotlin.test.assertTrue(langIdx >= 0)
     assertEquals("2.1", cmd.args[langIdx + 1])
     assertEquals("2.1", cmd.args[apiIdx + 1])
+  }
+
+  @Test
+  fun testBuildCommandForwardsModuleNameFromConfig() {
+    val cmd = testBuildCommand(config = testConfig(name = "my-app"), classesDir = "build/classes")
+
+    val moduleNameIdx = cmd.args.indexOf("-module-name")
+    kotlin.test.assertTrue(
+      moduleNameIdx >= 0,
+      "expected -module-name flag in argv but got: ${cmd.args}",
+    )
+    assertEquals("my-app", cmd.args[moduleNameIdx + 1])
+  }
+
+  @Test
+  fun testBuildCommandForwardsXfriendPathsFromClassesDir() {
+    val cmd = testBuildCommand(config = testConfig(), classesDir = "build/classes")
+
+    val friendArg = cmd.args.firstOrNull { it.startsWith("-Xfriend-paths=") }
+    kotlin.test.assertNotNull(
+      friendArg,
+      "expected -Xfriend-paths=<classesDir> flag in argv but got: ${cmd.args}",
+    )
+    assertEquals("-Xfriend-paths=build/classes", friendArg)
   }
 
   @Test


### PR DESCRIPTION
Closes part of #315.

## Summary

Daemon JUnit 5 suites now run under `kolt test` directly. Each daemon project's `kolt.toml` declares the bundles, sysprops, and test deps it needs (via the ADR 0032 schema landed in #318), and `./gradlew check` is gone from `tech.md`. Orphan Gradle config still sits in the repo and gets removed in the follow-up #316.

Three things expanded the spec mid-flight; review knows where to look:

1. **R1.2 (filter passthrough) was deferred to #323.** Pre-flight Gate found JUnit Platform Console Launcher 1.11.4 rejects `--scan-class-path` together with explicit `--select-class`, and `testRunCommand` always injects `--scan-class-path`. The fix lives in kolt CLI, so it is split out. Until #323 lands, narrow runs use the full daemon suite from `kolt-jvm-compiler-daemon/`.
2. **R7 (CLI bug fix) was added.** kolt's JVM test compile passed neither `-module-name` nor `-Xfriend-paths` to kotlinc, so test sources lost `internal` access to main. Without it dozens of daemon test references would not compile. Fix is in `TestBuilder.kt` + `SubprocessCompilerBackend.kt` with native unit tests; `DaemonCompilerBackend` already forwarded moduleName so only the subprocess path needed change. Spec boundary updated to permit bug fixes (not new features) in kolt CLI when they unblock the spec DoD.
3. **Option B over Option A for ic.** Original gap analysis preferred a separate ic kolt project; a closer look at Gradle's classpath structure showed root daemon test already imports ic main symbols, so a merged kolt project preserves Gradle parity exactly with one fewer config file. `IcModuleBoundaryInvariantTest` re-encodes the lost Gradle module isolation as a static source scan. See `research.md` for the full inversion record.

## Where reviewer attention helps

- **`TestBuilder.kt` / `SubprocessCompilerBackend.kt` change (task 4.1).** The argv addition is small but it changes the Kotlin module identity for every JVM test compile in the project. Existing `TestBuilderTest` exact-list cases were updated to include the new flags; the new behaviour-specific tests are the going-forward source of truth. Confirm the friend-paths value is the main classes output dir (it is `classesDir`, not a source dir).
- **`IcModuleBoundaryInvariantTest` assumption-skip (task 5.4).** Under Gradle the sysprop is absent, so the test would otherwise fail on the `?: error(...)` path. Switched to `org.junit.jupiter.api.Assumptions.assumeTrue` so Gradle skips and kolt enforces. Check whether you want the invariant to be louder (e.g. fail in CI when running under kolt but stay silent under Gradle); current behaviour is silent skip.
- **Maven transitive parity (task 2.4).** `kolt deps tree` and `./gradlew :…:dependencies` were diff'd for all 4 bundles plus the JUnit family. On-disk jar set matches Gradle byte-for-byte. The display-only divergence (platform-suffixed GAVs, declared-vs-resolved versions in the tree printout) and the `apiguardian-api:1.1.2` POM-vs-module-metadata difference are documented in research.md but do not affect test classpath.
- **Gradle ic test verdict (task 5.4).** `:kolt-jvm-compiler-daemon:ic:test` cannot be invoked standalone under Gradle 9.4 (`buildToolsImpl unsafe lock` error). ic test parity is therefore observed only via `kolt test` (73 tests pass). #316 removes the Gradle config so this gap closes naturally.
- **PATH-installed `kolt` is v3-aware (Implementation Notes).** Lockfile regeneration used `build/debug/kolt.kexe` directly — anyone re-running `kolt deps install` from PATH will get a v3 lockfile downgrade. Bootstrap pinch tracked under #316.

## Test evidence

- `kolt test` (root): 1396/1396 pass
- `cd kolt-jvm-compiler-daemon && kolt test`: 139/139 pass (138 ported daemon tests + IcModuleBoundary)
- `cd kolt-native-compiler-daemon && kolt test`: 48/48 pass
- `./gradlew check --no-parallel --max-workers=1`: BUILD SUCCESSFUL (root daemon 66 pass, IcModuleBoundary skipped via Assumptions, native daemon 48 pass)

## Follow-ups

- #316: orphan Gradle config physical removal (now unblocked)
- #323: kolt CLI `--scan-class-path` + selector filter passthrough (so ic-only / `--tests <Class>` style runs work again)