### PR TITLE
release: v0.17.0

### DIFF
--- a/.claude/skills/kolt-usage/SKILL.md
+++ b/.claude/skills/kolt-usage/SKILL.md
@@ -83,6 +83,7 @@ kolt --version              Show version
 | `--watch` | Watch source files and re-run on change (build/check/test/run) |
 | `--no-daemon` | Skip the warm compiler daemon for this invocation. Always available, even on Kotlin versions outside the daemon's supported range (ADR 0022). |
 | `--release` | Build under the release profile. Native: enables `-opt`, omits `-g`, writes artifacts to `build/release/`. JVM: declared no-op; the artifact still moves to `build/release/<name>.jar`. Debug remains the default. |
+| `-D<key>=<value>` | JVM system property for `kolt test` / `kolt run` (JVM target only). Overlays declared `[test.sys_props]` / `[run.sys_props]`; same-key collisions drop the toml entry. CLI values are literal-only. |
 
 ### Build Profiles
 
@@ -162,6 +163,18 @@ jitpack = "https://jitpack.io"
 name = "libcurl"
 def = "src/nativeInterop/cinterop/libcurl.def"
 package = "libcurl"
+
+# Named jar bundle, resolved independently of [dependencies].
+[classpaths.serialization-tools]
+"org.jetbrains.kotlinx:kotlinx-serialization-core" = "1.6.0"
+
+[test.sys_props]
+"my.app.fixture" = { project_dir = "test/fixtures" }
+"my.app.tools"   = { classpath = "serialization-tools" }
+"my.app.mode"    = { literal = "test" }
+
+[run.sys_props]
+"my.app.config" = { project_dir = "config" }
 ```
 
 ### Fields
@@ -184,10 +197,46 @@ package = "libcurl"
 | `[fmt] style` | ktfmt style: `"google"`, `"kotlinlang"`, `"meta"` | `"google"` |
 | `[[cinterop]]` | C interop bindings for native targets (array of `.def` entries) | `[]` |
 | `[repositories]` | Maven repositories (name = URL, tried in order) | Maven Central only |
+| `[classpaths.<name>]` | Named jar bundle resolved independently of `[dependencies]`. Same TOML shape (`"group:artifact" = "version"`). Referenced from `[test\|run.sys_props]` via `{ classpath = "<name>" }`. JVM target only. | `{}` |
+| `[test.sys_props]` | Map of `-D<key>=<value>` for the test JVM. Each value is `{ literal = "..." }` / `{ classpath = "<bundle>" }` / `{ project_dir = "<rel>" }`. JVM target only. | `{}` |
+| `[run.sys_props]` | Same shape as `[test.sys_props]` for `kolt run`. JVM target + `kind = "app"` only. | `{}` |
 
 ### C Interop
 
 For native target projects, declare one `[[cinterop]]` entry per `.def` file. kolt invokes the konan `cinterop` tool, caches `build/<name>.klib`, and links it via `konanc -l`. Fields: `name` (klib base), `def` (.def path), `package` (optional Kotlin package). Compiler and linker flags belong inside the `.def` file itself via the Kotlin/Native standard `compilerOpts.<platform>` / `linkerOpts.<platform>` keys — kolt does not duplicate them in `kolt.toml`. Klibs are regenerated when the `.def` file's mtime changes.
+
+### JVM System Properties (`[test.sys_props]` / `[run.sys_props]`)
+
+JVM target projects can declare `-D<key>=<value>` system properties for `kolt test` (`[test.sys_props]`) and `kolt run` (`[run.sys_props]`). Each value is one inline-table shape:
+
+| Shape | Resolution |
+|-------|------------|
+| `{ literal = "..." }` | Verbatim string. |
+| `{ classpath = "<bundle>" }` | Colon-joined absolute paths from `[classpaths.<bundle>]`. |
+| `{ project_dir = "<rel>" }` | `<project root>/<rel>` as absolute path; `"."` resolves to the project root. |
+
+```toml
+[classpaths.compiler-plugins]
+"org.example:my-plugin" = "1.2.0"
+
+[test.sys_props]
+"my.app.fixture" = { project_dir = "test/fixtures" }
+"my.app.plugins" = { classpath = "compiler-plugins" }
+"my.app.mode"    = { literal = "test" }
+
+[run.sys_props]
+"my.app.config" = { project_dir = "config" }
+```
+
+`-D<key>=<value>` flags on the command line overlay declared sysprops at invocation time. Toml entries are emitted first in declaration order; CLI entries are appended in command-line order; same-key collisions drop the toml entry (CLI wins). CLI values are literal-only.
+
+```sh
+kolt test -Dlog.level=DEBUG
+kolt run -Dapi.endpoint=http://localhost:8080
+kolt test -Dmy.app.mode=integration   # overlays [test.sys_props].my.app.mode
+```
+
+`kolt.toml` does not interpolate `${env.X}` — values are literal at parse time (ADR 0032). Per-machine values arrive through the CLI flag (now) or `kolt.local.toml` (future, #320). The schema rejects `[test.sys_props]` / `[run.sys_props]` / `[classpaths.*]` on native targets at parse time, and `[run.sys_props]` on `kind = "lib"`.
 
 ## Dependencies
 

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -41,7 +41,7 @@ it would cost startup speed, auditability, or mental-model simplicity.
 
 ## Current Maturity
 
-Pre-1.0 (current: v0.16.3). Breaking changes are expected and explicitly permitted.
+Pre-1.0 (current: v0.17.0). Breaking changes are expected and explicitly permitted.
 kolt does not ship migration shims or legacy probes for its own earlier versions —
 v1.0 is the first stability anchor.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
 
 [English](README.md) | 日本語
 
-> v0.16.3 — 初期段階のプロジェクトです。破壊的変更の可能性があります。
+> v0.17.0 — 初期段階のプロジェクトです。破壊的変更の可能性があります。
 
 Kotlin 向けの軽量ビルドツールです。TOML 設定ファイルのみで動作し、Kotlin DSL のビルドスクリプト評価は不要です。単一の Kotlin/Native バイナリとして配布されるため、利用に Java のインストールは必要ありません。
 
@@ -100,6 +100,7 @@ kolt --version         バージョンを表示
 | `--watch` | ソースファイルを監視し、変更時にコマンドを再実行（build/check/test/run） |
 | `--no-daemon` | この実行でウォームコンパイラデーモンをスキップ。daemon サポート対象外の Kotlin バージョン (ADR 0022) でも常に利用可能。 |
 | `--release` | release プロファイルでビルドする。Native は `-opt` を有効化し `-g` を外して `build/release/` に出力。JVM では宣言上 no-op（kotlinc 引数も daemon IC パスも変わらない）だが、両プロファイル成果物を相互に上書きしないよう成果物パスは `build/release/<name>.jar` に切り替わる。デフォルトは `debug` プロファイルで、両プロファイルの成果物はディスク上に共存するためプロファイルを切り替えても他方の IC が無効化されることはない。詳細は [ADR 0030](docs/adr/0030-build-profiles.md) を参照。 |
+| `-D<key>=<value>` | `kolt test` / `kolt run` 用の JVM システムプロパティ（JVM ターゲットのみ）。宣言済みの `[test.sys_props]` / `[run.sys_props]` に対するオーバーレイで、同一キーが衝突した場合は kolt.toml 側のエントリを破棄する。CLI 値は literal のみ。詳細は [ADR 0032](docs/adr/0032-kolt-toml-env-agnostic.md) を参照。 |
 
 ## 設定
 
@@ -151,6 +152,9 @@ jitpack = "https://jitpack.io"
 | `[fmt] style` | ktfmt スタイル：`"google"`、`"kotlinlang"`、`"meta"` | `"google"` |
 | `[[cinterop]]` | native target 用の C interop バインディング（`.def` ごとに 1 エントリ） | `[]` |
 | `[repositories]` | Maven リポジトリ（名前 = URL） | Maven Central のみ |
+| `[classpaths.<name>]` | `[dependencies]` と独立に解決される名前付き jar bundle。TOML 形式は `[dependencies]` と同じ（`"group:artifact" = "version"`）。JVM ターゲットのみ。 | `{}` |
+| `[test.sys_props]` | テスト JVM 用 `-D<key>=<value>` のマップ。各値は `{ literal = "..." }` / `{ classpath = "<bundle>" }` / `{ project_dir = "<rel>" }` のいずれか。JVM ターゲットのみ。 | `{}` |
+| `[run.sys_props]` | `kolt run` 用、形式は `[test.sys_props]` と同じ。JVM ターゲット + `kind = "app"` のみ。 | `{}` |
 
 ### 依存関係
 
@@ -225,6 +229,32 @@ linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -lcurl
 ```
 
 `cinterop` klib は `.def` ファイルの mtime が変更された場合に再生成されます。ソースのみの編集ではキャッシュ済み klib を再利用します。複数の `[[cinterop]]` エントリが許可され、宣言順にリンクされます。
