### PR TITLE
SelfHealingIC latch keys by (projectId, workingDir) (#384)

### DIFF
--- a/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/SelfHealingIncrementalCompiler.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/SelfHealingIncrementalCompiler.kt
@@ -61,42 +61,46 @@ class SelfHealingIncrementalCompiler(
   private val stderrWarn: (String) -> Unit = ::defaultStderrWarn,
 ) : IncrementalCompiler {
 
-  // Per-project latch: when the previous compile for a given
-  // `projectId` fired the self-heal retry path, we mark the project
-  // "just self-healed". The next `IcError.InternalError` for the
-  // same project skips the retry and surfaces the error directly
-  // instead of wiping + re-running. Issue #117 part 2: without this
-  // latch, a persistent client-side bug (e.g. the native client
-  // sending a directory where BTA expects a file) makes every
-  // incoming `Message.Compile` burn one wipe cycle with no chance
-  // of making progress. Any successful compile — or any non-
-  // InternalError failure — clears the latch for that project so a
-  // later transient corruption still gets a fresh self-heal chance.
+  // Per-(project, workingDir) latch: when the previous compile for a
+  // given (projectId, workingDir) fired the self-heal retry path, we
+  // mark that pair "just self-healed". The next `IcError.InternalError`
+  // for the same pair skips the retry and surfaces the error directly
+  // instead of wiping + re-running. Issue #117 part 2 set the policy
+  // for project-wide latching; #376 split each project into per-scope
+  // workingDirs (main / test) so the latch must match that granularity
+  // — keying by projectId alone would let a self-heal on the main
+  // compile suppress the test compile's first retry. workingDir is the
+  // natural proxy for scope: every wipe targets exactly one workingDir.
+  // Any successful compile — or any non-InternalError failure — clears
+  // the latch for that pair so a later transient corruption still gets
+  // a fresh self-heal chance.
   //
   // The set is synchronised because `DaemonServer` currently
   // serialises compile traffic, but a future parallel dispatch
   // would still want the read/modify/write to be atomic.
-  private val projectsJustSelfHealed: MutableSet<String> =
-    Collections.synchronizedSet(mutableSetOf())
+  private val justSelfHealed: MutableSet<LatchKey> = Collections.synchronizedSet(mutableSetOf())
+
+  private data class LatchKey(val projectId: String, val workingDir: Path)
 
   override fun compile(request: IcRequest): Result<IcResponse, IcError> {
+    val latchKey = LatchKey(request.projectId, request.workingDir)
     val first = delegate.compile(request)
     return first.mapBoth(
       success = {
         // Any successful compile clears the latch for this
-        // project — we just proved that whatever was wrong
-        // last time is either fixed or transient, so we
-        // should allow the next InternalError to self-heal
+        // (project, workingDir) — we just proved that whatever
+        // was wrong last time is either fixed or transient, so
+        // we should allow the next InternalError to self-heal
         // normally.
-        projectsJustSelfHealed.remove(request.projectId)
+        justSelfHealed.remove(latchKey)
         first
       },
       failure = { error ->
         if (error is IcError.InternalError) {
-          if (projectsJustSelfHealed.contains(request.projectId)) {
+          if (justSelfHealed.contains(latchKey)) {
             // Consecutive InternalError for the same
-            // project. The previous self-heal cycle
-            // already wiped the workingDir and retried;
+            // (project, workingDir). The previous self-heal
+            // cycle already wiped the workingDir and retried;
             // if a second wipe+retry would help, it would
             // have helped last time. Skip the retry, emit
             // an observability metric, and surface the
@@ -105,7 +109,7 @@ class SelfHealingIncrementalCompiler(
             metrics.record(METRIC_SELF_HEAL_SKIPPED_CONSECUTIVE)
             return@mapBoth first
           }
-          projectsJustSelfHealed.add(request.projectId)
+          justSelfHealed.add(latchKey)
           metrics.record(METRIC_SELF_HEAL)
           stderrWarn(
             "kolt-jvm-compiler-daemon: self-heal fired for project working dir " +
@@ -149,11 +153,11 @@ class SelfHealingIncrementalCompiler(
         } else {
           // Non-InternalError failure (CompilationFailed —
           // a user type error). Clear the latch so a later
-          // InternalError on the same project still gets
-          // a fresh self-heal chance; a failed compile
-          // that is the user's fault is unrelated to
-          // cache corruption.
-          projectsJustSelfHealed.remove(request.projectId)
+          // InternalError on the same (project, workingDir)
+          // still gets a fresh self-heal chance; a failed
+          // compile that is the user's fault is unrelated
+          // to cache corruption.
+          justSelfHealed.remove(latchKey)
           first
         }
       },

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingIncrementalCompilerTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingIncrementalCompilerTest.kt
@@ -521,6 +521,52 @@ class SelfHealingIncrementalCompilerTest {
   }
 
   @Test
+  fun `same project but different workingDir keeps independent self-heal latches`() {
+    // #384: scope-segregated workingDirs (main / test under the same
+    // project) must each get their own self-heal chance. A latch keyed
+    // by projectId alone would let the main compile's self-heal
+    // suppress the next test compile's first retry.
+    val metrics = RecordingMetricsSink()
+    val delegate = FakeCompiler { _ ->
+      com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt")))
+    }
+    val wrapper =
+      SelfHealingIncrementalCompiler(
+        delegate = delegate,
+        wipe = { emptyList() },
+        metrics = metrics,
+        stderrWarn = {},
+      )
+    val mainScope =
+      IcRequest(
+        projectId = "shared-project",
+        projectRoot = tmpRoot,
+        sources = emptyList(),
+        classpath = emptyList(),
+        outputDir = tmpRoot.resolve("out"),
+        workingDir = tmpRoot.resolve("ic/main").also { Files.createDirectories(it) },
+      )
+    val testScope =
+      mainScope.copy(workingDir = tmpRoot.resolve("ic/test").also { Files.createDirectories(it) })
+
+    wrapper.compile(mainScope) // main self-heals
+    wrapper.compile(testScope) // test independently self-heals
+    wrapper.compile(mainScope) // main skipped (latch set)
+    wrapper.compile(testScope) // test skipped (latch set)
+
+    assertEquals(
+      2,
+      metrics.events.count { it.first == "ic.self_heal" },
+      "each scope must self-heal independently on first InternalError",
+    )
+    assertEquals(
+      2,
+      metrics.events.count { it.first == "ic.self_heal_skipped_consecutive" },
+      "consecutive failure on each scope is skipped independently",
+    )
+  }
+
+  @Test
   fun `no self-heal events when the failure is a CompilationFailed`() {
     val metrics = RecordingMetricsSink()
     val delegate = FakeCompiler { _ ->


### PR DESCRIPTION
After #376 each project's IC state is split into per-scope workingDirs (`main` / `test`). The latch in `SelfHealingIncrementalCompiler` was still keyed by `projectId` alone, so a self-heal triggered by the main compile was silently suppressing the *next* test compile's first retry on the same project.

The fix uses a `(projectId, workingDir)` compound key. workingDir is the natural proxy for scope since every wipe targets exactly one workingDir, so the latch granularity now matches the wipe granularity. No `CompileScope` field gets added to `IcRequest` — the existing wire shape is enough.

**Reviewer focus**:
- Whether `(projectId, workingDir)` is the right granularity vs adding an explicit `CompileScope` to `IcRequest`. Going with workingDir because it's already there and uniquely identifies the wipe target — adding CompileScope would just move the same information through a second channel.
- Existing `different projects keep independent self-heal latches` test still passes (different projectId → different LatchKey, regardless of shared workingDir in the fixture).

Closes #384