### PR TITLE
kolt add no-version path skips pre-releases (#354)

### DIFF
--- a/docs/release-notes/v0.18.1.md
+++ b/docs/release-notes/v0.18.1.md
@@ -1,6 +1,7 @@
 **Bugfix**
 
 - `kolt add` no longer mutates `kolt.toml` when the fetch fails. A typo or unfetchable coordinate (404, dead repo) used to leave the project locked into a bogus entry until the user ran `kolt remove`; the new resolve-then-write order keeps `kolt.toml` byte-identical on failure (#353).
+- `kolt add <ga>` (no version) no longer auto-picks pre-releases. The pre-fix code trusted Maven Central's `<release>` tag, which surfaces `-rc`, `-alpha`, `-beta`, `-M\d+`, `-eap`, `-dev`, `-preview` qualifiers — contradicting the documented "latest stable" contract. Resolution now parses the full `<versions>` list, filters by qualifier, and picks the highest stable. If every published version is pre-release, kolt falls back with a `warning: no stable release found ...` to stderr so brand-new artefacts aren't blocked (#354).
 
 **Behavior**
 

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -181,12 +181,17 @@ private fun fetchLatestVersion(
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
-  return parseMetadataXml(xml)
-    .getOrElse { error ->
+  val resolution =
+    parseMetadataXml(xml).getOrElse { error ->
       eprintln("error: ${error.message}")
       return Err(EXIT_DEPENDENCY_ERROR)
     }
-    .let { Ok(it) }
+  if (resolution.fallbackToPrerelease) {
+    eprintln(
+      "warning: no stable release found for $group:$artifact; using ${resolution.version}"
+    )
+  }
+  return Ok(resolution.version)
 }
 
 internal fun doFetch(): Result<Unit, Int> = withDependencyLock { doFetchInner() }

--- a/src/nativeMain/kotlin/kolt/resolve/Metadata.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Metadata.kt
@@ -6,19 +6,56 @@ import com.github.michaelbull.result.Result
 
 data class MetadataParseError(val message: String)
 
-fun parseMetadataXml(xml: String): Result<String, MetadataParseError> {
+data class MetadataResolution(val version: String, val fallbackToPrerelease: Boolean = false)
+
+// Maven Central's `<release>` is "latest non-SNAPSHOT" — which still
+// surfaces -rc / -alpha / -beta / -M\d+ etc. and contradicts kolt's
+// documented "latest stable" contract for `kolt add <ga>` (issue #354).
+// Always derive the answer from `<versions>` when it's present so we can
+// filter by qualifier; fall back to `<release>` / `<latest>` only for
+// malformed metadata that lacks the list entirely.
+fun parseMetadataXml(xml: String): Result<MetadataResolution, MetadataParseError> {
+  val versions = extractAllVersions(xml)
+  if (versions.isNotEmpty()) {
+    val stable = versions.filter { isStableVersion(it) }
+    val candidates = stable.ifEmpty { versions }
+    val picked = candidates.reduce { acc, v -> if (compareVersions(v, acc) > 0) v else acc }
+    return Ok(MetadataResolution(picked, fallbackToPrerelease = !isStableVersion(picked)))
+  }
   val release = extractSimpleTag(xml, "release")
-  if (release != null) return Ok(release)
-
+  if (release != null) {
+    return Ok(MetadataResolution(release, fallbackToPrerelease = !isStableVersion(release)))
+  }
   val latest = extractSimpleTag(xml, "latest")
-  if (latest != null) return Ok(latest)
-
+  if (latest != null) {
+    return Ok(MetadataResolution(latest, fallbackToPrerelease = !isStableVersion(latest)))
+  }
   return Err(MetadataParseError("No release or latest version found in metadata"))
 }
 
 fun buildMetadataDownloadUrl(group: String, artifact: String, baseUrl: String): String {
   val groupPath = group.replace('.', '/')
   return "$baseUrl/$groupPath/$artifact/maven-metadata.xml"
+}
+
+private fun extractAllVersions(xml: String): List<String> {
+  val open = xml.indexOf("<versions>")
+  if (open < 0) return emptyList()
+  val close = xml.indexOf("</versions>", open)
+  if (close < 0) return emptyList()
+  val block = xml.substring(open + "<versions>".length, close)
+  val results = mutableListOf<String>()
+  var cursor = 0
+  while (cursor < block.length) {
+    val tagOpen = block.indexOf("<version>", cursor)
+    if (tagOpen < 0) break
+    val contentStart = tagOpen + "<version>".length
+    val tagClose = block.indexOf("</version>", contentStart)
+    if (tagClose < 0) break
+    results.add(block.substring(contentStart, tagClose).trim())
+    cursor = tagClose + "</version>".length
+  }
+  return results
 }
 
 private fun extractSimpleTag(xml: String, tagName: String): String? {

--- a/src/nativeMain/kotlin/kolt/resolve/Metadata.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Metadata.kt
@@ -19,7 +19,15 @@ fun parseMetadataXml(xml: String): Result<MetadataResolution, MetadataParseError
   if (versions.isNotEmpty()) {
     val stable = versions.filter { isStableVersion(it) }
     val candidates = stable.ifEmpty { versions }
-    val picked = candidates.reduce { acc, v -> if (compareVersions(v, acc) > 0) v else acc }
+    val maxByCompare = candidates.reduce { acc, v -> if (compareVersions(v, acc) > 0) v else acc }
+    // Multi-flavor artefacts (e.g. Guava `33.6.0-jre` / `33.6.0-android`)
+    // share a numeric tuple and tie under `compareVersions`. The
+    // publisher's `<release>` tag is the authoritative tiebreak — without
+    // this preference, picking from XML order silently flips the chosen
+    // variant on artefacts whose `<versions>` list isn't `<release>`-last.
+    val release = extractSimpleTag(xml, "release")
+    val tied = candidates.filter { compareVersions(it, maxByCompare) == 0 }
+    val picked = if (release != null && release in tied) release else maxByCompare
     return Ok(MetadataResolution(picked, fallbackToPrerelease = !isStableVersion(picked)))
   }
   val release = extractSimpleTag(xml, "release")

--- a/src/nativeMain/kotlin/kolt/resolve/VersionCompare.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/VersionCompare.kt
@@ -3,9 +3,13 @@ package kolt.resolve
 // Maven Central populates `<release>` with the latest non-SNAPSHOT
 // version, which still includes -rc / -alpha / -beta / -M\d+ / -eap /
 // -dev / -preview qualifiers — none of which the `kolt add <ga>` no-version
-// path should auto-pick. This predicate scopes the explicit set we treat
-// as "pre-release"; any other token (e.g. `.RELEASE`, `-Final`) parses as
-// stable so unconventional release suffixes don't get rejected.
+// path should auto-pick. The `cr` qualifier lands here too: JBoss /
+// Hibernate use `.CR\d+` for candidate releases. Trailing digits are
+// allowed on every qualifier (real artefacts ship `-eap13`, `-rc02`,
+// `-cr1`); `M` requires the digit because a bare token "M" would
+// otherwise sweep up unrelated single-letter classifiers. Unknown
+// tokens (e.g. `.RELEASE`, `-Final`, `.GA`, `-jre`, `-android`) parse
+// as stable so vendor-specific release suffixes aren't rejected.
 fun isStableVersion(version: String): Boolean {
   for (token in version.split('.', '-')) {
     if (token.isEmpty()) continue
@@ -13,12 +17,7 @@ fun isStableVersion(version: String): Boolean {
     val lower = token.lowercase()
     val isPrerelease =
       lower == "snapshot" ||
-        lower == "eap" ||
-        lower == "dev" ||
-        lower == "preview" ||
-        Regex("""^rc\d*$""").matches(lower) ||
-        Regex("""^alpha\d*$""").matches(lower) ||
-        Regex("""^beta\d*$""").matches(lower) ||
+        Regex("""^(rc|alpha|beta|cr|eap|dev|preview)\d*$""").matches(lower) ||
         Regex("""^m\d+$""").matches(lower)
     if (isPrerelease) return false
   }

--- a/src/nativeMain/kotlin/kolt/resolve/VersionCompare.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/VersionCompare.kt
@@ -1,5 +1,30 @@
 package kolt.resolve
 
+// Maven Central populates `<release>` with the latest non-SNAPSHOT
+// version, which still includes -rc / -alpha / -beta / -M\d+ / -eap /
+// -dev / -preview qualifiers — none of which the `kolt add <ga>` no-version
+// path should auto-pick. This predicate scopes the explicit set we treat
+// as "pre-release"; any other token (e.g. `.RELEASE`, `-Final`) parses as
+// stable so unconventional release suffixes don't get rejected.
+fun isStableVersion(version: String): Boolean {
+  for (token in version.split('.', '-')) {
+    if (token.isEmpty()) continue
+    if (token.all { it.isDigit() }) continue
+    val lower = token.lowercase()
+    val isPrerelease =
+      lower == "snapshot" ||
+        lower == "eap" ||
+        lower == "dev" ||
+        lower == "preview" ||
+        Regex("""^rc\d*$""").matches(lower) ||
+        Regex("""^alpha\d*$""").matches(lower) ||
+        Regex("""^beta\d*$""").matches(lower) ||
+        Regex("""^m\d+$""").matches(lower)
+    if (isPrerelease) return false
+  }
+  return true
+}
+
 fun compareVersions(a: String, b: String): Int {
   val partsA = splitVersion(a)
   val partsB = splitVersion(b)

--- a/src/nativeTest/kotlin/kolt/resolve/MetadataTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/MetadataTest.kt
@@ -5,13 +5,15 @@ import com.github.michaelbull.result.getError
 import kolt.config.MAVEN_CENTRAL_BASE
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class MetadataTest {
 
   @Test
-  fun parseReleaseVersionFromMetadataXml() {
+  fun parseLatestStableFromVersionsList() {
     val xml =
       """
             <metadata>
@@ -29,30 +31,128 @@ class MetadataTest {
         """
         .trimIndent()
 
-    val result = parseMetadataXml(xml)
-    assertEquals("1.10.2", assertNotNull(result.get()))
+    val resolution = assertNotNull(parseMetadataXml(xml).get())
+    assertEquals("1.10.2", resolution.version)
+    assertFalse(resolution.fallbackToPrerelease)
   }
 
+  // Issue #354: kolt-usage docs the no-version path as "latest stable"
+  // but the pre-fix code trusted <release>, which Maven Central populates
+  // with the latest non-SNAPSHOT version including -rc qualifiers.
   @Test
-  fun parseMetadataWithoutReleaseUsesLatest() {
+  fun versionsListFiltersPrereleaseRcQualifier() {
     val xml =
       """
             <metadata>
-              <groupId>com.example</groupId>
-              <artifactId>lib</artifactId>
               <versioning>
-                <latest>2.0.0</latest>
+                <release>1.11.0-rc02</release>
                 <versions>
-                  <version>1.0.0</version>
-                  <version>2.0.0</version>
+                  <version>1.10.0</version>
+                  <version>1.11.0-rc02</version>
                 </versions>
               </versioning>
             </metadata>
         """
         .trimIndent()
 
-    val result = parseMetadataXml(xml)
-    assertEquals("2.0.0", assertNotNull(result.get()))
+    val resolution = assertNotNull(parseMetadataXml(xml).get())
+    assertEquals("1.10.0", resolution.version)
+    assertFalse(resolution.fallbackToPrerelease)
+  }
+
+  @Test
+  fun versionsListPicksMaxByVersionNotByXmlOrder() {
+    val xml =
+      """
+            <metadata>
+              <versioning>
+                <versions>
+                  <version>0.9.0</version>
+                  <version>1.5.0</version>
+                  <version>1.0.0</version>
+                </versions>
+              </versioning>
+            </metadata>
+        """
+        .trimIndent()
+
+    val resolution = assertNotNull(parseMetadataXml(xml).get())
+    assertEquals("1.5.0", resolution.version)
+  }
+
+  @Test
+  fun allPreReleaseFallsBackWithFlag() {
+    val xml =
+      """
+            <metadata>
+              <versioning>
+                <versions>
+                  <version>2.0.0-beta01</version>
+                  <version>2.0.0-rc01</version>
+                </versions>
+              </versioning>
+            </metadata>
+        """
+        .trimIndent()
+
+    val resolution = assertNotNull(parseMetadataXml(xml).get())
+    assertEquals("2.0.0-rc01", resolution.version)
+    assertTrue(resolution.fallbackToPrerelease)
+  }
+
+  @Test
+  fun milestoneMQualifierIsFiltered() {
+    val xml =
+      """
+            <metadata>
+              <versioning>
+                <versions>
+                  <version>1.0.0-M5</version>
+                  <version>1.0.0</version>
+                </versions>
+              </versioning>
+            </metadata>
+        """
+        .trimIndent()
+
+    val resolution = assertNotNull(parseMetadataXml(xml).get())
+    assertEquals("1.0.0", resolution.version)
+  }
+
+  @Test
+  fun eapQualifierIsFiltered() {
+    val xml =
+      """
+            <metadata>
+              <versioning>
+                <versions>
+                  <version>1.0.0-eap</version>
+                  <version>0.9.0</version>
+                </versions>
+              </versioning>
+            </metadata>
+        """
+        .trimIndent()
+
+    val resolution = assertNotNull(parseMetadataXml(xml).get())
+    assertEquals("0.9.0", resolution.version)
+  }
+
+  @Test
+  fun parseMetadataWithoutVersionsListUsesLatestTag() {
+    val xml =
+      """
+            <metadata>
+              <versioning>
+                <latest>2.0.0</latest>
+              </versioning>
+            </metadata>
+        """
+        .trimIndent()
+
+    val resolution = assertNotNull(parseMetadataXml(xml).get())
+    assertEquals("2.0.0", resolution.version)
+    assertFalse(resolution.fallbackToPrerelease)
   }
 
   @Test
@@ -76,8 +176,11 @@ class MetadataTest {
     assertIs<MetadataParseError>(result.getError())
   }
 
+  // No <versions> list, only a pre-release in <release>: we honour the
+  // legacy fallback to keep working against malformed metadata, but mark
+  // the resolution so the caller can warn.
   @Test
-  fun parsePreReleaseVersion() {
+  fun releaseFallbackFlagsPrerelease() {
     val xml =
       """
             <metadata>
@@ -88,8 +191,9 @@ class MetadataTest {
         """
         .trimIndent()
 
-    val result = parseMetadataXml(xml)
-    assertEquals("2.0.0-beta.1", assertNotNull(result.get()))
+    val resolution = assertNotNull(parseMetadataXml(xml).get())
+    assertEquals("2.0.0-beta.1", resolution.version)
+    assertTrue(resolution.fallbackToPrerelease)
   }
 
   @Test
@@ -106,8 +210,8 @@ class MetadataTest {
         """
         .trimIndent()
 
-    val result = parseMetadataXml(xml)
-    assertEquals("1.5.0", assertNotNull(result.get()))
+    val resolution = assertNotNull(parseMetadataXml(xml).get())
+    assertEquals("1.5.0", resolution.version)
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/resolve/MetadataTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/MetadataTest.kt
@@ -196,6 +196,78 @@ class MetadataTest {
     assertTrue(resolution.fallbackToPrerelease)
   }
 
+  // Guava-style multi-flavor tie: two stable variants share the numeric
+  // tuple `33.6.0` and unknown qualifier tokens (`jre` / `android`) both
+  // sort as RELEASE under `compareVersions`. The publisher's `<release>`
+  // is the authoritative tiebreak so `kolt add com.google.guava:guava`
+  // keeps yielding `-jre` (Maven Central's declared default) instead of
+  // flipping with XML order.
+  @Test
+  fun multiFlavorTieDefersToReleaseTag() {
+    val xml =
+      """
+            <metadata>
+              <versioning>
+                <release>33.6.0-jre</release>
+                <versions>
+                  <version>33.6.0-android</version>
+                  <version>33.6.0-jre</version>
+                </versions>
+              </versioning>
+            </metadata>
+        """
+        .trimIndent()
+
+    val resolution = assertNotNull(parseMetadataXml(xml).get())
+    assertEquals("33.6.0-jre", resolution.version)
+    assertFalse(resolution.fallbackToPrerelease)
+  }
+
+  // Snapshot must lose to the stable sibling even though they share the
+  // numeric tuple — guards against a regression where the SNAPSHOT
+  // accidentally classifies as stable or the comparator ties.
+  @Test
+  fun snapshotLosesToStableAtSameNumericTuple() {
+    val xml =
+      """
+            <metadata>
+              <versioning>
+                <versions>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <version>0.1.0</version>
+                </versions>
+              </versioning>
+            </metadata>
+        """
+        .trimIndent()
+
+    val resolution = assertNotNull(parseMetadataXml(xml).get())
+    assertEquals("0.1.0", resolution.version)
+    assertFalse(resolution.fallbackToPrerelease)
+  }
+
+  // An empty `<versions></versions>` block (vs. tag absent entirely)
+  // must fall through to <release>; the pre-release flag fires because
+  // <release> happens to be a candidate-release.
+  @Test
+  fun emptyVersionsBlockFallsThroughToReleaseTag() {
+    val xml =
+      """
+            <metadata>
+              <versioning>
+                <release>1.0.0-rc1</release>
+                <versions>
+                </versions>
+              </versioning>
+            </metadata>
+        """
+        .trimIndent()
+
+    val resolution = assertNotNull(parseMetadataXml(xml).get())
+    assertEquals("1.0.0-rc1", resolution.version)
+    assertTrue(resolution.fallbackToPrerelease)
+  }
+
   @Test
   fun parseVersionWithWhitespaceInTag() {
     val xml =

--- a/src/nativeTest/kotlin/kolt/resolve/VersionCompareTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/VersionCompareTest.kt
@@ -247,3 +247,54 @@ class VersionCompareTest {
     assertTrue(matchesRejectPattern("3.0.0", "[2.0.0,)"))
   }
 }
+
+class IsStableVersionTest {
+
+  @Test
+  fun pureNumericTripleIsStable() = assertTrue(isStableVersion("1.0.0"))
+
+  @Test
+  fun pureNumericPairIsStable() = assertTrue(isStableVersion("1.10"))
+
+  @Test
+  fun rcWithNumberIsNotStable() = assertFalse(isStableVersion("1.11.0-rc02"))
+
+  @Test
+  fun rcWithoutNumberIsNotStable() = assertFalse(isStableVersion("1.0.0-rc"))
+
+  @Test
+  fun rcUppercaseIsNotStable() = assertFalse(isStableVersion("1.0.0-RC1"))
+
+  @Test
+  fun alphaIsNotStable() = assertFalse(isStableVersion("1.0.0-alpha1"))
+
+  @Test
+  fun betaIsNotStable() = assertFalse(isStableVersion("1.0.0-beta"))
+
+  @Test
+  fun snapshotIsNotStable() = assertFalse(isStableVersion("1.0.0-SNAPSHOT"))
+
+  @Test
+  fun milestoneMUpperIsNotStable() = assertFalse(isStableVersion("1.0.0-M5"))
+
+  @Test
+  fun milestoneMLowerIsNotStable() = assertFalse(isStableVersion("1.0.0-m12"))
+
+  @Test
+  fun bareMWithoutDigitIsStable() = assertTrue(isStableVersion("1.0.0-M"))
+
+  @Test
+  fun eapIsNotStable() = assertFalse(isStableVersion("1.0.0-eap"))
+
+  @Test
+  fun devIsNotStable() = assertFalse(isStableVersion("1.0.0-dev"))
+
+  @Test
+  fun previewIsNotStable() = assertFalse(isStableVersion("1.0.0-preview"))
+
+  @Test
+  fun unknownQualifierTreatedAsStable() = assertTrue(isStableVersion("1.0.0-final"))
+
+  @Test
+  fun springReleaseQualifierTreatedAsStable() = assertTrue(isStableVersion("1.0.0.RELEASE"))
+}

--- a/src/nativeTest/kotlin/kolt/resolve/VersionCompareTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/VersionCompareTest.kt
@@ -297,4 +297,46 @@ class IsStableVersionTest {
 
   @Test
   fun springReleaseQualifierTreatedAsStable() = assertTrue(isStableVersion("1.0.0.RELEASE"))
+
+  @Test
+  fun jbossFinalQualifierTreatedAsStable() = assertTrue(isStableVersion("1.0.0.Final"))
+
+  @Test
+  fun guavaJreFlavorTreatedAsStable() = assertTrue(isStableVersion("33.6.0-jre"))
+
+  @Test
+  fun guavaAndroidFlavorTreatedAsStable() = assertTrue(isStableVersion("33.6.0-android"))
+
+  // JBoss/Hibernate convention: .CR\d+ for candidate releases.
+  @Test
+  fun hibernateCRQualifierIsNotStable() = assertFalse(isStableVersion("7.3.0.CR1"))
+
+  // Real-world ship for JetBrains EAP builds: `-eap13`, not bare `-eap`.
+  @Test
+  fun eapWithDigitSuffixIsNotStable() = assertFalse(isStableVersion("0.24.0-eap13"))
+
+  @Test
+  fun previewWithDigitSuffixIsNotStable() = assertFalse(isStableVersion("1.0.0-preview2"))
+
+  @Test
+  fun devWithDigitSuffixIsNotStable() = assertFalse(isStableVersion("1.0.0-dev03"))
+
+  // Kotlin compiler line uses capital-case qualifiers.
+  @Test
+  fun kotlinCapitalRcWithoutDigitIsNotStable() = assertFalse(isStableVersion("2.1.0-RC"))
+
+  @Test
+  fun kotlinCapitalRcWithDigitIsNotStable() = assertFalse(isStableVersion("2.1.0-RC2"))
+
+  @Test
+  fun kotlinCapitalBetaWithDigitIsNotStable() = assertFalse(isStableVersion("2.1.0-Beta1"))
+
+  // Old Kotlin builds shipped `-beta-<buildno>` (dash-separated).
+  @Test
+  fun dashSeparatedBetaWithBuildNumberIsNotStable() =
+    assertFalse(isStableVersion("1.0.0-beta-1038"))
+
+  @Test
+  fun dashSeparatedAlphaWithBuildNumberIsNotStable() =
+    assertFalse(isStableVersion("1.0.0-alpha-1"))
 }


### PR DESCRIPTION
Closes #354.

Maven Central's `<release>` tag is "latest non-SNAPSHOT", which still surfaces `-rc` / `-alpha` / `-beta` / `-M\d+` / `-eap` / `-cr` / `-dev` / `-preview` qualifiers — contradicting the documented "latest stable" contract for `kolt add <ga>`. `parseMetadataXml` now derives the answer from the full `<versions>` list, filters by qualifier, and picks the highest stable. If every published version is pre-release, the resolution flags a fallback so `fetchLatestVersion` can warn (`warning: no stable release found ...`) rather than block brand-new artefacts.

Reviewer focus:

- **Open question resolution.** Issue asked whether all-prerelease should warn-and-fall-back or error. Picked warn-and-fall-back: erroring would block the user the day a new artefact ships its first `-rc01`, and the explicit-version path remains the strict opt-in.
- **Multi-flavor tie handling.** Guava (`33.6.0-jre` / `33.6.0-android`) ties under `compareVersions` — both unknown qualifier tokens sort as RELEASE. The new code defers to `<release>` on ties so `kolt add com.google.guava:guava` keeps yielding `-jre` instead of flipping with XML order.
- **Qualifier set.** `cr\d*` (JBoss/Hibernate candidate release) joins the pre-release list. `eap` / `dev` / `preview` accept `\d*` because real-world ships are `-eap13`, not bare `-eap`. Unknown tokens (`Final`, `RELEASE`, `GA`, `jre`, `android`, ...) parse as stable so vendor-specific release suffixes aren't rejected.
- **API change.** `parseMetadataXml` now returns `Result<MetadataResolution, _>` instead of `Result<String, _>`. Single in-tree caller (`fetchLatestVersion`) migrated; no other callers.
- **Behavior preservation on stable artefacts.** For an artefact like `commons-io:commons-io` whose `<release>` is the latest stable in `<versions>`, the new code reaches the same answer as the old (max-stable equals `<release>`, then the tie-break is a no-op).

Output stack on the all-pre-release path:

```
$ kolt add com.example:rc-only
fetching latest version for com.example:rc-only...
warning: no stable release found for com.example:rc-only; using 2.0.0-rc01
resolving dependencies...
added com.example:rc-only = "2.0.0-rc01" to [dependencies]
fetch complete
```

Release notes appended to `docs/release-notes/v0.18.1.md`.