### PR TITLE
kolt remove drops emptied section header (#360)

### DIFF
--- a/docs/release-notes/v0.18.1.md
+++ b/docs/release-notes/v0.18.1.md
@@ -3,6 +3,7 @@
 - `kolt add` no longer mutates `kolt.toml` when the fetch fails. A typo or unfetchable coordinate (404, dead repo) used to leave the project locked into a bogus entry until the user ran `kolt remove`; the new resolve-then-write order keeps `kolt.toml` byte-identical on failure (#353).
 - `kolt add <ga>` (no version) no longer auto-picks pre-releases. The pre-fix code trusted Maven Central's `<release>` tag, which surfaces `-rc`, `-alpha`, `-beta`, `-M\d+`, `-eap`, `-dev`, `-preview` qualifiers — contradicting the documented "latest stable" contract. Resolution now parses the full `<versions>` list, filters by qualifier, and picks the highest stable. If every published version is pre-release, kolt falls back with a `warning: no stable release found ...` to stderr so brand-new artefacts aren't blocked (#354).
 - Failed downloads now name the URL and HTTP status (or network-error message) for every repository tried, instead of collapsing to a bare `failed to download <ga>`. Distinguishing typo / 401 / 5xx / DNS no longer requires re-running under strace. Empty `[repositories]` surfaces a config-fix hint rather than a network-style message (#355).
+- `kolt remove` of the last entry in a section now drops the section header. A bare `[dependencies]` no longer dangles in the diff — the function still only normalizes sections it actually removed from, so a pre-existing empty header survives untouched (#360).
 
 **Behavior**
 

--- a/src/nativeMain/kotlin/kolt/resolve/RemoveDependency.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/RemoveDependency.kt
@@ -34,6 +34,10 @@ private val VERSION_PATTERN = Regex("""=\s*['"]([^'"]+)['"]""")
 fun removeDependencyFromToml(toml: String, groupArtifact: String): RemoveResult {
   val lines = toml.lines().toMutableList()
   val removed = mutableListOf<RemovedEntry>()
+  // Headers we removed at least one entry from. Only these are eligible
+  // for elision so a pre-existing bare `[dependencies]` (no removal) is
+  // left intact — the function does only what its name suggests.
+  val touchedHeaders = mutableSetOf<String>()
 
   for ((header, isTest) in SECTIONS) {
     val sectionStart = lines.indexOfFirst { it.trim() == header }
@@ -51,8 +55,25 @@ fun removeDependencyFromToml(toml: String, groupArtifact: String): RemoveResult 
         val version = VERSION_PATTERN.find(lines[i])?.groupValues?.get(1) ?: ""
         removed.add(RemovedEntry(version, isTest))
         lines.removeAt(i)
+        touchedHeaders.add(header)
       } else {
         i++
+      }
+    }
+  }
+
+  // Drop newly-emptied section headers (#360). The blank line that used
+  // to sit BEFORE this header (if any) survives and becomes the
+  // separator before the following section, so we don't double up
+  // separators when we delete the header + its blank-only body.
+  for (header in touchedHeaders) {
+    val headerIdx = lines.indexOfFirst { it.trim() == header }
+    if (headerIdx < 0) continue
+    val bodyEnd = nextSectionStart(lines, headerIdx + 1)
+    val bodyEmpty = (headerIdx + 1 until bodyEnd).all { lines[it].isBlank() }
+    if (bodyEmpty) {
+      for (k in (bodyEnd - 1) downTo headerIdx) {
+        lines.removeAt(k)
       }
     }
   }
@@ -60,4 +81,11 @@ fun removeDependencyFromToml(toml: String, groupArtifact: String): RemoveResult 
   val joined = lines.joinToString("\n")
   val final = if (toml.endsWith("\n") && !joined.endsWith("\n")) "$joined\n" else joined
   return RemoveResult(final, removed)
+}
+
+private fun nextSectionStart(lines: List<String>, from: Int): Int {
+  for (i in from until lines.size) {
+    if (lines[i].trim().startsWith("[")) return i
+  }
+  return lines.size
 }

--- a/src/nativeTest/kotlin/kolt/resolve/RemoveDependencyTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/RemoveDependencyTest.kt
@@ -208,6 +208,138 @@ class RemoveDependencyTest {
     assertEquals(toml, result.newToml)
   }
 
+  // Issue #360: removing the last entry from a section must elide the
+  // section header. A bare `[dependencies]` reads as "still has deps" at
+  // a glance and looks unfinished in PR diffs.
+  @Test
+  fun removingLastEntryElidesMainSectionHeader() {
+    val toml =
+      """
+        |name = "app"
+        |
+        |[dependencies]
+        |"foo:bar" = "1.0"
+        |
+        |[repositories]
+        |central = "https://repo1.maven.org/maven2"
+        |"""
+        .trimMargin()
+
+    val result = removeDependencyFromToml(toml, "foo:bar")
+
+    assertFalse("[dependencies]" in result.newToml, "header must be dropped: ${result.newToml}")
+    assertTrue("[repositories]" in result.newToml)
+    assertTrue("central" in result.newToml)
+    assertTrue(result.newToml.endsWith("\n"))
+  }
+
+  @Test
+  fun removingLastEntryElidesTestSectionHeader() {
+    val toml =
+      """
+        |[dependencies]
+        |"foo:bar" = "1.0"
+        |
+        |[test-dependencies]
+        |"io.kotest:kotest-runner" = "5.8.0"
+        |"""
+        .trimMargin()
+
+    val result = removeDependencyFromToml(toml, "io.kotest:kotest-runner")
+
+    assertFalse(
+      "[test-dependencies]" in result.newToml,
+      "test header must be dropped: ${result.newToml}",
+    )
+    assertTrue("[dependencies]" in result.newToml)
+    assertTrue("foo:bar" in result.newToml)
+  }
+
+  @Test
+  fun removingLastEntryFromBothSectionsElidesBothHeaders() {
+    val toml =
+      """
+        |name = "app"
+        |
+        |[dependencies]
+        |"foo:bar" = "1.0"
+        |
+        |[test-dependencies]
+        |"foo:bar" = "2.0"
+        |"""
+        .trimMargin()
+
+    val result = removeDependencyFromToml(toml, "foo:bar")
+
+    assertFalse("[dependencies]" in result.newToml)
+    assertFalse("[test-dependencies]" in result.newToml)
+    assertTrue("name = \"app\"" in result.newToml)
+  }
+
+  // The header sits at the file tail, no following section. Drop the
+  // header and preserve the input's trailing-newline shape.
+  @Test
+  fun removingLastEntryWhenSectionIsAtEofElidesHeader() {
+    val toml =
+      """
+        |name = "app"
+        |
+        |[dependencies]
+        |"foo:bar" = "1.0"
+        |"""
+        .trimMargin()
+
+    val result = removeDependencyFromToml(toml, "foo:bar")
+
+    assertFalse("[dependencies]" in result.newToml)
+    assertTrue(result.newToml.startsWith("name = \"app\""))
+    assertTrue(result.newToml.endsWith("\n"))
+  }
+
+  // Pre-existing empty section (the user already had `[dependencies]`
+  // with nothing under it) must NOT be touched: removeDependencyFromToml
+  // only normalizes sections it removed from, so it does only what its
+  // name suggests. Mirrors the existing emptySectionAtEndOfFileIsHandled
+  // case, but spelled out as an invariant guard.
+  @Test
+  fun preExistingEmptyHeaderSurvivesWhenNothingWasRemoved() {
+    val toml =
+      """
+        |name = "app"
+        |
+        |[dependencies]
+        |"""
+        .trimMargin()
+
+    val result = removeDependencyFromToml(toml, "foo:bar")
+
+    assertTrue(result.removed.isEmpty())
+    assertTrue("[dependencies]" in result.newToml, "untouched empty header must survive")
+    assertEquals(toml, result.newToml)
+  }
+
+  // Stray non-blank content (a comment, leftover hand edit) inside the
+  // section must block elision: dropping the header in that case would
+  // leave the comment dangling without a section, which silently changes
+  // the file's meaning. Pins the "blank-only" predicate so a future
+  // refactor doesn't broaden it to "blank or comment".
+  @Test
+  fun headerWithCommentInBodySurvivesElision() {
+    val toml =
+      """
+        |[dependencies]
+        |# kept across releases
+        |"foo:bar" = "1.0"
+        |"""
+        .trimMargin()
+
+    val result = removeDependencyFromToml(toml, "foo:bar")
+
+    assertEquals(1, result.removed.size)
+    assertTrue("[dependencies]" in result.newToml, "comment must keep header alive")
+    assertTrue("# kept across releases" in result.newToml)
+  }
+
   @Test
   fun preservesUnrelatedSectionsAndTrailingNewline() {
     val toml =


### PR DESCRIPTION
Closes #360.

After removing the last entry the bare `[dependencies]` / `[test-dependencies]` header used to dangle. The post-removal pass now elides headers whose body is blank-only — but only for sections we removed at least one entry from. A pre-existing empty header survives so `removeDependencyFromToml` keeps doing only what its name says (and the `emptySectionAtEndOfFileIsHandled` invariant stays intact, with a fresh `preExistingEmptyHeaderSurvivesWhenNothingWasRemoved` regression guard).

Reviewer focus:

- **Touched-only elision policy.** A user could deliberately keep `[dependencies]` empty as a placeholder during a refactor, so flipping the function into a normalizer would surprise-edit unrelated formatting. Six tests pin the contract on both sides.
- **Blank-line handling.** The blank line that used to sit *before* the header is preserved as the separator before the following section, so we don't double-blank when collapsing the empty body. Cases covered: header in the middle, header at EOF, header with stray comment in body (elision blocked).
- **`nextSectionStart` predicate.** Trims and matches `[`-prefix — broad enough to stop at `[[arrays]]` or `[sub.tables]` if a future schema introduces them after `[dependencies]`. Today's flat-map schema makes this moot but the loose predicate stays safe.

Release notes appended to `docs/release-notes/v0.18.1.md`.