### PR TITLE
kolt update no longer evicts cached JARs (#347)

### DIFF
--- a/docs/release-notes/v0.18.0.md
+++ b/docs/release-notes/v0.18.0.md
@@ -1,3 +1,7 @@
+**`kolt update` no longer evicts cached JARs (#347)**
+
+`kolt update` re-resolves and rewrites `kolt.lock` but no longer deletes JARs from `~/.kolt/cache/`. The cache is host-shared across projects, and a project-local `update` invalidating other projects' cache entries was a bad cross-project side effect — peer tools (cargo, npm, yarn, pnpm, poetry) all leave the shared cache alone. Side benefit: `git checkout` to an older `kolt.lock` after `update` no longer forces a re-download. Use `kolt cache clean` for explicit eviction.
+
 **`kolt remove <group:artifact>` (#343)**
 
 Closes the per-invocation symmetry gap named in ADR 0033 §7. Auto-searches both `[dependencies]` and `[test-dependencies]`; if the same coord lives in both, both are dropped. Removing an absent entry is idempotent (exit 0 with a one-line message). The shared cache at `~/.kolt/cache/` is left untouched — use `kolt cache clean` to reclaim disk space.

--- a/docs/release-notes/v0.18.0.md
+++ b/docs/release-notes/v0.18.0.md
@@ -1,6 +1,6 @@
 **`kolt update` no longer evicts cached JARs (#347)**
 
-`kolt update` re-resolves and rewrites `kolt.lock` but no longer deletes JARs from `~/.kolt/cache/`. The cache is host-shared across projects, and a project-local `update` invalidating other projects' cache entries was a bad cross-project side effect — peer tools (cargo, npm, yarn, pnpm, poetry) all leave the shared cache alone. Side benefit: `git checkout` to an older `kolt.lock` after `update` no longer forces a re-download. Use `kolt cache clean` for explicit eviction.
+`kolt update` re-resolves and rewrites `kolt.lock` but leaves `~/.kolt/cache/` alone — the cache is host-shared across projects and a project-local `update` should not invalidate other projects' entries. Stale or corrupt cache must now be cleared explicitly via `kolt cache clean`; pre-#347 the eviction implicitly re-fetched and "fixed" partial / truncated JARs on `update`, and that no longer happens.
 
 **`kolt remove <group:artifact>` (#343)**
 

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -203,8 +203,8 @@ private fun doUpdateInner(): Result<Unit, Int> {
     }
   val mainSeeds = autoInjectedMainDeps(config) + config.dependencies
   val testSeeds = autoInjectedTestDeps(config) + config.testDependencies
-  // Bundle seeds are deleted from cache and re-resolved with `existingLock = null`
-  // so [classpaths.<name>] follow the same update policy as main / test (Req 4.3).
+  // Bundles are re-resolved with `existingLock = null` so `[classpaths.<name>]`
+  // follow the same update policy as main / test (Req 4.3).
   val bundleSeedsAll =
     config.classpaths.values.fold(emptyMap<String, String>()) { acc, m -> acc + m }
   val allSeeds = mainSeeds + testSeeds + bundleSeedsAll
@@ -218,14 +218,6 @@ private fun doUpdateInner(): Result<Unit, Int> {
       eprintln("error: $it")
       return Err(EXIT_DEPENDENCY_ERROR)
     }
-
-  for ((groupArtifact, version) in allSeeds) {
-    val coord = parseCoordinate(groupArtifact, version).getOrElse { continue }
-    val jarPath = "${paths.cacheBase}/${buildCachePath(coord)}"
-    if (fileExists(jarPath)) {
-      deleteFile(jarPath)
-    }
-  }
 
   println("updating dependencies...")
   val resolverDeps = createResolverDeps()

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -196,11 +196,9 @@ private fun doFetchInner(): Result<Unit, Int> {
 
 internal fun doUpdate(): Result<Unit, Int> = withDependencyLock { doUpdateInner() }
 
-// `kolt update` does not evict cached JARs (#347). The cache is host-shared
-// across projects; project-local eviction is a cross-project side effect.
-// Stale or corrupt cache entries must be cleared explicitly via `kolt cache
-// clean`. Re-introducing eviction here breaks the invariant declared in the
-// v0.18 release note.
+// Cache eviction is reserved for `kolt cache clean`: `~/.kolt/cache/` is
+// host-shared, so a project-local update must not invalidate other projects'
+// entries.
 private fun doUpdateInner(): Result<Unit, Int> {
   val config =
     loadProjectConfig().getOrElse {
@@ -239,7 +237,7 @@ private fun doUpdateInner(): Result<Unit, Int> {
       }
 
   // Bundles re-resolve with `existingLock = null` so `[classpaths.<name>]`
-  // follow the same update policy as main / test (Req 4.3).
+  // follow the same update policy as main / test.
   val bundleResolutions =
     resolveAllBundles(config, existingLock = null, paths.cacheBase, resolverDeps).getOrElse { error
       ->

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -196,6 +196,11 @@ private fun doFetchInner(): Result<Unit, Int> {
 
 internal fun doUpdate(): Result<Unit, Int> = withDependencyLock { doUpdateInner() }
 
+// `kolt update` does not evict cached JARs (#347). The cache is host-shared
+// across projects; project-local eviction is a cross-project side effect.
+// Stale or corrupt cache entries must be cleared explicitly via `kolt cache
+// clean`. Re-introducing eviction here breaks the invariant declared in the
+// v0.18 release note.
 private fun doUpdateInner(): Result<Unit, Int> {
   val config =
     loadProjectConfig().getOrElse {
@@ -203,8 +208,6 @@ private fun doUpdateInner(): Result<Unit, Int> {
     }
   val mainSeeds = autoInjectedMainDeps(config) + config.dependencies
   val testSeeds = autoInjectedTestDeps(config) + config.testDependencies
-  // Bundles are re-resolved with `existingLock = null` so `[classpaths.<name>]`
-  // follow the same update policy as main / test (Req 4.3).
   val bundleSeedsAll =
     config.classpaths.values.fold(emptyMap<String, String>()) { acc, m -> acc + m }
   val allSeeds = mainSeeds + testSeeds + bundleSeedsAll
@@ -235,6 +238,8 @@ private fun doUpdateInner(): Result<Unit, Int> {
         return Err(EXIT_DEPENDENCY_ERROR)
       }
 
+  // Bundles re-resolve with `existingLock = null` so `[classpaths.<name>]`
+  // follow the same update policy as main / test (Req 4.3).
   val bundleResolutions =
     resolveAllBundles(config, existingLock = null, paths.cacheBase, resolverDeps).getOrElse { error
       ->


### PR DESCRIPTION
Closes #347. **Stacked on #346** — base is `343/kolt-remove`. Re-target to `main` once #346 lands. Both belong to the v0.18 "shared cache is sacrosanct" theme alongside #343.

Drops the for-loop in `doUpdateInner` that called `deleteFile` on every seed's cached JAR before re-resolving. Update still re-resolves with `existingLock = null` and rewrites `kolt.lock`; only the eviction step is gone.

Reviewer focus:

- **Req 4.3 (jvm-sys-props spec) is preserved.** Req 4.3 only requires bundles to follow the same update policy as main / test — it doesn't pin "delete from cache" as that policy. With this change, all three (main / test / bundles) share the new "leave cache, re-resolve" policy.
- **Why removal is safe.** The eviction predates current spec discipline (introduced before the keel→kolt rename) with no documented rationale. Peer tools (cargo, npm, yarn, pnpm, poetry, uv) all re-resolve without touching their shared caches; kolt was the outlier.
- **Side benefit beyond cross-project hygiene.** A `git checkout` to an older `kolt.lock` after `update` now builds without network if the cache hits — useful for bisects and branch-hopping.

E2E smoke (in /tmp fixture): `kolt add okhttp:4.12.0` populated cache, `kolt update` ran clean ("updated 16 dependencies"), JAR persisted at original mtime. 1484 tests pass; pre-existing `NestedLockAcquireTest` flake unrelated.

No test referenced the eviction (no `doUpdate` / "kolt update" test ever asserted it). Nothing to update on the test side.