### PR TITLE
kolt unknown subcommand exits 127 (#361)

### DIFF
--- a/docs/release-notes/v0.18.1.md
+++ b/docs/release-notes/v0.18.1.md
@@ -4,6 +4,7 @@
 - `kolt add <ga>` (no version) no longer auto-picks pre-releases. The pre-fix code trusted Maven Central's `<release>` tag, which surfaces `-rc`, `-alpha`, `-beta`, `-M\d+`, `-eap`, `-dev`, `-preview` qualifiers — contradicting the documented "latest stable" contract. Resolution now parses the full `<versions>` list, filters by qualifier, and picks the highest stable. If every published version is pre-release, kolt falls back with a `warning: no stable release found ...` to stderr so brand-new artefacts aren't blocked (#354).
 - Failed downloads now name the URL and HTTP status (or network-error message) for every repository tried, instead of collapsing to a bare `failed to download <ga>`. Distinguishing typo / 401 / 5xx / DNS no longer requires re-running under strace. Empty `[repositories]` surfaces a config-fix hint rather than a network-style message (#355).
 - `kolt remove` of the last entry in a section now drops the section header. A bare `[dependencies]` no longer dangles in the diff — the function still only normalizes sections it actually removed from, so a pre-existing empty header survives untouched (#360).
+- Unknown subcommand now exits `127` (`Command not found`) instead of `1` (`Build error`), matching the README exit-code table. CI scripts that grep for `$? == 1` to gate on a typo'd `kolt foo` should switch to `127` (#361).
 
 **Behavior**
 

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -92,7 +92,7 @@ fun main(args: Array<String>) {
     else -> {
       eprintln("error: unknown command '${filteredArgs[0]}'")
       printUsage()
-      exitProcess(EXIT_BUILD_ERROR)
+      exitProcess(EXIT_COMMAND_NOT_FOUND)
     }
   }
 }


### PR DESCRIPTION
Closes #361.

`ExitCode.kt:10` already defines `EXIT_COMMAND_NOT_FOUND = 127` and the README's exit-code table reserves 127 for `Command not found`, but the dispatcher's else-branch in `Main.kt:95` was wired to `EXIT_BUILD_ERROR` (=1). The constant was dead; this PR connects it.

Reviewer focus: the contract value itself is the only judgment call. POSIX convention reserves 127 for "shell can't find the binary" — kolt is repurposing it for "binary received an unknown subcommand," which is non-standard but already the documented public contract (README.md:382). Doc-side fix would have meant deleting the row + the unused constant; code-side fix is one line and preserves the table as-is.

No new test: dispatch in `Main.kt` calls `exitProcess` per branch with no extracted decision function, and `ExitCodeTest.kt:30` already pins `EXIT_COMMAND_NOT_FOUND == 127`. Refactoring to make the else-branch unit-testable is bigger than the fix. Verified via `kolt foobar; echo $?` → 127 and `kolt version; echo $?` → 0.

Release note in `docs/release-notes/v0.18.1.md` flags the exit-code change for any CI script grepping `$? == 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)