### PR TITLE
feat: thread CLI -D<key>=<value> through kolt test / kolt run (#319)

### DIFF
--- a/docs/adr/0032-kolt-toml-env-agnostic.md
+++ b/docs/adr/0032-kolt-toml-env-agnostic.md
@@ -9,7 +9,7 @@ date: 2026-04-30
 
 - `kolt.toml` is a project-shared, commit-tracked file. Per-machine and per-environment values do not belong in it (§1).
 - The parser does not perform `${env.X}` interpolation on any value. The decision is enforced at parse time, not by convention (§2).
-- Environment-specific values arrive through two designated channels: a CLI `-D<key>=<value>` flag on `kolt test` / `kolt run` (#319), and a per-user `kolt.local.toml` overlay (#320). Both are deferred to follow-up issues; this ADR commits the contract they will satisfy (§3).
+- Environment-specific values arrive through two designated channels: a CLI `-D<key>=<value>` flag on `kolt test` / `kolt run` (#319, landed), and a per-user `kolt.local.toml` overlay (#320, deferred). The CLI flag overlays kolt.toml-declared sysprops literal-only; CLI value wins on key collision (§3).
 - The `[test.sys_props]` and `[run.sys_props]` value shapes admitted today (literal / classpath / project_dir) are deliberately limited to project-derivable forms so the env-agnostic invariant is structural, not stylistic (§4).
 - The decision is reversible only by superseding ADR if a future contributor wants to add interpolation. The follow-up issues are the path that does not require superseding (§5).
 
@@ -58,7 +58,7 @@ Two channels are committed for environment-specific override of declared sysprop
 - **CLI flag** (#319). `kolt test -D<key>=<value> [...]` and `kolt run -D<key>=<value> [...]` overlay literal values onto the kolt.toml-declared sysprops at invocation time. CLI values are literal-only — the structured `{ classpath = ... }` / `{ project_dir = ... }` forms remain `kolt.toml`-exclusive because they only make sense in the context of declared bundles and project paths. Use case: one-off debugging, ad-hoc fixture overrides.
 - **Per-user override file** (#320). `kolt.local.toml` (project-local, recommended `.gitignore` entry) overlays kolt.toml's `[test.sys_props]` / `[run.sys_props]` for a single working tree. Use case: persistent per-developer settings that should not be committed.
 
-Both channels are scheduled as follow-up issues. They are not load-bearing for the v0.X release of `[test.sys_props]` / `[run.sys_props]` itself — the existing surface is useful as-is for project-derivable values (e.g., compiler-plugin classpaths, daemon source roots) which is the primary motivating use case (#315).
+The CLI flag landed (PR for #319 wires `-D<key>=<value>` through `parseKoltArgs` into `jvmTestArgv` / `jvmRunArgv` with overlay semantics: kolt.toml-declared sysprops first in declaration order, CLI flags appended in command-line order, same-key collisions drop the toml entry). The per-user overlay (#320) remains deferred. Neither was load-bearing for the v0.X release of `[test.sys_props]` / `[run.sys_props]` itself — the existing surface is useful as-is for project-derivable values (e.g., compiler-plugin classpaths, daemon source roots) which is the primary motivating use case (#315).
 
 ### §4 Admitted value shapes are project-derivable by design
 
@@ -84,8 +84,8 @@ The CLI flag (#319) and per-user overlay (#320) are the path that does not requi
 - Two designated channels (CLI flag, override file) cover the common env-specific use cases without polluting `kolt.toml`.
 
 **Negative**
-- Common idioms like "log level controlled by `LOG_LEVEL`" require either CLI flag at every invocation (until #319 lands, then via `-Dlog.level=...`) or `kolt.local.toml` (until #320 lands).
-- Until #319 and #320 land, contributors with env-specific needs have only the indirect path: set the env var before running `kolt test`, and have application code read it directly via `System.getenv(...)` rather than through a sysprop.
+- Common idioms like "log level controlled by `LOG_LEVEL`" require either a CLI flag at every invocation (`-Dlog.level=...`) or `kolt.local.toml` (until #320 lands).
+- Until #320 lands, persistent per-developer sysprop overrides require an alias / wrapper script around `kolt test` / `kolt run`; the CLI flag covers one-off invocations only.
 
 ### Confirmation
 
@@ -102,7 +102,7 @@ The CLI flag (#319) and per-user overlay (#320) are the path that does not requi
 ## Related
 
 - #318 — jvm-sys-props spec (this ADR's parent)
-- #319 — CLI `-D<key>=<value>` flag for `kolt test` / `kolt run` (deferred channel)
+- #319 — CLI `-D<key>=<value>` flag for `kolt test` / `kolt run` (landed)
 - #320 — Per-user `kolt.local.toml` override file (deferred channel)
 - ADR 0028 — v1 release policy (pre-v1 breaking changes are acceptable; this ADR commits a long-term contract)
 - `.kiro/specs/jvm-sys-props/design.md` — design that this ADR codifies

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -59,6 +59,11 @@ internal data class BuildResult(
 // argv for the JUnit Console Launcher. Lifted out of `doTestInner` so the
 // sysprop wiring (config selection + resolver + runner) can be tested
 // without spinning up a build pipeline. Req 3.1 (test JVM `-D`).
+//
+// `cliSysProps` (#319) overlays `[test.sys_props]`: same-key toml entries
+// are dropped, CLI entries appear after surviving toml entries in the
+// command-line order they were given. Empty list (the default) is the
+// no-op for callers that don't surface CLI sysprops yet.
 internal fun jvmTestArgv(
   config: KoltConfig,
   projectRoot: String,
@@ -70,8 +75,13 @@ internal fun jvmTestArgv(
   testClasspath: String?,
   testArgs: List<String>,
   javaPath: String?,
+  cliSysProps: List<Pair<String, String>> = emptyList(),
 ): List<String> {
-  val sysProps = resolveSysProps(config.testSection.sysProps, projectRoot, bundleClasspaths)
+  val sysProps =
+    overlayCliSysProps(
+      resolveSysProps(config.testSection.sysProps, projectRoot, bundleClasspaths),
+      cliSysProps,
+    )
   return testRunCommand(
       classesDir = classesDir,
       testClassesDir = testClassesDir,
@@ -95,12 +105,17 @@ internal fun jvmRunArgv(
   appArgs: List<String>,
   javaPath: String?,
   profile: Profile,
+  cliSysProps: List<Pair<String, String>> = emptyList(),
 ): List<String> {
   // Parser invariant `kind == "app" ⇒ main != null`; lib kind is gated by
   // `rejectIfLibrary` upstream of every doRun-class path. The `?: error`
   // is ADR 0001 safety against a future caller that forgets the gate.
   val main = config.build.main ?: error("invariant: jvmRunArgv requires config.build.main")
-  val sysProps = resolveSysProps(config.runSection.sysProps, projectRoot, bundleClasspaths)
+  val sysProps =
+    overlayCliSysProps(
+      resolveSysProps(config.runSection.sysProps, projectRoot, bundleClasspaths),
+      cliSysProps,
+    )
   return runCommand(
       config,
       main = main,
@@ -125,6 +140,7 @@ internal fun runJvmCommandFor(
   projectRoot: String,
   appArgs: List<String>,
   profile: Profile,
+  cliSysProps: List<Pair<String, String>> = emptyList(),
 ): RunCommand =
   RunCommand(
     args =
@@ -136,8 +152,23 @@ internal fun runJvmCommandFor(
         appArgs = appArgs,
         javaPath = buildResult.javaPath,
         profile = profile,
+        cliSysProps = cliSysProps,
       )
   )
+
+// CLI -D overlay (#319). DoD: CLI flags placed after toml-declared sysprops
+// in command-line order; same-key collisions drop the toml entry and keep
+// the CLI value. Within CLI, duplicate keys pass through verbatim — the
+// JVM resolves last-write-wins for `-Dfoo=a -Dfoo=b`, which matches user
+// expectations from `java -Dfoo=...`.
+private fun overlayCliSysProps(
+  toml: List<Pair<String, String>>,
+  cli: List<Pair<String, String>>,
+): List<Pair<String, String>> {
+  if (cli.isEmpty()) return toml
+  val cliKeys = cli.map { it.first }.toSet()
+  return toml.filter { it.first !in cliKeys } + cli
+}
 
 // ADR 0027 §4 kind/target matrix: JVM `kind = "app"` emits
 // `build/<name>-runtime.classpath`; every other combination (JVM lib,
@@ -795,6 +826,25 @@ internal fun rejectIfLibrary(
   return Err(EXIT_CONFIG_ERROR)
 }
 
+// CLI `-D<key>=<value>` is JVM-only (ADR 0032 §3). Mirrors the parse-time
+// rejection of `[test.sys_props]` / `[run.sys_props]` on native targets
+// (Config.kt) so the contract is symmetric: a user who declares sysprops
+// in kolt.toml hits the parser error; a user who supplies them on the CLI
+// hits this one. Without this gate `kolt {run,test} -Dfoo=bar` on native
+// silently drops the flag.
+internal fun rejectCliSysPropsOnNative(
+  config: KoltConfig,
+  cliSysProps: List<Pair<String, String>>,
+  eprint: (String) -> Unit = ::eprintln,
+): Result<Unit, Int> {
+  if (cliSysProps.isEmpty() || config.build.target !in NATIVE_TARGETS) return Ok(Unit)
+  eprint(
+    "error: -D<key>=<value> is JVM-only and cannot be used with native target " +
+      "'${config.build.target}'"
+  )
+  return Err(EXIT_CONFIG_ERROR)
+}
+
 // `doRun` does not acquire the project lock. ADR 0029 §1's contract
 // limits the lock to `kolt.lock` rewrite plus `build/` finalisation;
 // `doRunInner` performs neither, only reading prebuilt artifacts and
@@ -808,7 +858,9 @@ internal fun doRun(
   javaPath: String? = null,
   profile: Profile = Profile.Debug,
   bundleClasspaths: Map<String, String> = emptyMap(),
-): Result<Unit, Int> = doRunInner(config, classpath, appArgs, javaPath, profile, bundleClasspaths)
+  cliSysProps: List<Pair<String, String>> = emptyList(),
+): Result<Unit, Int> =
+  doRunInner(config, classpath, appArgs, javaPath, profile, bundleClasspaths, cliSysProps)
 
 private fun doRunInner(
   config: KoltConfig,
@@ -817,10 +869,14 @@ private fun doRunInner(
   javaPath: String?,
   profile: Profile,
   bundleClasspaths: Map<String, String>,
+  cliSysProps: List<Pair<String, String>>,
 ): Result<Unit, Int> {
   // ADR 0023 §1 kind gate: reject libraries before any artifact lookup
   // or process launch. Target-agnostic by design (R4.3).
   rejectIfLibrary(config).getOrElse {
+    return Err(it)
+  }
+  rejectCliSysPropsOnNative(config, cliSysProps).getOrElse {
     return Err(it)
   }
 
@@ -864,6 +920,7 @@ private fun doRunInner(
       appArgs = appArgs,
       javaPath = javaPath,
       profile = profile,
+      cliSysProps = cliSysProps,
     )
   executeCommand(args).getOrElse { error ->
     return Err(
@@ -880,18 +937,25 @@ internal fun doTest(
   testArgs: List<String> = emptyList(),
   useDaemon: Boolean = true,
   profile: Profile = Profile.Debug,
-): Result<Unit, Int> = withProjectLock { lock -> doTestInner(testArgs, useDaemon, profile, lock) }
+  cliSysProps: List<Pair<String, String>> = emptyList(),
+): Result<Unit, Int> = withProjectLock { lock ->
+  doTestInner(testArgs, useDaemon, profile, cliSysProps, lock)
+}
 
 private fun doTestInner(
   testArgs: List<String>,
   useDaemon: Boolean,
   profile: Profile,
+  cliSysProps: List<Pair<String, String>>,
   lock: LockHandle,
 ): Result<Unit, Int> {
   val config =
     loadProjectConfig().getOrElse {
       return Err(it)
     }
+  rejectCliSysPropsOnNative(config, cliSysProps).getOrElse {
+    return Err(it)
+  }
   if (config.build.target in NATIVE_TARGETS) {
     return doNativeTest(config, testArgs, useDaemon, profile, lock)
   }
@@ -975,6 +1039,7 @@ private fun doTestInner(
       testClasspath = testClasspath,
       testArgs = testArgs,
       javaPath = javaPath,
+      cliSysProps = cliSysProps,
     )
   // Release the project lock before spawning the test child. Test compile
   // above wrote build/classes/ under the lock; the test runner is a pure

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -16,6 +16,7 @@ fun main(args: Array<String>) {
   val useDaemon = parsed.useDaemon
   val watch = parsed.watch
   val profile = parsed.profile
+  val cliSysProps = parsed.cliSysProps
   val filteredArgs = parsed.filteredArgs
   if (filteredArgs.isEmpty()) {
     printUsage()
@@ -38,7 +39,7 @@ fun main(args: Array<String>) {
           if (sep >= 0) all.subList(sep + 1, all.size) else emptyList()
         }
       if (watch) {
-        watchRunLoop(useDaemon, appArgs, profile = profile)
+        watchRunLoop(useDaemon, appArgs, profile = profile, cliSysProps = cliSysProps)
       } else {
         // ADR 0023 §1 kind gate: reject libraries before the
         // build pipeline runs (R4.2). doRun has the same guard
@@ -58,6 +59,7 @@ fun main(args: Array<String>) {
             buildResult.javaPath,
             profile = profile,
             bundleClasspaths = buildResult.bundleClasspaths,
+            cliSysProps = cliSysProps,
           )
           .getOrElse { exitProcess(it) }
       }
@@ -68,8 +70,11 @@ fun main(args: Array<String>) {
           val sep = all.indexOf("--")
           if (sep >= 0) all.subList(sep + 1, all.size) else emptyList()
         }
-      if (watch) watchCommandLoop("test", useDaemon, testArgs, profile = profile)
-      else doTest(testArgs, useDaemon = useDaemon, profile = profile).getOrElse { exitProcess(it) }
+      if (watch)
+        watchCommandLoop("test", useDaemon, testArgs, profile = profile, cliSysProps = cliSysProps)
+      else
+        doTest(testArgs, useDaemon = useDaemon, profile = profile, cliSysProps = cliSysProps)
+          .getOrElse { exitProcess(it) }
     }
     "fmt" -> doFmt(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
     "clean" -> doClean().getOrElse { exitProcess(it) }
@@ -95,17 +100,19 @@ fun main(args: Array<String>) {
 internal const val NO_DAEMON_FLAG = "--no-daemon"
 internal const val WATCH_FLAG = "--watch"
 internal const val RELEASE_FLAG = "--release"
+internal const val SYS_PROP_PREFIX = "-D"
 
 internal data class KoltArgs(
   val useDaemon: Boolean,
   val watch: Boolean,
   val profile: Profile,
+  val cliSysProps: List<Pair<String, String>>,
   val filteredArgs: List<String>,
 )
 
 // Splits the kolt-level flags from the subcommand and from any `--`
 // passthrough segment. The kolt-level flags (--no-daemon, --watch,
-// --release) are extracted into typed fields and stripped from
+// --release, -D<k>=<v>) are extracted into typed fields and stripped from
 // `filteredArgs`; the passthrough block (after `--`) is appended verbatim
 // so `kolt run -- --foo` still passes `-- --foo` to the subcommand parser.
 internal fun parseKoltArgs(argList: List<String>): KoltArgs {
@@ -116,10 +123,28 @@ internal fun parseKoltArgs(argList: List<String>): KoltArgs {
   val useDaemon = !koltLevel.contains(NO_DAEMON_FLAG)
   val watch = koltLevel.contains(WATCH_FLAG)
   val profile = if (koltLevel.contains(RELEASE_FLAG)) Profile.Release else Profile.Debug
+  val cliSysProps = koltLevel.mapNotNull(::parseDFlag)
   val filteredArgs =
-    koltLevel.filter { it != NO_DAEMON_FLAG && it != WATCH_FLAG && it != RELEASE_FLAG } +
-      passthrough
-  return KoltArgs(useDaemon, watch, profile, filteredArgs)
+    koltLevel.filter {
+      it != NO_DAEMON_FLAG && it != WATCH_FLAG && it != RELEASE_FLAG && parseDFlag(it) == null
+    } + passthrough
+  return KoltArgs(useDaemon, watch, profile, cliSysProps, filteredArgs)
+}
+
+// Returns null when `arg` is not a valid `-D<key>=<value>` form. Bare `-D`,
+// `-D=value` (empty key), and non-`-D` args fall back to filteredArgs so the
+// dispatcher can surface a normal "unknown command" / passthrough error.
+// Recognised forms: `-Dkey=value` -> ("key","value"); `-Dkey` -> ("key","");
+// `-Dkey=` -> ("key","").
+internal fun parseDFlag(arg: String): Pair<String, String>? {
+  if (!arg.startsWith(SYS_PROP_PREFIX)) return null
+  val rest = arg.substring(SYS_PROP_PREFIX.length)
+  if (rest.isEmpty()) return null
+  val eq = rest.indexOf('=')
+  if (eq < 0) return rest to ""
+  val key = rest.substring(0, eq)
+  if (key.isEmpty()) return null
+  return key to rest.substring(eq + 1)
 }
 
 private fun printUsage() {
@@ -145,7 +170,8 @@ private fun printUsage() {
   eprintln("  version    Show version information")
   eprintln("")
   eprintln("flags:")
-  eprintln("  --watch      Watch source files and re-run on change")
-  eprintln("  --no-daemon  Skip the warm compiler daemon for this invocation")
-  eprintln("  --release    Build under the release profile (Native: -opt; JVM: no-op)")
+  eprintln("  --watch         Watch source files and re-run on change")
+  eprintln("  --no-daemon     Skip the warm compiler daemon for this invocation")
+  eprintln("  --release       Build under the release profile (Native: -opt; JVM: no-op)")
+  eprintln("  -D<key>=<value> JVM system property for kolt test/run; overlays [test|run.sys_props]")
 }

--- a/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
+++ b/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
@@ -166,11 +166,13 @@ internal fun watchCommandLoop(
   useDaemon: Boolean,
   testArgs: List<String> = emptyList(),
   profile: Profile = Profile.Debug,
+  cliSysProps: List<Pair<String, String>> = emptyList(),
   commandRunner: (String, Boolean, List<String>) -> Result<*, Int> = { cmd, daemon, args ->
     when (cmd) {
       "build" -> doBuild(useDaemon = daemon, profile = profile)
       "check" -> doCheck(useDaemon = daemon, profile = profile)
-      "test" -> doTest(testArgs = args, useDaemon = daemon, profile = profile)
+      "test" ->
+        doTest(testArgs = args, useDaemon = daemon, profile = profile, cliSysProps = cliSysProps)
       else -> doBuild(useDaemon = daemon, profile = profile)
     }
   },
@@ -277,6 +279,7 @@ internal fun watchRunLoop(
   useDaemon: Boolean,
   appArgs: List<String> = emptyList(),
   profile: Profile = Profile.Debug,
+  cliSysProps: List<Pair<String, String>> = emptyList(),
   eprint: (String) -> Unit = ::eprintln,
 ) {
   val config =
@@ -288,6 +291,7 @@ internal fun watchRunLoop(
   // and return cleanly so a library invocation does not enter the
   // rebuild-poll loop (R4.2 "no per-source-change error spam").
   if (rejectIfLibrary(config, eprint).getError() != null) return
+  if (rejectCliSysPropsOnNative(config, cliSysProps, eprint).getError() != null) return
 
   val watchDirs = collectWatchPaths(config, "run")
   val setup = setupWatches(watchDirs, config) ?: return
@@ -315,7 +319,7 @@ internal fun watchRunLoop(
       if (buildResult.config.build.target in NATIVE_TARGETS) {
         nativeRunCommand(buildResult.config, appArgs, profile)
       } else {
-        runJvmCommandFor(buildResult, projectRoot, appArgs, profile)
+        runJvmCommandFor(buildResult, projectRoot, appArgs, profile, cliSysProps)
       }
     val childPid = spawnInProcessGroup(runCmd.args)
     if (childPid < 0) {

--- a/src/nativeTest/kotlin/kolt/cli/BuildCommandsSysPropTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BuildCommandsSysPropTest.kt
@@ -1,5 +1,6 @@
 package kolt.cli
 
+import com.github.michaelbull.result.getError
 import kolt.build.Profile
 import kolt.config.RunSection
 import kolt.config.SysPropValue
@@ -356,5 +357,229 @@ class BuildCommandsSysPropTest {
     assertTrue(cmd.args.none { it.startsWith("-D") }, "no -D flags expected: ${cmd.args}")
     assertEquals("java", cmd.args[0])
     assertEquals("-cp", cmd.args[1])
+  }
+
+  // #319: CLI -D flags appended after toml-declared sysprops, in
+  // command-line order, when there are no key collisions.
+  @Test
+  fun jvmTestArgvAppendsCliSysPropsAfterTomlSysProps() {
+    val config =
+      testConfig()
+        .copy(
+          testSection =
+            TestSection(sysProps = linkedMapOf("toml.first" to SysPropValue.Literal("a")))
+        )
+
+    val args =
+      jvmTestArgv(
+        config = config,
+        projectRoot = "/proj",
+        bundleClasspaths = emptyMap(),
+        classesDir = "build/classes",
+        testClassesDir = "build/test-classes",
+        consoleLauncherPath = "/tools/launcher.jar",
+        testResourceDirs = emptyList(),
+        testClasspath = null,
+        testArgs = emptyList(),
+        javaPath = null,
+        cliSysProps = listOf("cli.first" to "b", "cli.second" to "c"),
+      )
+
+    assertEquals("java", args[0])
+    assertEquals("-Dtoml.first=a", args[1])
+    assertEquals("-Dcli.first=b", args[2])
+    assertEquals("-Dcli.second=c", args[3])
+    assertEquals("-jar", args[4])
+  }
+
+  // #319: a CLI -D flag with the same key as a `[test.sys_props]` entry
+  // overlays it. Toml entry is dropped; CLI value appears at the CLI
+  // position (after surviving toml entries).
+  @Test
+  fun jvmTestArgvCliOverlayWinsOnKeyCollision() {
+    val config =
+      testConfig()
+        .copy(
+          testSection =
+            TestSection(
+              sysProps =
+                linkedMapOf(
+                  "shared" to SysPropValue.Literal("toml-value"),
+                  "toml.only" to SysPropValue.Literal("survives"),
+                )
+            )
+        )
+
+    val args =
+      jvmTestArgv(
+        config = config,
+        projectRoot = "/proj",
+        bundleClasspaths = emptyMap(),
+        classesDir = "build/classes",
+        testClassesDir = "build/test-classes",
+        consoleLauncherPath = "/tools/launcher.jar",
+        testResourceDirs = emptyList(),
+        testClasspath = null,
+        testArgs = emptyList(),
+        javaPath = null,
+        cliSysProps = listOf("shared" to "cli-value"),
+      )
+
+    assertTrue(
+      args.none { it == "-Dshared=toml-value" },
+      "toml entry must be dropped on collision: $args",
+    )
+    assertEquals(1, args.count { it == "-Dshared=cli-value" })
+    assertEquals(1, args.count { it == "-Dtoml.only=survives" })
+    assertTrue(
+      args.indexOf("-Dtoml.only=survives") < args.indexOf("-Dshared=cli-value"),
+      "non-colliding toml entries come before CLI overlay: $args",
+    )
+  }
+
+  // #319: same shape as the test counterpart for jvmRunArgv (Req 3.2).
+  @Test
+  fun jvmRunArgvAppendsCliSysPropsAfterTomlSysProps() {
+    val config =
+      testConfig()
+        .copy(
+          runSection = RunSection(sysProps = linkedMapOf("run.toml" to SysPropValue.Literal("t")))
+        )
+
+    val args =
+      jvmRunArgv(
+        config = config,
+        projectRoot = "/proj",
+        bundleClasspaths = emptyMap(),
+        classpath = null,
+        appArgs = emptyList(),
+        javaPath = null,
+        profile = Profile.Debug,
+        cliSysProps = listOf("run.cli" to "c"),
+      )
+
+    assertEquals("java", args[0])
+    assertEquals("-Drun.toml=t", args[1])
+    assertEquals("-Drun.cli=c", args[2])
+  }
+
+  @Test
+  fun jvmRunArgvCliOverlayWinsOnKeyCollision() {
+    val config =
+      testConfig()
+        .copy(
+          runSection =
+            RunSection(
+              sysProps =
+                linkedMapOf(
+                  "run.shared" to SysPropValue.Literal("toml-value"),
+                  "run.only" to SysPropValue.Literal("survives"),
+                )
+            )
+        )
+
+    val args =
+      jvmRunArgv(
+        config = config,
+        projectRoot = "/proj",
+        bundleClasspaths = emptyMap(),
+        classpath = null,
+        appArgs = emptyList(),
+        javaPath = null,
+        profile = Profile.Debug,
+        cliSysProps = listOf("run.shared" to "cli-value"),
+      )
+
+    assertTrue(args.none { it == "-Drun.shared=toml-value" }, "toml entry dropped on collision")
+    assertEquals(1, args.count { it == "-Drun.shared=cli-value" })
+    assertEquals(1, args.count { it == "-Drun.only=survives" })
+  }
+
+  // #319 (watch): CLI -D flags must reach the watched JVM run path through
+  // `runJvmCommandFor`, mirroring the one-shot `kolt run -D...` shape.
+  @Test
+  fun runJvmCommandForThreadsCliSysProps() {
+    val buildResult = BuildResult(config = testConfig(), classpath = null, javaPath = null)
+
+    val cmd =
+      runJvmCommandFor(
+        buildResult,
+        "/proj",
+        emptyList(),
+        Profile.Debug,
+        cliSysProps = listOf("foo" to "bar"),
+      )
+
+    assertEquals("java", cmd.args[0])
+    assertEquals("-Dfoo=bar", cmd.args[1])
+  }
+
+  // #319: CLI duplicate keys pass through verbatim. JVM resolves
+  // last-write-wins for `-Dfoo=a -Dfoo=b`; if a future edit introduces
+  // CLI-side dedup the contract documented on `overlayCliSysProps` would
+  // silently shift, so pin both occurrences in the argv.
+  @Test
+  fun jvmRunArgvCliDuplicateKeysPassThroughVerbatim() {
+    val args =
+      jvmRunArgv(
+        config = testConfig(),
+        projectRoot = "/proj",
+        bundleClasspaths = emptyMap(),
+        classpath = null,
+        appArgs = emptyList(),
+        javaPath = null,
+        profile = Profile.Debug,
+        cliSysProps = listOf("foo" to "a", "foo" to "b"),
+      )
+
+    val foos = args.filter { it.startsWith("-Dfoo=") }
+    assertEquals(listOf("-Dfoo=a", "-Dfoo=b"), foos, "both CLI dup keys must reach the JVM argv")
+  }
+
+  // #319: CLI `-D` is JVM-only. Mirrors the parse-time native rejection
+  // of `[run.sys_props]` / `[test.sys_props]` so the contract is symmetric:
+  // declaring sysprops in kolt.toml on a native target errors at parse;
+  // supplying them on the CLI errors here. Without this gate the flag is
+  // silently dropped.
+  @Test
+  fun rejectCliSysPropsOnNativeReturnsConfigErrorWithCanonicalMessage() {
+    val nativeConfig = testConfig(target = "linuxX64")
+    val stderr = mutableListOf<String>()
+
+    val exit =
+      rejectCliSysPropsOnNative(nativeConfig, listOf("foo" to "bar"), eprint = { stderr.add(it) })
+        .getError()
+
+    assertEquals(EXIT_CONFIG_ERROR, exit)
+    assertEquals(1, stderr.size)
+    assertTrue(
+      stderr[0].contains("-D<key>=<value> is JVM-only") &&
+        stderr[0].contains("native target 'linuxX64'"),
+      "stderr must mention JVM-only and the native target name, got: ${stderr[0]}",
+    )
+  }
+
+  // Pass-through cases: no CLI flags, or JVM target. Either yields Ok with
+  // no stderr; the gate must never spam.
+  @Test
+  fun rejectCliSysPropsOnNativeIsNoopForJvmTargetOrEmptyCliSysProps() {
+    val stderr = mutableListOf<String>()
+
+    val jvmWithCli =
+      rejectCliSysPropsOnNative(
+        testConfig(target = "jvm"),
+        listOf("foo" to "bar"),
+        eprint = { stderr.add(it) },
+      )
+    val nativeWithoutCli =
+      rejectCliSysPropsOnNative(
+        testConfig(target = "linuxX64"),
+        emptyList(),
+        eprint = { stderr.add(it) },
+      )
+
+    assertTrue(jvmWithCli.isOk, "JVM target with CLI flags must pass")
+    assertTrue(nativeWithoutCli.isOk, "native target without CLI flags must pass")
+    assertTrue(stderr.isEmpty(), "no stderr expected: $stderr")
   }
 }

--- a/src/nativeTest/kotlin/kolt/cli/ParseKoltArgsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ParseKoltArgsTest.kt
@@ -60,4 +60,97 @@ class ParseKoltArgsTest {
     assertEquals(before.profile, after.profile)
     assertEquals(before.filteredArgs, after.filteredArgs)
   }
+
+  @Test
+  fun absentDflagYieldsEmptyCliSysProps() {
+    val parsed = parseKoltArgs(listOf("test"))
+
+    assertEquals(emptyList<Pair<String, String>>(), parsed.cliSysProps)
+  }
+
+  @Test
+  fun singleDflagIsExtractedAndStrippedFromFilteredArgs() {
+    val parsed = parseKoltArgs(listOf("test", "-Dfoo=bar"))
+
+    assertEquals(listOf("foo" to "bar"), parsed.cliSysProps)
+    assertEquals(listOf("test"), parsed.filteredArgs)
+  }
+
+  @Test
+  fun multipleDflagsPreserveCommandLineOrder() {
+    val parsed = parseKoltArgs(listOf("test", "-Dfirst=1", "-Dsecond=2", "-Dthird=3"))
+
+    assertEquals(listOf("first" to "1", "second" to "2", "third" to "3"), parsed.cliSysProps)
+    assertEquals(listOf("test"), parsed.filteredArgs)
+  }
+
+  @Test
+  fun dflagWithoutEqualsHasEmptyValue() {
+    val parsed = parseKoltArgs(listOf("test", "-Dfoo"))
+
+    assertEquals(listOf("foo" to ""), parsed.cliSysProps)
+  }
+
+  @Test
+  fun dflagValueSplitsOnFirstEqualsOnly() {
+    val parsed = parseKoltArgs(listOf("test", "-Dfoo=a=b=c"))
+
+    assertEquals(listOf("foo" to "a=b=c"), parsed.cliSysProps)
+  }
+
+  @Test
+  fun dflagWithEmptyValueAfterEqualsIsAllowed() {
+    val parsed = parseKoltArgs(listOf("test", "-Dfoo="))
+
+    assertEquals(listOf("foo" to ""), parsed.cliSysProps)
+  }
+
+  @Test
+  fun bareDashDStaysInFilteredArgs() {
+    val parsed = parseKoltArgs(listOf("test", "-D"))
+
+    assertEquals(emptyList<Pair<String, String>>(), parsed.cliSysProps)
+    assertTrue(
+      parsed.filteredArgs.contains("-D"),
+      "bare -D is not a valid sysprop flag and must reach the dispatcher: ${parsed.filteredArgs}",
+    )
+  }
+
+  @Test
+  fun dflagWithEmptyKeyStaysInFilteredArgs() {
+    val parsed = parseKoltArgs(listOf("test", "-D=value"))
+
+    assertEquals(emptyList<Pair<String, String>>(), parsed.cliSysProps)
+    assertTrue(
+      parsed.filteredArgs.contains("-D=value"),
+      "-D=<value> with empty key is not a valid sysprop flag: ${parsed.filteredArgs}",
+    )
+  }
+
+  @Test
+  fun dflagAfterDoubleDashIsTreatedAsPassthrough() {
+    val parsed = parseKoltArgs(listOf("run", "--", "-Dfoo=bar"))
+
+    assertEquals(emptyList<Pair<String, String>>(), parsed.cliSysProps)
+    assertEquals(listOf("run", "--", "-Dfoo=bar"), parsed.filteredArgs)
+  }
+
+  @Test
+  fun dflagPositionDoesNotMatter() {
+    val before = parseKoltArgs(listOf("-Dfoo=bar", "test"))
+    val after = parseKoltArgs(listOf("test", "-Dfoo=bar"))
+
+    assertEquals(before.cliSysProps, after.cliSysProps)
+    assertEquals(before.filteredArgs, after.filteredArgs)
+  }
+
+  @Test
+  fun dflagCombinesWithOtherKoltLevelFlags() {
+    val parsed = parseKoltArgs(listOf("--no-daemon", "-Dfoo=bar", "--release", "test", "-Dbaz=qux"))
+
+    assertEquals(Profile.Release, parsed.profile)
+    assertFalse(parsed.useDaemon)
+    assertEquals(listOf("foo" to "bar", "baz" to "qux"), parsed.cliSysProps)
+    assertEquals(listOf("test"), parsed.filteredArgs)
+  }
 }


### PR DESCRIPTION
Closes #319.

Adds `-D<key>=<value>` to `kolt test` and `kolt run` (and their `--watch` variants). `parseKoltArgs` extracts `-D` flags into a new `KoltArgs.cliSysProps` field; `jvmTestArgv` / `jvmRunArgv` / `runJvmCommandFor` overlay them onto `[test.sys_props]` / `[run.sys_props]`. Overlay semantics per #319 DoD: toml entries first in declaration order, CLI entries appended in command-line order, same-key collisions drop the toml entry. CLI is literal-only — the `{ classpath = ... }` / `{ project_dir = ... }` shapes remain `kolt.toml`-exclusive.

Worth a careful look:

- **Native-target rejection.** `rejectCliSysPropsOnNative` mirrors the parse-time native rejection of `[run.sys_props]` / `[test.sys_props]` (Config.kt:275-296). Without it, `kolt run -Dfoo=bar` on a native target would silently drop the flag — the parse-time rejection only catches kolt.toml-declared sysprops. The helper is wired at the same gate point as `rejectIfLibrary` (doRunInner / doTestInner / watchRunLoop) so the symmetry survives a future caller add.
- **CLI-side duplicate keys pass through verbatim.** `overlayCliSysProps` does not dedup CLI-side; `-Dfoo=a -Dfoo=b` produces `-Dfoo=a -Dfoo=b` in argv and the JVM resolves last-write-wins. This matches `java -Dfoo=...` semantics and is pinned by `jvmRunArgvCliDuplicateKeysPassThroughVerbatim`.
- **Bare `-D` / `-D=value` left in filteredArgs.** `parseDFlag` returns null for these, so they reach the subcommand dispatcher and surface as a normal "unknown command" error rather than being silently dropped.
- **Other subcommands (`build`, `fmt`, `clean`, ...) silently parse and discard `-D`.** This matches the existing precedent for `--watch` on subcommands that don't support it. JVM-only is enforced for `test`/`run`; for the rest, the flag is harmless dead weight.
- **ADR 0032 amendment.** §3 / Negative bullets / Related flip from "deferred" to "landed" for #319; #320 (kolt.local.toml) remains deferred.

Verification:
- `kolt test` 1419/1419 pass — new tests: 11 in `ParseKoltArgsTest`, 8 in `BuildCommandsSysPropTest` (5 overlay + 3 native-rejection/dup-key).
- `kolt build` clean.
- `--help` shows the new flag aligned with existing flag column.