### PR TITLE
Strip task/issue/Req refs from comments touched in recent PRs (#330)

### DIFF
--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/AdapterBoundaryInvariantTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/AdapterBoundaryInvariantTest.kt
@@ -15,10 +15,9 @@ import kotlin.test.assertTrue
 // surface and future compiler bumps would break the build at the
 // wrong layer.
 //
-// Issue #112 made this a human-review gate (acceptance criterion 2).
-// This test mechanises the gate so a contributor who adds a direct
-// BTA import anywhere in daemon core gets a red test instead of a
-// reviewer catching it weeks later. Putting the check in JUnit means
+// This test mechanises a human-review gate so a contributor who adds a
+// direct BTA import anywhere in daemon core gets a red test instead of
+// a reviewer catching it weeks later. Putting the check in JUnit means
 // the invariant is enforced on every `kolt test`, shares its reporting
 // with other regressions, and is easy to run in IDE.
 class AdapterBoundaryInvariantTest {

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsSysPropTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsSysPropTest.kt
@@ -307,11 +307,11 @@ class BuildCommandsSysPropTest {
     )
   }
 
-  // #322: `kolt run --watch` shares this argv-build helper with the one-shot
+  // `kolt run --watch` shares this argv-build helper with the one-shot
   // path so `[run.sys_props]` resolution cannot diverge between modes.
-  // The helper unpacks BuildResult into the same jvmRunArgv call doRunInner
-  // makes; this test pins that the bundle-classpath threading survives the
-  // BuildResult round-trip.
+  // The helper unpacks BuildResult into the same jvmRunArgv call the
+  // one-shot path makes; this test pins that the bundle-classpath
+  // threading survives the BuildResult round-trip.
   @Test
   fun runJvmCommandForUnpacksBuildResultThroughJvmRunArgv() {
     val config =
@@ -343,10 +343,10 @@ class BuildCommandsSysPropTest {
     assertEquals("--app-arg", cmd.args.last())
   }
 
-  // Req 7.3 watch-mode counterpart: a BuildResult without `[run.sys_props]`
-  // produces argv with no `-D` slots, byte-identical to the pre-feature
-  // shape. Guards against a future helper edit accidentally inserting an
-  // empty-key sysprop or a default `-D` flag.
+  // A BuildResult without `[run.sys_props]` must produce argv with no
+  // `-D` slots, byte-identical to the no-sysprops shape. Guards against
+  // a future helper edit accidentally inserting an empty-key sysprop or
+  // a default `-D` flag.
   @Test
   fun runJvmCommandForOmitsSysPropsWhenRunSectionEmpty() {
     val buildResult = BuildResult(config = testConfig(), classpath = null, javaPath = null)


### PR DESCRIPTION
Three comment-only slips from the 2026-05-01 PR run (#325, #327, #329) carried task/issue/Req references that CLAUDE.md and `feedback_no_task_refs_in_comments` say belong in the PR description, not the source. Stripping them keeps the WHY content; the references rot as the codebase evolves and are recoverable via git blame.

- `AdapterBoundaryInvariantTest`: dropped the leading `Issue #112 made this a human-review gate (acceptance criterion 2).` line. It survived #327's rewrite of the surrounding block by accident.
- `BuildCommandsSysPropTest`: stripped `#322:` and `Req 7.3 watch-mode counterpart:` prefixes from the two helper-coverage tests added in #329. The behavioural explanation in each comment is preserved verbatim.

ADR refs (e.g. `ADR 0019 §3`) continue to be cited per CLAUDE.md "Code Style".