+
+### JVM システムプロパティ
+
+JVM ターゲットのプロジェクトは、`kolt test` 用の `[test.sys_props]` と `kolt run` 用の `[run.sys_props]` で `-D<key>=<value>` JVM システムプロパティを宣言できます。各値は 3 種類のインラインテーブル形式のいずれか：`{ literal = "..." }` (リテラル文字列)、`{ classpath = "<bundle>" }` (`[classpaths.<bundle>]` の解決後コロン区切り絶対パス)、`{ project_dir = "<rel>" }` (`<project root>/<rel>` の絶対パス)。
+
+```toml
+[classpaths.compiler-plugins]
+"org.example:my-plugin" = "1.2.0"
+
+[test.sys_props]
+"my.app.fixture" = { project_dir = "test/fixtures" }
+"my.app.plugins" = { classpath = "compiler-plugins" }
+"my.app.mode"    = { literal = "test" }
+
+[run.sys_props]
+"my.app.config" = { project_dir = "config" }
+```
+
+コマンドラインの `-D<key>=<value>` フラグは、起動時に宣言済みの sysprops にオーバーレイします。toml エントリは宣言順に先頭側、CLI エントリはコマンドライン順で末尾側に配置され、同一キー衝突時は toml 側のエントリを破棄します（CLI が勝つ）。CLI 値は literal のみ。
+
+```sh
+kolt test -Dlog.level=DEBUG
+kolt run -Dapi.endpoint=http://localhost:8080
+```
+
+`kolt.toml` は `${env.X}` 補間を行いません — 値は parse 時にリテラルとして扱われます。マシン固有値は CLI フラグ（現在）か `kolt.local.toml`（v1.x ロードマップ）で渡します。スキーマは native ターゲットの `[test.sys_props]` / `[run.sys_props]` / `[classpaths.*]`、および `kind = "lib"` の `[run.sys_props]` を parse 時に拒否します。詳細は [ADR 0032](docs/adr/0032-kolt-toml-env-agnostic.md) を参照。
 
 ### リソースファイル
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 English | [日本語](README.ja.md)
 
