### PR TITLE
Redirect deleted-Gradle-file references in test messages (#326)

### DIFF
--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalAbiCascadeTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalAbiCascadeTest.kt
@@ -196,7 +196,9 @@ class BtaIncrementalAbiCascadeTest {
   private fun systemClasspath(key: String): List<Path> {
     val raw =
       System.getProperty(key)
-        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        ?: error(
+          "$key system property not set — check kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]"
+        )
     return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
   }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
@@ -25,8 +25,8 @@ import kotlin.test.fail
 // output end-to-end, which is the structural claim ADR 0019 §3 needs before
 // B-2b layers state management on top.
 //
-// Both jar classpaths come from system properties that :ic/build.gradle.kts
-// injects into the Gradle test task from resolvable configurations:
+// Both jar classpaths come from system properties declared in
+// kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]:
 //   kolt.ic.btaImplClasspath  — kotlin-build-tools-impl:2.3.20 transitive
 //   kolt.ic.fixtureClasspath  — kotlin-stdlib:2.3.20 (compile classpath for the fixture)
 class BtaIncrementalCompilerColdPathTest {
@@ -273,7 +273,9 @@ class BtaIncrementalCompilerColdPathTest {
   private fun systemClasspath(key: String): List<Path> {
     val raw =
       System.getProperty(key)
-        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        ?: error(
+          "$key system property not set — check kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]"
+        )
     return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
   }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerWarmPathTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerWarmPathTest.kt
@@ -25,10 +25,9 @@ import kotlin.test.fail
 // This test deliberately does **not** assert a specific recompile-set
 // size. The size-based assertion (1 class file recompiled on ABI-neutral
 // edits for linear-10 / hub-10) lives in a separate integration test
-// that pulls the spike fixtures into the `:ic` test task — see task #8
-// / a later commit. Keeping this test shape-only lets it run in every
-// `./gradlew :kolt-jvm-compiler-daemon:ic:test` cycle without dragging the
-// spike fixtures into the daemon module's test classpath.
+// that pulls the spike fixtures into the test source set. Keeping this
+// test shape-only lets it run in every `kolt test` cycle without
+// dragging the spike fixtures into the daemon module's test classpath.
 class BtaIncrementalCompilerWarmPathTest {
 
   private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
@@ -240,7 +239,9 @@ class BtaIncrementalCompilerWarmPathTest {
   private fun systemClasspath(key: String): List<Path> {
     val raw =
       System.getProperty(key)
-        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        ?: error(
+          "$key system property not set — check kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]"
+        )
     return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
   }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCorruptionSmokeTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCorruptionSmokeTest.kt
@@ -128,7 +128,9 @@ class BtaIncrementalCorruptionSmokeTest {
   private fun systemClasspath(key: String): List<Path> {
     val raw =
       System.getProperty(key)
-        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        ?: error(
+          "$key system property not set — check kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]"
+        )
     return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
   }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalLockFailureTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalLockFailureTest.kt
@@ -148,7 +148,9 @@ class BtaIncrementalLockFailureTest {
   private fun systemClasspath(key: String): List<Path> {
     val raw =
       System.getProperty(key)
-        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        ?: error(
+          "$key system property not set — check kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]"
+        )
     return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
   }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalRecompileSetTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalRecompileSetTest.kt
@@ -171,7 +171,9 @@ class BtaIncrementalRecompileSetTest {
   private fun systemClasspath(key: String): List<Path> {
     val raw =
       System.getProperty(key)
-        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        ?: error(
+          "$key system property not set — check kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]"
+        )
     return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
   }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
@@ -141,8 +141,8 @@ class BtaSerializationPluginTest {
 
   @Test
   fun `serialization plugin jars resolve from the classpath system property`() {
-    // Guard the build.gradle.kts wiring: if a future edit drops the
-    // serializationPluginClasspath configuration or misroutes the
+    // Guard the kolt.toml wiring: if a future edit drops the
+    // `[classpaths.serialization_plugin]` bundle or misroutes the
     // system property, we want the failure signal here rather than
     // buried inside the compile test above.
     assertTrue(
@@ -259,7 +259,9 @@ class BtaSerializationPluginTest {
   private fun systemClasspath(key: String): List<Path> {
     val raw =
       System.getProperty(key)
-        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        ?: error(
+          "$key system property not set — check kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]"
+        )
     return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
   }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClassloaderIsolationTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClassloaderIsolationTest.kt
@@ -64,7 +64,7 @@ class ClassloaderIsolationTest {
   @OptIn(org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi::class)
   private fun buildTopology(): Pair<ClassLoader, ClassLoader> {
     require(btaImplJars.isNotEmpty()) {
-      "kolt.ic.btaImplClasspath system property is empty — check :ic/build.gradle.kts test task config"
+      "kolt.ic.btaImplClasspath system property is empty — check kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]"
     }
     val parent = org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader()
     val child =

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCacheTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCacheTest.kt
@@ -174,7 +174,9 @@ class ClasspathSnapshotCacheTest {
   private fun systemClasspath(key: String): List<Path> {
     val raw =
       System.getProperty(key)
-        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        ?: error(
+          "$key system property not set — check kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]"
+        )
     return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
   }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCostTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/ClasspathSnapshotCostTest.kt
@@ -92,7 +92,9 @@ class ClasspathSnapshotCostTest {
   private fun systemClasspath(key: String): List<Path> {
     val raw =
       System.getProperty(key)
-        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        ?: error(
+          "$key system property not set — check kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]"
+        )
     return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
   }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingBtaCompositionTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingBtaCompositionTest.kt
@@ -149,7 +149,9 @@ class SelfHealingBtaCompositionTest {
   private fun systemClasspath(key: String): List<Path> {
     val raw =
       System.getProperty(key)
-        ?: error("$key system property not set — check :ic/build.gradle.kts test task config")
+        ?: error(
+          "$key system property not set — check kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]"
+        )
     return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
   }
 }

--- a/kolt-jvm-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
+++ b/kolt-jvm-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
@@ -16,10 +16,10 @@ import kolt.daemon.server.DaemonServer
 import kotlin.system.exitProcess
 
 // Kotlin compiler version pin. ADR 0019 §1 requires this to move in
-// lockstep with the `kotlin-build-tools-impl` artifact version in
-// `kolt-jvm-compiler-daemon/ic/build.gradle.kts`. Both are updated together
-// whenever the daemon's kotlinc is bumped. This constant is read by
-// `DaemonServer` to stamp the IC state directory
+// lockstep with the `kotlin-build-tools-impl` pin under
+// `kolt-jvm-compiler-daemon/kolt.toml [classpaths.bta_impl]`. Both are
+// updated together whenever the daemon's kotlinc is bumped. This
+// constant is read by `DaemonServer` to stamp the IC state directory
 // (`~/.kolt/daemon/ic/<this>/<projectHash>/`, ADR 0019 §5) so that a
 // compiler bump invalidates the cache in one move.
 internal const val KOLT_DAEMON_KOTLIN_VERSION: String = "2.3.20"

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/AdapterBoundaryInvariantTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/AdapterBoundaryInvariantTest.kt
@@ -18,10 +18,9 @@ import kotlin.test.assertTrue
 // Issue #112 made this a human-review gate (acceptance criterion 2).
 // This test mechanises the gate so a contributor who adds a direct
 // BTA import anywhere in daemon core gets a red test instead of a
-// reviewer catching it weeks later. A non-test Gradle task would
-// also work, but putting the check in JUnit means the invariant
-// is enforced on every `./gradlew test`, shares its reporting with
-// other regressions, and is easy to run in IDE.
+// reviewer catching it weeks later. Putting the check in JUnit means
+// the invariant is enforced on every `kolt test`, shares its reporting
+// with other regressions, and is easy to run in IDE.
 class AdapterBoundaryInvariantTest {
 
   @Test
@@ -31,7 +30,7 @@ class AdapterBoundaryInvariantTest {
         System.getProperty("kolt.daemon.coreMainSourceRoot")
           ?: error(
             "kolt.daemon.coreMainSourceRoot system property not set — " +
-              "check :kolt-jvm-compiler-daemon/build.gradle.kts `tasks.test`"
+              "check kolt-jvm-compiler-daemon/kolt.toml `[test.sys_props]`"
           )
       )
     assertTrue(Files.isDirectory(sourceRoot), "expected daemon core source root at $sourceRoot")

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/IcModuleBoundaryInvariantTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/IcModuleBoundaryInvariantTest.kt
@@ -21,11 +21,9 @@ class IcModuleBoundaryInvariantTest {
 
   @Test
   fun `ic test sources do not import root daemon production packages`() {
-    // Skip when run outside kolt (e.g. cross-check via `./gradlew check` while
-    // the orphan Gradle config is still around): the Gradle test task does not
-    // declare this sysprop, and adding it would mean editing config that #316
-    // is about to delete. The kolt path always sets the sysprop via
-    // [test.sys_props.kolt.daemon.icTestSourceRoot] in kolt.toml.
+    // The sysprop is set under `kolt test` via
+    // [test.sys_props.kolt.daemon.icTestSourceRoot] in kolt.toml; skip
+    // when the sysprop is missing rather than failing.
     val sourceRootProp = System.getProperty("kolt.daemon.icTestSourceRoot")
     assumeTrue(
       sourceRootProp != null,

--- a/src/nativeTest/kotlin/kolt/cli/BuildProfileIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildProfileIT.kt
@@ -101,7 +101,7 @@ class BuildProfileIT {
   // release) using the bootstrapped kolt.kexe; assert both jars exist.
   // JVM-target rather than native because Native end-to-end requires
   // konanc + a working bootstrap toolchain in CI; JVM-target end-to-end
-  // is closer in cost to a normal `./gradlew test` run.
+  // is closer in cost to a normal `kolt test` run.
   @Test
   fun debugAndReleaseJarsCoexistAfterAlternation() {
     if (!enabled()) return
@@ -223,16 +223,12 @@ class BuildProfileIT {
 
   private fun locateKoltKexe(): String? {
     val cwd = currentWorkingDir() ?: return null
-    val candidates =
-      listOf(
-        "$cwd/build/bin/linuxX64/debugExecutable/kolt.kexe",
-        "$cwd/build/bin/linuxX64/releaseExecutable/kolt.kexe",
-      )
+    val candidates = listOf("$cwd/build/debug/kolt.kexe", "$cwd/build/release/kolt.kexe")
     val found = candidates.firstOrNull { fileExists(it) }
     if (found == null) {
       error(
         "KOLT_PROFILE_IT=1 but kolt.kexe is not built. Run " +
-          "`./gradlew linkDebugExecutableLinuxX64` first. Looked under: $candidates"
+          "`kolt build` first. Looked under: $candidates"
       )
     }
     return found
@@ -289,9 +285,7 @@ class BuildProfileIT {
     val on = getenv("KOLT_PROFILE_IT")?.toKString() == "1"
     if (!on && !skipNoticePrinted) {
       skipNoticePrinted = true
-      eprintln(
-        "BuildProfileIT: skipped (set KOLT_PROFILE_IT=1 and run linkDebugExecutableLinuxX64 to enable)"
-      )
+      eprintln("BuildProfileIT: skipped (set KOLT_PROFILE_IT=1 and run `kolt build` to enable)")
     }
     return on
   }

--- a/src/nativeTest/kotlin/kolt/cli/ConcurrentBuildIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ConcurrentBuildIT.kt
@@ -31,12 +31,11 @@ import platform.posix.mkdtemp
  * Spawns the built `kolt.kexe` against tmp fixture projects to drive the project-local advisory
  * lock and the temp+rename atomic Downloader path end-to-end.
  *
- * The cases are gated behind `KOLT_CONCURRENT_IT=1` because the realistic scenarios depend on
- * `./gradlew linkDebugExecutableLinuxX64` having produced `build/bin/linuxX64/debugExecutable/
- * kolt.kexe` and on Maven Central being reachable for the Downloader scenario. Without the env
- * variable each case returns immediately so `./gradlew linuxX64Test` stays offline-safe and fast;
- * with the env variable the test exercises real `fork+execvp` of the binary and asserts on its exit
- * code, stderr, and the resulting filesystem state.
+ * The cases are gated behind `KOLT_CONCURRENT_IT=1` because the realistic scenarios depend on `kolt
+ * build` having produced `build/debug/kolt.kexe` and on Maven Central being reachable for the
+ * Downloader scenario. Without the env variable each case returns immediately so `kolt test` stays
+ * offline-safe and fast; with the env variable the test exercises real `fork+execvp` of the binary
+ * and asserts on its exit code, stderr, and the resulting filesystem state.
  *
  * Shell harness scripts use a Kotlin-side `D = "$"` token for shell variable references so the
  * raw-string templates do not collide with Kotlin's own `$variable` interpolation.
@@ -235,24 +234,20 @@ class ConcurrentBuildIT {
     )
   }
 
-  // The IT cases need the Gradle-produced `kolt.kexe`. The Gradle test
-  // task does not depend on `linkDebugExecutableLinuxX64` by default, so
-  // we cannot assume the binary is present. When it is missing we
-  // surface a clear error rather than silently passing — the env-gate
-  // already guarded the "do not run" path; if the user opted in, the
-  // binary really should be there.
+  // The IT cases need a kolt-built `kolt.kexe`. `kolt test` does not
+  // produce the executable on its own, so we cannot assume the binary
+  // is present. When it is missing we surface a clear error rather
+  // than silently passing — the env-gate already guarded the "do not
+  // run" path; if the user opted in, the binary really should be
+  // there.
   private fun locateKoltKexe(): String? {
     val cwd = currentWorkingDir() ?: return null
-    val candidates =
-      listOf(
-        "$cwd/build/bin/linuxX64/debugExecutable/kolt.kexe",
-        "$cwd/build/bin/linuxX64/releaseExecutable/kolt.kexe",
-      )
+    val candidates = listOf("$cwd/build/debug/kolt.kexe", "$cwd/build/release/kolt.kexe")
     val found = candidates.firstOrNull { fileExists(it) }
     if (found == null) {
       error(
         "KOLT_CONCURRENT_IT=1 but kolt.kexe is not built. Run " +
-          "`./gradlew linkDebugExecutableLinuxX64` first. Looked under: $candidates"
+          "`kolt build` first. Looked under: $candidates"
       )
     }
     return found
@@ -309,7 +304,7 @@ class ConcurrentBuildIT {
   }
 
   // Without an explicit env opt-in the four scenarios early-return rather
-  // than running, so the suite ships clean to default `linuxX64Test`. Print
+  // than running, so the suite ships clean to default `kolt test`. Print
   // the skip notice once so a developer running tests without the env
   // variable does not assume "4 passed" means concurrent safety was
   // exercised.
@@ -318,7 +313,7 @@ class ConcurrentBuildIT {
     if (!on && !skipNoticePrinted) {
       skipNoticePrinted = true
       eprintln(
-        "ConcurrentBuildIT: skipped (set KOLT_CONCURRENT_IT=1 and run linkDebugExecutableLinuxX64 to enable)"
+        "ConcurrentBuildIT: skipped (set KOLT_CONCURRENT_IT=1 and run `kolt build` to enable)"
       )
     }
     return on

--- a/src/nativeTest/kotlin/kolt/cli/JvmTestSysPropIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/JvmTestSysPropIT.kt
@@ -89,22 +89,12 @@ class JvmTestSysPropIT {
   }
 
   // Mirrors ConcurrentBuildIT/BuildProfileIT: the IT case relies on the
-  // bootstrap-built `kolt.kexe`. When the env gate is on we expect the
-  // binary to be present; surface a loud error otherwise so a misconfigured
-  // run does not silently pass.
-  // kolt.kexe is sourced from `build/<profile>/kolt.kexe` first (kolt-on-kolt
-  // bootstrap output) so the IT exercises the latest sysprop wiring, falling
-  // back to Gradle's `build/bin/linuxX64/...` layout for CI environments that
-  // have not run `kolt build` (only `./gradlew linkDebugExecutableLinuxX64`).
+  // bootstrap-built `kolt.kexe` under `build/<profile>/kolt.kexe`. When
+  // the env gate is on we expect the binary to be present; surface a
+  // loud error otherwise so a misconfigured run does not silently pass.
   private fun locateKoltKexe(): String? {
     val cwd = currentWorkingDir() ?: return null
-    val candidates =
-      listOf(
-        "$cwd/build/debug/kolt.kexe",
-        "$cwd/build/release/kolt.kexe",
-        "$cwd/build/bin/linuxX64/debugExecutable/kolt.kexe",
-        "$cwd/build/bin/linuxX64/releaseExecutable/kolt.kexe",
-      )
+    val candidates = listOf("$cwd/build/debug/kolt.kexe", "$cwd/build/release/kolt.kexe")
     val found = candidates.firstOrNull { fileExists(it) }
     if (found == null) {
       error(


### PR DESCRIPTION
Follow-up to #316. 11 ic/ tests, `AdapterBoundaryInvariantTest`, `IcModuleBoundaryInvariantTest`, and the three IT tests (`ConcurrentBuildIT`, `BuildProfileIT`, `JvmTestSysPropIT`) emit failure messages that pointed developers at Gradle files that no longer exist. The same configuration now lives under `kolt.toml [test.sys_props]` / `[classpaths.bta_impl]` (#318) or runs via `kolt test`, so the messages misdirect rather than help.

Each affected message is redirected to the kolt schema section or the kolt CLI command. Comments mentioning `:ic/build.gradle.kts` / `./gradlew :ic:test` / `./gradlew test` are similarly rewritten — `kolt test` is now the only build entry point in the repo.

Scope expanded slightly: the IT tests had pre-ADR-0030 `build/bin/linuxX64/.../kolt.kexe` candidate paths sitting on the same line as the misdirecting `./gradlew linkDebugExecutableLinuxX64` hint. Rewriting only the message would leave the candidate path stale (the hinted command would never produce a binary the test could find). Updated to `build/<profile>/kolt.kexe` in lockstep so the hint and the path stay consistent.

Reviewer focus: are any of the new redirects pointing at the wrong section? In particular `[classpaths.bta_impl]` for `kotlin-build-tools-impl` and `[classpaths.serialization_plugin]` for the serialization compiler plugin — these are real bundle names declared in `kolt-jvm-compiler-daemon/kolt.toml`, not invented.