### PR TITLE
drop kolt check --watch (#340)

### DIFF
--- a/.claude/skills/kolt-usage/SKILL.md
+++ b/.claude/skills/kolt-usage/SKILL.md
@@ -80,7 +80,7 @@ kolt --version              Show version
 
 | Flag | Description |
 |------|-------------|
-| `--watch` | Watch source files and re-run on change (build/check/test/run) |
+| `--watch` | Watch source files and re-run on change (build/test/run). Not supported for `check` — use an LSP for editor type-check feedback. |
 | `--no-daemon` | Skip the warm compiler daemon for this invocation. Always available, even on Kotlin versions outside the daemon's supported range (ADR 0022). |
 | `--release` | Build under the release profile. Native: enables `-opt`, omits `-g`, writes artifacts to `build/release/`. JVM: declared no-op; the artifact still moves to `build/release/<name>.jar`. Debug remains the default. |
 | `-D<key>=<value>` | JVM system property for `kolt test` / `kolt run` (JVM target only). Overlays declared `[test.sys_props]` / `[run.sys_props]`; same-key collisions drop the toml entry. CLI values are literal-only. |

--- a/.kiro/specs/toml-change-handling/design.md
+++ b/.kiro/specs/toml-change-handling/design.md
@@ -185,7 +185,7 @@ flowchart TD
 **Key decisions** (ダイアグラム外の補足):
 - **Mixed-window prevails**: `HasNotify` ブランチが yes になると、 同時変更された AutoReload sections は **skip** される。 reload も rebuild も走らない。 user が notify-only sections の推奨アクションを取って watch を再起動した時点で、 fresh process の startup load で auto-reload sections も反映される (Req 4.6)
 - **Build serialization**: handler が synchronous で `Invoke` から戻るまで次の inotify event は kernel buffer 保留。 explicit in-flight flag は不要 (Req 7.1〜7.3 が構造的に成立)
-- **`[run.sys_props]` respawn (D-8 確定)**: `watchRunLoop` 専用の post-AutoReload step。 `plan.rebuild = false` かつ `plan.changedSections` に `run.sys_props` が含まれる時、 running app を kill して新 sysprops で respawn。 `watchCommandLoop` (build/test/check) ではこの step は no-op
+- **`[run.sys_props]` respawn (D-8 確定)**: `watchRunLoop` 専用の post-AutoReload step。 `plan.rebuild = false` かつ `plan.changedSections` に `run.sys_props` が含まれる時、 running app を kill して新 sysprops で respawn。 `watchCommandLoop` (build/test) ではこの step は no-op
 - **Empty changes (Req 2.3)**: `classifyChange` が空 list を返すケース (file が touch されたが内容同一) は plan を組み立てる前に early return
 
 ## Requirements Traceability

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -84,7 +84,7 @@ kolt init [name]                  # create project
 kolt build    [--watch] [--release]   # compile (debug default; --release writes build/release/)
 kolt run      [--watch] [--release]   # build + run
 kolt test     [--watch] [--release]   # build + run tests
-kolt check    [--watch] [--release]   # type-check only
+kolt check    [--release]             # type-check only (no --watch; use LSP)
 kolt fmt      [--check]           # ktfmt format (or verify in CI)
 kolt add <dep>                    # add dependency to kolt.toml
 kolt deps [install|update|tree]   # resolve / inspect deps

--- a/README.ja.md
+++ b/README.ja.md
@@ -72,7 +72,6 @@ kolt add <dep>         依存を追加（deps add のエイリアス）
 kolt build --watch     監視して再ビルド
 kolt test --watch      監視して再テスト
 kolt run --watch       監視して再ビルド・アプリ再起動
-kolt check --watch     監視して型チェック
 kolt fmt               ktfmt でソースファイルをフォーマット
 kolt fmt --check       フォーマットチェック（CI モード）
 kolt clean             ビルド成果物を削除
@@ -97,7 +96,7 @@ kolt --version         バージョンを表示
 
 | フラグ | 説明 |
 |--------|------|
-| `--watch` | ソースファイルを監視し、変更時にコマンドを再実行（build/check/test/run） |
+| `--watch` | ソースファイルを監視し、変更時にコマンドを再実行（build/test/run）。`check` では非対応 — エディタ向け型チェックは LSP を利用してください。 |
 | `--no-daemon` | この実行でウォームコンパイラデーモンをスキップ。daemon サポート対象外の Kotlin バージョン (ADR 0022) でも常に利用可能。 |
 | `--release` | release プロファイルでビルドする。Native は `-opt` を有効化し `-g` を外して `build/release/` に出力。JVM では宣言上 no-op（kotlinc 引数も daemon IC パスも変わらない）だが、両プロファイル成果物を相互に上書きしないよう成果物パスは `build/release/<name>.jar` に切り替わる。デフォルトは `debug` プロファイルで、両プロファイルの成果物はディスク上に共存するためプロファイルを切り替えても他方の IC が無効化されることはない。詳細は [ADR 0030](docs/adr/0030-build-profiles.md) を参照。 |
 | `-D<key>=<value>` | `kolt test` / `kolt run` 用の JVM システムプロパティ（JVM ターゲットのみ）。宣言済みの `[test.sys_props]` / `[run.sys_props]` に対するオーバーレイで、同一キーが衝突した場合は kolt.toml 側のエントリを破棄する。CLI 値は literal のみ。詳細は [ADR 0032](docs/adr/0032-kolt-toml-env-agnostic.md) を参照。 |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ kolt add <dep>         Add a dependency (alias for deps add)
 kolt build --watch     Watch and rebuild
 kolt test --watch      Watch and retest
 kolt run --watch       Watch, rebuild, and restart app
-kolt check --watch     Watch and type-check
 kolt fmt               Format source files with ktfmt
 kolt fmt --check       Check formatting (CI mode)
 kolt clean             Remove build artifacts
@@ -98,7 +97,7 @@ kolt --version         Show version
 
 | Flag | Description |
 |------|-------------|
-| `--watch` | Watch source files and re-run the command on change (build/check/test/run) |
+| `--watch` | Watch source files and re-run the command on change (build/test/run). Not supported for `check` — use an LSP for editor type-check feedback. |
 | `--no-daemon` | Skip the warm compiler daemon for this invocation. Always available, including on Kotlin versions outside the daemon's supported range (ADR 0022). |
 | `--release` | Build under the release profile. Native: enables `-opt`, omits `-g`, writes artifacts to `build/release/`. JVM: declared no-op (same kotlinc args, same daemon IC path) — the artifact still moves to `build/release/<name>.jar` so the two profiles' outputs do not overwrite each other. Default profile is `debug`; both profiles' artifacts coexist on disk so switching between them does not invalidate the other. See [ADR 0030](docs/adr/0030-build-profiles.md). |
 | `-D<key>=<value>` | JVM system property for `kolt test` / `kolt run` (JVM target only). Overlays declared `[test.sys_props]` / `[run.sys_props]`; same-key collisions drop the toml entry. CLI values are literal-only. See [ADR 0032](docs/adr/0032-kolt-toml-env-agnostic.md). |

--- a/docs/adr/0033-kolt-toml-change-handling-model.md
+++ b/docs/adr/0033-kolt-toml-change-handling-model.md
@@ -106,7 +106,7 @@ Each row's "Section" cell uses the canonical key in `SECTION_ACTIONS` (`src/nati
 
 For the `AutoReload` rows that include `[build] sources` or `[build] resources`, the watch loop additionally reconstructs its watcher path set (full rebuild: unregister all existing inotify watches, re-run `collectWatchPaths`, re-register the new path set) before triggering the rebuild. Differential watcher updates are out of scope; a kolt project's watch path count is small enough that full rebuild costs nothing measurable.
 
-For `[run.sys_props]` in `kolt run --watch` specifically, when the AutoReload path applies (i.e. `plan.reload && !plan.rebuild` and `[run.sys_props]` is in the changed sections), the running app is killed and respawned with the new sysprops via the existing run-loop spawn path. This is the only loop-specific dispatch — `watchCommandLoop` (build / test / check) does not respawn anything.
+For `[run.sys_props]` in `kolt run --watch` specifically, when the AutoReload path applies (i.e. `plan.reload && !plan.rebuild` and `[run.sys_props]` is in the changed sections), the running app is killed and respawned with the new sysprops via the existing run-loop spawn path. This is the only loop-specific dispatch — `watchCommandLoop` (build / test) does not respawn anything.
 
 ### §4 Notify-only-prevail in mixed windows
 

--- a/docs/release-notes/v0.18.0.md
+++ b/docs/release-notes/v0.18.0.md
@@ -1,0 +1,13 @@
+**`kolt check --watch` removed (#340) — breaking**
+
+`kolt check --watch` overlapped with LSP responsibility. The flag is now rejected with a one-line error pointing at LSP; `--watch` remains valid for `build`, `run`, and `test`.
+
+**Installation**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh
+```
+
+**Upgrade notes**
+
+- Drop `--watch` from any `kolt check` invocations in scripts / CI. `kolt check` is fast enough for one-shot use; for live editor feedback, wire an LSP.

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -839,6 +839,13 @@ internal fun rejectIfLibrary(
   return Err(EXIT_CONFIG_ERROR)
 }
 
+// `kolt check --watch` overlaps with LSP responsibility — incremental
+// editor type-check feedback is what an LSP exists for.
+internal fun rejectCheckWatch(eprint: (String) -> Unit = ::eprintln): Int {
+  eprint("error: --watch is not supported on `kolt check`; use an LSP for live type-check feedback")
+  return EXIT_CONFIG_ERROR
+}
+
 // CLI `-D<key>=<value>` is JVM-only (ADR 0032 §3). Mirrors the parse-time
 // rejection of `[test.sys_props]` / `[run.sys_props]` on native targets
 // (Config.kt) so the contract is symmetric: a user who declares sysprops

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -30,7 +30,7 @@ fun main(args: Array<String>) {
       if (watch) watchCommandLoop("build", useDaemon, profile = profile)
       else doBuild(useDaemon = useDaemon, profile = profile).getOrElse { exitProcess(it) }
     "check" ->
-      if (watch) watchCommandLoop("check", useDaemon, profile = profile)
+      if (watch) exitProcess(rejectCheckWatch())
       else doCheck(useDaemon = useDaemon, profile = profile).getOrElse { exitProcess(it) }
     "run" -> {
       val appArgs =

--- a/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
+++ b/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
@@ -182,7 +182,6 @@ internal fun watchCommandLoop(
   commandRunner: (String, Boolean, List<String>) -> Result<*, Int> = { cmd, daemon, args ->
     when (cmd) {
       "build" -> doBuild(useDaemon = daemon, profile = profile)
-      "check" -> doCheck(useDaemon = daemon, profile = profile)
       "test" ->
         doTest(testArgs = args, useDaemon = daemon, profile = profile, cliSysProps = cliSysProps)
       else -> doBuild(useDaemon = daemon, profile = profile)

--- a/src/nativeTest/kotlin/kolt/cli/CheckWatchRejectionTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/CheckWatchRejectionTest.kt
@@ -1,0 +1,23 @@
+package kolt.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CheckWatchRejectionTest {
+
+  @Test
+  fun rejectCheckWatchEmitsLspGuidanceAndReturnsConfigError() {
+    val stderr = mutableListOf<String>()
+
+    val exit = rejectCheckWatch(eprint = { stderr.add(it) })
+
+    assertEquals(EXIT_CONFIG_ERROR, exit)
+    assertEquals(1, stderr.size, "rejection must emit exactly one stderr line")
+    assertTrue(
+      stderr[0].contains("--watch") && stderr[0].contains("check"),
+      "stderr must name the rejected flag/command, got: ${stderr[0]}",
+    )
+    assertTrue(stderr[0].contains("LSP"), "stderr must point at LSP, got: ${stderr[0]}")
+  }
+}

--- a/src/nativeTest/kotlin/kolt/cli/WatchLoopTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/WatchLoopTest.kt
@@ -25,12 +25,6 @@ class CollectWatchPathsTest {
   }
 
   @Test
-  fun checkWatchesSameAsBuild() {
-    val config = testConfig(sources = listOf("src"))
-    assertEquals(collectWatchPaths(config, "build"), collectWatchPaths(config, "check"))
-  }
-
-  @Test
   fun runWatchesSameAsBuild() {
     val config = testConfig(sources = listOf("src"))
     assertEquals(collectWatchPaths(config, "build"), collectWatchPaths(config, "run"))


### PR DESCRIPTION
Closes #340.

`kolt check --watch` is now rejected at the dispatcher with `EXIT_CONFIG_ERROR` and a single stderr line pointing at LSP. `--watch` remains valid for `build` / `run` / `test`. The `"check"` branch is removed from `watchCommandLoop`'s default `commandRunner`.

Reviewer focus:

- **Exit code**: chose `EXIT_CONFIG_ERROR` to match `rejectIfLibrary` / `rejectCliSysPropsOnNative`. The "unknown command" precedent uses `EXIT_BUILD_ERROR`, but this is a flag-combination usage error, closer to the config-error family.
- **Helper return type**: `rejectCheckWatch` returns plain `Int`, not `Result<Unit, Int>`, because the caller has already branched on `watch=true` and there is no pass-through case. Sibling `reject*` helpers carry an `Ok` branch because their predicates can pass — this one cannot.
- **Doc surface sweep**: ADR 0033 §3 line 109 and the toml-change-handling spec design.md both mentioned `watchCommandLoop (build / test / check)`; both updated for accuracy. README/README.ja/SKILL.md/tech.md all dropped `check` from the `--watch` enumeration.

Drive-by: `docs/release-notes/v0.18.0.md` is the v0.18 release note seed; #339 / #343 will append.

Pre-existing flake in `NestedLockAcquireTest.projectLockIsAvailableInsideKoltTestChild` reproduces on `main` HEAD too — unrelated to this PR.