-> v0.16.3 — Early-stage project. Expect breaking changes.
+> v0.17.0 — Early-stage project. Expect breaking changes.
 
 A lightweight build tool for Kotlin. TOML config — no Kotlin DSL build scripts to evaluate. Distributed as a single Kotlin/Native binary — no Java install required to use it.
 
@@ -100,6 +100,7 @@ kolt --version         Show version
 | `--watch` | Watch source files and re-run the command on change (build/check/test/run) |
 | `--no-daemon` | Skip the warm compiler daemon for this invocation. Always available, including on Kotlin versions outside the daemon's supported range (ADR 0022). |
 | `--release` | Build under the release profile. Native: enables `-opt`, omits `-g`, writes artifacts to `build/release/`. JVM: declared no-op (same kotlinc args, same daemon IC path) — the artifact still moves to `build/release/<name>.jar` so the two profiles' outputs do not overwrite each other. Default profile is `debug`; both profiles' artifacts coexist on disk so switching between them does not invalidate the other. See [ADR 0030](docs/adr/0030-build-profiles.md). |
+| `-D<key>=<value>` | JVM system property for `kolt test` / `kolt run` (JVM target only). Overlays declared `[test.sys_props]` / `[run.sys_props]`; same-key collisions drop the toml entry. CLI values are literal-only. See [ADR 0032](docs/adr/0032-kolt-toml-env-agnostic.md). |
 
 ## Configuration
 
@@ -151,6 +152,9 @@ jitpack = "https://jitpack.io"
 | `[fmt] style` | ktfmt style: `"google"`, `"kotlinlang"`, `"meta"` | `"google"` |
 | `[[cinterop]]` | C interop bindings for native targets (one array entry per `.def`) | `[]` |
 | `[repositories]` | Maven repositories (name = URL) | Maven Central only |
