### PR TITLE
kolt fmt suppresses ktfmt sun.misc.Unsafe warning on JDK 23+ (#358)

### DIFF
--- a/docs/release-notes/v0.18.1.md
+++ b/docs/release-notes/v0.18.1.md
@@ -5,6 +5,7 @@
 - Failed downloads now name the URL and HTTP status (or network-error message) for every repository tried, instead of collapsing to a bare `failed to download <ga>`. Distinguishing typo / 401 / 5xx / DNS no longer requires re-running under strace. Empty `[repositories]` surfaces a config-fix hint rather than a network-style message (#355).
 - `kolt remove` of the last entry in a section now drops the section header. A bare `[dependencies]` no longer dangles in the diff — the function still only normalizes sections it actually removed from, so a pre-existing empty header survives untouched (#360).
 - Unknown subcommand now exits `127` (`Command not found`) instead of `1` (`Build error`), matching the README exit-code table. CI scripts that grep for `$? == 1` to gate on a typo'd `kolt foo` should switch to `127` (#361).
+- `kolt fmt` no longer leaks the 4-line `sun.misc.Unsafe::objectFieldOffset` deprecation warning ktfmt's bundled intellij-util triggers on JDK 23+. The fix passes `--sun-misc-unsafe-memory-access=allow` to the ktfmt JVM, gated on the resolved JDK major version so projects pinned to JDK <23 (where the flag is unrecognised) keep working unchanged (#358).
 
 **Behavior**
 

--- a/docs/release-notes/v0.18.1.md
+++ b/docs/release-notes/v0.18.1.md
@@ -5,7 +5,7 @@
 - Failed downloads now name the URL and HTTP status (or network-error message) for every repository tried, instead of collapsing to a bare `failed to download <ga>`. Distinguishing typo / 401 / 5xx / DNS no longer requires re-running under strace. Empty `[repositories]` surfaces a config-fix hint rather than a network-style message (#355).
 - `kolt remove` of the last entry in a section now drops the section header. A bare `[dependencies]` no longer dangles in the diff — the function still only normalizes sections it actually removed from, so a pre-existing empty header survives untouched (#360).
 - Unknown subcommand now exits `127` (`Command not found`) instead of `1` (`Build error`), matching the README exit-code table. CI scripts that grep for `$? == 1` to gate on a typo'd `kolt foo` should switch to `127` (#361).
-- `kolt fmt` no longer leaks the 4-line `sun.misc.Unsafe::objectFieldOffset` deprecation warning ktfmt's bundled intellij-util triggers on JDK 23+. The fix passes `--sun-misc-unsafe-memory-access=allow` to the ktfmt JVM, gated on the resolved JDK major version so projects pinned to JDK <23 (where the flag is unrecognised) keep working unchanged (#358).
+- `kolt fmt` no longer leaks the 4-line `sun.misc.Unsafe::objectFieldOffset` deprecation warning ktfmt's bundled intellij-util triggers on JDK 23+. The fix passes `--sun-misc-unsafe-memory-access=allow` to the ktfmt JVM, gated to JDK 23+ where the warning fires (the flag is unrecognised on older JDKs, which never saw the warning either) (#358).
 
 **Behavior**
 

--- a/src/nativeMain/kotlin/kolt/build/Formatter.kt
+++ b/src/nativeMain/kotlin/kolt/build/Formatter.kt
@@ -8,9 +8,16 @@ fun formatCommand(
   checkOnly: Boolean,
   style: String = "google",
   javaPath: String? = null,
+  jdkMajorVersion: Int? = null,
 ): FormatCommand {
   val args = buildList {
     add(javaPath ?: "java")
+    // ktfmt's bundled intellij-util fork calls `sun.misc.Unsafe::objectFieldOffset`,
+    // which JEP 498 (JDK 23) starts warning about. The flag silences that
+    // warning and is itself unrecognised on JDK <23, so gate before adding.
+    if (jdkMajorVersion != null && jdkMajorVersion >= 23) {
+      add("--sun-misc-unsafe-memory-access=allow")
+    }
     add("-jar")
     add(ktfmtJarPath)
     add("--${style}-style")

--- a/src/nativeMain/kotlin/kolt/cli/FormatCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/FormatCommands.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
+import kolt.build.daemon.BOOTSTRAP_JDK_VERSION
 import kolt.build.formatCommand
 import kolt.config.*
 import kolt.infra.*
@@ -59,6 +60,7 @@ internal fun doFmt(args: List<String>): Result<Unit, Int> {
     return Ok(Unit)
   }
 
+  val jdkVersion = config.build.jdk ?: BOOTSTRAP_JDK_VERSION
   val cmd =
     formatCommand(
       ktfmtPath,
@@ -66,6 +68,7 @@ internal fun doFmt(args: List<String>): Result<Unit, Int> {
       checkOnly,
       style = config.fmt.style,
       javaPath = managedJdkBins.java,
+      jdkMajorVersion = jdkVersion.substringBefore('.').toIntOrNull(),
     )
 
   if (checkOnly) {

--- a/src/nativeMain/kotlin/kolt/cli/FormatCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/FormatCommands.kt
@@ -68,7 +68,7 @@ internal fun doFmt(args: List<String>): Result<Unit, Int> {
       checkOnly,
       style = config.fmt.style,
       javaPath = managedJdkBins.java,
-      jdkMajorVersion = jdkVersion.substringBefore('.').toIntOrNull(),
+      jdkMajorVersion = jdkVersion.takeWhile { it.isDigit() }.toIntOrNull(),
     )
 
   if (checkOnly) {

--- a/src/nativeTest/kotlin/kolt/build/FormatterTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/FormatterTest.kt
@@ -121,4 +121,82 @@ class FormatterTest {
       cmd.args,
     )
   }
+
+  @Test
+  fun formatCommandOmitsUnsafeFlagOnPreJdk23() {
+    val cmd =
+      formatCommand(
+        ktfmtJarPath = "/tools/ktfmt.jar",
+        files = listOf("src/Main.kt"),
+        checkOnly = false,
+        jdkMajorVersion = 22,
+      )
+
+    assertEquals(
+      listOf("java", "-jar", "/tools/ktfmt.jar", "--google-style", "src/Main.kt"),
+      cmd.args,
+    )
+  }
+
+  @Test
+  fun formatCommandOmitsUnsafeFlagWhenJdkVersionUnknown() {
+    val cmd =
+      formatCommand(
+        ktfmtJarPath = "/tools/ktfmt.jar",
+        files = listOf("src/Main.kt"),
+        checkOnly = false,
+        jdkMajorVersion = null,
+      )
+
+    assertEquals(
+      listOf("java", "-jar", "/tools/ktfmt.jar", "--google-style", "src/Main.kt"),
+      cmd.args,
+    )
+  }
+
+  @Test
+  fun formatCommandAddsUnsafeFlagBeforeJarOnJdk23() {
+    val cmd =
+      formatCommand(
+        ktfmtJarPath = "/tools/ktfmt.jar",
+        files = listOf("src/Main.kt"),
+        checkOnly = false,
+        jdkMajorVersion = 23,
+      )
+
+    assertEquals(
+      listOf(
+        "java",
+        "--sun-misc-unsafe-memory-access=allow",
+        "-jar",
+        "/tools/ktfmt.jar",
+        "--google-style",
+        "src/Main.kt",
+      ),
+      cmd.args,
+    )
+  }
+
+  @Test
+  fun formatCommandAddsUnsafeFlagOnJdk25() {
+    val cmd =
+      formatCommand(
+        ktfmtJarPath = "/tools/ktfmt.jar",
+        files = listOf("src/Main.kt"),
+        checkOnly = false,
+        jdkMajorVersion = 25,
+      )
+
+    assertEquals(
+      listOf(
+        "java",
+        "--sun-misc-unsafe-memory-access=allow",
+        "-jar",
+        "/tools/ktfmt.jar",
+        "--google-style",
+        "src/Main.kt",
+      ),
+      cmd.args,
+    )
+  }
 }


### PR DESCRIPTION
Closes #358.

ktfmt 0.54 (and 0.62, the current latest — verified on JDK 25) bundles an intellij-util fork whose \`ConcurrentLongObjectHashMap\` calls \`sun.misc.Unsafe::objectFieldOffset\`. JEP 498 in JDK 23 turned that into a 4-line warning printed once per process, so every \`kolt fmt\` / \`fmt --check\` now spams that block. Bumping ktfmt does *not* fix it; the underlying intellij-util fork still uses Unsafe.

Pass \`--sun-misc-unsafe-memory-access=allow\` to the ktfmt JVM. The flag silences the warning entirely, but is itself unrecognised on JDK <23, so we gate on \`config.build.jdk ?: BOOTSTRAP_JDK_VERSION\` parsed to an integer. Projects pinned to JDK <23 see no behavior change (and no warning either, since JEP 498 is JDK 23+).

**Reviewer focus**

- **Why not run ktfmt under the bootstrap JDK (25) regardless of project setting?** That's the cleaner conceptual fix — ktfmt is a developer tool, not project code; it doesn't share a process with anything. Same logic applies to junit-platform-console-standalone. But that's an ADR-level change with broader implications (e.g. users on \`jdk = "8"\` currently can't run \`kolt fmt\` at all because ktfmt 0.54 needs JDK 11+; B would silently fix that too). Out of scope here; worth a separate Issue if desired.
- **Version parsing.** \`substringBefore('.').toIntOrNull()\` is intentionally narrow — kolt's JDK version strings are major-only ("21", "25") per ADR 0017, but Adoptium occasionally surfaces full versions in error paths. Falling back to "no flag" on parse failure is the safe default (omits the flag rather than risking an unrecognised JVM arg).
- **Flag position.** Inserted before \`-jar\` (JVM arg), not after (would be passed to ktfmt itself).

**Verification**

- \`build/debug/kolt.kexe fmt --check\` on this repo produces 2 lines (\`checking format...\` / \`format check passed\`) — zero warning lines, vs the prior 4-line block.
- 1544 tests PASS including 4 new \`FormatterTest\` cases pinning gated/ungated args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)