### PR TITLE
ic test layout follow-ups (#382, #383, #378)

### DIFF
--- a/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
+++ b/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
@@ -103,6 +103,8 @@ Daemon-owned: the daemon is the sole writer, reader, and invalidation authority.
 
 **Scope segment (#376).** The original "1 project ⇒ 1 module ⇒ 1 outputDir" framing this section assumed does not match the JVM `kolt test` shape, which compiles the same project twice — once for main (`build/classes/`) and once for test (`build/test-classes/`). BTA persists its `inputsCache` under `workingDir/inputs/` keyed by source-file path. Sharing one workingDir across the two compiles makes BTA see the *other* compile's source list as "removed" and invoke `removeOutputForSourceFiles` against the previously-tracked outputs — wiping `build/classes/` after a test compile. The `<scope>` segment (`main` / `test`) gives each scope its own workingDir under the shared `<projectIdHash>` directory, mirroring Gradle KGP's one-task-one-workingDir model. `LOCK` and the `project.path` breadcrumb stay at the `<projectIdHash>` level (one per project) so the reaper continues to see one entry per project regardless of scope.
 
+**Future axes (#382).** A third flat scope (Benchmark, IntegrationTest) is additive: the wire enum and the layout absorb it without migration. A KMP-target axis (e.g. `linuxX64`, `jvmMain`) collides at `<scope>` and forces a layout reshape — either `<projectIdHash>/<target>/<scope>/` or one packed segment. Inserting a `<LAYOUT_VERSION>` segment would make such a migration detectable on disk and let the reaper drop the prior version; deferred until the second axis is real because the migration also needs a reaper rule for the prior layout.
+
 ### §6 Session model: no wire state
 
 `BuildSession` is JVM-local and `AutoCloseable`. The daemon opens one at the start of each `Message.Compile` dispatch and closes it on completion. `ProjectId` = `sha256(projectRoot)`. Neither appears on the wire. No `previousBuildId` field is added to `Message.Compile`; `SourcesChanges.ToBeCalculated` handles change detection from on-disk state.
@@ -181,6 +183,7 @@ IC is the default compile path from the first B-2 release. No opt-in flag, no `k
 - #104 — Phase B-1b `kotlin-build-tools-api` spike and REPORT.md
 - #105 — this ADR's tracking issue
 - #376 — JVM `kolt test` daemon route + scope segment in §5
+- #382 — future-axes note in §5 (third flat scope vs KMP-target reshape)
 - ADR 0001 — `Result<V, E>` discipline applied to `IncrementalCompiler` and `IcError`
 - ADR 0016 — JVM daemon (compile backend this ADR extends; wire protocol unchanged)
 - ADR 0022 — Kotlin version policy (supersedes §1's single-version pin)

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalAbiCascadeTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalAbiCascadeTest.kt
@@ -49,7 +49,8 @@ class BtaIncrementalAbiCascadeTest {
     val workRoot = Files.createTempDirectory("bta-abi-cascade-")
     val sourcesDir = workRoot.resolve("src").apply { createDirectories() }
     val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-    val workingDir = workRoot.resolve("ic-state")
+    val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
+    val workingDir = projectStateDir.resolve("main").apply { createDirectories() }
 
     // Each file owns exactly one top-level `fun` so .class files map
     // 1:1 to source files (modulo synthetic artefacts BTA may emit).

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerWarmPathTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerWarmPathTest.kt
@@ -47,8 +47,9 @@ class BtaIncrementalCompilerWarmPathTest {
         )
       }
     val outputDir = workRoot.resolve("classes").apply { createDirectories() }
+    val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
     // Intentionally NOT created — the adapter must materialise it.
-    val workingDir = workRoot.resolve("ic-state")
+    val workingDir = projectStateDir.resolve("main")
     assertTrue(!Files.exists(workingDir), "precondition: workingDir must not exist")
 
     val compiler =
@@ -88,7 +89,8 @@ class BtaIncrementalCompilerWarmPathTest {
         )
       }
     val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-    val workingDir = workRoot.resolve("ic-state")
+    val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
+    val workingDir = projectStateDir.resolve("main").apply { createDirectories() }
 
     val compiler =
       BtaIncrementalCompiler.create(btaImplJars).getOrElse {
@@ -160,7 +162,8 @@ class BtaIncrementalCompilerWarmPathTest {
         )
       }
     val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-    val workingDir = workRoot.resolve("ic-state")
+    val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
+    val workingDir = projectStateDir.resolve("main").apply { createDirectories() }
 
     val metrics = RecordingMetricsSink()
     val compiler =

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCorruptionSmokeTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCorruptionSmokeTest.kt
@@ -55,7 +55,8 @@ class BtaIncrementalCorruptionSmokeTest {
         )
       }
     val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-    val workingDir = workRoot.resolve("ic-state")
+    val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
+    val workingDir = projectStateDir.resolve("main").apply { createDirectories() }
 
     val metrics = RecordingMetricsSink()
     val adapter =

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalRecompileSetTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalRecompileSetTest.kt
@@ -50,7 +50,8 @@ class BtaIncrementalRecompileSetTest {
     val workRoot = Files.createTempDirectory("bta-recompile-set-")
     val sourcesDir = workRoot.resolve("src").apply { createDirectories() }
     val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-    val workingDir = workRoot.resolve("ic-state")
+    val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
+    val workingDir = projectStateDir.resolve("main").apply { createDirectories() }
 
     // Linear chain: F1 calls F2 calls F3 calls F4 calls F5. Each file
     // holds one top-level function. F5 is the leaf whose body we

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaInputsCacheCrossScopeTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaInputsCacheCrossScopeTest.kt
@@ -1,0 +1,181 @@
+@file:OptIn(kotlin.io.path.ExperimentalPathApi::class)
+
+package kolt.daemon.ic
+
+import com.github.michaelbull.result.getOrElse
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.extension
+import kotlin.io.path.walk
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+// Pins the ADR 0019 §5 scope-segment contract: a main compile followed by a
+// test compile against the same project must not wipe the main outputDir's
+// class files when the two compiles use scope-segregated workingDirs. The
+// negative variant proves the symptom reproduces under a shared workingDir,
+// which is what would happen if a future regression collapsed the segment.
+//
+// Surfaces faster than the kolt-jvm-compiler-daemon self-host smoke (#376),
+// which spins up a real daemon process and a JUnit run; here BTA is driven
+// in-process against a tiny fixture.
+class BtaInputsCacheCrossScopeTest {
+
+  private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
+  private val fixtureClasspath: List<Path> = systemClasspath("kolt.ic.fixtureClasspath")
+
+  @Test
+  fun `per-scope workingDir keeps main outputDir intact after a test compile`() {
+    val fixture = setupFixture(prefix = "bta-cross-scope-positive-")
+    val mainOutput = fixture.workRoot.resolve("classes").apply { createDirectories() }
+    val testOutput = fixture.workRoot.resolve("test-classes").apply { createDirectories() }
+    val projectStateDir = fixture.workRoot.resolve("ic").apply { createDirectories() }
+    val mainWorking = projectStateDir.resolve("main").apply { createDirectories() }
+    val testWorking = projectStateDir.resolve("test").apply { createDirectories() }
+
+    val compiler = newCompiler()
+
+    compiler
+      .compile(
+        IcRequest(
+          projectId = "cross-scope-positive",
+          projectRoot = fixture.workRoot,
+          sources = listOf(fixture.mainSource),
+          classpath = fixtureClasspath,
+          outputDir = mainOutput,
+          workingDir = mainWorking,
+        )
+      )
+      .getOrElse { fail("main compile failed: $it") }
+
+    val mainClassFilesBefore = relativeClassFiles(mainOutput)
+    assertTrue(
+      mainClassFilesBefore.isNotEmpty(),
+      "main compile must produce class files; got: $mainClassFilesBefore",
+    )
+
+    compiler
+      .compile(
+        IcRequest(
+          projectId = "cross-scope-positive",
+          projectRoot = fixture.workRoot,
+          sources = listOf(fixture.testSource),
+          classpath = fixtureClasspath + listOf(mainOutput),
+          outputDir = testOutput,
+          workingDir = testWorking,
+        )
+      )
+      .getOrElse { fail("test compile failed: $it") }
+
+    val mainClassFilesAfter = relativeClassFiles(mainOutput)
+    assertEquals(
+      mainClassFilesBefore.toSet(),
+      mainClassFilesAfter.toSet(),
+      "main outputDir's class files must survive a per-scope test compile",
+    )
+  }
+
+  @Test
+  fun `shared workingDir reproduces the inputsCache cross-scope wipe`() {
+    val fixture = setupFixture(prefix = "bta-cross-scope-negative-")
+    val mainOutput = fixture.workRoot.resolve("classes").apply { createDirectories() }
+    val testOutput = fixture.workRoot.resolve("test-classes").apply { createDirectories() }
+    val sharedWorking = fixture.workRoot.resolve("ic-shared").apply { createDirectories() }
+
+    val compiler = newCompiler()
+
+    compiler
+      .compile(
+        IcRequest(
+          projectId = "cross-scope-negative",
+          projectRoot = fixture.workRoot,
+          sources = listOf(fixture.mainSource),
+          classpath = fixtureClasspath,
+          outputDir = mainOutput,
+          workingDir = sharedWorking,
+        )
+      )
+      .getOrElse { fail("main compile failed: $it") }
+
+    val mainClassFilesBefore = relativeClassFiles(mainOutput)
+    assertTrue(
+      mainClassFilesBefore.isNotEmpty(),
+      "main compile must produce class files; got: $mainClassFilesBefore",
+    )
+
+    // Compile result may be Ok or CompilationFailed: BTA's
+    // removeOutputForSourceFiles can wipe Main.class before kotlinc runs,
+    // making the test compile itself fail with `Unresolved reference 'Main'`.
+    // Either outcome counts as the wipe symptom; the load-bearing assertion
+    // below is on mainOutput state after the second compile.
+    val testResult =
+      compiler.compile(
+        IcRequest(
+          projectId = "cross-scope-negative",
+          projectRoot = fixture.workRoot,
+          sources = listOf(fixture.testSource),
+          classpath = fixtureClasspath + listOf(mainOutput),
+          outputDir = testOutput,
+          workingDir = sharedWorking,
+        )
+      )
+
+    val mainClassFilesAfter = relativeClassFiles(mainOutput)
+    assertTrue(
+      mainClassFilesAfter.size < mainClassFilesBefore.size,
+      "shared workingDir must wipe at least one main class file; " +
+        "testResult=$testResult before=$mainClassFilesBefore after=$mainClassFilesAfter",
+    )
+  }
+
+  private data class Fixture(val workRoot: Path, val mainSource: Path, val testSource: Path)
+
+  private fun setupFixture(prefix: String): Fixture {
+    val workRoot = Files.createTempDirectory(prefix)
+    val mainSource =
+      workRoot.resolve("Main.kt").apply {
+        writeText(
+          """
+                package fixture
+                object Main {
+                    fun greeting(): String = "hello"
+                }
+                """
+            .trimIndent()
+        )
+      }
+    val testSource =
+      workRoot.resolve("MainTest.kt").apply {
+        writeText(
+          """
+                package fixture
+                fun usesMain(): String = Main.greeting()
+                """
+            .trimIndent()
+        )
+      }
+    return Fixture(workRoot, mainSource, testSource)
+  }
+
+  private fun newCompiler(): IncrementalCompiler =
+    BtaIncrementalCompiler.create(btaImplJars).getOrElse {
+      fail("failed to load BTA toolchain: $it")
+    }
+
+  private fun relativeClassFiles(dir: Path): List<String> =
+    dir.walk().filter { it.extension == "class" }.map { dir.relativize(it).toString() }.toList()
+
+  private fun systemClasspath(key: String): List<Path> {
+    val raw =
+      System.getProperty(key)
+        ?: error(
+          "$key system property not set — check kolt-jvm-compiler-daemon/kolt.toml [test.sys_props]"
+        )
+    return raw.split(File.pathSeparator).filter { it.isNotBlank() }.map { Path.of(it) }
+  }
+}

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
@@ -59,7 +59,8 @@ class BtaSerializationPluginTest {
         )
       }
     val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-    val workingDir = workRoot.resolve("ic-state")
+    val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
+    val workingDir = projectStateDir.resolve("main").apply { createDirectories() }
 
     val resolverCalls = mutableListOf<String>()
     val compiler =
@@ -194,7 +195,8 @@ class BtaSerializationPluginTest {
         )
       }
     val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-    val workingDir = workRoot.resolve("ic-state")
+    val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
+    val workingDir = projectStateDir.resolve("main").apply { createDirectories() }
 
     val compiler =
       BtaIncrementalCompiler.create(

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingBtaCompositionTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingBtaCompositionTest.kt
@@ -47,7 +47,8 @@ class SelfHealingBtaCompositionTest {
         )
       }
     val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-    val workingDir = workRoot.resolve("ic-state")
+    val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
+    val workingDir = projectStateDir.resolve("main").apply { createDirectories() }
 
     val metrics = RecordingMetricsSink()
     val adapter =
@@ -93,7 +94,8 @@ class SelfHealingBtaCompositionTest {
         )
       }
     val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-    val workingDir = workRoot.resolve("ic-state")
+    val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
+    val workingDir = projectStateDir.resolve("main").apply { createDirectories() }
 
     val metrics = RecordingMetricsSink()
     val adapter =


### PR DESCRIPTION
Three #376 follow-ups bundled because all three are test-only / docs-only and touch the same area.

**#383** — six existing IC tests (`BtaIncrementalCompilerWarmPathTest`, `BtaIncrementalAbiCascadeTest`, `BtaIncrementalRecompileSetTest`, `BtaSerializationPluginTest`, `SelfHealingBtaCompositionTest`, `BtaIncrementalCorruptionSmokeTest`) now use the `projectStateDir = workRoot/ic` + `workingDir = projectStateDir/main` shape that `BtaIncrementalCompilerColdPathTest` and `BtaIncrementalLockFailureTest` already use. Mechanical refactor; no production code touched.

**#378** — new `BtaInputsCacheCrossScopeTest` with both directions:
- positive: per-scope `workingDir` (`main` vs `test`) → main outputDir survives a test compile.
- negative: shared `workingDir` → assertion is that `mainOutput` ends up with fewer class files than before. The test compile may itself fail with `Unresolved reference 'Main'` because BTA's `removeOutputForSourceFiles` wipes `Main.class` *before* kotlinc runs against the test source. That's a symptom variant; the load-bearing assertion is on `mainOutput` state rather than the second compile's `Result`.

**#382** — added a 3-sentence "Future axes" paragraph to ADR 0019 §5 covering: third flat scope is additive, KMP-target axis forces a layout reshape, `<LAYOUT_VERSION>` segment is the future migration handle.

**Reviewer focus**:
- Whether the negative-variant assertion in `BtaInputsCacheCrossScopeTest` is the right shape — it tolerates either a failed test compile or a successful-but-wiped one. I went this way because the actual BTA behavior (wipe before kotlinc) makes the second compile fail mid-flight.
- `Path` is `Iterable<Path>`, so `fixtureClasspath + mainOutput` resolves to the iterable overload and explodes the path into segments. The test uses `fixtureClasspath + listOf(mainOutput)` to dodge it.

Closes #382
Closes #383
Closes #378