### PR TITLE
Drop @KOLT_LIBEXEC@ sed bridge after bootstrap bump (#336 follow-up)

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 env:
-  KOLT_BOOTSTRAP_TAG: v0.16.3
+  KOLT_BOOTSTRAP_TAG: v0.18.0
   # Run the bootstrap kolt from inside the extracted release tree so
   # `DaemonJarResolver` can find `libexec/<daemon>/*.jar` siblings and
   # spawn the warm daemon. Copying the binary out (as the original
@@ -82,10 +82,6 @@ jobs:
             --dir "$BOOTSTRAP_DIR"
           tar -xzf "$BOOTSTRAP_DIR"/kolt-*-linux-x64.tar.gz \
             -C "$BOOTSTRAP_DIR" --strip-components=1
-          # Bridge for #336: see unit-tests.yml for the rationale.
-          # Drop on the next bootstrap bump.
-          sed -i "s|@KOLT_LIBEXEC@|$BOOTSTRAP_DIR/libexec|g" \
-            "$BOOTSTRAP_DIR"/libexec/classpath/*.argfile
           "$BOOTSTRAP_KOLT" --version
 
       # Native daemon canary: `kolt build` for kolt itself is a Native

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 env:
-  KOLT_BOOTSTRAP_TAG: v0.17.0
+  KOLT_BOOTSTRAP_TAG: v0.18.0
   # Run the bootstrap kolt from inside the extracted release tree so
   # `DaemonJarResolver` can find `libexec/<daemon>/*.jar` siblings and
   # spawn the warm daemon. Copying the binary out (as the original
@@ -81,14 +81,6 @@ jobs:
             --dir "$BOOTSTRAP_DIR"
           tar -xzf "$BOOTSTRAP_DIR"/kolt-*-linux-x64.tar.gz \
             -C "$BOOTSTRAP_DIR" --strip-components=1
-          # Bridge for #336: bootstrap pre-bump (v0.17.0) ships argfiles
-          # with the unsubstituted @KOLT_LIBEXEC@ placeholder. install.sh
-          # would substitute on its own, but this CI step extracts the
-          # tarball directly. Mirror install.sh:214 here so the bootstrap
-          # daemon has a valid classpath. Drop this once KOLT_BOOTSTRAP_TAG
-          # is bumped to a release that contains the resolver-side fix.
-          sed -i "s|@KOLT_LIBEXEC@|$BOOTSTRAP_DIR/libexec|g" \
-            "$BOOTSTRAP_DIR"/libexec/classpath/*.argfile
           "$BOOTSTRAP_KOLT" --version
 
       # `--ktest_logger=SILENT` collapses the per-test GTEST output (~2k
@@ -114,10 +106,7 @@ jobs:
       # subprocess compile`. The canary asserts both that the daemon
       # code path was reached (`starting compiler daemon`) and that the
       # daemon actually engaged (no `falling back to subprocess`) so a
-      # silent regression to subprocess fallback fails the build. The
-      # bootstrap step's @KOLT_LIBEXEC@ sed bridge keeps this assertion
-      # green on the v0.17.0 bootstrap; #336's resolver-side fix makes
-      # the bridge unnecessary on the next bootstrap bump.
+      # silent regression to subprocess fallback fails the build.
       - name: Verify daemon thin jar builds standalone
         run: |
           set -euo pipefail

--- a/docs/release-notes/v0.17.0.md
+++ b/docs/release-notes/v0.17.0.md
@@ -1,56 +1,47 @@
-**kolt.toml schema: classpath bundles + JVM system properties (#318)**
+**kolt.toml: classpath bundles + JVM sysprops (#318)**
 
-Three new tables let kolt drive `-D<key>=<value>` JVM sysprops and pre-resolved jar bundles into `kolt test` / `kolt run` without dropping to a wrapper script. Primary motivation: `[run.sys_props]` for projects that need to point at compiler-plugin classpaths (e.g., kolt's own daemon source roots) — the surface that finally let kolt build itself without `./gradlew check`.
+- `[classpaths.<bundle>]` declares a named jar bundle (same shape as `[dependencies]`). Bundles resolve through an isolated pass — independent of `[dependencies]` / `[test-dependencies]` conflict resolution.
+- `[test.sys_props]` / `[run.sys_props]` declare `-D<key>=<value>` entries. Three inline-table shapes: `{ literal = "..." }`, `{ classpath = "<bundle>" }`, `{ project_dir = "<rel>" }`.
+- Native targets reject all three at parse time; `kind = "lib"` rejects `[run.sys_props]`.
 
-- `[classpaths.<bundle>]` declares a named jar bundle, same TOML shape as `[dependencies]` (`"group:artifact" = "version"`). Bundles are resolved through an isolated resolver pass — they do not co-exist with `[dependencies]` / `[test-dependencies]` in version conflict resolution, so a bundle's transitive closure is independent.
-- `[test.sys_props]` and `[run.sys_props]` declare `-D<key>=<value>` entries for the test / run JVM. Each value is one of three inline-table shapes: `{ literal = "..." }`, `{ classpath = "<bundle>" }`, or `{ project_dir = "<rel>" }`. The literal branch is verbatim; classpath resolves to a colon-joined absolute path from a declared bundle; project_dir resolves to `<project root>/<rel>`.
-- Native targets reject all three at parse time (sysprops are JVM-only); a `kind = "lib"` project rejects `[run.sys_props]` (libraries cannot be run).
+**CLI `-D<key>=<value>` for `kolt test` / `kolt run` (#319)**
 
-**CLI `-D<key>=<value>` flag for `kolt test` / `kolt run` (#319)**
-
-`kolt test -D<key>=<value> [...]` and `kolt run -D<key>=<value> [...]` accept zero or more `-D` flags and overlay them onto declared `[test.sys_props]` / `[run.sys_props]`. Toml entries appear first in declaration order, CLI entries appended in command-line order, same-key collisions drop the toml entry (CLI wins). CLI values are literal-only — the structured `{ classpath = ... }` / `{ project_dir = ... }` shapes remain `kolt.toml`-exclusive.
-
-- Symmetric with the parse-time native rejection: `-D` on a native target errors with `EXIT_CONFIG_ERROR` rather than silently dropping the flag.
-- Bare `-D` and `-D=value` (empty key) are not recognised as sysprop flags and reach the dispatcher as a normal "unknown command" / passthrough error.
-- Use case: one-off log-level overrides, ad-hoc fixture paths. The persistent per-developer counterpart (`kolt.local.toml`, #320) is on the v1.x roadmap.
-
-ADR 0032 commits the env-agnostic invariant: `kolt.toml` does not interpolate `${env.X}`; the CLI flag (now landed) and the planned `kolt.local.toml` (deferred) are the two designated channels for environment-specific values.
+- CLI `-D` overlays declared `[test.sys_props]` / `[run.sys_props]`; same-key collisions drop the toml entry.
+- CLI values are literal-only; `{ classpath = ... }` / `{ project_dir = ... }` remain `kolt.toml`-exclusive.
+- Native rejection symmetric with parse-time. Bare `-D` and `-D=value` are not recognised as sysprop flags.
+- ADR 0032: `kolt.toml` does not interpolate `${env.X}`; CLI `-D` and the planned `kolt.local.toml` are the designated channels.
 
 **`kolt run --watch` threads `[run.sys_props]` (#322)**
 
-The watch loop's run path was calling `runCommand` directly with no sysprop resolution, so declared `-D` entries silently dropped on every restart. Lifted into a shared helper `runJvmCommandFor` so one-shot and watch-mode produce byte-identical argv. `kolt test --watch` is intentionally still out of scope (separate issue).
+Watch and one-shot now share `runJvmCommandFor` and produce byte-identical argv.
 
 **JVM compiler daemon: connect budget 3s -> 10s (#310)**
 
-Cold-cache CI runs cleared the prior 3s budget before the daemon listened (ADR 0016 §2 cold-start ~2.6s plus the documented WSL2/CI 9p stat-storm outlier ~3.3s), causing every first build to false-positively fall back to subprocess. The retry loop runs only after a spawn — warm reconnects short-circuit on the first connector call — so dev-loop responsiveness on warm caches is unaffected. Cost: when the daemon is genuinely broken, fallback now takes up to ~10s before subprocess engages. ADR 0016 amended.
-
-A follow-up will tighten the unit-tests.yml daemon canary's negative assertion (`! falling back to subprocess`) once the bootstrap kolt is on this release.
+Cold-cache CI runs cleared the prior 3s budget before the daemon listened, false-positively falling back to subprocess. Warm reconnects short-circuit on the first connector call. ADR 0016 amended.
 
 **`kolt test` filter args no longer pass `--scan-class-path` (#323)**
 
-`kolt test -- --select-class kolt.cli.ParseKoltArgsTest` was double-binding: the user's `--select-*` competed with kolt's auto-injected `--scan-class-path`, producing a Console Launcher error. kolt now suppresses `--scan-class-path` whenever any `--select-*` argument is present in `testArgs`.
+`--scan-class-path` is suppressed when any `--select-*` is present in `testArgs`.
 
 **Bug fixes**
 
-- `doNativeTest` was bypassing `resolveNativeCompilerBackend` and routing directly to subprocess; native daemon engagement now goes through the same backend resolver as `doBuild` (#312).
-- The project lock is now released between the test compile and the test child spawn so nested `kolt` invocations from inside the test process do not deadlock against the parent (#303).
+- `doNativeTest` now routes through `resolveNativeCompilerBackend` instead of bypassing to subprocess (#312).
+- Project lock released between test compile and test child spawn so nested `kolt` invocations no longer deadlock against the parent (#303).
 
 **Internals: kolt builds itself without Gradle**
 
-This release closes the Gradle removal arc:
+- Daemon subprojects build / test through `kolt build` / `kolt test` (#315, #324).
+- Orphan Gradle config files removed (#316).
+- CI bootstrap uses the prebuilt kolt binary in `unit-tests.yml` and `self-host-smoke.yml` (#301, #302, #308).
+- Native compiler daemon canary added to self-host-smoke (#313).
 
-- `./gradlew check` replaced with kolt-native daemon test runners — kolt's own native compiler daemon and JVM compiler daemon subprojects are now built and tested through `kolt build` / `kolt test` (#324, #315).
-- Orphan Gradle config files removed from the kolt repo (#316).
-- CI bootstrap path runs the prebuilt kolt binary instead of Gradle — both `unit-tests.yml` and `self-host-smoke.yml` (#301, #302, #308).
-- Native compiler daemon canary added to self-host-smoke to detect silent fallback regressions (#313).
+**libarchive replaces unzip / tar shell-outs (#43)**
 
-**Internals: libarchive replaces unzip / tar shell-outs (#43)**
-
-The toolchain extractor (`~/.kolt/toolchains/<tool>/<ver>/`) now uses libarchive cinterop instead of forking `unzip` / `tar`. Removes a system-binary dependency on the install path. Schema unchanged; users see no difference.
+Toolchain extractor (`~/.kolt/toolchains/<tool>/<ver>/`) no longer forks `unzip` / `tar`. Schema unchanged.
 
 **Yanked v0.16.1 / v0.16.2**
 
-These releases shipped the same daemon-bind regression as v0.16.x and were yanked in favor of v0.16.3. v0.17.0 supersedes the yank gate; install.sh's YANKED check is unchanged.
+Same daemon-bind regression as v0.16.x; superseded by v0.16.3 then v0.17.0. install.sh's YANKED check is unchanged.
 
 **Installation**
 
@@ -60,6 +51,6 @@ curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | s
 
 **Upgrade notes**
 
-- Existing `kolt.toml` files continue to parse with no changes; the new `[classpaths.*]` / `[test.sys_props]` / `[run.sys_props]` tables are all opt-in.
-- If you used `./gradlew check` directly against the kolt repo (e.g. forks contributing back), switch to `kolt build && kolt test`. Standalone daemon subprojects use `cd kolt-jvm-compiler-daemon && kolt build` (and the native counterpart).
-- The 10s daemon connect budget extends fallback latency on a genuinely broken daemon by up to 7s; if you rely on fast subprocess fallback in CI for any reason, audit your daemon path before upgrading.
+- New `[classpaths.*]` / `[test.sys_props]` / `[run.sys_props]` tables are opt-in; existing `kolt.toml` files parse unchanged.
+- If you ran `./gradlew check` against the kolt repo, switch to `kolt build && kolt test`. Standalone daemon subprojects: `cd kolt-jvm-compiler-daemon && kolt build` (and the native counterpart).
+- 10s daemon connect budget extends fallback latency on a genuinely broken daemon by up to 7s.


### PR DESCRIPTION
The sed bridge in both unit-tests.yml and self-host-smoke.yml's bootstrap step mirrored install.sh:214 to substitute @KOLT_LIBEXEC@ in argfiles shipped by the v0.17.0 / v0.16.3 bootstraps (which predated #338's resolver-side fix). Bootstraps are now both at v0.18.0, which contains the resolver fix; the bridge is dead code.

The negative `falling back to subprocess` assertion in each daemon canary stays — that is the permanent guard against silent subprocess fallback. The `Smoke-build without install.sh` step in the post-migration job also stays as the regression guard for #336 itself.