### PR TITLE
ci: dump daemon log on canary step (#336 observability)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -121,3 +121,30 @@ jobs:
             exit 1
           fi
           echo "Canary OK: daemon spawn path was reached"
+
+      # #336 observability: bootstrap kolt redirects daemon stdio to
+      # ~/.kolt/daemon/<hash>/<ver>/*-compiler-daemon[-<fp>].log via
+      # spawnDetached. When the daemon fails to bind on cold-cache CI
+      # we currently can only see the parent's connect-side timeout;
+      # this dump surfaces whatever the JVM child managed to write
+      # before exit. An empty / missing file means the JVM never wrote
+      # anything (daemon init slower than the 10s budget OR exec failed
+      # silently). always() so a failed canary does not skip this.
+      - name: Dump daemon logs for #336
+        if: always()
+        run: |
+          set +e
+          shopt -s globstar nullglob
+          dir="$HOME/.kolt/daemon"
+          echo "::group::tree under $dir"
+          find "$dir" -maxdepth 6 -printf '%y %s %p\n' 2>/dev/null || true
+          echo "::endgroup::"
+          found=0
+          for f in "$dir"/**/*-compiler-daemon*.log; do
+            found=1
+            echo "::group::$f"
+            wc -c "$f"
+            cat "$f"
+            echo "::endgroup::"
+          done
+          [ "$found" = "0" ] && echo "no daemon log files found under $dir"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -147,4 +147,6 @@ jobs:
             cat "$f"
             echo "::endgroup::"
           done
-          [ "$found" = "0" ] && echo "no daemon log files found under $dir"
+          if [ "$found" = "0" ]; then
+            echo "no daemon log files found under $dir"
+          fi


### PR DESCRIPTION
First investigative step for #336. The bootstrap kolt's \`spawnDetached\` already redirects the daemon child's stdout/stderr to \`~/.kolt/daemon/<hash>/<ver>/*-compiler-daemon[-<fp>].log\`, but that file is never surfaced on CI. When the daemon fails to bind within the 10s connect budget the parent side only knows that the socket never appeared — the JVM child's own output goes unread.

This PR adds a single read-only step after the canary that prints the daemon log files (plus the daemon dir tree as fallback). \`always()\` so a failed canary does not skip it, and there are no \`exit\` statements that could turn a passing canary into a failure.

This PR's own CI run will likely hit warm cache (cache key matches main), so we should see the success path's daemon log as a baseline. If the next cold-cache failure happens (e.g. on a kolt.toml change that busts the cache, or via deliberate cache-miss in a separate run), the dump will surface what the JVM wrote — empty/missing means JVM startup was slower than the budget OR exec failed silently; non-empty means the daemon got far enough to log, which narrows the candidate set significantly.

Reviewer focus: the new step is the only change. No code or test edits. No bootstrap pin churn. Safe to revert when #336 is resolved.