### PR TITLE
Suppress --scan-class-path when testArgs include --select-* (#323)

### DIFF
--- a/docs/dogfood.md
+++ b/docs/dogfood.md
@@ -26,4 +26,4 @@ distinguishable from external-user reports.
 
 ## 2026-05
 
-- 2026-05-01 `kolt test -- --select-class=<FQCN>` fails: JUnit Platform Console Launcher 1.11.4 rejects `--scan-class-path` together with explicit selectors (`Scanning the classpath and using explicit selectors at the same time is not supported`). `testRunCommand` always inserts `--scan-class-path`, so trailing-arg passthrough cannot be used to narrow execution to a single class or package. Surfaced during the daemon-test-via-kolt (#315) Pre-flight Gate → #323.
+- 2026-05-01 `kolt test -- --select-class=<FQCN>` fails: JUnit Platform Console Launcher 1.11.4 rejects `--scan-class-path` together with explicit selectors (`Scanning the classpath and using explicit selectors at the same time is not supported`). `testRunCommand` always inserts `--scan-class-path`, so trailing-arg passthrough cannot be used to narrow execution to a single class or package. Surfaced during the daemon-test-via-kolt (#315) Pre-flight Gate → #323 (fixed).

--- a/src/nativeMain/kotlin/kolt/build/TestRunner.kt
+++ b/src/nativeMain/kotlin/kolt/build/TestRunner.kt
@@ -20,6 +20,12 @@ fun testRunCommand(
         if (!classpath.isNullOrEmpty()) add(classpath)
       }
       .joinToString(":")
+  // JUnit Platform Console Launcher 1.11 rejects `--scan-class-path`
+  // together with any `--select-*` flag. Suppress the implicit scan so
+  // `kolt test -- --select-class=...` is honoured. `--include-*` /
+  // `--exclude-*` filters do not collide with class-path scanning, so
+  // they continue to compose with the default scan.
+  val hasExplicitSelector = testArgs.any { it.startsWith("--select-") }
   val args = buildList {
     add(javaPath ?: "java")
     for ((k, v) in sysProps) add("-D$k=$v")
@@ -27,7 +33,7 @@ fun testRunCommand(
     add(consoleLauncherPath)
     add("--class-path")
     add(cp)
-    add("--scan-class-path")
+    if (!hasExplicitSelector) add("--scan-class-path")
     addAll(testArgs)
   }
   return TestRunCommand(args = args)

--- a/src/nativeTest/kotlin/kolt/build/TestRunnerTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/TestRunnerTest.kt
@@ -254,4 +254,55 @@ class TestRunnerTest {
       cmd.args,
     )
   }
+
+  // JUnit Platform Console Launcher 1.11 rejects `--scan-class-path` together
+  // with `--select-class=` / `--select-package=` etc. Suppress the implicit
+  // scan when the caller passes any explicit `--select-*` selector, so
+  // `kolt test -- --select-class=foo.bar.AlphaTest` actually runs the
+  // single class instead of failing argv parsing.
+  @Test
+  fun testRunCommandSuppressesScanClassPathWhenSelectClassPresent() {
+    val cmd =
+      testRunCommand(
+        classesDir = "build/classes",
+        testClassesDir = "build/test-classes",
+        consoleLauncherPath = "/tools/launcher.jar",
+        testArgs = listOf("--select-class=foo.bar.AlphaTest"),
+      )
+
+    assertEquals(
+      listOf(
+        "java",
+        "-jar",
+        "/tools/launcher.jar",
+        "--class-path",
+        "build/classes:build/test-classes",
+        "--select-class=foo.bar.AlphaTest",
+      ),
+      cmd.args,
+    )
+  }
+
+  @Test
+  fun testRunCommandSuppressesScanClassPathWhenSelectPackagePresent() {
+    val cmd =
+      testRunCommand(
+        classesDir = "build/classes",
+        testClassesDir = "build/test-classes",
+        consoleLauncherPath = "/tools/launcher.jar",
+        testArgs = listOf("--select-package=foo.bar"),
+      )
+
+    assertEquals(
+      listOf(
+        "java",
+        "-jar",
+        "/tools/launcher.jar",
+        "--class-path",
+        "build/classes:build/test-classes",
+        "--select-package=foo.bar",
+      ),
+      cmd.args,
+    )
+  }
 }


### PR DESCRIPTION
JUnit Platform Console Launcher 1.11 rejects `--scan-class-path` together with any `--select-*` flag, so `kolt test -- --select-class=foo.bar.AlphaTest` was failing argv parsing instead of running the requested class. Surfaced during the #315 Pre-flight Gate; #324 deferred R1.2 / R5.3 on this issue.

`testRunCommand` now drops the unconditional `--scan-class-path` when any `testArg` starts with `--select-`. `--include-*` / `--exclude-*` filters do not collide with class-path scanning and continue to compose with the default scan.

Reviewer focus: prefix-only detection (`startsWith("--select-")`) is intentionally narrower than the issue's "et cetera" wording. JUnit's reject list is exactly the `--select-*` family; expanding to `--include-*` / `--exclude-*` would break the common `kolt test -- --include-classname=.*Test` filter usage. The two existing testArgs unit tests (`testRunCommandWithTestArgs`, `testRunCommandWithIncludeClassname` — uses `--include-classname`) continue to expect `--scan-class-path` so they pin that the suppression is selector-only.