### PR TITLE
kolt scaffold .gitignore covers IDE/OS noise + workspace.json (#362)

### DIFF
--- a/docs/release-notes/v0.18.1.md
+++ b/docs/release-notes/v0.18.1.md
@@ -8,6 +8,7 @@
 **Behavior**
 
 - `kolt add` happy-path output reorders from `added → resolving → fetch complete` to `resolving → added → fetch complete`. Same set of lines, different order — the `added` line now means "added and persisted." Watch-mode parsers and CI scripts that key on these strings should be unaffected (no order assumption was found in-tree), but flagging in case any external tooling cares (#353).
+- `kolt new` / `kolt init` now scaffold a `.gitignore` covering `build/`, `workspace.json` (env-dependent absolute paths in the LSP workspace file), `.idea/`, `*.iml`, and `.DS_Store` — previously only `build/` was listed, so first commits typically dragged in IDE state and `workspace.json`. Existing `.gitignore` files are still left untouched (#362).
 
 **Installation**
 

--- a/src/nativeMain/kotlin/kolt/config/Init.kt
+++ b/src/nativeMain/kotlin/kolt/config/Init.kt
@@ -91,7 +91,15 @@ fun generateLibTestKt(packageDecl: String? = null): String = buildString {
   appendLine("}")
 }
 
-fun generateGitignore(): String = "build/\n"
+fun generateGitignore(): String =
+  """
+  build/
+  workspace.json
+  .idea/
+  *.iml
+  .DS_Store
+  """
+    .trimIndent() + "\n"
 
 fun inferProjectName(dirPath: String): String {
   val name = dirPath.trimEnd('/').substringAfterLast('/')

--- a/src/nativeTest/kotlin/kolt/config/InitTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/InitTest.kt
@@ -77,8 +77,17 @@ class InitTest {
   }
 
   @Test
-  fun generateGitignoreContainsBuildDir() {
-    assertEquals("build/\n", generateGitignore())
+  fun generateGitignoreCoversBuildAndCommonNoise() {
+    val expected =
+      """
+      build/
+      workspace.json
+      .idea/
+      *.iml
+      .DS_Store
+      """
+        .trimIndent() + "\n"
+    assertEquals(expected, generateGitignore())
   }
 
   @Test


### PR DESCRIPTION
Closes #362.

Scope is the discussion point. The 5-line set lands at:

\`\`\`
build/
workspace.json
.idea/
*.iml
.DS_Store
\`\`\`

Reviewer focus:

- **\`workspace.json\` is the non-obvious entry.** Issue #362 only mentioned IDE/OS noise; investigation surfaced that \`DependencyResolution.kt:344\` writes \`workspace.json\` to project root from \`fetch\`/\`update\`/\`add\` for LSP, with host-absolute paths inside. kolt's own repo gitignores it for the same reason — so first-time users hit the same surprise. Including it here is the change that prevents the most-frequent bad commit; happy to drop if you'd rather track that separately.
- **What was deliberately *not* added.** \`.vscode/\` (teams ship workspace settings), \`.fleet/\` (still niche), \`*.swp\`/\`Thumbs.db\` (better as global gitignore). Cargo's \`cargo new\` generates a 1-liner; gradle's init bloats. We're aiming closer to Cargo with the realistic landmines covered.
- **\`.idea/\` is whole-dir ignore.** Some teams check in \`.idea/runConfigurations/\`. They can re-include with \`!\` after the fact; default-ignore is the industry baseline.

Existing \`.gitignore\` files are still left untouched (\`Scaffold.kt:189\` guard); only the freshly-scaffolded content changes. \`InitTest.generateGitignoreCoversBuildAndCommonNoise\` pins the new contents byte-exact.

Verified via 1536 tests PASS + \`kolt new gitignore-smoke\` smoke (output matches the 5-line set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)