### PR TITLE
Multi-shape daemon test coverage for kolt test (#381)

### DIFF
--- a/.kiro/specs/381-multi-shape-test-coverage/design.md
+++ b/.kiro/specs/381-multi-shape-test-coverage/design.md
@@ -1,0 +1,202 @@
+# Design Document
+
+## Overview
+
+**Purpose**: PR #376 で `kolt test` (JVM) が JVM compile daemon 経由化されたが、 回帰防御は `kolt-jvm-compiler-daemon` の self-host smoke (BTA layer の unit/integration test) のみで、 一つの project shape (serialization plugin あり、 多依存) に依存している。 別 shape (plugin なし最小、 plugin あり別種) で発火する regression は捕まらない。 本 spec は native integration test 集合に「複数 shape を scaffold して `kolt build && kolt test` を daemon 経由で実走させ、 daemon-side IC layout と build artifact survival を assert する」 IT を追加する。
+
+**Users**: kolt メンテナーが PR レビュー / CI 確認時に「daemon 経由 `kolt test` が複数 shape で壊れていないこと」 を mechanical に確認できる。
+
+**Impact**: Production code は変更しない。 テスト集合に 1 ファイル (新規 IT) と関連 fixture content が追加される。 CI default の `kolt test` は変化しない (gate 条件なし時 skip)。
+
+### Goals
+- JVM プロジェクト 2 種類 (plugin なし、 serialization plugin あり) に対する end-to-end IT の追加
+- Daemon-side IC state の `main/` / `test/` segment populate を mechanical に検証
+- `kolt build` 後の main `.class` artifact が `kolt test` 通過後も残ることを mechanical に検証
+- Bootstrap-gated 実行 (`KOLT_DAEMON_JAR` env 必須) で parent kolt の通常 `kolt test` を汚染しない
+
+### Non-Goals
+- Multi-module shape のカバレッジ (#322 系)
+- Scripts-only / no-main shape のカバレッジ (DoD 外)
+- Native-compiler daemon (`kolt-native-compiler-daemon`) のカバレッジ拡張
+- 既存 `BtaSerializationPluginTest` 等 daemon 内 unit/integration test の構造変更
+- Production code (kolt resolver, daemon, build pipeline) への変更
+
+## Boundary Commitments
+
+### This Spec Owns
+- 新規 IT ファイル `MultiShapeDaemonTestCoverageIT.kt` (`src/nativeTest/kotlin/kolt/cli/`) の追加
+- Fixture content (kolt.toml + Kotlin sources) を IT 内に embedded literal として持つ
+- IT 内で完結する gate / scaffold / subprocess 実行 / IC path 観察 / artifact survival 観察 helper
+- IT が前提とする `KOLT_DAEMON_JAR` env の解釈 (set + valid path = 実行、 unset = silent skip、 set + invalid = fail)
+
+### Out of Boundary
+- Daemon (`kolt-jvm-compiler-daemon`) 側の IC layout 実装 / wire protocol / fallback policy
+- `KOLT_DAEMON_JAR` resolver (`DaemonJarResolver.kt`) の挙動変更
+- `kolt.cli.testfixture` package への helper 外出し (将来別 IT で再利用が必要になった時点で別 spec)
+- CI workflow の env 設定変更 (どこで `KOLT_DAEMON_JAR` を set するかは運用判断、 本 spec は「set されている前提で動く」のみ規定)
+- `BtaIncrementalCorruptionSmokeTest` 等既存 daemon-side smoke の置き換え
+
+### Allowed Dependencies
+- `src/nativeMain/kotlin/kolt/infra/Process.kt` の `executeCommand`
+- `src/nativeMain/kotlin/kolt/infra/Sha256.kt` の `sha256Hex`
+- `src/nativeMain/kotlin/kolt/build/daemon/IcStateCleanup.kt` の `daemonIcProjectIdOf` (公開 API である前提)
+- POSIX cinterop (`platform.posix`): `mkdtemp`, `getenv`, `getcwd` 系
+- `JvmTestSysPropIT.kt` 内 helper のうち、 同パッケージから可視なもの (例: `locateKoltKexe`、 `currentWorkingDir`、 `printOnceSkipNotice`)。 可視性が `private` ならば本 IT 内に同等関数を再定義する
+
+### Revalidation Triggers
+- `IcStateLayout` の path 規約変更 (`<icRoot>/<kotlinVersion>/<projectId>/<scope>/` の構造変更)
+- `daemonIcProjectIdOf` の sha256 算式変更 (`take(32)` の桁数変更含む)
+- Build artifact 出力先の変更 (`build/classes/` → `build/<profile>/classes/` 等)
+- `KOLT_DAEMON_JAR` env semantics の変更 (例: 廃止、 名称変更)
+- `JvmTestSysPropIT` から借用した helper の signature 変更
+
+## Architecture
+
+### Existing Architecture Analysis
+
+本 spec は production architecture には触らず、 既存 native test layer に試験ファイルを 1 件追加するのみ:
+
+- `src/nativeTest/kotlin/kolt/cli/` には既に `JvmTestSysPropIT.kt` が同形パターン (mkdtemp + kolt.toml emit + `executeCommand` で `kolt build && kolt test` を呼ぶ + 結果 assert) で存在し、 そのまま rolemodel として参照できる
+- Daemon-side IC layout は JVM 側 (`IcStateLayout.kt`) で定義されているが、 native 側にも `IcStateCleanup.daemonIcProjectIdOf` という同算式の復元式が存在する。 本 IT はそれを呼び出して expected `<projectId>` を組み立てる
+- 既存 `BtaSerializationPluginTest` の fixture content (kolt.toml + `@Serializable` Kotlin source) を serialization shape のテンプレートとして参考
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+    IT[MultiShapeDaemonTestCoverageIT]
+    IT --> Gate[Gate check getenv KOLT_DAEMON_JAR]
+    IT --> Fixture[Scaffold fixture in mkdtemp]
+    IT --> Run[executeCommand kolt build then kolt test]
+    IT --> Snap[Snapshot build classes before run]
+    IT --> Assert[Assert IC segments and class survival]
+
+    Run --> KoltKexe[build debug kolt kexe]
+    KoltKexe --> Daemon[JVM compile daemon via KOLT_DAEMON_JAR]
+    Daemon --> IcLayout[home dot kolt daemon ic version projectId scope]
+    Daemon --> ClassDir[fixture build classes]
+
+    Assert --> IcLayout
+    Assert --> ClassDir
+```
+
+**Architecture Integration**:
+- Selected pattern: file-private helper + 2 `@Test` methods (一つの shape あたり一つの test)
+- Domain/feature boundaries: IT は production code を import しない (test fixture content は文字列リテラル)。 ただし IC path 算式と subprocess API は production code から借用する (`daemonIcProjectIdOf`、 `executeCommand`、 `sha256Hex`)
+- Existing patterns preserved: `JvmTestSysPropIT` の scaffold + subprocess + assert 構造、 `BtaSerializationPluginTest` の serialization fixture
+- New components rationale: 既存 IT に shape 追加するのではなく独立ファイルにする → assertion 軸 (IC segment + artifact survival) が異なるため
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Test framework | kotlin.test (既存) | `@Test` annotation, `assertEquals`, `assertTrue` | nativeTest デフォルト |
+| Subprocess | `kolt.infra.executeCommand` | child kolt build/test の実走 | POSIX fork+execvp wrap |
+| Filesystem | POSIX cinterop (`mkdtemp`, `stat`) | fixture dir, file 存在 / 列挙 | 既存 native test と同じ |
+| Hashing | `kolt.infra.sha256Hex` + `daemonIcProjectIdOf` | expected projectId 算出 | 既存 production helper を借用 |
+| Fixture Kotlin version | `2.3.20` (literal) | fixture kolt.toml と IC path 計算で共通 | drift 抑止のため IT 内 `const val` で 1 か所定義 |
+
+## File Structure Plan
+
+### Directory Structure
+```
+src/nativeTest/kotlin/kolt/cli/
+└── MultiShapeDaemonTestCoverageIT.kt    # 新規: 2 shape の IT + file-private helpers
+```
+
+### Modified Files
+- なし (既存 production / test code は変更しない)
+
+### File 内構造 (`MultiShapeDaemonTestCoverageIT.kt`)
+- Top-level `const val FIXTURE_KOTLIN_VERSION = "2.3.20"`
+- `class MultiShapeDaemonTestCoverageIT` containing:
+  - `@Test fun runs daemon-routed test on JVM project without plugins()`
+  - `@Test fun runs daemon-routed test on JVM project with serialization plugin()`
+- File-private helpers:
+  - `private fun ensureGateOrSkip(): Boolean` — `getenv("KOLT_DAEMON_JAR")` が null なら 1 度だけ stderr に notice を出して `false` を返す。 set されているが path が存在しないなら `fail(...)`
+  - `private fun scaffoldNoPluginFixture(): String` — fixture dir abs path を返す
+  - `private fun scaffoldSerializationFixture(): String` — 同上
+  - `private fun snapshotMainClassFiles(fixtureDir: String): Set<String>` — `<fixtureDir>/build/classes/` 配下 `.class` の abs path 集合を返す
+  - `private fun runKoltBuildAndTest(fixtureDir: String): Int` — `executeCommand` で `kolt.kexe build && kolt.kexe test` を実行、 exit code を返す。 `KOLT_DAEMON_JAR` を child env に明示伝搬
+  - `private fun assertIcSegmentsPopulated(fixtureDir: String)` — `~/.kolt/daemon/ic/<FIXTURE_KOTLIN_VERSION>/<daemonIcProjectIdOf(absFixture)>/{main,test}/bta/` が exist かつ non-empty
+  - `private fun assertMainClassesSurvive(fixtureDir: String, before: Set<String>)` — `before` 内の各 path が現在も file として exist
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces / Behaviors |
+|-------------|---------|------------|------------------------|
+| 1.1 | Plugin なし fixture | `MultiShapeDaemonTestCoverageIT.scaffoldNoPluginFixture` | kolt.toml に `[plugins]` 不在、 `src/main/kotlin/Main.kt` + `src/test/kotlin/MainTest.kt` |
+| 1.2 | Serialization plugin fixture | `MultiShapeDaemonTestCoverageIT.scaffoldSerializationFixture` | kolt.toml に `[kotlin.plugins] serialization = true`、 `@Serializable` data class + Json 往復 test |
+| 1.3 | Daemon 経由 `kolt build && kolt test` 実走 | `runKoltBuildAndTest` | `executeCommand` 経由で `build/debug/kolt.kexe`、 `KOLT_DAEMON_JAR` env を child に伝搬 |
+| 1.4 | 各 fixture isolated tempdir | `scaffold*Fixture` | `mkdtemp` で fixture ごとに独立 dir |
+| 2.1 | `main/bta/` populate 確認 | `assertIcSegmentsPopulated` | `~/.kolt/daemon/ic/<v>/<projectId>/main/bta/` non-empty |
+| 2.2 | `test/bta/` populate 確認 | 同上 | `~/.kolt/daemon/ic/<v>/<projectId>/test/bta/` non-empty |
+| 2.3 | `main/` と `test/` が同じ projectId 配下 | 同上 | 2 path の親 dir (= projectId 部分) を比較 |
+| 2.4 | 欠損時の identifying message | 同上 | `assertTrue(condition, message="missing $segment for fixture $fixtureName")` |
+| 3.1 | Build 後 `.class` snapshot | `snapshotMainClassFiles` (build 直後呼ぶ) | `build/classes/` 配下 `.class` の abs path 集合 |
+| 3.2 | Test 後 snapshot 全 path 残存 | `assertMainClassesSurvive` | `before` 集合の各 path に対し `stat` が file として成功 |
+| 3.3 | 欠損時の identifying message | 同上 | `assertTrue(file exists, message="$path was deleted in fixture $fixtureName")` |
+| 4.1 | Gate unset 時 silent skip | `ensureGateOrSkip` | `getenv("KOLT_DAEMON_JAR") == null` で early return |
+| 4.2 | Gate set 時に全 fixture 実行 | `@Test` 2 個がそれぞれ独立に gate check + 実行 | — |
+| 4.3 | env-pointed jar が daemon backend として使われる | `runKoltBuildAndTest` | `KOLT_DAEMON_JAR` を child env に明示注入 (parent inherit に依存しない) |
+| 4.4 | Gate set + invalid path で fail | `ensureGateOrSkip` | env value の path が `stat` で存在しないなら `fail("KOLT_DAEMON_JAR points to non-existent path: $value")` |
+| 5.1 | Default `kolt test` で fixture 実行しない | `ensureGateOrSkip` | gate unset 時に scaffold/subprocess を一切呼ばない (early return) |
+| 5.2 | Skip 時の 1 行 notice | `ensureGateOrSkip` | `printOnceSkipNotice` 相当を file-private で持つ |
+
+## Components and Interfaces
+
+### Test Suite Layer
+
+#### MultiShapeDaemonTestCoverageIT
+
+| Field | Detail |
+|-------|--------|
+| Intent | 複数 JVM project shape に対する daemon-routed `kolt build && kolt test` の end-to-end regression test |
+| Requirements | 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 4.4, 5.1, 5.2 |
+| Owner / Reviewers | (kolt maintainers) |
+
+**Responsibilities & Constraints**
+- Production code を import しない (helper 借用は test 自身が import)
+- Fixture content は文字列リテラル (separate resource ファイルにしない)
+- 各 `@Test` は独立 fixture dir で完結。 test 間で state を共有しない
+- Gate (`KOLT_DAEMON_JAR`) 未設定なら scaffold / subprocess を一切呼ばない
+
+**Dependencies**
+- Inbound: kolt.test 経由 `@Test` discovery (P0)
+- Outbound: `kolt.infra.executeCommand` (P0)、 `kolt.infra.sha256Hex` (P0)、 `kolt.build.daemon.daemonIcProjectIdOf` (P0)
+- External: POSIX cinterop `mkdtemp` / `getenv` / `stat` (P0)、 child process `build/debug/kolt.kexe` (P0)
+
+**Contracts**: Service [ ] / API [ ] / Event [ ] / Batch [ ] / State [x]
+
+##### State Management
+- State model: 各 `@Test` 内で `mkdtemp` → fixture dir のローカル state。 daemon の `~/.kolt/daemon/ic/` への副作用はあるが projectId が温度 dir 由来なので test 間で衝突しない
+- Persistence & consistency: 試験終了後 fixture dir も IC state も明示削除しない (parent kolt の reaper / 後続 test の独立 projectId に依存)
+- Concurrency strategy: kotlin.test nativeTest はデフォルト sequential。 daemon socket は他 build/test と共有だが kolt 側の lock で吸収される
+
+**Implementation Notes**
+- Integration: `JvmTestSysPropIT.kt` 内 helper (`locateKoltKexe`, `currentWorkingDir`, `printOnceSkipNotice` 等) のうち file-public なものは再利用、 private のものは本 IT 内に同名で再実装する
+- Validation:
+  - `runKoltBuildAndTest` は exit code 0 を assertion (テスト失敗を `kolt test` 失敗と区別するため stderr/stdout はファイル経由でキャプチャし、 失敗時にメッセージへ含める)
+  - IC path 算式 (`daemonIcProjectIdOf` + `FIXTURE_KOTLIN_VERSION`) は test 内で 1 か所だけ参照
+- Risks:
+  - 借用 helper (`locateKoltKexe` 等) が `private` で見えない可能性 — その場合本 IT 内に同等関数を再実装
+  - `daemonIcProjectIdOf` の現行 visibility (internal / public) が不明 — impl 時に確認、 internal なら同算式を IT 内に再実装するか visibility を緩める判断が必要
+  - Serialization fixture の正確な dependency 宣言 (`kotlinx-serialization-json` runtime を `[dependencies]` に明示する必要があるか、 plugin 宣言だけで足りるか) は impl 時に最小再現で確定する。 設計上の契約は「serialization plugin を使う JVM project が build/test 成功する」 のみ
+  - `BtaSerializationPluginTest` の fixture と Kotlin version literal が drift する可能性 — 本 IT は `FIXTURE_KOTLIN_VERSION` 1 か所のみ。 daemon-side test との sync はメンテナンス時の手動確認
+
+## Testing Strategy
+
+本 spec 自身がテストの追加なので、 通常の test pyramid 配置とは異なる。 代わりに「追加された IT 自体の妥当性検証」 を記述する:
+
+### IT 動作検証 (manual)
+- IT を `KOLT_DAEMON_JAR` set + valid path で実走させ、 両 `@Test` が pass することを確認
+- IT を `KOLT_DAEMON_JAR` unset で実走させ、 silent skip + 1 行 notice が出ることを確認 (parent `kolt test` 実行)
+- IT を `KOLT_DAEMON_JAR=/nonexistent/path` で実走させ、 fail with clear message が出ることを確認
+
+### 回帰防御性の確認 (manual)
+- #376 が修正したバグ (BTA `inputsCache` cross-contamination で main `.class` が消える) を一時的に revert した状態で IT を回し、 Requirement 3 の assertion (`assertMainClassesSurvive`) が fail することを確認
+- IC path 規約を意図的に間違えた literal (例 `<icRoot>/wrong-version/...`) で `assertIcSegmentsPopulated` を呼び、 fail することを確認
+
+### Boundary 確認
+- IT が production import を持っていないこと (test 自身の import 文を grep で確認、 借用は `kolt.infra.*` と `kolt.build.daemon.daemonIcProjectIdOf` のみ)
+- Default `kolt test` の wall time が IT 追加前後で計測上ほぼ変化しないこと (gate skip path の overhead が ms 単位であること)

--- a/.kiro/specs/381-multi-shape-test-coverage/requirements.md
+++ b/.kiro/specs/381-multi-shape-test-coverage/requirements.md
@@ -1,0 +1,74 @@
+# Requirements Document
+
+## Introduction
+
+PR #376 は `kolt test` (JVM) を JVM compile daemon 経由に変更したが、 その回帰カバレッジは `kolt-jvm-compiler-daemon` 自身を build/test する self-host smoke (`BtaIncrementalCorruptionSmokeTest` ほか) のみである。 当該プロジェクトは serialization plugin あり、 多数の依存、 大規模テスト集合という一つの shape に偏った特徴を持つため、 別 shape (plugin なし、 依存なし) でしか発火しない regression は見落とされる。
+
+本 spec は kolt の native integration test 集合に「複数の project shape を scaffold して `kolt build && kolt test` を daemon 経由で実走させ、 daemon 側 IC state segment と build artifact survival を assert する」テスト群を追加することで、 #376 の回帰防御層を多様化する。 production code は変更しない。
+
+## Boundary Context
+
+- **In scope**:
+  - JVM プロジェクトの 2 種類の shape (plugin なし最小構成、 serialization plugin あり) に対する end-to-end regression test の追加
+  - `kolt build` と `kolt test` を daemon 経由で実走させ、 daemon-side IC state の `main/` / `test/` segment が独立して populate されることの assertion
+  - `kolt build` で生成した main の `.class` artifact が、 続く `kolt test` の test compile 過程で削除されないことの assertion
+  - 親 kolt の `kolt test` の中で false-RED にならないように、 既存の bootstrap-gated test pattern (`KOLT_DAEMON_JAR` env override) に従った gating
+- **Out of scope**:
+  - Multi-module shape のカバレッジ (#322 系の独立スコープ)
+  - "Scripts only / no main code" shape (DoD 外、 必要なら別 issue)
+  - Production code の変更 (test code only)
+  - 既存の `BtaIncrementalCorruptionSmokeTest` 等の置き換えや構造変更
+  - Native daemon (`kolt-native-compiler-daemon`) のカバレッジ拡張
+- **Adjacent expectations**:
+  - JVM compile daemon の挙動 (IC state layout、 wire protocol) は既存実装をそのまま観察対象とする。 daemon 側に hook を追加することは想定しない
+  - `KOLT_DAEMON_JAR` env による daemon 差し替え機構は既存実装に依存する (本 spec で新規導入しない)
+  - `~/.kolt/daemon/ic/<kotlinVersion>/<projectId>/<scope>/` の path 規約は `IcStateLayout` の現行定義に従う
+
+## Requirements
+
+### Requirement 1: マルチシェイプ regression coverage
+
+**Objective:** kolt のメンテナーとして、 `kolt test` の daemon 経路を複数の代表的な project shape に対して回帰テストできるようにしたい。 これにより、 一つの自社 shape に固有な特徴 (plugin、 依存、 テスト規模) でしか拾えない regression が見落とされることを防げる。
+
+#### Acceptance Criteria
+1. The multi-shape daemon test suite shall include a fixture for a JVM プロジェクト with plugin なし最小構成 (`kolt.toml` に `[plugins]` セクションを持たず、 `src/main/kotlin/` に 1 ファイル、 `src/test/kotlin/` に JUnit 5 テスト 1 ファイル).
+2. The multi-shape daemon test suite shall include a fixture for a JVM プロジェクト with kotlinx.serialization plugin (`kolt.toml` に serialization plugin 宣言、 `@Serializable` を使う main コードと、 シリアライズ往復を verify する test コードを含む).
+3. When the multi-shape daemon test suite runs against either fixture, the suite shall execute `kolt build` followed by `kolt test` via the same JVM compile daemon code path that production `kolt test` uses.
+4. The multi-shape daemon test suite shall scaffold each fixture into an isolated temporary directory so that fixtures do not share state across tests or with the host kolt project.
+
+### Requirement 2: Daemon-side IC state segment assertion
+
+**Objective:** kolt のメンテナーとして、 daemon が main scope と test scope の IC state を分離して populate していることを各 shape で検証したい。 これにより、 #376 で修正した「main と test が同じ workingDir を共有して BTA `inputsCache` が cross-contaminate する」回帰の再発を捕捉できる。
+
+#### Acceptance Criteria
+1. When the multi-shape daemon test suite has executed `kolt build` followed by `kolt test` against a fixture, the suite shall assert that `~/.kolt/daemon/ic/<kotlinVersion>/<projectId>/main/bta/` exists and is non-empty.
+2. When the multi-shape daemon test suite has executed `kolt build` followed by `kolt test` against a fixture, the suite shall assert that `~/.kolt/daemon/ic/<kotlinVersion>/<projectId>/test/bta/` exists and is non-empty.
+3. The multi-shape daemon test suite shall verify that the `main/` and `test/` segments are sibling directories under the same `<projectId>` (同一プロジェクトに対して main と test の `<projectId>` 部分が一致する).
+4. If either segment is missing or empty after the test execution, the suite shall fail with a message identifying which segment is missing and for which fixture.
+
+### Requirement 3: Build artifact survival across compile scopes
+
+**Objective:** kolt のメンテナーとして、 `kolt build` で生成された main の `.class` artifact が、 続く `kolt test` の test compile 過程で削除されないことを各 shape で検証したい。 これは #376 が直接修正した不具合の再発を捕捉するための user-observable な assertion である。
+
+#### Acceptance Criteria
+1. When the multi-shape daemon test suite has executed `kolt build` against a fixture, the suite shall record the set of `.class` files that exist under the fixture's main output directory.
+2. When the multi-shape daemon test suite has subsequently executed `kolt test` against the same fixture, the suite shall assert that every `.class` file recorded after `kolt build` still exists at the same path.
+3. If any recorded main `.class` file is missing after `kolt test` completes, the suite shall fail with a message identifying the deleted artifact path and the fixture name.
+
+### Requirement 4: Bootstrap-gated execution
+
+**Objective:** kolt のメンテナーとして、 これらの integration test が parent kolt の通常の `kolt test` の中で false-RED にならず、 意図したときだけ走るように env-gate したい。 既存の `KOLT_DAEMON_JAR` を使う bootstrap-gated test pattern と一貫させる。
+
+#### Acceptance Criteria
+1. While `KOLT_DAEMON_JAR` env var (or 既存の integration-test gate flag) is unset, the multi-shape daemon test suite shall skip without failing.
+2. Where the gate env flag is set, the multi-shape daemon test suite shall execute against all included fixtures in sequence.
+3. When the suite runs, the suite shall use the `KOLT_DAEMON_JAR` でポイントされた thin jar as the JVM daemon backend, not whatever daemon the host kolt installation would resolve.
+4. If the gate env flag is set but `KOLT_DAEMON_JAR` is unset or points to a non-existent path, the suite shall fail with an error message that names the missing/invalid env var rather than silently skipping or producing a misleading downstream failure.
+
+### Requirement 5: Default `kolt test` 走行への影響回避
+
+**Objective:** kolt のメンテナーとして、 各 shape あたり実 1 分前後かかるこの integration suite が、 default `kolt test` (gate 無し) の wall time を増やさないようにしたい。
+
+#### Acceptance Criteria
+1. When `kolt test` is invoked without the gate env flag, the multi-shape daemon test suite shall not perform any `kolt build` or `kolt test` subprocess invocation against fixtures.
+2. The multi-shape daemon test suite shall surface a single skip notice (例: stderr に 1 行) when skipped due to gate flag absence, so that operator が「テストが silently 消えた」と誤解しないようにする.

--- a/.kiro/specs/381-multi-shape-test-coverage/research.md
+++ b/.kiro/specs/381-multi-shape-test-coverage/research.md
@@ -1,0 +1,139 @@
+# Research & Design Decisions
+
+## Summary
+- **Feature**: `381-multi-shape-test-coverage`
+- **Discovery Scope**: Extension (test code only; integrate with existing IT scaffolding)
+- **Key Findings**:
+  - 既存 `JvmTestSysPropIT.kt` の `createFixtureProject` + `executeCommand` パターンが scaffold + subprocess 実走の rolemodel として完全に再利用可能
+  - Daemon-side IC layout は native 側にも `daemonIcProjectIdOf` (`IcStateCleanup.kt`) として復元式があり、 native test から直接 expected path を計算できる
+  - `BtaSerializationPluginTest` の fixture (kolt.toml に `[kotlin.plugins] serialization = true`、 `@Serializable` data class) が serialization shape のテンプレートとして借用できる
+
+## Research Log
+
+### 既存 integration test の scaffolding パターン
+- **Context**: 新規 IT を追加するにあたり、 既存 IT の構築・ subprocess 実走・ gate 機構を再利用可能か確認する
+- **Sources Consulted**:
+  - `src/nativeTest/kotlin/kolt/cli/JvmTestSysPropIT.kt`
+  - `src/nativeMain/kotlin/kolt/infra/Process.kt`
+- **Findings**:
+  - `createFixtureProject(prefix)` は `mkdtemp` で temp dir を作り `kolt.toml` + `src/Main.kt` + `test/Test.kt` を書き出す。 各 fixture は独立 dir
+  - `executeCommand(args, extraEnv)` は POSIX `fork+execvp+waitpid` を wrap。 `extraEnv` で env 注入可能。 stdout/stderr は bash harness 経由でファイルにキャプチャ
+  - `locateKoltKexe()` は `currentWorkingDir() + build/debug/kolt.kexe` (なければ release) を返す
+  - Gate: `getenv("KOLT_INTEGRATION") == "1"` のときのみ実行、 それ以外は早期 return + stderr に 1 回だけ skip notice
+- **Implications**:
+  - 本 spec も同パターンを踏襲。 専用 helper を `kolt.cli.testfixture` か同等の場所に置く必要なく、 IT 内に閉じ込めて良い (1 file)
+
+### Daemon-side IC state の native 側からの観察
+- **Context**: 各 fixture の build/test 後、 `~/.kolt/daemon/ic/<v>/<projectId>/{main,test}/bta/` segment が populate されたかを native test から assert する必要がある
+- **Sources Consulted**:
+  - `kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/IcStateLayout.kt` (JVM 側 path 規約: `<icRoot>/<kotlinVersion>/<sha256(projectRoot).take16bytes=32hex>/<scope>`)
+  - `src/nativeMain/kotlin/kolt/build/daemon/IcStateCleanup.kt` (native 側に `daemonIcProjectIdOf(absProjectPath: String): String = sha256Hex(...).take(32)` が既に存在)
+  - `src/nativeMain/kotlin/kolt/infra/Sha256.kt` (`sha256Hex(bytes: ByteArray): String`)
+- **Findings**:
+  - JVM 側の `IcStateLayout.projectIdFor(projectRoot)` は `sha256(projectRoot.toString()).take(16 bytes).toHex()` = 32 hex chars
+  - Native 側 `daemonIcProjectIdOf(absProjectPath)` は同じ算式 (32 hex chars take)
+  - `~/.kolt/daemon/ic` の literal は `kolt.cli.KoltPaths` または `kolt.infra` 系から取得可能 (要確認、 既存 `IcStateCleanup` がどう取っているかを参照)
+- **Implications**:
+  - Native test は `daemonIcProjectIdOf(fixtureDirAbs)` を直接呼んで expected `<projectId>` を組み立てる
+  - Kotlin version は fixture の `kolt.toml` で hard-pin した値 (例 `2.3.20`) を test code で同じ literal として使う
+
+### Daemon jar override (KOLT_DAEMON_JAR) の挙動
+- **Context**: テストが parent kolt の daemon resolution を bypass し、 deterministic な jar を使うために env override の semantics を確認する
+- **Sources Consulted**:
+  - `src/nativeMain/kotlin/kolt/build/daemon/DaemonJarResolver.kt`
+  - Memory: `reference_kolt_daemon_jar_env`、 `feedback_bootstrap_gated_test`
+- **Findings**:
+  - `DaemonJarResolver.resolveDaemonJarPure()` は env (`KOLT_DAEMON_JAR`) を最優先 probe。 set されていれば libexec / dev fallback を skip
+  - Env は jar path を指定するだけで daemon を起動はしない。 kolt 側が解決後の classpath で spawn する
+  - `KOLT_DAEMON_JAR` は path 指定であり gate flag ではない。 ただし本 spec の文脈では「set されていれば integration test 実行を許可、 unset なら skip」と扱う (issue body の "env-gated KOLT_DAEMON_JAR override" の解釈)
+- **Implications**:
+  - Test 側 gate condition は `getenv("KOLT_DAEMON_JAR") != null && jar が実在する` の AND 条件
+  - 環境変数は subprocess (`kolt build && kolt test`) にも `extraEnv` で伝搬する (parent test process の env を inherit するので明示的に追加しなくても良いが、 念のため明示する)
+
+### 既存の serialization plugin fixture
+- **Context**: serialization shape の fixture 構築を、 既存 daemon ic test で使われている形に合わせるか確認
+- **Sources Consulted**:
+  - `kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt`
+- **Findings**:
+  - `kolt.toml` minimal: `[kotlin] version = "2.3.20"` + `[kotlin.plugins] serialization = true`
+  - Source: 単一 `Payload.kt` に `@Serializable data class Payload(val id: Int, val name: String)`
+  - Test 側 assertion は `$serializer` symbol が .class に含まれることだが、 本 spec では subprocess の終了 code 0 + IC segment 存在で済む
+- **Implications**:
+  - Native IT 側の serialization fixture も同様 minimal で OK。 main コードに `@Serializable` を含む 1 ファイル、 test コードに `Json.encodeToString` の往復 assertion 1 ケースで足りる
+
+### Build artifact output path
+- **Context**: `build/classes/` survival assertion を行うため、 JVM build の `.class` 出力先を確定する
+- **Sources Consulted**:
+  - `src/nativeMain/kotlin/kolt/build/Builder.kt` (`BUILD_DIR = "build"`、 `CLASSES_DIR = "build/classes"`、 `TEST_CLASSES_DIR = "build/test-classes"`)
+  - `kolt.build.Profile`
+- **Findings**:
+  - JVM build は profile に依らず `build/classes/` (main) と `build/test-classes/` (test) に出力
+  - Native build と異なり `build/<profile>/` segregation は適用されない
+- **Implications**:
+  - Survival assertion の対象は fixture root 直下 `build/classes/**/*.class` の集合
+
+## Design Decisions
+
+### Decision: 単一 IT ファイルに 2 shape の test を並べる (parameterize しない)
+- **Context**: 2 shape (no-plugin、 serialization plugin) のテストをどう構造化するか
+- **Alternatives Considered**:
+  1. `MultiShapeDaemonTestCoverageIT.kt` 1 ファイル + `@Test` 2 個 + 共通 helper 関数
+  2. Parameterized test (kotlin.test には JUnit5 相当の `@ParameterizedTest` がない、 自作 dispatcher が必要)
+  3. Shape ごとに別ファイル
+- **Selected Approach**: (1) — 1 ファイル + 2 `@Test` + private helper
+- **Rationale**: shape 数が 2 で、 fixture content だけが違う。 helper を切れば test コードは 5 行程度に収まる。 parameterize は overengineering、 別ファイル化は近接性が下がる
+- **Trade-offs**: shape 追加時に `@Test` を 1 個増やすだけで済む反面、 dynamic shape registry はない (将来 shape が 5 個超えたら見直す)
+- **Follow-up**: なし
+
+### Decision: Gate 条件は `KOLT_DAEMON_JAR` 単独
+- **Context**: `KOLT_INTEGRATION` (既存)、 `KOLT_DAEMON_JAR`、 あるいは新規 dedicated env のどれを gate にするか
+- **Alternatives Considered**:
+  1. `KOLT_DAEMON_JAR` 単独 (set されていれば実行)
+  2. `KOLT_INTEGRATION=1` AND `KOLT_DAEMON_JAR` set
+  3. 専用 env (`KOLT_DAEMON_TEST_COVERAGE=1`)
+- **Selected Approach**: (1) `KOLT_DAEMON_JAR` 単独
+- **Rationale**:
+  - Issue body の "env-gated KOLT_DAEMON_JAR override per the bootstrap-gated test pattern" を素直に解釈
+  - これらの test は daemon override がない限り意味を持たない (素の daemon resolution だと parent kolt 実装に依存して deterministic でない)
+  - 既存 memory (`feedback_bootstrap_gated_test`) の "env gate で false-RED を回避" にも合致
+- **Trade-offs**: `KOLT_INTEGRATION` の慣習から外れる。 ただし当該 IT は性質上 daemon jar override を必須とするので、 gate 条件を一致させる方が運用上明快
+- **Follow-up**: 本 IT の README / コメントに gate condition を明記
+
+### Decision: Helper を file-private で IT 内に置く (testfixture/ には出さない)
+- **Context**: 共通 scaffold + assert helper を `testfixture/` package に出して再利用性を上げるか
+- **Alternatives Considered**:
+  1. IT file 内 file-private 関数
+  2. `kolt.cli.testfixture.MultiShapeDaemonFixture` として外出し
+- **Selected Approach**: (1) file-private
+- **Rationale**: 現状 caller は本 IT 1 件のみ。 別 spec が同形を欲しがった時点で外出しを検討
+- **Trade-offs**: 将来別 IT で再利用したくなった場合 refactor 必要。 ただしそれまで out
+- **Follow-up**: なし
+
+### Decision: Tests are skipped silently when KOLT_DAEMON_JAR is unset (no notice)
+- **Context**: `JvmTestSysPropIT` は skip 時 stderr に 1 行 notice を出す。 同パターンを踏襲するか
+- **Alternatives Considered**:
+  1. Silent skip
+  2. Stderr に 1 回だけ notice
+- **Selected Approach**: (2) — `JvmTestSysPropIT` と同じく `printOnceSkipNotice` 相当を踏襲
+- **Rationale**: Operator が「テストが消えた」と誤解しないため (Req 5.2)
+- **Trade-offs**: `kolt test` 出力に 1 行追加。 既存 IT も同様なので許容
+- **Follow-up**: なし
+
+## Risks & Mitigations
+- **Risk**: 並列 test 実行時に共有 daemon socket への競合が起きる
+  - Mitigation: Native test は kotlin.test のデフォルト sequential 実行。 fixture ごとに projectId が異なる (温度 dir → 異なる sha256) ので IC state は分離。 socket 競合は daemon 側のロックで吸収される
+- **Risk**: Test 実行時間が CI の budget を超える (各 1 分 × 2 = 2 分超)
+  - Mitigation: Gate (`KOLT_DAEMON_JAR`) で default `kolt test` から除外。 CI 側で意図的に opt-in した job だけが回す
+- **Risk**: Fixture 内 `kolt.toml` の Kotlin version が実装と drift
+  - Mitigation: Test 内に literal `KOTLIN_VERSION_FIXTURE = "2.3.20"` を 1 か所だけ置き、 fixture toml と IC path 計算で共通参照
+- **Risk**: Daemon が build と test の間に再起動される (e.g., daemon stale auto-restart) と build/classes survival 仮説が崩れる
+  - Mitigation: Test は `kolt build && kolt test` を bash 1 行で実行。 daemon が間に死ぬ規模の障害が起きたらそれ自体がテスト失敗 (#379 の対象範囲) で扱う
+
+## References
+- `kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/IcStateLayout.kt` — JVM-side IC path 算式
+- `src/nativeMain/kotlin/kolt/build/daemon/IcStateCleanup.kt` — native-side projectId 算式 `daemonIcProjectIdOf`
+- `src/nativeTest/kotlin/kolt/cli/JvmTestSysPropIT.kt` — IT scaffolding rolemodel
+- `kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt` — serialization fixture template
+- `src/nativeMain/kotlin/kolt/infra/Process.kt` — `executeCommand` API
+- Memory: `reference_kolt_daemon_jar_env`, `feedback_bootstrap_gated_test`
+- ADR 0019 (BTA), ADR 0016 (warm daemon), ADR 0030 (build profiles)

--- a/.kiro/specs/381-multi-shape-test-coverage/spec.json
+++ b/.kiro/specs/381-multi-shape-test-coverage/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "381-multi-shape-test-coverage",
+  "created_at": "2026-05-04T17:14:09Z",
+  "updated_at": "2026-05-06T00:00:00Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/381-multi-shape-test-coverage/tasks.md
+++ b/.kiro/specs/381-multi-shape-test-coverage/tasks.md
@@ -8,7 +8,7 @@
   - Observable: `KOLT_DAEMON_JAR` 未設定で parent `kolt test` を回したとき、 当該 IT class が discovered されつつ stderr に 1 行の skip notice が出力され、 一切の subprocess / fixture I/O が起きない。 `KOLT_DAEMON_JAR=/nonexistent/path` を指定したときは IT 失敗メッセージに env var 名と invalid path が両方含まれる
   - _Requirements: 4.1, 4.4, 5.1, 5.2_
 
-- [ ] 2. Core: per-shape end-to-end coverage
+- [x] 2. Core: per-shape end-to-end coverage
 - [x] 2.1 Plugin なし shape の end-to-end test と共通 helper 一式
   - File-private helpers を IT 内に追加: `scaffoldNoPluginFixture`、 `runKoltBuildAndTest`、 `snapshotMainClassFiles`、 `assertMainClassesSurvive`、 `assertIcSegmentsPopulated`。 IC path 計算は `daemonIcProjectIdOf` を呼ぶか visibility が `private/internal` で見えなければ同算式を IT 内に再実装する
   - `scaffoldNoPluginFixture` は `mkdtemp` で温度 dir を作り、 `[kotlin] version`、 `[build] target = "jvm"` のみの `kolt.toml` と `src/main/kotlin/Main.kt` + `src/test/kotlin/MainTest.kt` (kolt.test の最小ケース) を書き出す
@@ -19,7 +19,7 @@
   - Observable: `KOLT_DAEMON_JAR` 設定下で parent `kolt test` を回したとき、 当該 `@Test` が緑になり、 IC layout 配下に `<projectId>/{main,test}/bta/` が物理生成され、 fixture 内 `build/classes/**/*.class` が `kolt build` 直後と `kolt test` 通過後で同一集合
   - _Requirements: 1.1, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 4.2, 4.3_
 
-- [ ] 2.2 Serialization plugin shape の end-to-end test
+- [x] 2.2 Serialization plugin shape の end-to-end test
   - `scaffoldSerializationFixture` を IT 内に追加: `[kotlin] version` + `[kotlin.plugins] serialization = true` を持つ `kolt.toml`、 `src/main/kotlin/Payload.kt` に `@Serializable data class Payload(...)`、 `src/test/kotlin/PayloadTest.kt` に `Json.encodeToString` / `decodeFromString` の往復 assertion を 1 ケース置く。 `kotlinx-serialization-json` runtime dependency が必要なら `[dependencies]` に追加 (impl 時に最小再現で確定)
   - `@Test fun runs daemon-routed test on JVM project with serialization plugin()` を追加: gate → `scaffoldSerializationFixture` → 2.1 で追加した共通 helper (`runKoltBuildAndTest`, `snapshotMainClassFiles`, `assertMainClassesSurvive`, `assertIcSegmentsPopulated`) を呼んで同じ assertion 列を回す
   - Observable: `KOLT_DAEMON_JAR` 設定下で parent `kolt test` を回したとき、 当該 `@Test` が緑になり、 fixture の `Payload.class` が `$serializer` を含む状態で生成され、 build → test 通過後も artifact が残る
@@ -32,3 +32,12 @@
   - 借用 helper (`locateKoltKexe`、 `currentWorkingDir`、 `printOnceSkipNotice` 等) が `JvmTestSysPropIT` 内で `private` だった場合、 本 IT 内に同等関数として再実装が完了しており、 import で参照していないことを確認
   - Observable: 3 モード実走の各結果が expected と一致する記録 (test output snippet) と、 import grep の結果リストが手元に揃う
   - _Requirements: 4.1, 4.2, 4.4, 5.1, 5.2_
+
+## Implementation Notes
+
+- Dev daemon thin jar is at `kolt-jvm-compiler-daemon/build/debug/kolt-jvm-compiler-daemon.jar` (Cargo-style profile dir), not directly under `build/`. Used by task 3.1 mode (b) and any developer running the IT locally.
+- `kolt.build.daemon.daemonIcProjectIdOf` and `KoltPaths` are `internal` to their packages. Reimplemented locally in the IT (`expectedProjectId` + `$HOME/.kolt/daemon/ic`) per design Implementation Notes risk. If production algorithm changes, IT will fail loud (the segments will not be found at the expected path).
+- `JvmTestSysPropIT.locateKoltKexe()` is `private`; reimplemented locally in the IT.
+- `runKoltCommand` was split from the design's `runKoltBuildAndTest` because Req 3.1 requires a `.class` snapshot between `kolt build` and `kolt test`. Design name was inconsistent with its own Req mapping.
+- Serialization fixture needs `kotlinx-serialization-json:1.7.3` runtime dep in `[dependencies]`; the plugin enable alone does not bring `kotlinx.serialization.json.Json` onto the test classpath. Determined empirically per design Risks.
+- The two `@Test` bodies are ~33-line near-duplicates differing only in test name + scaffold call + fixture name. Intentional per design "file-private helper + 2 `@Test` methods" pattern. Do NOT introduce a parameterizing abstraction.

--- a/.kiro/specs/381-multi-shape-test-coverage/tasks.md
+++ b/.kiro/specs/381-multi-shape-test-coverage/tasks.md
@@ -1,7 +1,7 @@
 # Implementation Plan
 
-- [ ] 1. Foundation: IT skeleton with gate and skip notice
-- [ ] 1.1 Establish gated IT class with silent-skip and invalid-path failure
+- [x] 1. Foundation: IT skeleton with gate and skip notice
+- [x] 1.1 Establish gated IT class with silent-skip and invalid-path failure
   - 新規ファイルを `src/nativeTest/kotlin/kolt/cli/` 配下に作成し、 IT class と一つの no-op `@Test` (gate check のみを呼ぶ) を置く
   - File-private gate helper を実装: `KOLT_DAEMON_JAR` env が unset なら 1 度だけ stderr に skip notice を出して early return、 set されているが指す path が存在しなければ `fail(...)` で明示メッセージ付き失敗
   - Top-level `const val FIXTURE_KOTLIN_VERSION = "2.3.20"` を file 先頭に置き、 後続タスクで fixture toml と IC path 計算が共通参照する

--- a/.kiro/specs/381-multi-shape-test-coverage/tasks.md
+++ b/.kiro/specs/381-multi-shape-test-coverage/tasks.md
@@ -9,7 +9,7 @@
   - _Requirements: 4.1, 4.4, 5.1, 5.2_
 
 - [ ] 2. Core: per-shape end-to-end coverage
-- [ ] 2.1 Plugin なし shape の end-to-end test と共通 helper 一式
+- [x] 2.1 Plugin なし shape の end-to-end test と共通 helper 一式
   - File-private helpers を IT 内に追加: `scaffoldNoPluginFixture`、 `runKoltBuildAndTest`、 `snapshotMainClassFiles`、 `assertMainClassesSurvive`、 `assertIcSegmentsPopulated`。 IC path 計算は `daemonIcProjectIdOf` を呼ぶか visibility が `private/internal` で見えなければ同算式を IT 内に再実装する
   - `scaffoldNoPluginFixture` は `mkdtemp` で温度 dir を作り、 `[kotlin] version`、 `[build] target = "jvm"` のみの `kolt.toml` と `src/main/kotlin/Main.kt` + `src/test/kotlin/MainTest.kt` (kolt.test の最小ケース) を書き出す
   - `runKoltBuildAndTest` は `executeCommand` で `bash -c "cd <fixture> && <kolt.kexe> build && <kolt.kexe> test"` を実行、 `KOLT_DAEMON_JAR` を child env に明示注入、 exit code を返す

--- a/.kiro/specs/381-multi-shape-test-coverage/tasks.md
+++ b/.kiro/specs/381-multi-shape-test-coverage/tasks.md
@@ -1,0 +1,34 @@
+# Implementation Plan
+
+- [ ] 1. Foundation: IT skeleton with gate and skip notice
+- [ ] 1.1 Establish gated IT class with silent-skip and invalid-path failure
+  - 新規ファイルを `src/nativeTest/kotlin/kolt/cli/` 配下に作成し、 IT class と一つの no-op `@Test` (gate check のみを呼ぶ) を置く
+  - File-private gate helper を実装: `KOLT_DAEMON_JAR` env が unset なら 1 度だけ stderr に skip notice を出して early return、 set されているが指す path が存在しなければ `fail(...)` で明示メッセージ付き失敗
+  - Top-level `const val FIXTURE_KOTLIN_VERSION = "2.3.20"` を file 先頭に置き、 後続タスクで fixture toml と IC path 計算が共通参照する
+  - Observable: `KOLT_DAEMON_JAR` 未設定で parent `kolt test` を回したとき、 当該 IT class が discovered されつつ stderr に 1 行の skip notice が出力され、 一切の subprocess / fixture I/O が起きない。 `KOLT_DAEMON_JAR=/nonexistent/path` を指定したときは IT 失敗メッセージに env var 名と invalid path が両方含まれる
+  - _Requirements: 4.1, 4.4, 5.1, 5.2_
+
+- [ ] 2. Core: per-shape end-to-end coverage
+- [ ] 2.1 Plugin なし shape の end-to-end test と共通 helper 一式
+  - File-private helpers を IT 内に追加: `scaffoldNoPluginFixture`、 `runKoltBuildAndTest`、 `snapshotMainClassFiles`、 `assertMainClassesSurvive`、 `assertIcSegmentsPopulated`。 IC path 計算は `daemonIcProjectIdOf` を呼ぶか visibility が `private/internal` で見えなければ同算式を IT 内に再実装する
+  - `scaffoldNoPluginFixture` は `mkdtemp` で温度 dir を作り、 `[kotlin] version`、 `[build] target = "jvm"` のみの `kolt.toml` と `src/main/kotlin/Main.kt` + `src/test/kotlin/MainTest.kt` (kolt.test の最小ケース) を書き出す
+  - `runKoltBuildAndTest` は `executeCommand` で `bash -c "cd <fixture> && <kolt.kexe> build && <kolt.kexe> test"` を実行、 `KOLT_DAEMON_JAR` を child env に明示注入、 exit code を返す
+  - `assertIcSegmentsPopulated` は `~/.kolt/daemon/ic/<FIXTURE_KOTLIN_VERSION>/<projectId>/main/bta/` と `.../test/bta/` の 2 dir が exist かつ entry を持つことを確認、 失敗時 message に欠損 segment 名と fixture 名を含める。 同じ `<projectId>` の sibling であることも確認
+  - `snapshotMainClassFiles` は `<fixtureDir>/build/classes/` を再帰列挙して `.class` の abs path 集合を返す。 `assertMainClassesSurvive` は集合の各 path が `stat` で file として残存していることを確認、 欠損時 message に削除された path と fixture 名を含める
+  - `@Test fun runs daemon-routed test on JVM project without plugins()` を追加: gate → scaffold → `kolt build` → snapshot → `kolt test` → exit 0 assert → IC segments assert → class survival assert
+  - Observable: `KOLT_DAEMON_JAR` 設定下で parent `kolt test` を回したとき、 当該 `@Test` が緑になり、 IC layout 配下に `<projectId>/{main,test}/bta/` が物理生成され、 fixture 内 `build/classes/**/*.class` が `kolt build` 直後と `kolt test` 通過後で同一集合
+  - _Requirements: 1.1, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 4.2, 4.3_
+
+- [ ] 2.2 Serialization plugin shape の end-to-end test
+  - `scaffoldSerializationFixture` を IT 内に追加: `[kotlin] version` + `[kotlin.plugins] serialization = true` を持つ `kolt.toml`、 `src/main/kotlin/Payload.kt` に `@Serializable data class Payload(...)`、 `src/test/kotlin/PayloadTest.kt` に `Json.encodeToString` / `decodeFromString` の往復 assertion を 1 ケース置く。 `kotlinx-serialization-json` runtime dependency が必要なら `[dependencies]` に追加 (impl 時に最小再現で確定)
+  - `@Test fun runs daemon-routed test on JVM project with serialization plugin()` を追加: gate → `scaffoldSerializationFixture` → 2.1 で追加した共通 helper (`runKoltBuildAndTest`, `snapshotMainClassFiles`, `assertMainClassesSurvive`, `assertIcSegmentsPopulated`) を呼んで同じ assertion 列を回す
+  - Observable: `KOLT_DAEMON_JAR` 設定下で parent `kolt test` を回したとき、 当該 `@Test` が緑になり、 fixture の `Payload.class` が `$serializer` を含む状態で生成され、 build → test 通過後も artifact が残る
+  - _Requirements: 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 4.2, 4.3_
+
+- [ ] 3. Validation
+- [ ] 3.1 多モード手動実走と boundary 検査
+  - Parent `kolt test` を 3 モードで実走させ各挙動を確認: (a) `KOLT_DAEMON_JAR` 未設定 → IT 2 件 silent skip + stderr に 1 行 notice、 (b) `KOLT_DAEMON_JAR=<repo>/kolt-jvm-compiler-daemon/build/kolt-jvm-compiler-daemon.jar` (dev thin jar) → IT 2 件 pass、 (c) `KOLT_DAEMON_JAR=/nonexistent/path` → IT 失敗メッセージに env var 名と invalid path が含まれる
+  - 当該 IT ファイルの import 文を grep し、 production import が `kolt.infra.executeCommand`、 `kolt.infra.sha256Hex`、 `kolt.build.daemon.daemonIcProjectIdOf` (借用が成立した場合)、 POSIX cinterop に限定されていることを確認
+  - 借用 helper (`locateKoltKexe`、 `currentWorkingDir`、 `printOnceSkipNotice` 等) が `JvmTestSysPropIT` 内で `private` だった場合、 本 IT 内に同等関数として再実装が完了しており、 import で参照していないことを確認
+  - Observable: 3 モード実走の各結果が expected と一致する記録 (test output snippet) と、 import grep の結果リストが手元に揃う
+  - _Requirements: 4.1, 4.2, 4.4, 5.1, 5.2_

--- a/.kiro/specs/381-multi-shape-test-coverage/tasks.md
+++ b/.kiro/specs/381-multi-shape-test-coverage/tasks.md
@@ -25,8 +25,8 @@
   - Observable: `KOLT_DAEMON_JAR` 設定下で parent `kolt test` を回したとき、 当該 `@Test` が緑になり、 fixture の `Payload.class` が `$serializer` を含む状態で生成され、 build → test 通過後も artifact が残る
   - _Requirements: 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 4.2, 4.3_
 
-- [ ] 3. Validation
-- [ ] 3.1 多モード手動実走と boundary 検査
+- [x] 3. Validation
+- [x] 3.1 多モード手動実走と boundary 検査
   - Parent `kolt test` を 3 モードで実走させ各挙動を確認: (a) `KOLT_DAEMON_JAR` 未設定 → IT 2 件 silent skip + stderr に 1 行 notice、 (b) `KOLT_DAEMON_JAR=<repo>/kolt-jvm-compiler-daemon/build/kolt-jvm-compiler-daemon.jar` (dev thin jar) → IT 2 件 pass、 (c) `KOLT_DAEMON_JAR=/nonexistent/path` → IT 失敗メッセージに env var 名と invalid path が含まれる
   - 当該 IT ファイルの import 文を grep し、 production import が `kolt.infra.executeCommand`、 `kolt.infra.sha256Hex`、 `kolt.build.daemon.daemonIcProjectIdOf` (借用が成立した場合)、 POSIX cinterop に限定されていることを確認
   - 借用 helper (`locateKoltKexe`、 `currentWorkingDir`、 `printOnceSkipNotice` 等) が `JvmTestSysPropIT` 内で `private` だった場合、 本 IT 内に同等関数として再実装が完了しており、 import で参照していないことを確認

--- a/src/nativeTest/kotlin/kolt/cli/MultiShapeDaemonTestCoverageIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/MultiShapeDaemonTestCoverageIT.kt
@@ -8,8 +8,10 @@ import kolt.infra.executeCommand
 import kolt.infra.fileExists
 import kolt.infra.isRegularFile
 import kolt.infra.readFileAsString
+import kolt.infra.removeDirectoryRecursive
 import kolt.infra.sha256Hex
 import kolt.infra.writeFileAsString
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -38,10 +40,39 @@ const val FIXTURE_KOTLIN_VERSION = "2.3.20"
 
 class MultiShapeDaemonTestCoverageIT {
 
+  private val createdDirs = mutableListOf<String>()
+
+  @AfterTest
+  fun cleanup() {
+    for (dir in createdDirs) {
+      if (fileExists(dir)) {
+        removeDirectoryRecursive(dir)
+      }
+    }
+    createdDirs.clear()
+  }
+
+  private fun ensureGateOrSkip(): Boolean {
+    val raw = getenv(GATE_ENV)?.toKString()
+    if (raw.isNullOrEmpty()) {
+      if (!skipNoticePrinted) {
+        skipNoticePrinted = true
+        eprintln(
+          "MultiShapeDaemonTestCoverageIT: skipped (set $GATE_ENV to a daemon thin jar to enable)"
+        )
+      }
+      return false
+    }
+    if (!isRegularFile(raw)) {
+      fail("$GATE_ENV must point to an existing thin jar file: $raw")
+    }
+    return true
+  }
+
   @Test
   fun runsDaemonRoutedTestOnJvmProjectWithoutPlugins() {
     if (!ensureGateOrSkip()) return
-    val fixture = scaffoldNoPluginFixture()
+    val fixture = scaffoldNoPluginFixture().also(createdDirs::add)
     val fixtureName = "no-plugin"
 
     val buildExit = runKoltCommand(fixture, "build", "b")
@@ -76,7 +107,7 @@ class MultiShapeDaemonTestCoverageIT {
   @Test
   fun runsDaemonRoutedTestOnJvmProjectWithSerializationPlugin() {
     if (!ensureGateOrSkip()) return
-    val fixture = scaffoldSerializationFixture()
+    val fixture = scaffoldSerializationFixture().also(createdDirs::add)
     val fixtureName = "serialization"
 
     val buildExit = runKoltCommand(fixture, "build", "b")
@@ -107,31 +138,16 @@ class MultiShapeDaemonTestCoverageIT {
     assertMainClassesSurvive(fixture, fixtureName, mainClassesBefore)
     assertIcSegmentsPopulated(fixture, fixtureName)
   }
+
+  companion object {
+    // Per-class flag so the skip notice prints exactly once per test JVM
+    // lifetime even when multiple `@Test` methods land on an unset gate.
+    // Mirrors `JvmTestSysPropIT`'s companion-scoped `skipNoticePrinted`.
+    private var skipNoticePrinted = false
+  }
 }
 
 private const val GATE_ENV = "KOLT_DAEMON_JAR"
-
-// Mirrors JvmTestSysPropIT's `printOnceSkipNotice` pattern: keep a file-local
-// flag so the skip notice prints exactly once per test JVM lifetime, even when
-// multiple `@Test` methods in this class land on an unset gate.
-private var skipNoticePrinted = false
-
-private fun ensureGateOrSkip(): Boolean {
-  val raw = getenv(GATE_ENV)?.toKString()
-  if (raw.isNullOrEmpty()) {
-    if (!skipNoticePrinted) {
-      skipNoticePrinted = true
-      eprintln(
-        "MultiShapeDaemonTestCoverageIT: skipped (set $GATE_ENV to a daemon thin jar to enable)"
-      )
-    }
-    return false
-  }
-  if (!fileExists(raw)) {
-    fail("$GATE_ENV points to non-existent path: $raw")
-  }
-  return true
-}
 
 private fun locateKoltKexe(): String {
   val cwd =
@@ -265,15 +281,12 @@ private fun isDir(path: String): Boolean = memScoped {
   (statBuf.st_mode.toInt() and S_IFMT) == S_IFDIR
 }
 
-private fun assertMainClassesSurvive(
-  @Suppress("UNUSED_PARAMETER") fixtureDir: String,
-  fixtureName: String,
-  before: Set<String>,
-) {
+private fun assertMainClassesSurvive(fixtureDir: String, fixtureName: String, before: Set<String>) {
   for (path in before) {
     assertTrue(
       isRegularFile(path),
-      "main .class artifact was deleted during kolt test for fixture $fixtureName: $path",
+      "main .class artifact was deleted during kolt test for fixture $fixtureName " +
+        "(under $fixtureDir): $path",
     )
   }
 }

--- a/src/nativeTest/kotlin/kolt/cli/MultiShapeDaemonTestCoverageIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/MultiShapeDaemonTestCoverageIT.kt
@@ -72,6 +72,41 @@ class MultiShapeDaemonTestCoverageIT {
     assertMainClassesSurvive(fixture, fixtureName, mainClassesBefore)
     assertIcSegmentsPopulated(fixture, fixtureName)
   }
+
+  @Test
+  fun runsDaemonRoutedTestOnJvmProjectWithSerializationPlugin() {
+    if (!ensureGateOrSkip()) return
+    val fixture = scaffoldSerializationFixture()
+    val fixtureName = "serialization"
+
+    val buildExit = runKoltCommand(fixture, "build", "b")
+    val buildStdout = readOptional(fixture, "b.stdout") ?: ""
+    val buildStderr = readOptional(fixture, "b.stderr") ?: ""
+    assertEquals(
+      0,
+      buildExit,
+      "kolt build must exit 0 for $fixtureName fixture; stdout=$buildStdout stderr=$buildStderr",
+    )
+
+    val mainClassesBefore = snapshotMainClassFiles(fixture)
+    assertTrue(
+      mainClassesBefore.isNotEmpty(),
+      "kolt build must produce at least one .class under build/classes/ for $fixtureName " +
+        "fixture; stdout=$buildStdout stderr=$buildStderr",
+    )
+
+    val testExit = runKoltCommand(fixture, "test", "t")
+    val testStdout = readOptional(fixture, "t.stdout") ?: ""
+    val testStderr = readOptional(fixture, "t.stderr") ?: ""
+    assertEquals(
+      0,
+      testExit,
+      "kolt test must exit 0 for $fixtureName fixture; stdout=$testStdout stderr=$testStderr",
+    )
+
+    assertMainClassesSurvive(fixture, fixtureName, mainClassesBefore)
+    assertIcSegmentsPopulated(fixture, fixtureName)
+  }
 }
 
 private const val GATE_ENV = "KOLT_DAEMON_JAR"
@@ -138,6 +173,24 @@ private fun scaffoldNoPluginFixture(): String {
   }
   writeFileAsString("$testDir/MainTest.kt", NO_PLUGIN_TEST).getOrElse {
     error("write MainTest.kt: ${it.path}")
+  }
+  return dir
+}
+
+private fun scaffoldSerializationFixture(): String {
+  val dir = createTempDir("kolt-it-multishape-serialization-")
+  writeFileAsString("$dir/kolt.toml", SERIALIZATION_TOML).getOrElse {
+    error("write kolt.toml: ${it.path}")
+  }
+  val mainDir = "$dir/src/main/kotlin"
+  val testDir = "$dir/src/test/kotlin"
+  executeCommand(listOf("mkdir", "-p", mainDir)).getOrElse { error("mkdir main: $it") }
+  executeCommand(listOf("mkdir", "-p", testDir)).getOrElse { error("mkdir test: $it") }
+  writeFileAsString("$mainDir/Payload.kt", SERIALIZATION_MAIN).getOrElse {
+    error("write Payload.kt: ${it.path}")
+  }
+  writeFileAsString("$testDir/PayloadTest.kt", SERIALIZATION_TEST).getOrElse {
+    error("write PayloadTest.kt: ${it.path}")
   }
   return dir
 }
@@ -332,6 +385,61 @@ private val NO_PLUGIN_TEST =
             @Test
             fun greetReturnsExpectedValue() {
                 assertEquals("hello-no-plugin", greet())
+            }
+        }
+        """
+    .trimIndent()
+
+private val SERIALIZATION_TOML =
+  """
+        name = "multishape-serialization"
+        version = "0.0.1"
+        kind = "lib"
+
+        [kotlin]
+        version = "$FIXTURE_KOTLIN_VERSION"
+
+        [kotlin.plugins]
+        serialization = true
+
+        [build]
+        target = "jvm"
+        jvm_target = "21"
+        sources = ["src/main/kotlin"]
+        test_sources = ["src/test/kotlin"]
+
+        [dependencies]
+        "org.jetbrains.kotlinx:kotlinx-serialization-json" = "1.7.3"
+        """
+    .trimIndent()
+
+private val SERIALIZATION_MAIN =
+  """
+        package multishape.serialization
+
+        import kotlinx.serialization.Serializable
+
+        @Serializable
+        data class Payload(val id: Int, val name: String)
+        """
+    .trimIndent()
+
+private val SERIALIZATION_TEST =
+  """
+        package multishape.serialization
+
+        import kotlin.test.Test
+        import kotlin.test.assertEquals
+        import kotlinx.serialization.encodeToString
+        import kotlinx.serialization.json.Json
+
+        class PayloadTest {
+            @Test
+            fun roundTripsThroughJson() {
+                val original = Payload(id = 42, name = "answer")
+                val encoded = Json.encodeToString(original)
+                val decoded = Json.decodeFromString<Payload>(encoded)
+                assertEquals(original, decoded)
             }
         }
         """

--- a/src/nativeTest/kotlin/kolt/cli/MultiShapeDaemonTestCoverageIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/MultiShapeDaemonTestCoverageIT.kt
@@ -1,0 +1,44 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package kolt.cli
+
+import kolt.infra.eprintln
+import kolt.infra.fileExists
+import kotlin.test.Test
+import kotlin.test.fail
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
+
+const val FIXTURE_KOTLIN_VERSION = "2.3.20"
+
+class MultiShapeDaemonTestCoverageIT {
+
+  @Test
+  fun gateAllowsTestToProceedOrSkipsCleanly() {
+    if (!ensureGateOrSkip()) return
+  }
+}
+
+private const val GATE_ENV = "KOLT_DAEMON_JAR"
+
+// Mirrors JvmTestSysPropIT's `printOnceSkipNotice` pattern: keep a file-local
+// flag so the skip notice prints exactly once per test JVM lifetime, even when
+// multiple `@Test` methods in this class land on an unset gate.
+private var skipNoticePrinted = false
+
+private fun ensureGateOrSkip(): Boolean {
+  val raw = getenv(GATE_ENV)?.toKString()
+  if (raw.isNullOrEmpty()) {
+    if (!skipNoticePrinted) {
+      skipNoticePrinted = true
+      eprintln(
+        "MultiShapeDaemonTestCoverageIT: skipped (set $GATE_ENV to a daemon thin jar to enable)"
+      )
+    }
+    return false
+  }
+  if (!fileExists(raw)) {
+    fail("$GATE_ENV points to non-existent path: $raw")
+  }
+  return true
+}

--- a/src/nativeTest/kotlin/kolt/cli/MultiShapeDaemonTestCoverageIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/MultiShapeDaemonTestCoverageIT.kt
@@ -2,20 +2,75 @@
 
 package kolt.cli
 
+import com.github.michaelbull.result.getOrElse
 import kolt.infra.eprintln
+import kolt.infra.executeCommand
 import kolt.infra.fileExists
+import kolt.infra.isRegularFile
+import kolt.infra.readFileAsString
+import kolt.infra.sha256Hex
+import kolt.infra.writeFileAsString
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.fail
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.pointed
+import kotlinx.cinterop.ptr
 import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.S_IFDIR
+import platform.posix.S_IFMT
+import platform.posix.closedir
+import platform.posix.getcwd
 import platform.posix.getenv
+import platform.posix.mkdtemp
+import platform.posix.opendir
+import platform.posix.readdir
+import platform.posix.stat
 
 const val FIXTURE_KOTLIN_VERSION = "2.3.20"
 
 class MultiShapeDaemonTestCoverageIT {
 
   @Test
-  fun gateAllowsTestToProceedOrSkipsCleanly() {
+  fun runsDaemonRoutedTestOnJvmProjectWithoutPlugins() {
     if (!ensureGateOrSkip()) return
+    val fixture = scaffoldNoPluginFixture()
+    val fixtureName = "no-plugin"
+
+    val buildExit = runKoltCommand(fixture, "build", "b")
+    val buildStdout = readOptional(fixture, "b.stdout") ?: ""
+    val buildStderr = readOptional(fixture, "b.stderr") ?: ""
+    assertEquals(
+      0,
+      buildExit,
+      "kolt build must exit 0 for $fixtureName fixture; stdout=$buildStdout stderr=$buildStderr",
+    )
+
+    val mainClassesBefore = snapshotMainClassFiles(fixture)
+    assertTrue(
+      mainClassesBefore.isNotEmpty(),
+      "kolt build must produce at least one .class under build/classes/ for $fixtureName " +
+        "fixture; stdout=$buildStdout stderr=$buildStderr",
+    )
+
+    val testExit = runKoltCommand(fixture, "test", "t")
+    val testStdout = readOptional(fixture, "t.stdout") ?: ""
+    val testStderr = readOptional(fixture, "t.stderr") ?: ""
+    assertEquals(
+      0,
+      testExit,
+      "kolt test must exit 0 for $fixtureName fixture; stdout=$testStdout stderr=$testStderr",
+    )
+
+    assertMainClassesSurvive(fixture, fixtureName, mainClassesBefore)
+    assertIcSegmentsPopulated(fixture, fixtureName)
   }
 }
 
@@ -42,3 +97,242 @@ private fun ensureGateOrSkip(): Boolean {
   }
   return true
 }
+
+private fun locateKoltKexe(): String {
+  val cwd =
+    currentWorkingDir()
+      ?: error("MultiShapeDaemonTestCoverageIT: getcwd() failed; cannot locate kolt.kexe")
+  val candidates = listOf("$cwd/build/debug/kolt.kexe", "$cwd/build/release/kolt.kexe")
+  return candidates.firstOrNull { fileExists(it) }
+    ?: error(
+      "MultiShapeDaemonTestCoverageIT: kolt.kexe not built; run `kolt build` first. " +
+        "Looked under: $candidates"
+    )
+}
+
+private fun currentWorkingDir(): String? = memScoped {
+  val buf = allocArray<ByteVar>(PATH_MAX)
+  getcwd(buf, PATH_MAX.toULong())?.toKString()
+}
+
+private fun createTempDir(prefix: String): String {
+  val template = "/tmp/${prefix}XXXXXX"
+  val buf = template.encodeToByteArray().copyOf(template.length + 1)
+  buf.usePinned { pinned ->
+    val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed for prefix '$prefix'")
+    return result.toKString()
+  }
+}
+
+private fun scaffoldNoPluginFixture(): String {
+  val dir = createTempDir("kolt-it-multishape-noplugin-")
+  writeFileAsString("$dir/kolt.toml", NO_PLUGIN_TOML).getOrElse {
+    error("write kolt.toml: ${it.path}")
+  }
+  val mainDir = "$dir/src/main/kotlin"
+  val testDir = "$dir/src/test/kotlin"
+  executeCommand(listOf("mkdir", "-p", mainDir)).getOrElse { error("mkdir main: $it") }
+  executeCommand(listOf("mkdir", "-p", testDir)).getOrElse { error("mkdir test: $it") }
+  writeFileAsString("$mainDir/Main.kt", NO_PLUGIN_MAIN).getOrElse {
+    error("write Main.kt: ${it.path}")
+  }
+  writeFileAsString("$testDir/MainTest.kt", NO_PLUGIN_TEST).getOrElse {
+    error("write MainTest.kt: ${it.path}")
+  }
+  return dir
+}
+
+// Bash harness mirrors JvmTestSysPropIT: capture exit code via `echo $? >` so
+// `executeCommand`'s Result wrapper does not collapse non-zero kolt exits onto
+// the bash exit channel before we can read stdout/stderr.
+private fun runKoltCommand(fixtureDir: String, koltSubcommand: String, fileStem: String): Int {
+  val kolt = locateKoltKexe()
+  val daemonJar =
+    getenv(GATE_ENV)?.toKString()
+      ?: error("$GATE_ENV must be set when runKoltCommand runs (gate already passed)")
+  val script =
+    """
+        set -u
+        cd "$fixtureDir"
+        "$kolt" $koltSubcommand > $fileStem.stdout 2> $fileStem.stderr
+        echo $D? > $fileStem.exit
+        """
+      .trimIndent()
+  executeCommand(listOf("bash", "-c", script), extraEnv = mapOf(GATE_ENV to daemonJar)).getOrElse {
+    error("harness bash failed for `kolt $koltSubcommand` in $fixtureDir: $it")
+  }
+  val raw =
+    readFileAsString("$fixtureDir/$fileStem.exit").getOrElse {
+      error("missing $fixtureDir/$fileStem.exit — harness did not record an exit code")
+    }
+  return raw.trim().toIntOrNull()
+    ?: error("could not parse exit code from $fixtureDir/$fileStem.exit: '$raw'")
+}
+
+private fun readOptional(dir: String, name: String): String? {
+  val path = "$dir/$name"
+  if (!fileExists(path)) return null
+  return readFileAsString(path).getOrElse {
+    return null
+  }
+}
+
+private fun snapshotMainClassFiles(fixtureDir: String): Set<String> {
+  val classesRoot = "$fixtureDir/build/classes"
+  if (!fileExists(classesRoot)) return emptySet()
+  val collected = mutableSetOf<String>()
+  collectClassFiles(classesRoot, collected)
+  return collected
+}
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+private fun collectClassFiles(root: String, into: MutableSet<String>) {
+  val dir = opendir(root) ?: return
+  try {
+    while (true) {
+      val entry = readdir(dir) ?: break
+      val name = entry.pointed.d_name.toKString()
+      if (name == "." || name == "..") continue
+      val child = "$root/$name"
+      if (isDir(child)) {
+        collectClassFiles(child, into)
+      } else if (name.endsWith(".class")) {
+        into.add(child)
+      }
+    }
+  } finally {
+    closedir(dir)
+  }
+}
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+private fun isDir(path: String): Boolean = memScoped {
+  val statBuf = alloc<stat>()
+  if (platform.posix.lstat(path, statBuf.ptr) != 0) return false
+  (statBuf.st_mode.toInt() and S_IFMT) == S_IFDIR
+}
+
+private fun assertMainClassesSurvive(
+  @Suppress("UNUSED_PARAMETER") fixtureDir: String,
+  fixtureName: String,
+  before: Set<String>,
+) {
+  for (path in before) {
+    assertTrue(
+      isRegularFile(path),
+      "main .class artifact was deleted during kolt test for fixture $fixtureName: $path",
+    )
+  }
+}
+
+// Daemon IC layout (kolt.build.daemon.IcStateCleanup §`daemonIcProjectIdOf`):
+// `<icRoot>/<kotlinVersion>/<sha256Hex(absProjectPath).take(32)>/<scope>/bta/`.
+// The production helper has `internal` visibility, so reimplement locally with
+// the same algorithm. A drift in either side breaks this assertion loud.
+private fun expectedProjectId(absProjectPath: String): String =
+  sha256Hex(absProjectPath.encodeToByteArray()).take(32)
+
+private fun assertIcSegmentsPopulated(fixtureDir: String, fixtureName: String) {
+  val home =
+    getenv("HOME")?.toKString()
+      ?: fail("HOME env var not set; cannot resolve daemon IC root for fixture $fixtureName")
+  val icRoot = "$home/.kolt/daemon/ic"
+  val projectId = expectedProjectId(fixtureDir)
+  val versionDir = "$icRoot/$FIXTURE_KOTLIN_VERSION/$projectId"
+  val mainBta = "$versionDir/main/bta"
+  val testBta = "$versionDir/test/bta"
+
+  assertTrue(
+    fileExists(mainBta),
+    "missing IC segment 'main/bta' for fixture $fixtureName at $mainBta",
+  )
+  assertTrue(
+    isDir(mainBta) && hasAtLeastOneEntry(mainBta),
+    "IC segment 'main/bta' is empty for fixture $fixtureName at $mainBta",
+  )
+  assertTrue(
+    fileExists(testBta),
+    "missing IC segment 'test/bta' for fixture $fixtureName at $testBta",
+  )
+  assertTrue(
+    isDir(testBta) && hasAtLeastOneEntry(testBta),
+    "IC segment 'test/bta' is empty for fixture $fixtureName at $testBta",
+  )
+
+  // Req 2.3: main/ and test/ must be siblings under the same <projectId>.
+  assertEquals(
+    versionDir,
+    parentOf(parentOf(mainBta)),
+    "main/bta parent chain must climb to <projectId> dir for fixture $fixtureName",
+  )
+  assertEquals(
+    versionDir,
+    parentOf(parentOf(testBta)),
+    "test/bta parent chain must climb to <projectId> dir for fixture $fixtureName",
+  )
+}
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+private fun hasAtLeastOneEntry(directory: String): Boolean {
+  val dir = opendir(directory) ?: return false
+  try {
+    while (true) {
+      val entry = readdir(dir) ?: return false
+      val name = entry.pointed.d_name.toKString()
+      if (name != "." && name != "..") return true
+    }
+  } finally {
+    closedir(dir)
+  }
+}
+
+private fun parentOf(path: String): String {
+  val idx = path.lastIndexOf('/')
+  if (idx <= 0) return "/"
+  return path.substring(0, idx)
+}
+
+// Single literal "$" token for use inside the bash heredoc raw strings.
+// Kotlin would otherwise interpret `$?` as a template lookup.
+private const val D = "$"
+
+private val NO_PLUGIN_TOML =
+  """
+        name = "multishape-noplugin"
+        version = "0.0.1"
+        kind = "lib"
+
+        [kotlin]
+        version = "$FIXTURE_KOTLIN_VERSION"
+
+        [build]
+        target = "jvm"
+        jvm_target = "21"
+        sources = ["src/main/kotlin"]
+        test_sources = ["src/test/kotlin"]
+        """
+    .trimIndent()
+
+private val NO_PLUGIN_MAIN =
+  """
+        package multishape.noplugin
+
+        fun greet(): String = "hello-no-plugin"
+        """
+    .trimIndent()
+
+private val NO_PLUGIN_TEST =
+  """
+        package multishape.noplugin
+
+        import kotlin.test.Test
+        import kotlin.test.assertEquals
+
+        class MainTest {
+            @Test
+            fun greetReturnsExpectedValue() {
+                assertEquals("hello-no-plugin", greet())
+            }
+        }
+        """
+    .trimIndent()


### PR DESCRIPTION
Closes #381.

Adds a single native IT (`MultiShapeDaemonTestCoverageIT`) that scaffolds two JVM project shapes (no plugins, kotlinx.serialization plugin), runs `kolt build && kolt test` through the JVM compile daemon for each, and asserts:

- daemon-side IC state populates `~/.kolt/daemon/ic/<v>/<projectId>/{main,test}/bta/` as siblings under the same projectId,
- main `.class` artifacts written by `kolt build` survive the subsequent `kolt test` (the regression #376 fixed).

The IT is gated on `KOLT_DAEMON_JAR`: unset → silent skip with a one-time stderr notice; set to a non-file path → fail with a message naming the env var and the bad value; set to a real thin jar → run.

## Where to look

- `src/nativeTest/kotlin/kolt/cli/MultiShapeDaemonTestCoverageIT.kt` is the only code change. Mirrors `JvmTestSysPropIT` for scaffolding, subprocess harness, gate semantics, companion-scoped skip flag, and `@AfterTest` cleanup of `/tmp` fixture dirs.
- The IT reimplements `daemonIcProjectIdOf` locally (`expectedProjectId`) because the production helper is `internal`. The algorithm (`sha256Hex(absProjectPath.encodeToByteArray()).take(32)`) is intentionally byte-for-byte identical to `IcStateCleanup.daemonIcProjectIdOf` — if production drifts, `assertIcSegmentsPopulated` fails loud rather than silent. Worth double-checking that pin.
- The serialization fixture needs `kotlinx-serialization-json` as a runtime dep; the plugin enable alone does not bring it onto the test classpath. Determined empirically.
- The two `@Test` bodies are deliberate ~33-line near-duplicates per the spec's "file-private helpers + 2 `@Test` methods" structure (no shape registry).
- Spec lives under `.kiro/specs/381-multi-shape-test-coverage/` if you want the requirements / design / tasks / research traceability.

## Verified locally

- `KOLT_DAEMON_JAR` unset → both tests OK at 0 ms with one skip notice.
- `KOLT_DAEMON_JAR=<dev thin jar>` → both pass (~30–40 s each), IC segments populate under distinct projectIds, fixture dirs cleaned by `@AfterTest`.
- `KOLT_DAEMON_JAR=/nonexistent/path` and `KOLT_DAEMON_JAR=/tmp` (a directory) → both fail fast with the env-var-named assertion message.

Pre-existing unrelated `NestedLockAcquireTest.projectLockIsAvailableInsideKoltTestChild` failure shows up in full-suite runs; unchanged by this PR.