### PR TITLE
ci: run on PRs targeting any base (#348)

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -17,7 +17,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 # Cancel superseded runs on the same branch / PR.
 concurrency:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Closes #348.

Drops the `branches: [main]` filter on `pull_request` in `unit-tests.yml` and `self-host-smoke.yml`. The `push` trigger keeps `branches: [main]`, so post-merge runs against `main` are unchanged; PRs to any base now get CI.

Reviewer focus: confirm there is no compute-budget concern from PRs targeting long-lived non-main branches. kolt's stacked-PR pattern is short-lived (rebased onto main immediately after the parent merges), so the extra runs are bounded and pay for themselves by catching regressions on the stacked PR before its parent merges.

This PR self-validates: it targets `main`, so unchanged behavior runs CI here. The "stacked PR" path is exercised next time a PR is opened against a non-main base.