+| `[classpaths.<name>]` | Named jar bundle, resolved independently of `[dependencies]`. Same TOML shape (`"group:artifact" = "version"`). JVM target only. | `{}` |
+| `[test.sys_props]` | Map of `-D<key>=<value>` for the test JVM. Each value is `{ literal = "..." }` / `{ classpath = "<bundle>" }` / `{ project_dir = "<rel>" }`. JVM target only. | `{}` |
+| `[run.sys_props]` | Same shape as `[test.sys_props]` for `kolt run`. JVM target + `kind = "app"` only. | `{}` |
 
 ### Dependencies
 
@@ -225,6 +229,32 @@ linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -lcurl
 ```
 
 The `cinterop` klib is regenerated when the `.def` file's mtime changes; source-only edits reuse the cached klib. Multiple `[[cinterop]]` entries are allowed and are linked in declaration order.
+
+### JVM System Properties
+
+JVM-target projects can declare `-D<key>=<value>` system properties for `kolt test` (`[test.sys_props]`) and `kolt run` (`[run.sys_props]`). Each value is one of three inline-table shapes: `{ literal = "..." }` (verbatim), `{ classpath = "<bundle>" }` (colon-joined paths from a `[classpaths.<bundle>]` declaration), or `{ project_dir = "<rel>" }` (`<project root>/<rel>` as absolute path).
+
+```toml
+[classpaths.compiler-plugins]
+"org.example:my-plugin" = "1.2.0"
+
+[test.sys_props]
+"my.app.fixture" = { project_dir = "test/fixtures" }
+"my.app.plugins" = { classpath = "compiler-plugins" }
+"my.app.mode"    = { literal = "test" }
+
+[run.sys_props]
+"my.app.config" = { project_dir = "config" }
+```
+
+`-D<key>=<value>` flags on the command line overlay declared sysprops at invocation time. Toml entries are emitted first in declaration order; CLI entries are appended in command-line order; same-key collisions drop the toml entry (CLI wins). CLI values are literal-only.
+
+```sh
+kolt test -Dlog.level=DEBUG
+kolt run -Dapi.endpoint=http://localhost:8080
+```
+
+`kolt.toml` does not interpolate `${env.X}` — values are literal at parse time. Per-machine values arrive through the CLI flag (now) or `kolt.local.toml` (planned, post-1.0). The schema rejects `[test.sys_props]` / `[run.sys_props]` / `[classpaths.*]` on native targets and `[run.sys_props]` on `kind = "lib"`. See [ADR 0032](docs/adr/0032-kolt-toml-env-agnostic.md).
 
 ### Resource Files
 

--- a/docs/release-notes/v0.17.0.md
+++ b/docs/release-notes/v0.17.0.md
@@ -1,0 +1,65 @@
+**kolt.toml schema: classpath bundles + JVM system properties (#318)**
+
+Three new tables let kolt drive `-D<key>=<value>` JVM sysprops and pre-resolved jar bundles into `kolt test` / `kolt run` without dropping to a wrapper script. Primary motivation: `[run.sys_props]` for projects that need to point at compiler-plugin classpaths (e.g., kolt's own daemon source roots) — the surface that finally let kolt build itself without `./gradlew check`.
+
+- `[classpaths.<bundle>]` declares a named jar bundle, same TOML shape as `[dependencies]` (`"group:artifact" = "version"`). Bundles are resolved through an isolated resolver pass — they do not co-exist with `[dependencies]` / `[test-dependencies]` in version conflict resolution, so a bundle's transitive closure is independent.
+- `[test.sys_props]` and `[run.sys_props]` declare `-D<key>=<value>` entries for the test / run JVM. Each value is one of three inline-table shapes: `{ literal = "..." }`, `{ classpath = "<bundle>" }`, or `{ project_dir = "<rel>" }`. The literal branch is verbatim; classpath resolves to a colon-joined absolute path from a declared bundle; project_dir resolves to `<project root>/<rel>`.
+- Native targets reject all three at parse time (sysprops are JVM-only); a `kind = "lib"` project rejects `[run.sys_props]` (libraries cannot be run).
+
+**CLI `-D<key>=<value>` flag for `kolt test` / `kolt run` (#319)**
+
+`kolt test -D<key>=<value> [...]` and `kolt run -D<key>=<value> [...]` accept zero or more `-D` flags and overlay them onto declared `[test.sys_props]` / `[run.sys_props]`. Toml entries appear first in declaration order, CLI entries appended in command-line order, same-key collisions drop the toml entry (CLI wins). CLI values are literal-only — the structured `{ classpath = ... }` / `{ project_dir = ... }` shapes remain `kolt.toml`-exclusive.
+
+- Symmetric with the parse-time native rejection: `-D` on a native target errors with `EXIT_CONFIG_ERROR` rather than silently dropping the flag.
+- Bare `-D` and `-D=value` (empty key) are not recognised as sysprop flags and reach the dispatcher as a normal "unknown command" / passthrough error.
+- Use case: one-off log-level overrides, ad-hoc fixture paths. The persistent per-developer counterpart (`kolt.local.toml`, #320) is on the v1.x roadmap.
+
+ADR 0032 commits the env-agnostic invariant: `kolt.toml` does not interpolate `${env.X}`; the CLI flag (now landed) and the planned `kolt.local.toml` (deferred) are the two designated channels for environment-specific values.
+
+**`kolt run --watch` threads `[run.sys_props]` (#322)**
+
+The watch loop's run path was calling `runCommand` directly with no sysprop resolution, so declared `-D` entries silently dropped on every restart. Lifted into a shared helper `runJvmCommandFor` so one-shot and watch-mode produce byte-identical argv. `kolt test --watch` is intentionally still out of scope (separate issue).
+
+**JVM compiler daemon: connect budget 3s -> 10s (#310)**
+
+Cold-cache CI runs cleared the prior 3s budget before the daemon listened (ADR 0016 §2 cold-start ~2.6s plus the documented WSL2/CI 9p stat-storm outlier ~3.3s), causing every first build to false-positively fall back to subprocess. The retry loop runs only after a spawn — warm reconnects short-circuit on the first connector call — so dev-loop responsiveness on warm caches is unaffected. Cost: when the daemon is genuinely broken, fallback now takes up to ~10s before subprocess engages. ADR 0016 amended.
+
+A follow-up will tighten the unit-tests.yml daemon canary's negative assertion (`! falling back to subprocess`) once the bootstrap kolt is on this release.
+
+**`kolt test` filter args no longer pass `--scan-class-path` (#323)**
+
+`kolt test -- --select-class kolt.cli.ParseKoltArgsTest` was double-binding: the user's `--select-*` competed with kolt's auto-injected `--scan-class-path`, producing a Console Launcher error. kolt now suppresses `--scan-class-path` whenever any `--select-*` argument is present in `testArgs`.
+
+**Bug fixes**
+
+- `doNativeTest` was bypassing `resolveNativeCompilerBackend` and routing directly to subprocess; native daemon engagement now goes through the same backend resolver as `doBuild` (#312).
+- The project lock is now released between the test compile and the test child spawn so nested `kolt` invocations from inside the test process do not deadlock against the parent (#303).
+
+**Internals: kolt builds itself without Gradle**
+
+This release closes the Gradle removal arc:
+
+- `./gradlew check` replaced with kolt-native daemon test runners — kolt's own native compiler daemon and JVM compiler daemon subprojects are now built and tested through `kolt build` / `kolt test` (#324, #315).
+- Orphan Gradle config files removed from the kolt repo (#316).
+- CI bootstrap path runs the prebuilt kolt binary instead of Gradle — both `unit-tests.yml` and `self-host-smoke.yml` (#301, #302, #308).
+- Native compiler daemon canary added to self-host-smoke to detect silent fallback regressions (#313).
+
+**Internals: libarchive replaces unzip / tar shell-outs (#43)**
+
+The toolchain extractor (`~/.kolt/toolchains/<tool>/<ver>/`) now uses libarchive cinterop instead of forking `unzip` / `tar`. Removes a system-binary dependency on the install path. Schema unchanged; users see no difference.
+
+**Yanked v0.16.1 / v0.16.2**
+
+These releases shipped the same daemon-bind regression as v0.16.x and were yanked in favor of v0.16.3. v0.17.0 supersedes the yank gate; install.sh's YANKED check is unchanged.
+
+**Installation**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh
+```
+
+**Upgrade notes**
+
+- Existing `kolt.toml` files continue to parse with no changes; the new `[classpaths.*]` / `[test.sys_props]` / `[run.sys_props]` tables are all opt-in.
+- If you used `./gradlew check` directly against the kolt repo (e.g. forks contributing back), switch to `kolt build && kolt test`. Standalone daemon subprojects use `cd kolt-jvm-compiler-daemon && kolt build` (and the native counterpart).
+- The 10s daemon connect budget extends fallback latency on a genuinely broken daemon by up to 7s; if you rely on fast subprocess fallback in CI for any reason, audit your daemon path before upgrading.

