### PR TITLE
kolt add no longer mutates kolt.toml when fetch fails (#353)

### DIFF
--- a/docs/release-notes/v0.18.1.md
+++ b/docs/release-notes/v0.18.1.md
@@ -1,0 +1,13 @@
+**Bugfix**
+
+- `kolt add` no longer mutates `kolt.toml` when the fetch fails. A typo or unfetchable coordinate (404, dead repo) used to leave the project locked into a bogus entry until the user ran `kolt remove`; the new resolve-then-write order keeps `kolt.toml` byte-identical on failure (#353).
+
+**Behavior**
+
+- `kolt add` happy-path output reorders from `added → resolving → fetch complete` to `resolving → added → fetch complete`. Same set of lines, different order — the `added` line now means "added and persisted." Watch-mode parsers and CI scripts that key on these strings should be unaffected (no order assumption was found in-tree), but flagging in case any external tooling cares (#353).
+
+**Installation**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/snicmakino/kolt/main/install.sh | sh
+```

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -66,6 +66,21 @@ private fun doAddInner(args: List<String>): Result<Unit, Int> {
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
+  // Resolve against the in-memory updated config before persisting
+  // kolt.toml. Writing first and fetching after (the pre-#353 order)
+  // left the project locked into a bogus entry whenever the coordinate
+  // was unfetchable (typo, 404, dead repo).
+  val newConfig =
+    parseConfig(updatedToml).getOrElse { error ->
+      when (error) {
+        is ConfigError.ParseFailed -> eprintln("error: ${error.message}")
+      }
+      return Err(EXIT_CONFIG_ERROR)
+    }
+  resolveDependencies(newConfig, allowLockfileMigration = true).getOrElse {
+    return Err(it)
+  }
+
   writeFileAsString(KOLT_TOML, updatedToml).getOrElse { error ->
     eprintln("error: could not write ${error.path}")
     return Err(EXIT_CONFIG_ERROR)
@@ -73,11 +88,8 @@ private fun doAddInner(args: List<String>): Result<Unit, Int> {
 
   val section = if (addArgs.isTest) "[test-dependencies]" else "[dependencies]"
   println("added $groupArtifact = \"$version\" to $section")
-
-  // doFetchInner (not doFetch) — the outer lock acquired by doAdd
-  // already covers the fetch; calling doFetch would attempt a second
-  // flock(2) acquire on a fresh OFD and deadlock against ourselves.
-  return doFetchInner()
+  println("fetch complete")
+  return Ok(Unit)
 }
 
 internal fun doRemove(args: List<String>): Result<Unit, Int> = withDependencyLock {

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -66,16 +66,17 @@ private fun doAddInner(args: List<String>): Result<Unit, Int> {
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
-  // Resolve against the in-memory updated config before persisting
-  // kolt.toml. Writing first and fetching after (the pre-#353 order)
-  // left the project locked into a bogus entry whenever the coordinate
-  // was unfetchable (typo, 404, dead repo).
+  // Resolve before persisting kolt.toml so an unfetchable coordinate
+  // leaves the file byte-identical. `resolveDependencies` may rewrite
+  // kolt.lock on the success path, so on a subsequent kolt.toml write
+  // failure the lockfile can be ahead of kolt.toml — self-healing on
+  // the next resolve.
   val newConfig =
-    parseConfig(updatedToml).getOrElse { error ->
-      when (error) {
-        is ConfigError.ParseFailed -> eprintln("error: ${error.message}")
-      }
-      return Err(EXIT_CONFIG_ERROR)
+    parseConfig(updatedToml).getOrElse {
+      // Unreachable: `addDependencyToToml` produced `updatedToml` from
+      // an already-parsed `toml` plus a validated coordinate, so the
+      // result must reparse.
+      error("invariant violation: addDependencyToToml emitted unparseable TOML: $it")
     }
   resolveDependencies(newConfig, allowLockfileMigration = true).getOrElse {
     return Err(it)

--- a/src/nativeTest/kotlin/kolt/cli/DoAddAtomicWriteTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DoAddAtomicWriteTest.kt
@@ -1,0 +1,103 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package kolt.cli
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.fileExists
+import kolt.infra.readFileAsString
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.chdir
+import platform.posix.getcwd
+import platform.posix.getenv
+import platform.posix.mkdtemp
+import platform.posix.setenv
+import platform.posix.unsetenv
+
+// Issue #353: a `kolt add g:a:v` with an unfetchable coordinate must not
+// mutate kolt.toml. The pre-fix code wrote the new entry first, then ran
+// the fetch — so a typo or 404 left every subsequent dep-touching command
+// erroring on the bogus entry.
+//
+// We force the fetch to fail deterministically by pointing the project at
+// a closed local port (ECONNREFUSED is immediate on Linux); HOME is
+// redirected to the tempdir so cache writes do not leak into the real
+// `~/.kolt/`.
+class DoAddAtomicWriteTest {
+  private var originalCwd: String = ""
+  private var originalHome: String? = null
+  private var tmpDir: String = ""
+
+  @BeforeTest
+  fun setUp() {
+    originalCwd = memScoped {
+      val buf = allocArray<ByteVar>(PATH_MAX)
+      getcwd(buf, PATH_MAX.toULong())?.toKString() ?: error("getcwd failed")
+    }
+    originalHome = getenv("HOME")?.toKString()
+    tmpDir = createTempDir("kolt-add-atomic-")
+    setenv("HOME", tmpDir, 1)
+    check(chdir(tmpDir) == 0) { "chdir to $tmpDir failed" }
+  }
+
+  @AfterTest
+  fun tearDown() {
+    chdir(originalCwd)
+    val home = originalHome
+    if (home != null) setenv("HOME", home, 1) else unsetenv("HOME")
+    if (tmpDir.isNotEmpty() && fileExists(tmpDir)) {
+      removeDirectoryRecursive(tmpDir)
+    }
+  }
+
+  @Test
+  fun badCoordinateLeavesKoltTomlByteIdentical() {
+    val originalToml =
+      """
+      |name = "atomic-fixture"
+      |version = "0.1.0"
+      |kind = "lib"
+      |
+      |[kotlin]
+      |version = "2.1.0"
+      |
+      |[build]
+      |target = "linuxX64"
+      |sources = ["src"]
+      |test_sources = []
+      |
+      |[repositories]
+      |fake = "http://127.0.0.1:1/"
+      |"""
+        .trimMargin()
+    writeFileAsString("kolt.toml", originalToml).getOrElse { error("setup write failed: $it") }
+
+    val exit = doAdd(listOf("com.example:does-not-exist:1.0.0")).getError()
+
+    assertNotNull(exit, "doAdd must fail when the coordinate is unfetchable")
+    val onDisk = readFileAsString("kolt.toml").getOrElse { error("readback failed: $it") }
+    assertEquals(originalToml, onDisk, "kolt.toml must be byte-identical after a failed kolt add")
+  }
+
+  private fun createTempDir(prefix: String): String {
+    val template = "/tmp/${prefix}XXXXXX"
+    val buf = template.encodeToByteArray().copyOf(template.length + 1)
+    buf.usePinned { pinned ->
+      val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+      return result.toKString()
+    }
+  }
+}


### PR DESCRIPTION
Closes #353.

`doAddInner` now resolves the new dependency against an in-memory copy of the updated TOML before touching disk; `kolt.toml` is rewritten only after the fetch succeeds. A typo or 404 leaves the project byte-identical instead of locking it into a bogus entry that every subsequent dep-touching command would error on.

Reviewer focus:

- **Output ordering on the happy path.** Was `added X = "v" to [deps]` → `resolving dependencies...` → `fetch complete`. Now it's `resolving dependencies...` → `added X = "v" to [deps]` → `fetch complete`. Same set of lines, different order. I think the new order reads better (final-state-last) but flag if the watch/CI snapshot tests assume the old order. Memoed in `docs/release-notes/v0.18.1.md`.
- **Why not reuse `doFetchInner()`.** It re-reads `kolt.toml` from disk via `loadProjectConfig`, which is exactly what we need to avoid. Inlining the `resolveDependencies(newConfig, allowLockfileMigration = true)` call keeps the fetch lockfile-migration semantics identical to `kolt fetch` without a refactor.
- **Atomicity gap.** `resolveDependencies` may rewrite `kolt.lock` on success; if the subsequent `kolt.toml` write then fails, the lockfile is ahead of `kolt.toml`. Harmless — the next resolve regenerates the lockfile to match — and `writeFileAsString` failures here are disk-full / permission-error rare. Noted in the in-source comment.
- **Test reliability.** The new test uses `http://127.0.0.1:1/` for the repository URL — ECONNREFUSED is immediate on Linux, but if any CI runner has something listening there this would hang on the 30s curl connect timeout. The 30s ceiling caps the worst case but it's worth knowing the assumption.
- **DoD substitution.** Issue #353 asks for an integration test running `kolt build` after a failed `kolt add`. The new `DoAddAtomicWriteTest` instead checks byte-equality of `kolt.toml` directly, which covers the user-facing invariant without paying for a full build in CI. Acceptable trade-off, but flagging.