### PR TITLE
Bump bootstrap to v0.17.0, ungate nested-lock test

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 env:
-  KOLT_BOOTSTRAP_TAG: v0.16.3
+  KOLT_BOOTSTRAP_TAG: v0.17.0
   # Run the bootstrap kolt from inside the extracted release tree so
   # `DaemonJarResolver` can find `libexec/<daemon>/*.jar` siblings and
   # spawn the warm daemon. Copying the binary out (as the original
@@ -105,12 +105,9 @@ jobs:
       # exercises the JVM compiler daemon. The pre-#302 bug surfaced as
       # `kolt-jvm-compiler-daemon jar not found — falling back to
       # subprocess compile`, which short-circuited before any spawn
-      # attempt. The canary requires `starting compiler daemon` in stderr
-      # — i.e. the daemon code path was reached. Whether the spawn itself
-      # connects within the retry budget is orthogonal: #310 raised the
-      # budget to 10s in the dev tree, but the bootstrap tag here still
-      # ships 3s, so the negative assertion (no `falling back to
-      # subprocess`) is gated on the next bootstrap bump.
+      # attempt. The canary asserts both that the daemon code path was
+      # reached (`starting compiler daemon`) and that the daemon
+      # actually engaged (no `falling back to subprocess`).
       - name: Verify daemon thin jar builds standalone
         run: |
           set -euo pipefail
@@ -121,4 +118,8 @@ jobs:
             echo "Canary failed: bootstrap kolt did not reach the daemon spawn path (jar resolution likely failed)" >&2
             exit 1
           fi
-          echo "Canary OK: daemon spawn path was reached"
+          if grep -q 'falling back to subprocess' kolt-build.stderr; then
+            echo "Canary failed: daemon was reached but did not engage (fell back to subprocess)" >&2
+            exit 1
+          fi
+          echo "Canary OK: daemon engaged"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -105,9 +105,11 @@ jobs:
       # exercises the JVM compiler daemon. The pre-#302 bug surfaced as
       # `kolt-jvm-compiler-daemon jar not found — falling back to
       # subprocess compile`, which short-circuited before any spawn
-      # attempt. The canary asserts both that the daemon code path was
-      # reached (`starting compiler daemon`) and that the daemon
-      # actually engaged (no `falling back to subprocess`).
+      # attempt. The canary requires `starting compiler daemon` in
+      # stderr — i.e. the daemon code path was reached. The negative
+      # assertion (no `falling back to subprocess`) is deferred: #332
+      # raised the connect budget to 10s but cold-cache CI still
+      # subprocess-falls-back, see #336.
       - name: Verify daemon thin jar builds standalone
         run: |
           set -euo pipefail
@@ -118,8 +120,4 @@ jobs:
             echo "Canary failed: bootstrap kolt did not reach the daemon spawn path (jar resolution likely failed)" >&2
             exit 1
           fi
-          if grep -q 'falling back to subprocess' kolt-build.stderr; then
-            echo "Canary failed: daemon was reached but did not engage (fell back to subprocess)" >&2
-            exit 1
-          fi
-          echo "Canary OK: daemon engaged"
+          echo "Canary OK: daemon spawn path was reached"

--- a/src/nativeTest/kotlin/kolt/cli/NestedLockAcquireTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/NestedLockAcquireTest.kt
@@ -1,5 +1,3 @@
-@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
-
 package kolt.cli
 
 import com.github.michaelbull.result.getOrElse
@@ -7,8 +5,6 @@ import kolt.build.BUILD_DIR
 import kolt.concurrency.ProjectLock
 import kotlin.test.Test
 import kotlin.test.fail
-import kotlinx.cinterop.toKString
-import platform.posix.getenv
 
 class NestedLockAcquireTest {
 
@@ -18,19 +14,8 @@ class NestedLockAcquireTest {
   // doTest from inside a test deadlocks against the parent's still-held
   // lock and exits at EXIT_LOCK_TIMEOUT. A 200ms timeout makes a
   // regression fail fast instead of the default 30s budget.
-  //
-  // Gated behind `KOLT_NESTED_LOCK_TEST=1`. CI bootstrap kolt
-  // (`KOLT_BOOTSTRAP_TAG=v0.16.3`) holds the lock through child
-  // lifetime — the very bug this test asserts is fixed — so the test
-  // would unavoidably fail under the old bootstrap. After
-  // `KOLT_BOOTSTRAP_TAG` advances past a release that includes #303,
-  // set the env in `unit-tests.yml` and remove this gate in a
-  // follow-up.
   @Test
   fun projectLockIsAvailableInsideKoltTestChild() {
-    val gate = getenv("KOLT_NESTED_LOCK_TEST")?.toKString()
-    if (gate != "1") return
-
     val handle =
       ProjectLock.acquire(BUILD_DIR, timeoutMs = 200L).getOrElse {
         fail(


### PR DESCRIPTION
v0.17.0 ships both #317 (lock release before test child spawn) and #332 (10s daemon connect budget). With a post-fix bootstrap pin, two follow-ups become unblocked:

- `NestedLockAcquireTest` was gated behind `KOLT_NESTED_LOCK_TEST=1` because the v0.16.3 bootstrap held the project lock through child lifetime — the very bug #317 fixed. Ungated, it now runs unconditionally as a regression guard for #303.
- The daemon-canary comment in `unit-tests.yml` is updated to reflect the post-bump state.

The follow-up promised in #332 — adding a negative `falling back to subprocess` assertion to the canary — was attempted in the first commit on this branch and reverted in the second. The first CI run on this PR fired the new assertion: v0.17.0's 10s budget still subprocess-falls-back on cold-cache GHA runners with `errno=2` across the full window. #332's "10s is enough" was a guess and turned out to be insufficient. Tracked separately in #336.

Reviewer focus: the nested-lock test ungate is mechanical (gate removal + dead-import cleanup); the canary comment is the only deliberate text change in `unit-tests.yml`. Local `kolt test` (HEAD binary) passes 1419/1419 with the gate removed.