--- a/kolt-jvm-compiler-daemon/kolt.toml
+++ b/kolt-jvm-compiler-daemon/kolt.toml
@@ -1,5 +1,5 @@
 name = "kolt-jvm-compiler-daemon"
-version = "0.16.3"
+version = "0.17.0"
 kind = "app"
 
 [kotlin]

--- a/kolt-native-compiler-daemon/kolt.toml
+++ b/kolt-native-compiler-daemon/kolt.toml
@@ -1,5 +1,5 @@
 name = "kolt-native-compiler-daemon"
-version = "0.16.3"
+version = "0.17.0"
 kind = "app"
 
 [kotlin]

--- a/kolt.toml
+++ b/kolt.toml
@@ -1,5 +1,5 @@
 name = "kolt"
-version = "0.16.3"
+version = "0.17.0"
 
 [kotlin]
 version = "2.3.20"

--- a/src/nativeMain/kotlin/kolt/config/Version.kt
+++ b/src/nativeMain/kotlin/kolt/config/Version.kt
@@ -1,5 +1,5 @@
 package kolt.config
 
-const val KOLT_VERSION = "0.16.3"
+const val KOLT_VERSION = "0.17.0"
 
 fun versionString(): String = "kolt $KOLT_VERSION"


### PR DESCRIPTION
Bumps kolt to v0.17.0. 20 commits since v0.16.3 — `kolt.toml` schema additions (`[classpaths.*]`, `[test.sys_props]`, `[run.sys_props]`), CLI `-D<key>=<value>` flag, daemon connect budget 3s -> 10s, Gradle removed from kolt's own build, libarchive replaces unzip/tar shell-outs.

