### PR TITLE
strip current-task ref from SelfHealingIC scope-aware latch test

### DIFF
--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingIncrementalCompilerTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/SelfHealingIncrementalCompilerTest.kt
@@ -522,10 +522,10 @@ class SelfHealingIncrementalCompilerTest {
 
   @Test
   fun `same project but different workingDir keeps independent self-heal latches`() {
-    // #384: scope-segregated workingDirs (main / test under the same
-    // project) must each get their own self-heal chance. A latch keyed
-    // by projectId alone would let the main compile's self-heal
-    // suppress the next test compile's first retry.
+    // Scope-segregated workingDirs (main / test under the same project)
+    // must each get their own self-heal chance. A latch keyed by
+    // projectId alone would let the main compile's self-heal suppress
+    // the next test compile's first retry.
     val metrics = RecordingMetricsSink()
     val delegate = FakeCompiler { _ ->
       com.github.michaelbull.result.Err(IcError.InternalError(RuntimeException("corrupt")))


### PR DESCRIPTION
The test comment introduced in #389 opens with \`// #384:\` — a current-task reference that violates the CLAUDE.md "don't reference the current task/fix/callers" rule. The remaining sentences carry the WHY just fine; just strip the prefix.

Trivial follow-up; flagged by post-merge review.