### PR TITLE
Thread [run.sys_props] through kolt run --watch (#322)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -113,6 +113,32 @@ internal fun jvmRunArgv(
     .args
 }
 
+// `kolt run --watch` shares the JVM-app argv shape with one-shot `kolt
+// run`. Lifted to a helper so `[run.sys_props]` resolution stays on a
+// single path through `jvmRunArgv` instead of WatchLoop drifting on its
+// own `runCommand(...)` call. Native targets keep going through
+// `nativeRunCommand` upstream of this helper — the `[run.sys_props]`
+// gate at config-validation time forbids the section on native targets,
+// so a watch-mode native run has nothing to thread.
+internal fun runJvmCommandFor(
+  buildResult: BuildResult,
+  projectRoot: String,
+  appArgs: List<String>,
+  profile: Profile,
+): RunCommand =
+  RunCommand(
+    args =
+      jvmRunArgv(
+        config = buildResult.config,
+        projectRoot = projectRoot,
+        bundleClasspaths = buildResult.bundleClasspaths,
+        classpath = buildResult.classpath,
+        appArgs = appArgs,
+        javaPath = buildResult.javaPath,
+        profile = profile,
+      )
+  )
+
 // ADR 0027 §4 kind/target matrix: JVM `kind = "app"` emits
 // `build/<name>-runtime.classpath`; every other combination (JVM lib,
 // native app, native lib) must not. A residual manifest from a previous

--- a/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
+++ b/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
@@ -5,7 +5,6 @@ import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
 import kolt.build.Profile
 import kolt.build.nativeRunCommand
-import kolt.build.runCommand
 import kolt.config.KoltConfig
 import kolt.config.NATIVE_TARGETS
 import kolt.infra.*
@@ -306,28 +305,17 @@ internal fun watchRunLoop(
         continue
       }
 
+    val projectRoot =
+      currentWorkingDirectory()
+        ?: run {
+          eprintln("error: could not determine current working directory")
+          break
+        }
     val runCmd =
       if (buildResult.config.build.target in NATIVE_TARGETS) {
         nativeRunCommand(buildResult.config, appArgs, profile)
       } else {
-        // Parser invariant `kind == "app" ⇒ main != null` guarantees
-        // non-null; the lib kind gate at loop entry pre-empts libraries,
-        // so this `?: run` is ADR 0001 safety for the parser invariant
-        // and is unreachable on apps at runtime.
-        val jvmMain =
-          buildResult.config.build.main
-            ?: run {
-              eprintln("error: [build] main is required to run")
-              break
-            }
-        runCommand(
-          buildResult.config,
-          main = jvmMain,
-          classpath = buildResult.classpath,
-          appArgs = appArgs,
-          javaPath = buildResult.javaPath,
-          profile = profile,
-        )
+        runJvmCommandFor(buildResult, projectRoot, appArgs, profile)
       }
     val childPid = spawnInProcessGroup(runCmd.args)
     if (childPid < 0) {

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsSysPropTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsSysPropTest.kt
@@ -306,4 +306,55 @@ class BuildCommandsSysPropTest {
       "test.sys_props value must not leak into app JVM: $args",
     )
   }
+
+  // #322: `kolt run --watch` shares this argv-build helper with the one-shot
+  // path so `[run.sys_props]` resolution cannot diverge between modes.
+  // The helper unpacks BuildResult into the same jvmRunArgv call doRunInner
+  // makes; this test pins that the bundle-classpath threading survives the
+  // BuildResult round-trip.
+  @Test
+  fun runJvmCommandForUnpacksBuildResultThroughJvmRunArgv() {
+    val config =
+      testConfig()
+        .copy(
+          runSection =
+            RunSection(
+              sysProps =
+                linkedMapOf(
+                  "run.lit" to SysPropValue.Literal("v"),
+                  "run.plug" to SysPropValue.ClasspathRef("plugins"),
+                )
+            )
+        )
+    val buildResult =
+      BuildResult(
+        config = config,
+        classpath = "/cache/dep.jar",
+        javaPath = "/jdk/bin/java",
+        bundleClasspaths = mapOf("plugins" to "/cache/p1.jar:/cache/p2.jar"),
+      )
+
+    val cmd = runJvmCommandFor(buildResult, "/abs/proj", listOf("--app-arg"), Profile.Debug)
+
+    assertEquals("/jdk/bin/java", cmd.args[0])
+    assertEquals("-Drun.lit=v", cmd.args[1])
+    assertEquals("-Drun.plug=/cache/p1.jar:/cache/p2.jar", cmd.args[2])
+    assertEquals("-cp", cmd.args[3])
+    assertEquals("--app-arg", cmd.args.last())
+  }
+
+  // Req 7.3 watch-mode counterpart: a BuildResult without `[run.sys_props]`
+  // produces argv with no `-D` slots, byte-identical to the pre-feature
+  // shape. Guards against a future helper edit accidentally inserting an
+  // empty-key sysprop or a default `-D` flag.
+  @Test
+  fun runJvmCommandForOmitsSysPropsWhenRunSectionEmpty() {
+    val buildResult = BuildResult(config = testConfig(), classpath = null, javaPath = null)
+
+    val cmd = runJvmCommandFor(buildResult, "/proj", emptyList(), Profile.Debug)
+
+    assertTrue(cmd.args.none { it.startsWith("-D") }, "no -D flags expected: ${cmd.args}")
+    assertEquals("java", cmd.args[0])
+    assertEquals("-cp", cmd.args[1])
+  }
 }


### PR DESCRIPTION
`kolt run --watch` was calling `runCommand(...)` directly with no `[run.sys_props]` resolution, so declared sysprops silently dropped on every watch restart. The one-shot `kolt run` path got this wiring in #318 (PR #321) but `WatchLoop.watchRunLoop` was the leftover.

Lift the JVM-app argv build into a shared helper `runJvmCommandFor` (BuildCommands.kt). WatchLoop now goes through it, mirroring the one-shot path. Native-target watch runs keep going through `nativeRunCommand` upstream — `[run.sys_props]` is rejected at config-validation time on native targets, so there is nothing to thread.

Reviewer focus: the deleted `[build].main` null check in `watchRunLoop` is intentional — `jvmRunArgv` already enforces the same parser invariant (`kind == "app" ⇒ main != null`), so the watch-loop branch was redundant. Two unit tests on the helper pin the BuildResult unpacking and the empty-sysprops byte-identity (Req 7.3 watch-mode counterpart). `kolt test --watch` is intentionally out of scope per the issue.