Worth a careful look:

- **`docs/release-notes/v0.17.0.md`** — `release.yml` consumes this via `--notes-file` (per #300). Hand-written; tone follows v0.16.0's structure (per-feature blocks with WHY, then Installation + Upgrade notes).
- **README.md / README.ja.md** — added `-D<key>=<value>` row to flags table, three rows to fields table (`[classpaths.<name>]`, `[test.sys_props]`, `[run.sys_props]`), and a "JVM System Properties" section after C Interop. ja README mirrors the en version.
- **`.claude/skills/kolt-usage/SKILL.md`** — same shape as README; the kolt.toml example now includes a `[classpaths.*]` + `[test.sys_props]` + `[run.sys_props]` snippet so users invoking the skill get a complete example.
- **`KOLT_BOOTSTRAP_TAG: v0.16.3` left untouched** in all 3 workflows. Bootstrap kolt is intentionally one release behind per kolt's bootstrap policy; bumping to `v0.17.0` is a follow-up after this release publishes (the scheduled routine `trig_01Qx4GiRttRkBgyebyrxGNuw` will tighten the daemon canary once the bump lands).
- **`InfoCommandTest` fixtures still say `koltVersion = "0.16.3"`** — these are hermetic fixtures that hardcode an explicit string for both input and assertion, not state that flows from `KOLT_VERSION`. Left as-is (no behaviour change), but worth confirming you're OK with the inconsistency.
- **kolt-{jvm,native}-compiler-daemon `kolt.toml`** also bumped for consistency. They are independent kolt projects so the bump propagates manually.

Verification:
- `kolt test` 1419/1419 pass.
- `kolt build` clean.
- `./build/debug/kolt.kexe --version` -> `kolt 0.17.0`.

After merge, tag `v0.17.0` to trigger `release.yml` (publishes the binary tarball and consumes the release notes via `--notes-file`).