### PR TITLE
failed download surfaces per-repo URL + status (#355)

### DIFF
--- a/docs/release-notes/v0.18.1.md
+++ b/docs/release-notes/v0.18.1.md
@@ -2,6 +2,7 @@
 
 - `kolt add` no longer mutates `kolt.toml` when the fetch fails. A typo or unfetchable coordinate (404, dead repo) used to leave the project locked into a bogus entry until the user ran `kolt remove`; the new resolve-then-write order keeps `kolt.toml` byte-identical on failure (#353).
 - `kolt add <ga>` (no version) no longer auto-picks pre-releases. The pre-fix code trusted Maven Central's `<release>` tag, which surfaces `-rc`, `-alpha`, `-beta`, `-M\d+`, `-eap`, `-dev`, `-preview` qualifiers — contradicting the documented "latest stable" contract. Resolution now parses the full `<versions>` list, filters by qualifier, and picks the highest stable. If every published version is pre-release, kolt falls back with a `warning: no stable release found ...` to stderr so brand-new artefacts aren't blocked (#354).
+- Failed downloads now name the URL and HTTP status (or network-error message) for every repository tried, instead of collapsing to a bare `failed to download <ga>`. Distinguishing typo / 401 / 5xx / DNS no longer requires re-running under strace. Empty `[repositories]` surfaces a config-fix hint rather than a network-style message (#355).
 
 **Behavior**
 

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -153,7 +153,7 @@ private fun fetchLatestVersion(
     return Err(EXIT_DEPENDENCY_ERROR)
   }
 
-  val fetchErr =
+  val failure =
     downloadFromRepositories(
         repos,
         metadataPath,
@@ -161,17 +161,8 @@ private fun fetchLatestVersion(
         ::downloadFile,
       )
       .getError()
-  if (fetchErr != null) {
-    when (fetchErr) {
-      is DownloadError.HttpFailed ->
-        eprintln(
-          "error: could not fetch metadata for $group:$artifact (HTTP ${fetchErr.statusCode})"
-        )
-      is DownloadError.WriteFailed ->
-        eprintln("error: could not write metadata to ${fetchErr.path}")
-      is DownloadError.NetworkError ->
-        eprintln("error: network error fetching metadata for $group:$artifact: ${fetchErr.message}")
-    }
+  if (failure != null) {
+    eprintln(formatResolveError(ResolveError.MetadataDownloadFailed("$group:$artifact", failure)))
     return Err(EXIT_DEPENDENCY_ERROR)
   }
 

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -82,8 +82,8 @@ fun resolveNative(
           { buildKlibDownloadUrl(targetCoord, it) },
           deps::downloadFile,
         )
-        .getOrElse {
-          return Err(ResolveError.DownloadFailed(node.groupArtifact, it))
+        .getOrElse { failure ->
+          return Err(ResolveError.DownloadFailed(node.groupArtifact, failure))
         }
     }
 
@@ -267,7 +267,8 @@ private fun fetchAndRead(
       return Err(ResolveError.DirectoryCreateFailed(parentDir))
     }
     downloadFromRepositories(repos, cachePath, urlBuilder, deps::downloadFile).getOrElse {
-      return Err(ResolveError.DownloadFailed(groupArtifact, it))
+      failure ->
+      return Err(ResolveError.DownloadFailed(groupArtifact, failure))
     }
   }
   val content =

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -8,13 +8,35 @@ import kolt.infra.MkdirFailed
 import kolt.infra.OpenFailed
 import kolt.infra.Sha256Error
 
+// Per-repository attempt captured by `downloadFromRepositories`. The
+// resolver keeps the URL it tried alongside the underlying error so
+// `formatResolveError` can render a per-repo dump (#355). For 404s we
+// continue to the next repo and append; any other error stops the loop
+// and surfaces with the singleton attempts list.
+data class RepositoryAttempt(val url: String, val error: DownloadError)
+
+// Splits "no repositories were tried" from "all attempts failed" — the
+// two have different remediations (config fix vs. network/auth) so the
+// formatter renders distinct hints.
+sealed class RepositoryDownloadFailure {
+  data object NoRepositoriesConfigured : RepositoryDownloadFailure()
+
+  data class AllAttemptsFailed(val attempts: List<RepositoryAttempt>) : RepositoryDownloadFailure()
+}
+
 sealed class ResolveError {
   data class InvalidDependency(val input: String) : ResolveError()
 
   data class Sha256Mismatch(val groupArtifact: String, val expected: String, val actual: String) :
     ResolveError()
 
-  data class DownloadFailed(val groupArtifact: String, val error: DownloadError) : ResolveError()
+  data class DownloadFailed(val groupArtifact: String, val failure: RepositoryDownloadFailure) :
+    ResolveError()
+
+  data class MetadataDownloadFailed(
+    val groupArtifact: String,
+    val failure: RepositoryDownloadFailure,
+  ) : ResolveError()
 
   data class HashComputeFailed(val groupArtifact: String, val error: Sha256Error) : ResolveError()
 
@@ -49,7 +71,16 @@ fun formatResolveError(error: ResolveError): String =
         appendLine("  expected: ${error.expected}")
         append("  got:      ${error.actual}")
       }
-    is ResolveError.DownloadFailed -> "error: failed to download ${error.groupArtifact}"
+    is ResolveError.DownloadFailed ->
+      buildString {
+        append("error: failed to download ${error.groupArtifact}")
+        appendRepositoryDownloadFailure(error.failure)
+      }
+    is ResolveError.MetadataDownloadFailed ->
+      buildString {
+        append("error: could not fetch metadata for ${error.groupArtifact}")
+        appendRepositoryDownloadFailure(error.failure)
+      }
     is ResolveError.HashComputeFailed -> "error: failed to compute hash for ${error.groupArtifact}"
     is ResolveError.DirectoryCreateFailed -> "error: could not create directory ${error.path}"
     is ResolveError.NoNativeVariant ->
@@ -68,6 +99,28 @@ fun formatResolveError(error: ResolveError): String =
     is ResolveError.RejectedVersionResolved ->
       "error: resolved ${error.groupArtifact}:${error.version} is rejected by constraint '${error.rejectPattern}'"
   }
+
+internal fun formatAttemptStatus(error: DownloadError): String =
+  when (error) {
+    is DownloadError.HttpFailed -> error.statusCode.toString()
+    is DownloadError.NetworkError -> error.message
+    // The download itself reached the server and got a 200 — the *local*
+    // write of the tempfile is what failed. Rendering on the same per-repo
+    // line keeps the dump uniform; the wording flags it as local so the
+    // URL doesn't read as the offender.
+    is DownloadError.WriteFailed -> "local write failed (${error.path})"
+  }
+
+private fun StringBuilder.appendRepositoryDownloadFailure(failure: RepositoryDownloadFailure) {
+  when (failure) {
+    is RepositoryDownloadFailure.NoRepositoriesConfigured ->
+      append("\n  no repositories configured (add a `[repositories]` entry to kolt.toml)")
+    is RepositoryDownloadFailure.AllAttemptsFailed ->
+      for (attempt in failure.attempts) {
+        append("\n  ${attempt.url} -> ${formatAttemptStatus(attempt.error)}")
+      }
+  }
+}
 
 enum class Origin {
   MAIN,

--- a/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
@@ -75,25 +75,29 @@ internal fun resolveSourcesPath(
   return if (error == null) sourcesCachePath else null
 }
 
-// Falls back to next repo only on 404; any other error stops immediately.
+// Falls back to next repo only on 404; any other error stops the loop
+// and surfaces with the attempts list. Each attempt records the URL we
+// tried so the resolver can dump per-repo status (#355). Empty repos
+// surfaces as `NoRepositoriesConfigured` so the user gets a config-fix
+// hint instead of a "tried nothing" misread.
 internal fun downloadFromRepositories(
   repos: List<String>,
   destPath: String,
   urlBuilder: (String) -> String,
   download: (String, String) -> Result<Unit, DownloadError>,
-): Result<Unit, DownloadError> {
-  var lastError: DownloadError? = null
+): Result<Unit, RepositoryDownloadFailure> {
+  if (repos.isEmpty()) return Err(RepositoryDownloadFailure.NoRepositoriesConfigured)
+  val attempts = mutableListOf<RepositoryAttempt>()
   for (repo in repos) {
     val url = urlBuilder(repo)
     val error = download(url, destPath).getError()
     if (error == null) return Ok(Unit)
-    if (error is DownloadError.HttpFailed && error.statusCode == 404) {
-      lastError = error
-    } else {
-      return Err(error)
+    attempts.add(RepositoryAttempt(url, error))
+    if (error !is DownloadError.HttpFailed || error.statusCode != 404) {
+      return Err(RepositoryDownloadFailure.AllAttemptsFailed(attempts))
     }
   }
-  return Err(lastError ?: DownloadError.NetworkError("", "no repositories configured"))
+  return Err(RepositoryDownloadFailure.AllAttemptsFailed(attempts))
 }
 
 internal fun createPomLookup(
@@ -227,8 +231,8 @@ private fun materialize(
           { buildDownloadUrl(coord, it) },
           deps::downloadFile,
         )
-        .getOrElse { error ->
-          return Err(ResolveError.DownloadFailed(node.groupArtifact, error))
+        .getOrElse { failure ->
+          return Err(ResolveError.DownloadFailed(node.groupArtifact, failure))
         }
       lockChanged = true
     }

--- a/src/nativeTest/kotlin/kolt/build/daemon/BtaImplFetcherTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/BtaImplFetcherTest.kt
@@ -10,6 +10,8 @@ import kolt.infra.DownloadError
 import kolt.infra.OpenFailed
 import kolt.infra.Sha256Error
 import kolt.resolve.Lockfile
+import kolt.resolve.RepositoryAttempt
+import kolt.resolve.RepositoryDownloadFailure
 import kolt.resolve.ResolveError
 import kolt.resolve.ResolveResult
 import kolt.resolve.ResolvedDep
@@ -104,7 +106,11 @@ class BtaImplFetcherTest {
     val cause =
       ResolveError.DownloadFailed(
         "org.jetbrains.kotlin:kotlin-build-tools-impl",
-        DownloadError.HttpFailed("http://example/", 503),
+        RepositoryDownloadFailure.AllAttemptsFailed(
+          listOf(
+            RepositoryAttempt("http://example/", DownloadError.HttpFailed("http://example/", 503))
+          )
+        ),
       )
     val result =
       ensureBtaImplJars(

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
@@ -6,6 +6,8 @@ import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import kolt.config.KoltPaths
 import kolt.infra.DownloadError
+import kolt.resolve.RepositoryAttempt
+import kolt.resolve.RepositoryDownloadFailure
 import kolt.resolve.ResolveError
 import kolt.tool.ToolchainError
 import kotlin.test.Test
@@ -222,7 +224,11 @@ class DaemonPreconditionsTest {
         "2.3.10",
         ResolveError.DownloadFailed(
           "org.jetbrains.kotlin:kotlin-build-tools-impl",
-          DownloadError.HttpFailed("http://example", 503),
+          RepositoryDownloadFailure.AllAttemptsFailed(
+            listOf(
+              RepositoryAttempt("http://example", DownloadError.HttpFailed("http://example", 503))
+            )
+          ),
         ),
       )
     val result =
@@ -442,7 +448,14 @@ class DaemonPreconditionsTest {
               "2.3.10",
               ResolveError.DownloadFailed(
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                DownloadError.HttpFailed("http://example", 503),
+                RepositoryDownloadFailure.AllAttemptsFailed(
+                  listOf(
+                    RepositoryAttempt(
+                      "http://example",
+                      DownloadError.HttpFailed("http://example", 503),
+                    )
+                  )
+                ),
               ),
             ),
         )

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveErrorFormatTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveErrorFormatTest.kt
@@ -4,6 +4,7 @@ import kolt.infra.DownloadError
 import kolt.infra.Sha256Error
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ResolveErrorFormatTest {
@@ -29,13 +30,150 @@ class ResolveErrorFormatTest {
   }
 
   @Test
-  fun downloadFailedFormat() {
+  fun downloadFailedSingleHttpAttemptFormat() {
     val error =
       ResolveError.DownloadFailed(
         "com.example:lib",
-        DownloadError.NetworkError("https://example.com", "timeout"),
+        RepositoryDownloadFailure.AllAttemptsFailed(
+          listOf(
+            RepositoryAttempt(
+              "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar",
+              DownloadError.HttpFailed(
+                "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar",
+                404,
+              ),
+            )
+          )
+        ),
       )
-    assertEquals("error: failed to download com.example:lib", formatResolveError(error))
+    assertEquals(
+      "error: failed to download com.example:lib\n" +
+        "  https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar -> 404",
+      formatResolveError(error),
+    )
+  }
+
+  @Test
+  fun downloadFailedMultiRepoDumpsEachAttempt() {
+    val error =
+      ResolveError.DownloadFailed(
+        "com.example:lib",
+        RepositoryDownloadFailure.AllAttemptsFailed(
+          listOf(
+            RepositoryAttempt(
+              "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar",
+              DownloadError.HttpFailed("u1", 404),
+            ),
+            RepositoryAttempt(
+              "https://jitpack.io/com/example/lib/1.0.0/lib-1.0.0.jar",
+              DownloadError.HttpFailed("u2", 404),
+            ),
+          )
+        ),
+      )
+    val rendered = formatResolveError(error)
+    assertTrue(rendered.contains("error: failed to download com.example:lib"))
+    assertTrue(
+      rendered.contains(
+        "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar -> 404"
+      )
+    )
+    assertTrue(rendered.contains("https://jitpack.io/com/example/lib/1.0.0/lib-1.0.0.jar -> 404"))
+  }
+
+  @Test
+  fun downloadFailedNetworkErrorRendersMessage() {
+    val error =
+      ResolveError.DownloadFailed(
+        "com.example:lib",
+        RepositoryDownloadFailure.AllAttemptsFailed(
+          listOf(
+            RepositoryAttempt(
+              "https://example.com/lib-1.0.0.jar",
+              DownloadError.NetworkError(
+                "https://example.com/lib-1.0.0.jar",
+                "Could not resolve host",
+              ),
+            )
+          )
+        ),
+      )
+    assertEquals(
+      "error: failed to download com.example:lib\n" +
+        "  https://example.com/lib-1.0.0.jar -> Could not resolve host",
+      formatResolveError(error),
+    )
+  }
+
+  @Test
+  fun downloadFailedNoRepositoriesConfiguredRendersConfigHint() {
+    val error =
+      ResolveError.DownloadFailed(
+        "com.example:lib",
+        RepositoryDownloadFailure.NoRepositoriesConfigured,
+      )
+    assertEquals(
+      "error: failed to download com.example:lib\n" +
+        "  no repositories configured (add a `[repositories]` entry to kolt.toml)",
+      formatResolveError(error),
+    )
+  }
+
+  // Regression guard: the URL on a `WriteFailed` reached the server fine —
+  // the local tempfile write is what failed. The wording must not read as
+  // network blame.
+  @Test
+  fun writeFailedAttemptDoesNotMisattributeBlameToTheUrl() {
+    val error =
+      ResolveError.DownloadFailed(
+        "com.example:lib",
+        RepositoryDownloadFailure.AllAttemptsFailed(
+          listOf(
+            RepositoryAttempt(
+              "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar",
+              DownloadError.WriteFailed("/cache/lib-1.0.0.jar.tmp.42"),
+            )
+          )
+        ),
+      )
+    val rendered = formatResolveError(error)
+    assertTrue(rendered.contains("local write failed (/cache/lib-1.0.0.jar.tmp.42)"))
+    assertFalse(rendered.contains("write failed: "), "old framing must not regress")
+  }
+
+  @Test
+  fun metadataDownloadFailedRendersDistinctFirstLineButReusesPerRepoDump() {
+    val error =
+      ResolveError.MetadataDownloadFailed(
+        "com.example:lib",
+        RepositoryDownloadFailure.AllAttemptsFailed(
+          listOf(
+            RepositoryAttempt(
+              "https://repo1.maven.org/maven2/com/example/lib/maven-metadata.xml",
+              DownloadError.HttpFailed("u", 404),
+            )
+          )
+        ),
+      )
+    assertEquals(
+      "error: could not fetch metadata for com.example:lib\n" +
+        "  https://repo1.maven.org/maven2/com/example/lib/maven-metadata.xml -> 404",
+      formatResolveError(error),
+    )
+  }
+
+  @Test
+  fun metadataDownloadFailedNoReposConfiguredAlsoRendersConfigHint() {
+    val error =
+      ResolveError.MetadataDownloadFailed(
+        "com.example:lib",
+        RepositoryDownloadFailure.NoRepositoriesConfigured,
+      )
+    assertEquals(
+      "error: could not fetch metadata for com.example:lib\n" +
+        "  no repositories configured (add a `[repositories]` entry to kolt.toml)",
+      formatResolveError(error),
+    )
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
@@ -16,6 +16,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
 class TransitiveResolverTest {
 
@@ -1241,8 +1242,18 @@ class TransitiveResolverTest {
         download = { url, _ -> Err(DownloadError.HttpFailed(url, 404)) },
       )
 
-    val error = assertIs<DownloadError.HttpFailed>(result.getError())
-    assertEquals(404, error.statusCode)
+    val failure = assertIs<RepositoryDownloadFailure.AllAttemptsFailed>(result.getError())
+    assertEquals(2, failure.attempts.size)
+    assertTrue(failure.attempts.all { it.error is DownloadError.HttpFailed })
+    assertEquals(
+      "https://repo1.example.com/com/example/lib/1.0.0/lib-1.0.0.jar",
+      failure.attempts[0].url,
+    )
+    assertEquals(404, (failure.attempts[0].error as DownloadError.HttpFailed).statusCode)
+    assertEquals(
+      "https://repo2.example.com/com/example/lib/1.0.0/lib-1.0.0.jar",
+      failure.attempts[1].url,
+    )
   }
 
   @Test
@@ -1261,8 +1272,55 @@ class TransitiveResolverTest {
         },
       )
 
-    assertIs<DownloadError.NetworkError>(result.getError())
+    val failure = assertIs<RepositoryDownloadFailure.AllAttemptsFailed>(result.getError())
+    assertEquals(1, failure.attempts.size)
+    assertIs<DownloadError.NetworkError>(failure.attempts[0].error)
     assertEquals(1, downloadedUrls.size)
+  }
+
+  @Test
+  fun downloadFromRepositoriesMixedSequenceStopsOnFirstNon404AfterFallback() {
+    val coord = Coordinate("com.example", "lib", "1.0.0")
+    val repo1 = "https://repo1.example.com"
+    val repo2 = "https://repo2.example.com"
+    val repo3 = "https://repo3.example.com"
+    val touched = mutableListOf<String>()
+
+    val result =
+      downloadFromRepositories(
+        repos = listOf(repo1, repo2, repo3),
+        destPath = "/cache/lib.jar",
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
+        download = { url, _ ->
+          touched.add(url)
+          when {
+            url.startsWith(repo1) -> Err(DownloadError.HttpFailed(url, 404))
+            url.startsWith(repo2) -> Err(DownloadError.HttpFailed(url, 503))
+            else -> fail("repo3 should not be tried after a non-404 stop")
+          }
+        },
+      )
+
+    val failure = assertIs<RepositoryDownloadFailure.AllAttemptsFailed>(result.getError())
+    assertEquals(2, failure.attempts.size)
+    assertEquals(404, (failure.attempts[0].error as DownloadError.HttpFailed).statusCode)
+    assertEquals(503, (failure.attempts[1].error as DownloadError.HttpFailed).statusCode)
+    assertEquals(2, touched.size)
+  }
+
+  @Test
+  fun downloadFromRepositoriesEmptyReposSurfacesAsNoRepositoriesConfigured() {
+    val coord = Coordinate("com.example", "lib", "1.0.0")
+
+    val result =
+      downloadFromRepositories(
+        repos = emptyList(),
+        destPath = "/cache/lib.jar",
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
+        download = { _, _ -> fail("should not be invoked") },
+      )
+
+    assertEquals(RepositoryDownloadFailure.NoRepositoriesConfigured, result.getError())
   }
 
   @Test


### PR DESCRIPTION
Closes #355.

Pre-fix output collapsed every download failure to `error: failed to download <ga>`. Distinguishing typo / auth / transient 5xx / DNS failure required strace. `downloadFromRepositories` now returns a `RepositoryDownloadFailure` sealed value carrying per-repo `RepositoryAttempt` records; `formatResolveError` renders one `<url> -> <status>` line per attempt.

Reviewer focus:

- **Sealed split between \`NoRepositoriesConfigured\` and \`AllAttemptsFailed\`.** The split is justified by ADR 0015 (error on misuse): config-fix vs. network-fix hints are user-meaningfully different. The cost is one extra variant + one extra formatter branch. Reachability is narrow but real (user explicitly emptying \`[repositories]\` to point at internal-only).
- **\`MetadataDownloadFailed\` parallels \`DownloadFailed\`.** The no-version \`kolt add <ga>\` path used to print \`error: could not fetch metadata for X (HTTP 404)\` and the bare \`failed to download X\` framing would lose that "metadata" cue. The new variant reuses \`appendRepositoryDownloadFailure\` so the per-repo dump stays uniform — only the first line differs.
- **\`DownloadError\` exposed in resolve-package data classes.** Considered translating to a parallel \`AttemptResult\` sealed type but rejected as 1:1 boilerplate: \`formatResolveError\` already pattern-matches on \`DownloadError\` shape, so the mirror would just move the switch.
- **\`WriteFailed\` rendering.** Re-worded to \`local write failed (<path>)\` so the \`<url>\` in the same line doesn't read as the offender (the URL succeeded; the local tempfile write didn't). \`writeFailedAttemptDoesNotMisattributeBlameToTheUrl\` is a regression guard for this.
- **Early-break policy preserved.** 404 falls through to next repo; anything else stops the loop with the attempts captured so far. \`downloadFromRepositoriesMixedSequenceStopsOnFirstNon404AfterFallback\` pins this.

Release notes appended to \`docs/release-notes/v0.18.1.md\`.