### PR TITLE
Substitute @KOLT_LIBEXEC@ in daemon argfile (#336)

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -83,14 +83,19 @@ jobs:
             --dir "$BOOTSTRAP_DIR"
           tar -xzf "$BOOTSTRAP_DIR"/kolt-*-linux-x64.tar.gz \
             -C "$BOOTSTRAP_DIR" --strip-components=1
+          # Bridge for #336: see unit-tests.yml for the rationale.
+          # Drop on the next bootstrap bump.
+          sed -i "s|@KOLT_LIBEXEC@|$BOOTSTRAP_DIR/libexec|g" \
+            "$BOOTSTRAP_DIR"/libexec/classpath/*.argfile
           "$BOOTSTRAP_KOLT" --version
 
       # Native daemon canary: `kolt build` for kolt itself is a Native
       # target build, so it routes through `resolveNativeCompilerBackend`
       # and the K2Native sidecar daemon (ADR 0024). Mirrors the JVM-side
-      # canary in `unit-tests.yml`: assert `starting native compiler
-      # daemon` reached stderr — i.e. the daemon code path was exercised.
-      # Spawn-to-connect timing is orthogonal (#310).
+      # canary in `unit-tests.yml`: assert both that the daemon code
+      # path was reached (`starting native compiler daemon`) and that
+      # the daemon actually engaged (no `falling back to subprocess`)
+      # so a silent regression to subprocess fallback fails the build.
       #
       # `kolt test` does not engage the native daemon today (#312); use
       # `kolt build` here instead.
@@ -102,7 +107,11 @@ jobs:
             echo "Canary failed: bootstrap kolt did not reach the native daemon spawn path" >&2
             exit 1
           fi
-          echo "Canary OK: native daemon spawn path was reached"
+          if grep -q 'falling back to subprocess' kolt-build.stderr; then
+            echo "Canary failed: native daemon was reached but did not engage (fell back to subprocess)" >&2
+            exit 1
+          fi
+          echo "Canary OK: native daemon engaged"
 
       - name: Verify self-hosted binary
         run: |
@@ -293,6 +302,43 @@ jobs:
             esac
           done < <(printf '%s\n' "$expected")
           echo "guard: libexec/kolt-bta-impl matches BTA_IMPL_JARS and is present on the argfile"
+
+      # #336 end-to-end guard: a user who downloads the release tarball
+      # and just `tar xzf`s it (skipping install.sh) must still get a
+      # working daemon. Pre-fix: argfile @KOLT_LIBEXEC@ placeholders are
+      # left raw, JVM dies with ClassNotFoundException, daemon never
+      # binds, build subprocess-falls-back. The resolver-side fix on
+      # this branch substitutes the placeholder at spawn time. Drive
+      # the daemon-engaged path from the un-installed dist tree and
+      # fail if `falling back to subprocess` shows up.
+      - name: Smoke-build without install.sh (#336 resolver fix)
+        run: |
+          set -euo pipefail
+          DIST_ROOT="$GITHUB_WORKSPACE/dist/kolt-${KOLT_TOML_VERSION}-linux-x64"
+          # Sanity: this guard only exercises #336 if the dist argfile
+          # still ships the placeholder. If assemble-dist starts emitting
+          # absolute paths the test silently becomes a no-op.
+          if ! grep -q '@KOLT_LIBEXEC@' \
+              "$DIST_ROOT/libexec/classpath/kolt-jvm-compiler-daemon.argfile"; then
+            echo "Sanity failed: dist argfile no longer contains @KOLT_LIBEXEC@; #336 smoke is no-op" >&2
+            exit 1
+          fi
+          rm -rf "$HOME/.kolt/daemon"
+          cd kolt-jvm-compiler-daemon
+          rm -rf build
+          "$DIST_ROOT/bin/kolt" build 2> kolt-build.stderr
+          echo "--- kolt-build.stderr ---"
+          cat kolt-build.stderr
+          echo "--- end stderr ---"
+          if grep -q 'falling back to subprocess' kolt-build.stderr; then
+            echo "#336 regression: daemon fell back to subprocess on tarball-without-install path" >&2
+            exit 1
+          fi
+          if ! grep -q 'starting compiler daemon' kolt-build.stderr; then
+            echo "Smoke failed: daemon spawn path not reached" >&2
+            exit 1
+          fi
+          echo "Smoke OK: daemon engaged from tarball-without-install path"
 
       # Local HTTP server lets install.sh exercise its real download +
       # SHA-256 + extract + sed + symlink path against the assembled tarball

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -82,6 +82,14 @@ jobs:
             --dir "$BOOTSTRAP_DIR"
           tar -xzf "$BOOTSTRAP_DIR"/kolt-*-linux-x64.tar.gz \
             -C "$BOOTSTRAP_DIR" --strip-components=1
+          # Bridge for #336: bootstrap pre-bump (v0.17.0) ships argfiles
+          # with the unsubstituted @KOLT_LIBEXEC@ placeholder. install.sh
+          # would substitute on its own, but this CI step extracts the
+          # tarball directly. Mirror install.sh:214 here so the bootstrap
+          # daemon has a valid classpath. Drop this once KOLT_BOOTSTRAP_TAG
+          # is bumped to a release that contains the resolver-side fix.
+          sed -i "s|@KOLT_LIBEXEC@|$BOOTSTRAP_DIR/libexec|g" \
+            "$BOOTSTRAP_DIR"/libexec/classpath/*.argfile
           "$BOOTSTRAP_KOLT" --version
 
       # `--ktest_logger=SILENT` collapses the per-test GTEST output (~2k
@@ -104,12 +112,13 @@ jobs:
       # Daemon-path canary: this step builds a JVM target and therefore
       # exercises the JVM compiler daemon. The pre-#302 bug surfaced as
       # `kolt-jvm-compiler-daemon jar not found — falling back to
-      # subprocess compile`, which short-circuited before any spawn
-      # attempt. The canary requires `starting compiler daemon` in
-      # stderr — i.e. the daemon code path was reached. The negative
-      # assertion (no `falling back to subprocess`) is deferred: #332
-      # raised the connect budget to 10s but cold-cache CI still
-      # subprocess-falls-back, see #336.
+      # subprocess compile`. The canary asserts both that the daemon
+      # code path was reached (`starting compiler daemon`) and that the
+      # daemon actually engaged (no `falling back to subprocess`) so a
+      # silent regression to subprocess fallback fails the build. The
+      # bootstrap step's @KOLT_LIBEXEC@ sed bridge keeps this assertion
+      # green on the v0.17.0 bootstrap; #336's resolver-side fix makes
+      # the bridge unnecessary on the next bootstrap bump.
       - name: Verify daemon thin jar builds standalone
         run: |
           set -euo pipefail
@@ -120,7 +129,11 @@ jobs:
             echo "Canary failed: bootstrap kolt did not reach the daemon spawn path (jar resolution likely failed)" >&2
             exit 1
           fi
-          echo "Canary OK: daemon spawn path was reached"
+          if grep -q 'falling back to subprocess' kolt-build.stderr; then
+            echo "Canary failed: daemon was reached but did not engage (fell back to subprocess)" >&2
+            exit 1
+          fi
+          echo "Canary OK: daemon engaged"
 
       # #336 observability: bootstrap kolt redirects daemon stdio to
       # ~/.kolt/daemon/<hash>/<ver>/*-compiler-daemon[-<fp>].log via

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonJarResolver.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonJarResolver.kt
@@ -9,10 +9,14 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
 
 // ADR 0018 §2: the resolver returns the JVM arguments that sit between the
-// `java` executable and the daemon's own CLI args — either `@<argfile>` for
-// installed layouts or `-cp <cp> <MainClass>` for env-override and dev cases.
-// This keeps fat-jar packaging off kolt's build graph and lets the launcher
-// stay ignorant of where the classpath came from.
+// `java` executable and the daemon's own CLI args — `-cp <cp> <MainClass>`
+// in every case. For the libexec layout the classpath comes from the
+// `assemble-dist`-emitted argfile; the resolver reads it and substitutes
+// the `@KOLT_LIBEXEC@` placeholder with the absolute libexec path so the
+// JVM gets a valid classpath whether the user ran install.sh or just
+// `tar xzf && bin/kolt` (#336). install.sh's own substitution remains a
+// no-op shim under this resolver — the placeholder simply isn't there
+// anymore by the time we read it.
 sealed interface DaemonJarResolution {
   data class Resolved(val launchArgs: List<String>, val source: Source) : DaemonJarResolution
 
@@ -28,6 +32,7 @@ sealed interface DaemonJarResolution {
 internal const val DAEMON_JAR_STEM = "kolt-jvm-compiler-daemon"
 internal const val DAEMON_MAIN_CLASS = "kolt.daemon.MainKt"
 internal const val KOLT_DAEMON_JAR_ENV = "KOLT_DAEMON_JAR"
+internal const val LIBEXEC_PLACEHOLDER = "@KOLT_LIBEXEC@"
 
 // Probe order: env override -> libexec argfile -> dev fallback (kolt build output).
 fun resolveDaemonJarPure(
@@ -48,7 +53,10 @@ fun resolveDaemonJarPure(
   val prefix = parentDir(binDir) ?: return DaemonJarResolution.NotFound
   val argfile = "$prefix/libexec/classpath/$DAEMON_JAR_STEM.argfile"
   if (fileExists(argfile)) {
-    return DaemonJarResolution.Resolved(listOf("@$argfile"), DaemonJarResolution.Source.Libexec)
+    val launch =
+      launchArgsFromArgfile(argfile, "$prefix/libexec", readManifest)
+        ?: return DaemonJarResolution.NotFound
+    return DaemonJarResolution.Resolved(launch, DaemonJarResolution.Source.Libexec)
   }
 
   var repoRoot: String? = selfExePath
@@ -64,6 +72,22 @@ fun resolveDaemonJarPure(
   }
 
   return DaemonJarResolution.NotFound
+}
+
+// Read `<libexec>/classpath/<daemon>.argfile` (line-per-token format from
+// scripts/assemble-dist.sh `write_argfile`), substitute every
+// `@KOLT_LIBEXEC@` with the absolute libexec path, and return the parsed
+// launch args. Returns null if the argfile can't be read or yielded no
+// tokens. Whether install.sh already ran the same substitution doesn't
+// matter — `replace` on a placeholder-free string is a no-op.
+private fun launchArgsFromArgfile(
+  argfile: String,
+  libexecAbs: String,
+  readManifest: (String) -> List<String>?,
+): List<String>? {
+  val lines = readManifest(argfile) ?: return null
+  val tokens = lines.map { it.replace(LIBEXEC_PLACEHOLDER, libexecAbs) }.filter { it.isNotEmpty() }
+  return tokens.takeIf { it.isNotEmpty() }
 }
 
 // Build `-cp <thin>:<deps...> <MainClass>` from a thin jar and its sibling

--- a/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonJarResolver.kt
+++ b/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonJarResolver.kt
@@ -10,9 +10,12 @@ import kotlinx.cinterop.toKString
 
 // Parallel to DaemonJarResolver for the JVM daemon. ADR 0018 §2: the resolver
 // returns the JVM args to splice between `java` and the daemon's own CLI
-// args — `@<argfile>` for installed layouts, `-cp <cp> <MainClass>` otherwise.
-// Filename and env var differ from the JVM daemon so a dev machine with both
-// staged doesn't cross-wire them.
+// args — `-cp <cp> <MainClass>` in every case. The libexec branch reads
+// the `assemble-dist`-emitted argfile and substitutes `@KOLT_LIBEXEC@`
+// with the absolute libexec path so the JVM gets a valid classpath
+// whether the user ran install.sh or just `tar xzf && bin/kolt` (#336).
+// Filename and env var differ from the JVM daemon so a dev machine with
+// both staged doesn't cross-wire them.
 sealed interface NativeDaemonJarResolution {
   data class Resolved(val launchArgs: List<String>, val source: Source) : NativeDaemonJarResolution
 
@@ -28,6 +31,7 @@ sealed interface NativeDaemonJarResolution {
 internal const val NATIVE_DAEMON_JAR_STEM = "kolt-native-compiler-daemon"
 internal const val NATIVE_DAEMON_MAIN_CLASS = "kolt.nativedaemon.MainKt"
 internal const val KOLT_NATIVE_DAEMON_JAR_ENV = "KOLT_NATIVE_DAEMON_JAR"
+internal const val LIBEXEC_PLACEHOLDER = "@KOLT_LIBEXEC@"
 
 fun resolveNativeDaemonJarPure(
   envValue: String?,
@@ -47,10 +51,10 @@ fun resolveNativeDaemonJarPure(
   val prefix = parentDir(binDir) ?: return NativeDaemonJarResolution.NotFound
   val argfile = "$prefix/libexec/classpath/$NATIVE_DAEMON_JAR_STEM.argfile"
   if (fileExists(argfile)) {
-    return NativeDaemonJarResolution.Resolved(
-      listOf("@$argfile"),
-      NativeDaemonJarResolution.Source.Libexec,
-    )
+    val launch =
+      launchArgsFromArgfile(argfile, "$prefix/libexec", readManifest)
+        ?: return NativeDaemonJarResolution.NotFound
+    return NativeDaemonJarResolution.Resolved(launch, NativeDaemonJarResolution.Source.Libexec)
   }
 
   var repoRoot: String? = selfExePath
@@ -69,6 +73,19 @@ fun resolveNativeDaemonJarPure(
   }
 
   return NativeDaemonJarResolution.NotFound
+}
+
+// See `kolt.build.daemon.launchArgsFromArgfile` for the contract; this
+// is the native-daemon mirror, kept private to match the parentDir /
+// readManifestLines duplication pattern in this file.
+private fun launchArgsFromArgfile(
+  argfile: String,
+  libexecAbs: String,
+  readManifest: (String) -> List<String>?,
+): List<String>? {
+  val lines = readManifest(argfile) ?: return null
+  val tokens = lines.map { it.replace(LIBEXEC_PLACEHOLDER, libexecAbs) }.filter { it.isNotEmpty() }
+  return tokens.takeIf { it.isNotEmpty() }
 }
 
 private fun launchArgsFromThinJar(

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
@@ -63,7 +63,7 @@ private fun newBackend(
 ): DaemonCompilerBackend =
   DaemonCompilerBackend(
     javaBin = "/opt/jdk/bin/java",
-    daemonLaunchArgs = listOf("@/opt/kolt/libexec/classpath/kolt-jvm-compiler-daemon.argfile"),
+    daemonLaunchArgs = listOf("-cp", "/opt/kolt/libexec/jvm-daemon.jar", "kolt.daemon.MainKt"),
     compilerJars = listOf("/kt/lib/a.jar", "/kt/lib/b.jar"),
     btaImplJars = listOf("/opt/kolt/libexec/kolt-bta-impl/kotlin-build-tools-impl.jar"),
     socketPath = "/tmp/kolt-daemon-test.sock",

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonJarResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonJarResolverTest.kt
@@ -49,32 +49,131 @@ class DaemonJarResolverTest {
 
   @Test
   fun emptyEnvFallsThroughToLibexecArgfile() {
-    val argfile = "/opt/kolt/libexec/classpath/$DAEMON_JAR_STEM.argfile"
+    val prefix = "/opt/kolt"
+    val argfile = "$prefix/libexec/classpath/$DAEMON_JAR_STEM.argfile"
     val result =
       resolveDaemonJarPure(
         envValue = "",
-        selfExePath = "/opt/kolt/bin/kolt",
+        selfExePath = "$prefix/bin/kolt",
         fileExists = exists(argfile),
-        readManifest = { null },
+        readManifest =
+          manifests(
+            argfile to
+              listOf(
+                "-cp",
+                "$LIBEXEC_PLACEHOLDER/$DAEMON_JAR_STEM/$DAEMON_JAR_STEM.jar",
+                DAEMON_MAIN_CLASS,
+              )
+          ),
       )
     val resolved = assertIs<DaemonJarResolution.Resolved>(result)
-    assertEquals(listOf("@$argfile"), resolved.launchArgs)
+    assertEquals(
+      listOf("-cp", "$prefix/libexec/$DAEMON_JAR_STEM/$DAEMON_JAR_STEM.jar", DAEMON_MAIN_CLASS),
+      resolved.launchArgs,
+    )
     assertEquals(DaemonJarResolution.Source.Libexec, resolved.source)
   }
 
   @Test
   fun libexecArgfileResolvesFromInstalledPrefix() {
-    val argfile = "/usr/local/libexec/classpath/$DAEMON_JAR_STEM.argfile"
+    val prefix = "/usr/local"
+    val argfile = "$prefix/libexec/classpath/$DAEMON_JAR_STEM.argfile"
     val result =
       resolveDaemonJarPure(
         envValue = null,
-        selfExePath = "/usr/local/bin/kolt",
+        selfExePath = "$prefix/bin/kolt",
+        fileExists = exists(argfile),
+        readManifest =
+          manifests(
+            argfile to
+              listOf("-cp", "$LIBEXEC_PLACEHOLDER/some.jar:$LIBEXEC_PLACEHOLDER/other.jar", "Main")
+          ),
+      )
+    val resolved = assertIs<DaemonJarResolution.Resolved>(result)
+    assertEquals(
+      listOf("-cp", "$prefix/libexec/some.jar:$prefix/libexec/other.jar", "Main"),
+      resolved.launchArgs,
+    )
+    assertEquals(DaemonJarResolution.Source.Libexec, resolved.source)
+  }
+
+  // #336: an extracted-but-not-installed tarball ships argfiles still
+  // containing `@KOLT_LIBEXEC@`. Without resolver-side substitution the
+  // JVM dies with ClassNotFoundException and the daemon never binds.
+  @Test
+  fun libexecArgfileSubstitutesPlaceholderInsidePath() {
+    val prefix = "/srv/kolt-extracted"
+    val argfile = "$prefix/libexec/classpath/$DAEMON_JAR_STEM.argfile"
+    val classpathLine =
+      "$LIBEXEC_PLACEHOLDER/$DAEMON_JAR_STEM/$DAEMON_JAR_STEM.jar:" +
+        "$LIBEXEC_PLACEHOLDER/$DAEMON_JAR_STEM/deps/x.jar:" +
+        "$LIBEXEC_PLACEHOLDER/kolt-bta-impl/y.jar"
+    val result =
+      resolveDaemonJarPure(
+        envValue = null,
+        selfExePath = "$prefix/bin/kolt",
+        fileExists = exists(argfile),
+        readManifest = manifests(argfile to listOf("-cp", classpathLine, DAEMON_MAIN_CLASS)),
+      )
+    val resolved = assertIs<DaemonJarResolution.Resolved>(result)
+    val expectedClasspath =
+      "$prefix/libexec/$DAEMON_JAR_STEM/$DAEMON_JAR_STEM.jar:" +
+        "$prefix/libexec/$DAEMON_JAR_STEM/deps/x.jar:" +
+        "$prefix/libexec/kolt-bta-impl/y.jar"
+    assertEquals(listOf("-cp", expectedClasspath, DAEMON_MAIN_CLASS), resolved.launchArgs)
+  }
+
+  // install.sh-installed kolts have already had their argfiles sed-
+  // substituted, so the resolver sees absolute paths only. Verify the
+  // substitution-by-replace is a no-op when no placeholder is present.
+  @Test
+  fun libexecArgfileWithoutPlaceholderIsPassedThrough() {
+    val prefix = "/opt/kolt"
+    val argfile = "$prefix/libexec/classpath/$DAEMON_JAR_STEM.argfile"
+    val result =
+      resolveDaemonJarPure(
+        envValue = null,
+        selfExePath = "$prefix/bin/kolt",
+        fileExists = exists(argfile),
+        readManifest =
+          manifests(argfile to listOf("-cp", "/opt/kolt/libexec/x.jar", DAEMON_MAIN_CLASS)),
+      )
+    val resolved = assertIs<DaemonJarResolution.Resolved>(result)
+    assertEquals(listOf("-cp", "/opt/kolt/libexec/x.jar", DAEMON_MAIN_CLASS), resolved.launchArgs)
+  }
+
+  // assemble-dist's `printf '%s\n' ...` writes a trailing newline, which
+  // surfaces as a final empty element after `String.lines()`. The
+  // resolver must drop it; otherwise the JVM sees an empty argument
+  // token and aborts with `Error: Could not find or load main class`.
+  @Test
+  fun libexecArgfileDropsEmptyTrailingLines() {
+    val prefix = "/opt/kolt"
+    val argfile = "$prefix/libexec/classpath/$DAEMON_JAR_STEM.argfile"
+    val result =
+      resolveDaemonJarPure(
+        envValue = null,
+        selfExePath = "$prefix/bin/kolt",
+        fileExists = exists(argfile),
+        readManifest =
+          manifests(argfile to listOf("-cp", "$LIBEXEC_PLACEHOLDER/x.jar", DAEMON_MAIN_CLASS, "")),
+      )
+    val resolved = assertIs<DaemonJarResolution.Resolved>(result)
+    assertEquals(listOf("-cp", "$prefix/libexec/x.jar", DAEMON_MAIN_CLASS), resolved.launchArgs)
+  }
+
+  @Test
+  fun libexecArgfileUnreadableFallsThroughToNotFound() {
+    val prefix = "/opt/kolt"
+    val argfile = "$prefix/libexec/classpath/$DAEMON_JAR_STEM.argfile"
+    val result =
+      resolveDaemonJarPure(
+        envValue = null,
+        selfExePath = "$prefix/bin/kolt",
         fileExists = exists(argfile),
         readManifest = { null },
       )
-    val resolved = assertIs<DaemonJarResolution.Resolved>(result)
-    assertEquals(listOf("@$argfile"), resolved.launchArgs)
-    assertEquals(DaemonJarResolution.Source.Libexec, resolved.source)
+    assertEquals(DaemonJarResolution.NotFound, result)
   }
 
   @Test
@@ -100,18 +199,23 @@ class DaemonJarResolverTest {
 
   @Test
   fun libexecArgfileWinsOverDevFallbackWhenBothExist() {
-    val argfile = "/opt/kolt/libexec/classpath/$DAEMON_JAR_STEM.argfile"
+    val prefix = "/opt/kolt"
+    val argfile = "$prefix/libexec/classpath/$DAEMON_JAR_STEM.argfile"
     val devJar = "/$DAEMON_JAR_STEM/build/$DAEMON_JAR_STEM.jar"
     val result =
       resolveDaemonJarPure(
         envValue = null,
-        selfExePath = "/opt/kolt/bin/kolt",
+        selfExePath = "$prefix/bin/kolt",
         fileExists = exists(argfile, devJar),
         readManifest =
-          manifests("/$DAEMON_JAR_STEM/build/$DAEMON_JAR_STEM-runtime.classpath" to emptyList()),
+          manifests(
+            argfile to listOf("-cp", "$LIBEXEC_PLACEHOLDER/x.jar", DAEMON_MAIN_CLASS),
+            "/$DAEMON_JAR_STEM/build/$DAEMON_JAR_STEM-runtime.classpath" to emptyList(),
+          ),
       )
     val resolved = assertIs<DaemonJarResolution.Resolved>(result)
-    assertEquals(listOf("@$argfile"), resolved.launchArgs)
+    assertEquals(listOf("-cp", "$prefix/libexec/x.jar", DAEMON_MAIN_CLASS), resolved.launchArgs)
+    assertEquals(DaemonJarResolution.Source.Libexec, resolved.source)
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
@@ -49,7 +49,8 @@ private fun newBackend(
 ): NativeDaemonBackend =
   NativeDaemonBackend(
     javaBin = "/opt/jdk/bin/java",
-    daemonLaunchArgs = listOf("@/opt/kolt/libexec/classpath/kolt-native-compiler-daemon.argfile"),
+    daemonLaunchArgs =
+      listOf("-cp", "/opt/kolt/libexec/native-daemon.jar", "kolt.nativedaemon.MainKt"),
     konancJar = "/opt/konan/konan/lib/kotlin-native-compiler-embeddable.jar",
     konanHome = "/opt/konan",
     socketPath = "/tmp/kolt-native-daemon-test.sock",

--- a/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonJarResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonJarResolverTest.kt
@@ -39,31 +39,115 @@ class NativeDaemonJarResolverTest {
 
   @Test
   fun emptyEnvFallsThroughToLibexecArgfile() {
-    val argfile = "/opt/kolt/libexec/classpath/$NATIVE_DAEMON_JAR_STEM.argfile"
+    val prefix = "/opt/kolt"
+    val argfile = "$prefix/libexec/classpath/$NATIVE_DAEMON_JAR_STEM.argfile"
     val result =
       resolveNativeDaemonJarPure(
         envValue = "",
-        selfExePath = "/opt/kolt/bin/kolt",
+        selfExePath = "$prefix/bin/kolt",
         fileExists = exists(argfile),
-        readManifest = { null },
+        readManifest =
+          manifests(
+            argfile to
+              listOf(
+                "-cp",
+                "$LIBEXEC_PLACEHOLDER/$NATIVE_DAEMON_JAR_STEM/$NATIVE_DAEMON_JAR_STEM.jar",
+                NATIVE_DAEMON_MAIN_CLASS,
+              )
+          ),
       )
     val resolved = assertIs<NativeDaemonJarResolution.Resolved>(result)
-    assertEquals(listOf("@$argfile"), resolved.launchArgs)
+    assertEquals(
+      listOf(
+        "-cp",
+        "$prefix/libexec/$NATIVE_DAEMON_JAR_STEM/$NATIVE_DAEMON_JAR_STEM.jar",
+        NATIVE_DAEMON_MAIN_CLASS,
+      ),
+      resolved.launchArgs,
+    )
     assertEquals(NativeDaemonJarResolution.Source.Libexec, resolved.source)
   }
 
   @Test
   fun libexecArgfileIsPickedFromInstalledPrefix() {
-    val argfile = "/usr/local/libexec/classpath/$NATIVE_DAEMON_JAR_STEM.argfile"
+    val prefix = "/usr/local"
+    val argfile = "$prefix/libexec/classpath/$NATIVE_DAEMON_JAR_STEM.argfile"
     val result =
       resolveNativeDaemonJarPure(
         envValue = null,
-        selfExePath = "/usr/local/bin/kolt",
+        selfExePath = "$prefix/bin/kolt",
+        fileExists = exists(argfile),
+        readManifest =
+          manifests(
+            argfile to listOf("-cp", "$LIBEXEC_PLACEHOLDER/x.jar", NATIVE_DAEMON_MAIN_CLASS)
+          ),
+      )
+    val resolved = assertIs<NativeDaemonJarResolution.Resolved>(result)
+    assertEquals(
+      listOf("-cp", "$prefix/libexec/x.jar", NATIVE_DAEMON_MAIN_CLASS),
+      resolved.launchArgs,
+    )
+  }
+
+  // #336: an extracted-but-not-installed tarball ships argfiles still
+  // containing `@KOLT_LIBEXEC@`. Without resolver-side substitution the
+  // JVM dies with ClassNotFoundException and the daemon never binds.
+  @Test
+  fun libexecArgfileSubstitutesPlaceholderInsidePath() {
+    val prefix = "/srv/kolt-extracted"
+    val argfile = "$prefix/libexec/classpath/$NATIVE_DAEMON_JAR_STEM.argfile"
+    val classpathLine =
+      "$LIBEXEC_PLACEHOLDER/$NATIVE_DAEMON_JAR_STEM/$NATIVE_DAEMON_JAR_STEM.jar:" +
+        "$LIBEXEC_PLACEHOLDER/$NATIVE_DAEMON_JAR_STEM/deps/x.jar"
+    val result =
+      resolveNativeDaemonJarPure(
+        envValue = null,
+        selfExePath = "$prefix/bin/kolt",
+        fileExists = exists(argfile),
+        readManifest = manifests(argfile to listOf("-cp", classpathLine, NATIVE_DAEMON_MAIN_CLASS)),
+      )
+    val resolved = assertIs<NativeDaemonJarResolution.Resolved>(result)
+    val expectedClasspath =
+      "$prefix/libexec/$NATIVE_DAEMON_JAR_STEM/$NATIVE_DAEMON_JAR_STEM.jar:" +
+        "$prefix/libexec/$NATIVE_DAEMON_JAR_STEM/deps/x.jar"
+    assertEquals(listOf("-cp", expectedClasspath, NATIVE_DAEMON_MAIN_CLASS), resolved.launchArgs)
+  }
+
+  // assemble-dist's `printf '%s\n' ...` writes a trailing newline; without
+  // dropping it the JVM sees an empty argument token and aborts.
+  @Test
+  fun libexecArgfileDropsEmptyTrailingLines() {
+    val prefix = "/opt/kolt"
+    val argfile = "$prefix/libexec/classpath/$NATIVE_DAEMON_JAR_STEM.argfile"
+    val result =
+      resolveNativeDaemonJarPure(
+        envValue = null,
+        selfExePath = "$prefix/bin/kolt",
+        fileExists = exists(argfile),
+        readManifest =
+          manifests(
+            argfile to listOf("-cp", "$LIBEXEC_PLACEHOLDER/x.jar", NATIVE_DAEMON_MAIN_CLASS, "")
+          ),
+      )
+    val resolved = assertIs<NativeDaemonJarResolution.Resolved>(result)
+    assertEquals(
+      listOf("-cp", "$prefix/libexec/x.jar", NATIVE_DAEMON_MAIN_CLASS),
+      resolved.launchArgs,
+    )
+  }
+
+  @Test
+  fun libexecArgfileUnreadableFallsThroughToNotFound() {
+    val prefix = "/opt/kolt"
+    val argfile = "$prefix/libexec/classpath/$NATIVE_DAEMON_JAR_STEM.argfile"
+    val result =
+      resolveNativeDaemonJarPure(
+        envValue = null,
+        selfExePath = "$prefix/bin/kolt",
         fileExists = exists(argfile),
         readManifest = { null },
       )
-    val resolved = assertIs<NativeDaemonJarResolution.Resolved>(result)
-    assertEquals(listOf("@$argfile"), resolved.launchArgs)
+    assertEquals(NativeDaemonJarResolution.NotFound, result)
   }
 
   @Test
@@ -90,21 +174,27 @@ class NativeDaemonJarResolverTest {
 
   @Test
   fun libexecWinsOverDevFallbackWhenBothExist() {
-    val argfile = "/opt/kolt/libexec/classpath/$NATIVE_DAEMON_JAR_STEM.argfile"
+    val prefix = "/opt/kolt"
+    val argfile = "$prefix/libexec/classpath/$NATIVE_DAEMON_JAR_STEM.argfile"
     val devJar = "/$NATIVE_DAEMON_JAR_STEM/build/$NATIVE_DAEMON_JAR_STEM.jar"
     val result =
       resolveNativeDaemonJarPure(
         envValue = null,
-        selfExePath = "/opt/kolt/bin/kolt",
+        selfExePath = "$prefix/bin/kolt",
         fileExists = exists(argfile, devJar),
         readManifest =
           manifests(
+            argfile to listOf("-cp", "$LIBEXEC_PLACEHOLDER/x.jar", NATIVE_DAEMON_MAIN_CLASS),
             "/$NATIVE_DAEMON_JAR_STEM/build/$NATIVE_DAEMON_JAR_STEM-runtime.classpath" to
-              emptyList()
+              emptyList(),
           ),
       )
     val resolved = assertIs<NativeDaemonJarResolution.Resolved>(result)
-    assertEquals(listOf("@$argfile"), resolved.launchArgs)
+    assertEquals(
+      listOf("-cp", "$prefix/libexec/x.jar", NATIVE_DAEMON_MAIN_CLASS),
+      resolved.launchArgs,
+    )
+    assertEquals(NativeDaemonJarResolution.Source.Libexec, resolved.source)
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonPreconditionsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonPreconditionsTest.kt
@@ -25,7 +25,7 @@ class NativeDaemonPreconditionsTest {
     ensureJavaBin: (KoltPaths) -> Result<String, BootstrapJdkError> = { Ok("/opt/jdk/bin/java") },
     resolveNativeJar: () -> NativeDaemonJarResolution = {
       NativeDaemonJarResolution.Resolved(
-        listOf("@/opt/kolt/libexec/classpath/kolt-native-compiler-daemon.argfile"),
+        listOf("-cp", "/opt/kolt/libexec/native-daemon.jar", NATIVE_DAEMON_MAIN_CLASS),
         NativeDaemonJarResolution.Source.Libexec,
       )
     },
@@ -47,7 +47,7 @@ class NativeDaemonPreconditionsTest {
 
     assertEquals("/opt/jdk/bin/java", setup.javaBin)
     assertEquals(
-      listOf("@/opt/kolt/libexec/classpath/kolt-native-compiler-daemon.argfile"),
+      listOf("-cp", "/opt/kolt/libexec/native-daemon.jar", NATIVE_DAEMON_MAIN_CLASS),
       setup.daemonLaunchArgs,
     )
     // konanHome is the managed toolchain root for the Kotlin version.


### PR DESCRIPTION
Closes #336.

The release tarball's \`libexec/classpath/*.argfile\` ships the literal placeholder \`@KOLT_LIBEXEC@\` in every classpath entry. \`install.sh:214\` substitutes it via \`sed -i\` at install time. Anyone who skips \`install.sh\` — CI bootstrap (\`unit-tests.yml\`, \`self-host-smoke.yml\`), manual \`tar xzf && ./bin/kolt\` users, container images COPYing the tarball — gets the placeholder shipped to the JVM verbatim. Every classpath entry resolves to a non-existent path; the JVM dies with \`ClassNotFoundException: kolt.daemon.MainKt\`, the daemon never binds, and \`kolt build\` subprocess-falls-back silently. The positive-only canary (\`grep 'starting compiler daemon'\`) green-lit it on every CI run.

Diagnosed via the daemon log dump added in PR #337 (\`Caused by: java.lang.ClassNotFoundException: kolt.daemon.MainKt\` for both daemons). \`#332\` raised the connect budget from 3s → 10s assuming cold-cache CI was a timing problem; the placeholder bug means no budget would have been sufficient.

## What this PR does

**Fix the resolver.** \`DaemonJarResolver\` / \`NativeDaemonJarResolver\` now read the argfile themselves and substitute \`@KOLT_LIBEXEC@\` → absolute libexec path before returning the launch args. \`tar xzf && ./bin/kolt\` works without install.sh. install.sh's pre-substitution becomes a no-op shim — \`replace\` on a placeholder-free string is identity.

**Tighten both daemon canaries** in \`unit-tests.yml\` and \`self-host-smoke.yml\` with the negative \`! grep 'falling back to subprocess'\` assertion that PR #335 reverted. Without it the next regression at the daemon classpath layer stays silent.

**CI bridge for the v0.17.0 bootstrap.** Add \`sed -i 's|@KOLT_LIBEXEC@|...|g'\` (mirroring install.sh:214) to the bootstrap step in both yml files so this PR's CI run validates the canary with the existing bootstrap. The bridge becomes redundant — and removable — on the next bootstrap bump that contains this resolver fix.

**End-to-end guard for the regression.** A new step in \`self-host-smoke.yml\` post-migration drives \`dist/.../bin/kolt build\` against an unsubstituted argfile and fails on subprocess fallback. Includes a sanity check that fires if assemble-dist ever switches to absolute paths (which would silently turn the guard into a no-op).

## Reviewer focus

- The resolver delta in \`DaemonJarResolver.kt\` and \`NativeDaemonJarResolver.kt\` is the load-bearing change. Tests in \`*JarResolverTest.kt\` cover substitution with placeholder, without placeholder (install.sh-installed case), trailing-empty-line handling (assemble-dist's \`printf '%s\n'\`), and unreadable-argfile fallthrough.
- Test fixtures in three sibling test files were migrated from the stale \`["@<argfile>"]\` shape to the canonical \`["-cp", <cp>, <Main>]\`. Inert change, but flagging it for shape consistency.
- The CI bridges and the negative canaries are temporally coupled to v0.17.0. Plan: bump bootstrap on the next release, drop the bridges, leave the canaries in place permanently.

Local end-to-end: HEAD kolt.kexe dropped into the v0.17.0 tarball at bin/kolt, no install.sh, builds kolt-jvm-compiler-daemon. Daemon engages, no subprocess fallback in stderr, daemon log shows compilation work.