### PR TITLE
fix: raise daemon connect budget 3s -> 10s for cold-cache CI (#310)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -107,8 +107,10 @@ jobs:
       # subprocess compile`, which short-circuited before any spawn
       # attempt. The canary requires `starting compiler daemon` in stderr
       # — i.e. the daemon code path was reached. Whether the spawn itself
-      # connects within the 3s retry budget is orthogonal (cold-cache CI
-      # currently times out and falls back, tracked separately).
+      # connects within the retry budget is orthogonal: #310 raised the
+      # budget to 10s in the dev tree, but the bootstrap tag here still
+      # ships 3s, so the negative assertion (no `falling back to
+      # subprocess`) is gated on the next bootstrap bump.
       - name: Verify daemon thin jar builds standalone
         run: |
           set -euo pipefail

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -81,7 +81,7 @@ dependency direction: **cli → build → resolve / infra**.
   cache adapters. The kernel is the reliability floor — treat it with Gradle/Maven-
   spec parity in mind.
 - **Explicit fallback policy**: all daemon failures except `CompilationFailed` fall
-  back to subprocess. Retry budgets (e.g. 10..200ms within 3s) are inlined with ADR
+  back to subprocess. Retry budgets (e.g. 10..200ms within 10s) are inlined with ADR
   references rather than hidden in framework code.
 - **Daemon version sync**: Kotlin version pins, daemon main-class FQNs, and the
   bootstrap JDK pin each fan out across multiple files. `DriftGuardsTest`

--- a/docs/adr/0016-warm-jvm-compiler-daemon.md
+++ b/docs/adr/0016-warm-jvm-compiler-daemon.md
@@ -12,6 +12,7 @@ date: 2026-04-14
 - Transport is a Unix domain socket at `~/.kolt/daemon/<projectHash>/daemon.sock`. Frame format: big-endian u32 length prefix + UTF-8 JSON body; `classDiscriminator = "type"`; max body 64 MiB. One connection at a time (Phase A contract). (§3)
 - Bound leaks with periodic restart: thresholds are 1000 compiles, 30 min idle, 1.5 GiB heap (live set via `MemoryMXBean`). `ExitReason` tags the cause on exit. (§4)
 - The daemon is the default compile backend from day one (`FallbackCompilerBackend(DaemonCompilerBackend, SubprocessCompilerBackend)`). `--no-daemon` bypasses it per invocation. Only `BackendUnavailable` / `InternalMisuse` trigger fallback; `CompilationFailed` does not. (§5)
+- Cold-spawn connect budget is 10s (was 3s through 2026-04-30). Budget covers cold spawn only — warm reconnects short-circuit before the retry loop and are unaffected. (§5)
 - `kolt-compiler-daemon/` is an independent Gradle build included via `includeBuild`, not a subproject, to allow separate distribution per ADR 0018. (§6)
 
 ## Context and Problem Statement
@@ -91,6 +92,8 @@ The daemon is the default backend from PR3 of #14. `kolt build` wires `FallbackC
 `reportFallback` emits one stderr line per fallback: `warning` for `BackendUnavailable.*`, `error` for `InternalMisuse`. `InternalMisuse` is deliberately loud so dogfooding surfaces bugs. `kolt build --no-daemon` bypasses the daemon for a single invocation; no `kolt.toml` knob exists.
 
 The opt-in plan (ship as `kolt build --daemon`, flip default after spikes #88–#91) was abandoned because all its transient artifacts — flag, doc caveat, interim ADR status — would need reverting a release later.
+
+Cold-spawn connect budget: `DaemonCompilerBackend.CONNECT_TOTAL_BUDGET_MS = 10_000`. The 3s default shipped with #14 false-positively fell back on cold-cache CI (#310): the §2 cold-start figure (~2.6s) plus the WSL2/CI 9p stat-storm outlier (~3.3s, see Benchmark notes) routinely cleared 3s before the daemon listened. The retry loop runs only after a spawn — warm reconnects succeed on the first `connector()` call and never enter `retryConnect()` — so the headroom is invisible to dev-loop builds. Cost: when the daemon is genuinely broken, fallback now takes up to ~10s per build; this is paid once because subsequent builds still re-spawn rather than wait, but the failure mode is louder than before.
 
 ### §6 Independent Gradle build via includeBuild
 

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
@@ -28,7 +28,9 @@ import platform.posix.timespec
 import platform.posix.usleep
 
 // ADR 0016, #14. Not load-bearing for correctness — all failures are fallback-eligible
-// except CompilationFailed. Retry policy: exponential backoff (10..200ms) within 3s budget.
+// except CompilationFailed. Retry policy: exponential backoff (10..200ms) within 10s budget.
+// Budget covers cold-spawn only (warm reconnect short-circuits before the retry loop), so
+// dev-loop responsiveness on warm caches is unaffected; cold-cache CI needs the headroom.
 class DaemonCompilerBackend
 internal constructor(
   private val javaBin: String,
@@ -144,7 +146,7 @@ internal constructor(
   companion object {
     internal const val INITIAL_BACKOFF_MS = 10
     internal const val MAX_BACKOFF_MS = 200
-    internal const val CONNECT_TOTAL_BUDGET_MS: Long = 3000L
+    internal const val CONNECT_TOTAL_BUDGET_MS: Long = 10_000L
   }
 }
 

--- a/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
@@ -25,7 +25,7 @@ import kolt.nativedaemon.wire.Message
 import platform.posix.usleep
 
 // ADR 0024 §2/§3/§7. Parallel to `kolt.build.daemon.DaemonCompilerBackend`:
-// spawn-on-demand, exponential backoff connect (10..200ms within 3s budget),
+// spawn-on-demand, exponential backoff connect (10..200ms within 10s budget),
 // wire protocol over a Unix domain socket. Not load-bearing for correctness —
 // `FallbackNativeCompilerBackend` (ADR 0024 §7) retries eligible errors on
 // `NativeSubprocessBackend`.
@@ -150,7 +150,7 @@ internal constructor(
   companion object {
     internal const val INITIAL_BACKOFF_MS = 10
     internal const val MAX_BACKOFF_MS = 200
-    internal const val CONNECT_TOTAL_BUDGET_MS: Long = 3000L
+    internal const val CONNECT_TOTAL_BUDGET_MS: Long = 10_000L
 
     // Heap ceiling SSoT — lockstep with ADR 0024 §3.
     // JVM daemon's spawnArgv omits `-Xmx` by design: BTA's steady-state

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
@@ -472,9 +472,9 @@ class DaemonCompilerBackendConnectAndSpawnTest {
     val backend = newBackend(connector = connector, spawner = { _, _ -> Ok(Unit) }, clock = clock)
     val err = assertNotNull(backend.compile(sampleRequest()).getError())
     val unavailable = assertIs<CompileError.BackendUnavailable.Other>(err)
-    assertTrue(unavailable.detail.contains("within 3000ms"))
+    assertTrue(unavailable.detail.contains("within 10000ms"))
     assertTrue(attempts > 1, "expected at least one retry attempt after spawn")
-    assertTrue(clock.nowMs >= 3000L, "fake clock should have advanced past the budget")
+    assertTrue(clock.nowMs >= 10000L, "fake clock should have advanced past the budget")
   }
 }
 

--- a/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
@@ -358,7 +358,7 @@ class NativeDaemonBackendConnectAndSpawnTest {
 
     val unavailable = assertIs<NativeCompileError.BackendUnavailable.Other>(err)
     assertTrue(
-      unavailable.detail.contains("within 3000ms"),
+      unavailable.detail.contains("within 10000ms"),
       "expected budget mention, got: ${unavailable.detail}",
     )
     assertTrue(calls > 1, "expected multiple retry attempts before giving up")


### PR DESCRIPTION
Closes #310.

`DaemonCompilerBackend.CONNECT_TOTAL_BUDGET_MS` and `NativeDaemonBackend.CONNECT_TOTAL_BUDGET_MS` raised from 3000ms to 10_000ms. The 3s default false-positively fell back on cold-cache CI runs (PR #308 evidence): ADR 0016 §2 cold-start ~2.6s plus the documented WSL2/CI 9p stat-storm outlier ~3.3s routinely cleared 3s before the daemon began listening. The retry loop runs only after a spawn — `retryConnect()` is unreachable when `connector()` succeeds on the first try — so warm-cache dev builds never enter it and are unaffected.

Worth a careful look:

- **`unit-tests.yml` canary tightening intentionally deferred.** Issue #310's DoD asks for `! grep 'falling back to subprocess'` once the 3s false-positive is gone, but `KOLT_BOOTSTRAP_TAG=v0.16.3` here still ships the 3s budget. Adding the negative assertion now would fail on cold-cache CI for the same reason as before. Comment in the workflow explains the gating; tighten in the follow-up PR after the next bootstrap bump.
- **ADR 0016 amendment, not new ADR.** Per CLAUDE.md "fold any contract delta into the closest existing ADR" — added a Summary bullet and a §5 paragraph documenting the 3s→10s change and the broken-daemon trade-off. ADR 0024 doesn't pin the number so no amendment there; the code SSoT in `NativeDaemonBackend` carries the symmetric value.
- **Trade-off cost.** When the daemon is genuinely broken (jar missing, JVM crash on init, etc.), each build now waits up to ~10s before falling back to subprocess. Previously 3s. This is paid per-build, not per-session, since `connectOrSpawn()` re-enters fresh each time.

Verification:
- `kolt test` 1400/1400 pass; `retryExhaustedAfterBudget` (JVM) and `retryBudgetExhaustion` (native) green with the new 10000ms expectation. FakeClock-based, no real wall-clock impact.
- `kolt build` clean.