### PR TITLE
kolt fetch materialises [classpaths.X] bundle jars (#387)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
@@ -217,10 +217,23 @@ internal fun resolveAllBundles(
 
   val out = LinkedHashMap<String, BundleResolution>(config.classpaths.size)
   for ((bundleName, bundleSeeds) in config.classpaths) {
-    val cached = reuseBundleFromLock(bundleName, bundleSeeds, existingLock, cacheBase)
-    if (cached != null) {
-      out[bundleName] = cached
-      continue
+    if (existingLock != null) {
+      val cached = reuseBundleFromLock(bundleName, bundleSeeds, existingLock, cacheBase)
+      if (cached != null) {
+        materialiseBundleJarsFromLock(
+            cached,
+            config,
+            existingLock,
+            bundleName,
+            cacheBase,
+            resolverDeps,
+          )
+          .getOrElse {
+            return Err(it)
+          }
+        out[bundleName] = cached
+        continue
+      }
     }
     val resolution =
       resolveBundle(

--- a/src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt
@@ -1,6 +1,9 @@
 package kolt.resolve
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.map
 import kolt.build.ResolvedJar
 import kolt.config.KoltConfig
@@ -65,4 +68,64 @@ internal fun resolveBundle(
         deps = result.deps,
       )
     }
+}
+
+// The lockfile-trusted bundle reuse path skips the resolver kernel but
+// still needs to put jars on disk. A clean ~/.kolt/cache otherwise leaves
+// consumers handing out paths to non-existent jars; subsequent kolt build
+// / kolt test reads bundle classpaths through the reuse path and fails at
+// compile time with `Unresolved reference`. Mirrors the download-then-
+// verify shape of `materialize()` in TransitiveResolver but derives the
+// download URL from `dep.cachePath` rather than rebuilding it from the
+// `groupArtifact`: KMP module-metadata redirects (e.g. `kotlinx-coroutines-
+// core` ⇒ `-core-jvm`) are not persisted in the lockfile, so reusing the
+// stored GA to compose the URL would 404 against the redirected jar. The
+// cachePath is the source of truth for where the jar lives — swapping the
+// cacheBase prefix for a repo URL gives a URL that matches the cachePath.
+//
+// Sha-verify asymmetry: only freshly downloaded jars are re-hashed against
+// the locked entry. Cache-warm jars are trusted, matching the existing
+// reuse path's "lockfile is trusted while it remains in sync with kolt.toml"
+// policy. Re-verifying every warm bundle jar would defeat the reuse-path
+// performance win for no extra safety the main `kolt fetch` call doesn't
+// already provide on the next resolveTransitive pass.
+internal fun materialiseBundleJarsFromLock(
+  resolution: BundleResolution,
+  config: KoltConfig,
+  existingLock: Lockfile,
+  bundleName: String,
+  cacheBase: String,
+  deps: ResolverDeps,
+): Result<Unit, ResolveError> {
+  val locked = existingLock.classpathBundles[bundleName] ?: return Ok(Unit)
+  val repos = config.repositories.values.toList()
+  val cachePrefix = "$cacheBase/"
+  for (dep in resolution.deps) {
+    if (deps.fileExists(dep.cachePath)) continue
+    val relativePath =
+      if (dep.cachePath.startsWith(cachePrefix)) dep.cachePath.substring(cachePrefix.length)
+      else return Err(ResolveError.InvalidDependency(dep.groupArtifact))
+    val parentDir = dep.cachePath.substringBeforeLast('/')
+    deps.ensureDirectoryRecursive(parentDir).getOrElse {
+      return Err(ResolveError.DirectoryCreateFailed(parentDir))
+    }
+    downloadFromRepositories(
+        repos,
+        dep.cachePath,
+        { repo -> "$repo/$relativePath" },
+        deps::downloadFile,
+      )
+      .getOrElse { failure ->
+        return Err(ResolveError.DownloadFailed(dep.groupArtifact, failure))
+      }
+    val hash =
+      deps.computeSha256(dep.cachePath).getOrElse { error ->
+        return Err(ResolveError.HashComputeFailed(dep.groupArtifact, error))
+      }
+    val expected = locked[dep.groupArtifact]?.sha256
+    if (expected != null && expected != hash) {
+      return Err(ResolveError.Sha256Mismatch(dep.groupArtifact, expected, hash))
+    }
+  }
+  return Ok(Unit)
 }

--- a/src/nativeTest/kotlin/kolt/cli/BundleResolutionIntegrationTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BundleResolutionIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
 import kolt.build.ResolvedJar
 import kolt.infra.DownloadError
 import kolt.infra.MkdirFailed
@@ -13,9 +14,11 @@ import kolt.resolve.BundleResolution
 import kolt.resolve.LockEntry
 import kolt.resolve.Lockfile
 import kolt.resolve.Origin
+import kolt.resolve.ResolveError
 import kolt.resolve.ResolvedDep
 import kolt.resolve.ResolverDeps
 import kolt.resolve.buildLockfileFromResolved
+import kolt.resolve.materialiseBundleJarsFromLock
 import kolt.testConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -245,9 +248,15 @@ class BundleResolutionIntegrationTest {
           ),
       )
 
-    // No POMs / no jar SHAs configured: any attempt to resolveTransitive
-    // would explode on a missing pom lookup or download.
-    val deps = countingDeps(sha256Results = emptyMap(), pomContents = emptyMap())
+    // No POMs configured: any attempt to resolveTransitive would explode
+    // on a missing pom lookup. cachedFiles is pre-populated so the
+    // materialise step also short-circuits without downloads.
+    val deps =
+      countingDeps(
+        cachedFiles = mutableSetOf("/cache/com/example/fix/1.0.0/fix-1.0.0.jar"),
+        sha256Results = emptyMap(),
+        pomContents = emptyMap(),
+      )
 
     val result =
       assertNotNull(
@@ -264,8 +273,200 @@ class BundleResolutionIntegrationTest {
     assertEquals(1, fixture.jars.size)
     assertEquals("/cache/com/example/fix/1.0.0/fix-1.0.0.jar", fixture.jars[0].cachePath)
     assertEquals("/cache/com/example/fix/1.0.0/fix-1.0.0.jar", fixture.classpath)
-    assertEquals(0, deps.downloadCount, "no downloads should occur when declaration matches lock")
+    assertEquals(
+      0,
+      deps.downloadCount,
+      "no downloads should occur when declaration matches lock and cache is warm",
+    )
     assertEquals(0, deps.readFileCount, "no POM lookups should occur when declaration matches lock")
+  }
+
+  // A clean ~/.kolt/cache plus an existing lockfile that records bundle
+  // jars must materialise those jars during `kolt fetch` (which routes
+  // through `resolveAllBundles`). Otherwise subsequent kolt build /
+  // kolt test reads bundle classpaths through the lockfile-trusted reuse
+  // path and hands consumers paths to non-existent jars, surfacing as
+  // `Unresolved reference` at compile time.
+  @Test
+  fun resolveAllBundlesMaterialisesMissingJarsWhenLockMatchesAndCacheIsCold() {
+    val config =
+      testConfig().copy(classpaths = mapOf("fixture" to mapOf("com.example:fix" to "1.0.0")))
+
+    val existingLock =
+      Lockfile(
+        version = 4,
+        kotlin = config.kotlin.version,
+        jvmTarget = config.build.jvmTarget,
+        dependencies = emptyMap(),
+        classpathBundles =
+          mapOf(
+            "fixture" to
+              mapOf(
+                "com.example:fix" to
+                  LockEntry(version = "1.0.0", sha256 = "fixSha", transitive = false, test = false)
+              )
+          ),
+      )
+
+    // No POMs (no fresh resolve walk), but the post-download sha verify
+    // must succeed against the lock entry so a real Sha256Mismatch path
+    // stays reachable. cachedFiles starts empty — clean cache.
+    val deps =
+      countingDeps(
+        sha256Results = mapOf("/cache/com/example/fix/1.0.0/fix-1.0.0.jar" to "fixSha"),
+        pomContents = emptyMap(),
+      )
+
+    val result =
+      assertNotNull(
+        resolveAllBundles(
+            config,
+            existingLock = existingLock,
+            cacheBase = "/cache",
+            resolverDeps = deps,
+          )
+          .get()
+      )
+
+    val fixture = assertNotNull(result["fixture"])
+    assertEquals(1, fixture.jars.size)
+    assertEquals("/cache/com/example/fix/1.0.0/fix-1.0.0.jar", fixture.jars[0].cachePath)
+    assertEquals(1, deps.downloadCount, "missing bundle jar must be downloaded")
+    assertEquals(0, deps.readFileCount, "no POM lookups should occur when declaration matches lock")
+  }
+
+  // When a freshly downloaded bundle jar's sha256 does not match the
+  // locked entry, the materialise step must surface the same Sha256Mismatch
+  // the main-deps materialise() raises — this is the only line of defense
+  // once the lockfile-trusted reuse path is doing I/O.
+  @Test
+  fun resolveAllBundlesReportsSha256MismatchWhenDownloadedBundleJarDiffersFromLock() {
+    val config =
+      testConfig().copy(classpaths = mapOf("fixture" to mapOf("com.example:fix" to "1.0.0")))
+
+    val existingLock =
+      Lockfile(
+        version = 4,
+        kotlin = config.kotlin.version,
+        jvmTarget = config.build.jvmTarget,
+        dependencies = emptyMap(),
+        classpathBundles =
+          mapOf(
+            "fixture" to
+              mapOf(
+                "com.example:fix" to
+                  LockEntry(
+                    version = "1.0.0",
+                    sha256 = "expectedSha",
+                    transitive = false,
+                    test = false,
+                  )
+              )
+          ),
+      )
+
+    val deps =
+      countingDeps(
+        sha256Results = mapOf("/cache/com/example/fix/1.0.0/fix-1.0.0.jar" to "tamperedSha"),
+        pomContents = emptyMap(),
+      )
+
+    val outcome =
+      resolveAllBundles(
+        config,
+        existingLock = existingLock,
+        cacheBase = "/cache",
+        resolverDeps = deps,
+      )
+
+    val error = outcome.getError()
+    assertTrue(
+      error is ResolveError.Sha256Mismatch,
+      "expected ResolveError.Sha256Mismatch, got: $error",
+    )
+  }
+
+  // The materialise step must derive the download URL from `dep.cachePath`,
+  // not from `parseCoordinate(dep.groupArtifact)`. KMP module-metadata
+  // redirects (e.g. `kotlinx-coroutines-core` ⇒ `-core-jvm`) are not
+  // persisted in the lockfile, so a redirect-shaped cachePath that
+  // diverges from the GA must still produce a URL pointing at the
+  // redirected jar. This direct call bypasses reuseBundleFromLock so
+  // we can hand the function a redirected cachePath / non-redirected GA
+  // pair the lockfile alone could never round-trip.
+  @Test
+  fun materialiseBundleJarsFromLockBuildsUrlFromCachePathNotGroupArtifact() {
+    val config = testConfig().copy(repositories = mapOf("central" to "https://example.org/m2"))
+
+    val redirectedRelativePath = "org/example/lib-jvm/1.0.0/lib-jvm-1.0.0.jar"
+    val redirectedCachePath = "/cache/$redirectedRelativePath"
+    val expectedUrl = "https://example.org/m2/$redirectedRelativePath"
+
+    val downloadedUrls = mutableListOf<String>()
+    val deps =
+      object : ResolverDeps {
+        val cached = mutableSetOf<String>()
+
+        override fun fileExists(path: String): Boolean = path in cached
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          downloadedUrls.add(url)
+          cached.add(destPath)
+          return Ok(Unit)
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> = Ok("sha")
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> =
+          Err(OpenFailed(path))
+      }
+
+    val resolution =
+      BundleResolution(
+        jars = listOf(ResolvedJar(redirectedCachePath, "org.example:lib:1.0.0")),
+        classpath = redirectedCachePath,
+        deps =
+          listOf(
+            ResolvedDep(
+              groupArtifact = "org.example:lib",
+              version = "1.0.0",
+              sha256 = "sha",
+              cachePath = redirectedCachePath,
+              origin = Origin.MAIN,
+            )
+          ),
+      )
+
+    val existingLock =
+      Lockfile(
+        version = 4,
+        kotlin = config.kotlin.version,
+        jvmTarget = config.build.jvmTarget,
+        dependencies = emptyMap(),
+        classpathBundles =
+          mapOf(
+            "redirected" to
+              mapOf(
+                "org.example:lib" to
+                  LockEntry(version = "1.0.0", sha256 = "sha", transitive = false, test = false)
+              )
+          ),
+      )
+
+    val outcome =
+      materialiseBundleJarsFromLock(
+        resolution = resolution,
+        config = config,
+        existingLock = existingLock,
+        bundleName = "redirected",
+        cacheBase = "/cache",
+        deps = deps,
+      )
+
+    assertTrue(outcome.get() != null, "expected Ok, got ${outcome.getError()}")
+    assertEquals(listOf(expectedUrl), downloadedUrls)
   }
 
   // Req 4.4: when the declared version differs from the locked version, the


### PR DESCRIPTION
The lockfile-trusted bundle reuse path in `resolveAllBundles` skipped the resolver kernel but never put missing jars on disk. A clean `~/.kolt/cache` plus an existing lockfile recording bundle entries left consumers reading bundle classpaths from a resolution pointing to non-existent jars; `kolt build` / `kolt test` then failed at compile time with `Unresolved reference` for symbols carried by the bundle.

The fix adds `materialiseBundleJarsFromLock` alongside `reuseBundleFromLock`. It mirrors `materialize()` in TransitiveResolver: download missing jars via `downloadFromRepositories` and verify each freshly downloaded jar's sha256 against the locked entry.

**Reviewer focus**:
- The new function lives in `kolt.resolve` (not `kolt.cli`) because `downloadFromRepositories` is `internal` to that package. The alternative was widening visibility.
- Sha verification only fires on freshly downloaded jars; cache-warm entries are still trusted (consistent with the existing reuse-path comment "lockfile is trusted while it remains in sync with kolt.toml").
- Existing test `resolveAllBundlesSkipsResolveWhenDeclarationMatchesLock` had to pre-populate `cachedFiles` with the bundle jar to keep its "no downloads" assertion meaningful; new test `…WhenLockMatchesAndCacheIsCold` covers the previously-broken case, plus a sha-mismatch test.

Closes #387