### PR TITLE
Auto-restart stale daemon on wire-deserialize fail (#379)

### DIFF
--- a/.kiro/specs/379-auto-restart-stale-daemon/design.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/design.md
@@ -1,0 +1,536 @@
+# Design Document — Auto-Restart Stale Daemon on Wire-Deserialize Fail
+
+## Overview
+
+#376 の wire 拡張後に旧版 daemon プロセスが UNIX socket を握ったまま生き残ると、 新しい kolt クライアントは reply を decode できず subprocess fallback に落ちるが、 旧 daemon はそのまま生き続けるため以降の build も毎回 fallback してしまう。 ユーザは `kolt daemon stop` を手動で叩かない限り daemon の利得を失い続ける。
+
+本設計では、 native client が daemon reply を「wire レベルで解釈不能」と判定したとき、 同じ open connection 上で best-effort に `Message.Shutdown` を送り、 stderr に 1 行通知し、 当該 build を既存の subprocess fallback で完走させる。 これにより次回 invocation は通常通り fresh daemon を spawn できる。 JVM compiler daemon backend と native compiler daemon backend に対称的に適用する。
+
+### Goals
+
+- 「wire レベルで解釈不能な daemon reply」を新しいエラー variant として表面化し、 検出を Result chain に乗せる
+- daemon-side のコード変更なしに stale daemon を実質 1 build で退場させる
+- ユーザに「何が起きたか」を 1 行で伝える（沈黙 fallback の解消）
+
+### Non-Goals
+
+- daemon-side コードの変更（`Message.Shutdown` 受信処理は既存）
+- daemon の一般的なヘルス監視（hang / OOM / 応答遅延などは対象外）
+- in-flight build を fresh daemon に対して再試行すること
+- JVM 以外のクライアント経路（本機能は `kolt.kexe` のみ）
+- `kolt daemon stop` / `kolt daemon reap` 既存コマンドの挙動変更
+
+## Boundary Commitments
+
+### This Spec Owns
+
+- `CompileError.BackendUnavailable.WireMismatch(detail)` と `NativeCompileError.BackendUnavailable.WireMismatch(detail)` の追加
+- `DaemonCompilerBackend.compile()` / `NativeDaemonBackend.compile()` 内の wire-mismatch 検出 + Shutdown 送信ステップ
+- `mapFrameErrorToReceiveError` / `mapReplyToOutcome`（両 backend）の WireMismatch 振替
+- `StaleDaemonNotice` モジュール — compile-pass スコープ 1 回限りの stderr 通知制御
+- `reportFallback` / `reportNativeFallback` の WireMismatch 分岐
+- `BuildCommands` の compile pass entry に挿入する `StaleDaemonNotice.reset()` 呼び出し（単発 + watch 両対応）
+
+### Out of Boundary
+
+- `Message` / `FrameCodec` / `FrameError` の API 変更（既存定義を流用）
+- `FallbackCompilerBackend` / `FallbackNativeCompilerBackend` wrapper 自体の挙動変更
+- `connectOrSpawn` の retry policy（既存の 10..200ms / 10s budget のまま）
+- `DaemonCommands.kt` の `sendShutdown` / `sendNativeShutdown` ヘルパー（path 経由再接続のため別目的）
+- daemon-side 実装（`kolt-jvm-compiler-daemon/`, `kolt-native-compiler-daemon/`）
+- precondition 失敗（`DaemonPreconditionError` / `NativeDaemonPreconditionError`）経路
+
+### Allowed Dependencies
+
+- `kolt.daemon.wire.{Message, FrameCodec, FrameError}` — JVM daemon wire 型
+- `kolt.nativedaemon.wire.{Message, FrameCodec, FrameError}` — native daemon wire 型
+- `kolt.infra.eprintln` — 既存 stderr 書き出し
+- `kotlin-result` — 既存の `Result<V, E>` パターン
+- `DaemonConnection` / `NativeDaemonConnection` interface — 既存
+- `BackendUnavailable` / `isFallbackEligible` — 既存
+
+依存方向は **cli → build → resolve / infra**（structure.md §`Package Organization`）を踏襲する。 本設計の追加コンポーネントはすべて `kolt.build` 配下で完結する。
+
+### Revalidation Triggers
+
+以下の変更は依存先 spec/consumer の整合確認が必要：
+
+- `Message` sealed type の variant 追加（JVM/native どちらでも） — `mapReplyToOutcome` の網羅性が崩れる
+- `FrameError` variant 追加 — `mapFrameErrorToReceiveError` の網羅性が崩れる
+- `CompilerBackend` / `NativeCompilerBackend` の `compile` 戻り値型変更 — エラー sealed 階層の派生先全箇所
+- `FallbackCompilerBackend` / `FallbackNativeCompilerBackend` の `onFallback` callback signature 変更 — `reportFallback` / `reportNativeFallback` 含む全 caller
+- `BackendUnavailable` 配下の variant 追加 — `isFallbackEligible` / `formatCompileError` / `reportFallback` 全般
+
+## Architecture
+
+### Existing Architecture Analysis
+
+JVM daemon backend と native daemon backend は **完全並行構造**（research.md §1.1 参照）。 共通パターン：
+
+- `DaemonCompilerBackend` 系： `connectOrSpawn` → `connection.use { sendRequest → receiveReply → mapReplyToOutcome }`
+- 失敗時はすべて `Result<_, *CompileError>` で返し、 `FallbackCompilerBackend` 系 wrapper が `isFallbackEligible(err)` で分岐
+- `BackendUnavailable.*` 配下が fallback 対象、 `CompilationFailed` は素通り
+
+既存パターンの遵守事項：
+
+- ADR 0001：例外を投げない、 すべて `Result<V, E>`
+- ADR 0016 §3：`BackendUnavailable` は warning、 `InternalMisuse` は error
+- ADR 0024 §1：JVM daemon と native daemon の wire 型は別 sealed family を維持（並行で進化しうる）
+- structure.md §`Code Organization Principles` "Explicit fallback policy"：fallback policy は明示的に上層に集約
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+    subgraph cli[kolt.cli.BuildCommands]
+        Resolve[resolveCompilerBackend]
+    end
+
+    subgraph build[kolt.build]
+        Fallback[FallbackCompilerBackend]
+        Reporter[FallbackReporter]
+        Notice[StaleDaemonNotice]
+    end
+
+    subgraph daemon[kolt.build.daemon]
+        Backend[DaemonCompilerBackend]
+        Conn[DaemonConnection]
+    end
+
+    subgraph wire[kolt.daemon.wire]
+        Codec[FrameCodec]
+        Msg[Message]
+        FrameErr[FrameError]
+    end
+
+    Resolve --> Fallback
+    Fallback --> Backend
+    Fallback -- onFallback --> Reporter
+    Reporter --> Notice
+    Notice --> EprintLn[kolt.infra.eprintln]
+    Backend --> Conn
+    Conn --> Codec
+    Codec --> Msg
+    Codec --> FrameErr
+    Backend -- send Shutdown best-effort --> Conn
+```
+
+native 側 (`kolt.build.nativedaemon` + `kolt.nativedaemon.wire` + `NativeFallbackReporter`) も同形。 `StaleDaemonNotice` は **JVM/native 共有** の単一 module（一度の invocation で JVM 由来と native 由来の WireMismatch がそれぞれ起きても、 そのどちらかで 1 回だけ通知が出るよう統一する）。
+
+**Architecture Integration**:
+
+- Selected pattern: 既存の sealed-error + fallback-wrapper パターンを WireMismatch 変位の追加で延長
+- Domain boundaries: 検出 = backend、 ユーザ通知 policy = reporter (経由 `StaleDaemonNotice`)、 invocation 状態 = `StaleDaemonNotice`
+- Existing patterns preserved: JVM/native 並行ミラー、 Result<V, E>、 ADR 0001 / 0016 / 0024 既存方針
+- New components rationale: `StaleDaemonNotice` は once-per-invocation policy の単一 source of truth として独立化（JVM reporter と native reporter で共有される唯一のクロスカット）
+- Steering compliance: 例外なし（ADR 0001）、 fallback policy 上層集約（structure.md）、 ADR 番号コメント挿入規約（structure.md §`Code Organization Principles`）
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| CLI / Native binary | Kotlin/Native 2.3.x (linuxX64) | 全変更が `kolt.kexe` 内 | 新規依存なし |
+| Error model | `kotlin-result 2.3.x` | `WireMismatch` を含む `Result<V, E>` 表現 | 既存の `getOrElse` / `isErr` を踏襲 |
+| Wire protocol | `kotlinx.serialization` + 既存 `FrameCodec` | `Message.Shutdown` 送信に流用 | 変更なし |
+
+新規依存・version up はなし。 既存ライブラリのみで完結。
+
+## File Structure Plan
+
+### Directory Structure
+
+```
+src/nativeMain/kotlin/kolt/build/
+├── CompilerBackend.kt              # MODIFIED: BackendUnavailable.WireMismatch
+├── NativeCompilerBackend.kt        # MODIFIED: BackendUnavailable.WireMismatch
+├── FallbackReporter.kt             # MODIFIED: WireMismatch 分岐
+├── NativeFallbackReporter.kt       # MODIFIED: WireMismatch 分岐
+├── StaleDaemonNotice.kt            # NEW: once-per-compile-pass guard + emit + reset
+├── daemon/
+│   └── DaemonCompilerBackend.kt    # MODIFIED: receiveErr/replyVariant → WireMismatch、 Shutdown 送信
+└── nativedaemon/
+    └── NativeDaemonBackend.kt      # MODIFIED: 上記 native ミラー
+
+src/nativeMain/kotlin/kolt/cli/
+└── BuildCommands.kt                # MODIFIED: 各 compile pass entry で StaleDaemonNotice.reset() を呼ぶ（単発 + watch 両対応）
+
+src/nativeTest/kotlin/kolt/build/
+├── StaleDaemonNoticeTest.kt        # NEW
+├── FallbackReporterTest.kt         # MODIFIED: WireMismatch ケース追加
+├── NativeFallbackReporterTest.kt   # MODIFIED: 同上
+├── daemon/
+│   └── DaemonCompilerBackendTest.kt    # MODIFIED: WireMismatch + Shutdown 送信検証
+└── nativedaemon/
+    └── NativeDaemonBackendTest.kt      # MODIFIED: 同上 native
+
+src/nativeTest/kotlin/kolt/cli/
+└── StaleDaemonRecycleIT.kt         # NEW: 古い daemon 模擬 → 1 build 目に WireMismatch 通知 → 2 build 目で fresh spawn (initial PR scope)
+```
+
+### Modified Files
+
+- `src/nativeMain/kotlin/kolt/build/CompilerBackend.kt` — `BackendUnavailable` sealed に `data class WireMismatch(val detail: String) : BackendUnavailable` を追加。 `isFallbackEligible` は既に `is BackendUnavailable -> true` で網羅しているので分岐は不要、 ただしコメントで意図を明示。 `formatCompileError` に新分岐を追加（`"error: $context wire mismatch: ${error.detail}"` ）
+- `src/nativeMain/kotlin/kolt/build/NativeCompilerBackend.kt` — 上記 native ミラー
+- `src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt`：
+  - `mapFrameErrorToReceiveError(err)`：`Eof` / `Truncated` / `Malformed` / `Transport` の receive 側 4 変位を `WireMismatch(detail)` に振替（既存の `Other(detail)` を置換）
+  - `mapReplyToOutcome(reply)`：`Compile` / `Ping` / `Pong` / `Shutdown` 受信を `WireMismatch("unexpected reply type: ${reply::class.simpleName}")` に振替
+  - `compile(request)` フロー：`receiveReply()` から `WireMismatch` を生成すると判定したら、 **`Err(...)` を返す前に** `connection.sendRequest(Message.Shutdown)` を呼ぶ。 戻り値の `Err(FrameError.*)` は warn-log（`eprintln("warning: failed to send Shutdown to stale daemon: ...")`）してそのまま続行。 `mapReplyToOutcome` 由来の variant mismatch のときも同様に Shutdown を送る
+  - `mapFrameErrorToSendError` は **不変**（送信側エラーは別経路、 R1 の対象外）
+- `src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt` — 上記 native ミラー
+- `src/nativeMain/kotlin/kolt/build/FallbackReporter.kt`：`when (err)` に `is CompileError.BackendUnavailable.WireMismatch` を追加し、 `StaleDaemonNotice.emit("compiler daemon", err.detail, sink)` を呼ぶ。 既存の generic `BackendUnavailable.Other` warning は WireMismatch には流れない
+- `src/nativeMain/kotlin/kolt/build/NativeFallbackReporter.kt` — 上記 native ミラー（`StaleDaemonNotice.emit("native compiler daemon", ...)`）
+- `src/nativeMain/kotlin/kolt/cli/BuildCommands.kt` — 各 compile pass entry の直前で `StaleDaemonNotice.reset()` を 1 行呼ぶ（単発 build entry と `--watch` ループの各 cycle 両方）
+
+### New Files
+
+- `src/nativeMain/kotlin/kolt/build/StaleDaemonNotice.kt` — process-global once-per-invocation flag 1 つと、 `emit(label, detail, sink)` ヘルパー、 およびテスト用の `internal fun reset()`。 単一 module で JVM/native 両 reporter から呼ばれる
+- 新規テストは `src/nativeTest/kotlin/kolt/build/...` 配下に対応の package で配置
+
+## System Flows
+
+### Wire-mismatch detection and recycle (sequence)
+
+```mermaid
+sequenceDiagram
+    participant CLI as kolt.cli BuildCommands
+    participant Wrap as FallbackCompilerBackend
+    participant Backend as DaemonCompilerBackend
+    participant Conn as DaemonConnection
+    participant Daemon as stale daemon
+    participant Reporter as FallbackReporter
+    participant Notice as StaleDaemonNotice
+
+    CLI->>Wrap: compile(request)
+    Wrap->>Backend: compile(request)
+    Backend->>Conn: connectOrSpawn
+    Conn-->>Backend: open connection
+    Backend->>Conn: sendRequest Compile
+    Conn->>Daemon: write frame
+    Daemon-->>Conn: write reply with old wire
+    Conn-->>Backend: receiveReply Err FrameError Malformed
+    Backend->>Conn: sendRequest Shutdown best-effort
+    Conn-->>Backend: Ok or Err warn log
+    Backend-->>Wrap: Err WireMismatch
+    Wrap->>Reporter: onFallback WireMismatch
+    Reporter->>Notice: emit if first
+    Notice-->>Reporter: emitted true
+    Reporter-->>Wrap: stderr line written
+    Wrap->>Wrap: subprocess fallback compile
+```
+
+主要な分岐点：
+
+- `receiveReply` が `Err(FrameError.*)` または `mapReplyToOutcome` が「期待外 variant」を返した時点で WireMismatch 経路に入る
+- `connection.sendRequest(Message.Shutdown)` は **best-effort**：`Err(FrameError.*)` でも build は止めない（R2.2）
+- `StaleDaemonNotice.emit` は flag をチェックしてから 1 行書く。 既に true なら何もしない（R3.2 / R4.3）
+
+### Once-per-compile-pass guard (state)
+
+```mermaid
+stateDiagram-v2
+    [*] --> NotEmitted: compile pass start calls reset
+    NotEmitted --> Emitted: emit firstWireMismatch
+    Emitted --> Emitted: subsequent WireMismatch silent
+    Emitted --> NotEmitted: next compile pass calls reset
+    Emitted --> [*]: process exit
+```
+
+`StaleDaemonNotice` のスコープは「1 compile pass」。 `BuildCommands` の build entry が compile 開始直前に `reset()` を呼ぶため、 単発 invocation でも `--watch` の各 cycle でも最大 1 行の通知に統一される。 Single-process な watch セッションでも各 cycle が独立して 1 通知を許容する設計。
+
+### Subsequent invocation (R5)
+
+R5 は既存の `connectOrSpawn` 経路で自動的に成立する：
+
+1. 旧 daemon が `Message.Shutdown` を受けて socket を解放 → 次回 `connector(socketPath)` が ENOENT → retry → spawn → 新 daemon
+2. 旧 daemon がまだ socket を握っている → `connector` 成功 → wire 不整合再発 → WireMismatch 経路 → recycle 再起動
+3. 既存 `connectOrSpawn` の retry budget（10..200ms within 10s）はそのまま
+
+このフローには **新規コードは不要**。 重要なのは「Shutdown を送ったので daemon は退場の意思表示を受けた」という事実だけ。
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | frame 読み失敗を incompatibility 扱い | `DaemonCompilerBackend.mapFrameErrorToReceiveError`, `NativeDaemonBackend.mapFrameErrorToReceiveError` | `FrameError.{Eof,Truncated,Malformed,Transport}` → `WireMismatch` | wire-mismatch sequence |
+| 1.2 | payload deserialize 失敗 | 同上（`Malformed` に集約済） | 同上 | 同上 |
+| 1.3 | reply variant mismatch | `mapReplyToOutcome` 両 backend | 期待外 `Message` variant → `WireMismatch` | 同上 |
+| 1.4 | JVM/native 両 backend で同一 | `DaemonCompilerBackend` ＋ `NativeDaemonBackend` の対称改修 | `CompileError` / `NativeCompileError` どちらにも `WireMismatch` | – |
+| 1.5 | 他 daemon error は対象外 | `mapFatalConnectError` / `formatDaemonPreconditionWarning` 経路は不変 | precondition / connect-fatal は `WireMismatch` に振らない | – |
+| 2.1 | Shutdown を still-open connection で送信 | `DaemonCompilerBackend.compile`, `NativeDaemonBackend.compile` | `connection.sendRequest(Message.Shutdown)` | wire-mismatch sequence (`sendRequest Shutdown best-effort`) |
+| 2.2 | Shutdown 送信失敗時は warn-log し続行 | 両 backend `compile` 内 | `eprintln("warning: failed to send Shutdown to stale daemon: ...")` | 同上 (`Ok or Err warn log`) |
+| 2.3 | Shutdown 同期待ちなし | 両 backend `compile` 内 | 戻り値を待たず `Err(WireMismatch)` を返す | 同上 |
+| 3.1 | stderr 1 行通知 | `StaleDaemonNotice.emit`, `reportFallback`, `reportNativeFallback` | `eprintln(<dedicated message>)` | wire-mismatch sequence (`emit if first`) |
+| 3.2 | 1 compile pass あたり 1 回 | `StaleDaemonNotice` flag, `BuildCommands` reset 呼び出し | `emit` は 2 回目以降 no-op、 各 compile pass 開始時に `reset()` | once-per-compile-pass state |
+| 3.3 | verbosity 設定によらず出力 | `StaleDaemonNotice.emit` | `eprintln` 直呼び（既存 `reportFallback` も同様） | – |
+| 4.1 | in-flight build を fallback で完走 | `FallbackCompilerBackend` 既存 | `isFallbackEligible(WireMismatch) == true` | wire-mismatch sequence (`subprocess fallback compile`) |
+| 4.2 | fresh daemon で再試行しない | `FallbackCompilerBackend` 既存（subprocess 1 回のみ） | – | – |
+| 4.3 | invocation 中 1 回限り | `StaleDaemonNotice` flag が `emit` 抑止、 backend は 2 回目以降も WireMismatch を返すが silent fallback | – | once-per-compile-pass state |
+| 5.1 | 次回 invocation は fresh daemon | 既存 `connectOrSpawn` | – | subsequent invocation flow |
+| 5.2 | socket-occupied 時は既存挙動 | 既存 `connectOrSpawn` の retry budget | – | – |
+
+## Components and Interfaces
+
+| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies (P0/P1) | Contracts |
+|-----------|--------------|--------|--------------|--------------------------|-----------|
+| `CompileError.BackendUnavailable.WireMismatch` | build (sealed error) | wire 不整合の表面化 | 1.1, 1.2, 1.3, 1.5 | `kolt.build.CompileError` (P0) | State (sealed variant) |
+| `NativeCompileError.BackendUnavailable.WireMismatch` | build (sealed error) | 同上 native | 1.4 | `kolt.build.NativeCompileError` (P0) | State (sealed variant) |
+| `DaemonCompilerBackend` (modified) | build/daemon | wire-mismatch 検出と Shutdown 送信 | 1.1, 1.2, 1.3, 2.1, 2.2, 2.3 | `DaemonConnection` (P0), `Message.Shutdown` (P0) | Service |
+| `NativeDaemonBackend` (modified) | build/nativedaemon | 同上 native | 1.4, 2.1, 2.2, 2.3 | `NativeDaemonConnection` (P0) | Service |
+| `StaleDaemonNotice` (new) | build | once-per-compile-pass 通知制御 | 3.1, 3.2, 3.3, 4.3 | `kolt.infra.eprintln` (P0) | Service / State |
+| `reportFallback` (modified) | build | WireMismatch を `StaleDaemonNotice` に分岐 | 3.1 | `StaleDaemonNotice` (P0) | Service |
+| `reportNativeFallback` (modified) | build | 同上 native | 3.1 | `StaleDaemonNotice` (P0) | Service |
+
+### kolt.build (sealed errors)
+
+#### `CompileError.BackendUnavailable.WireMismatch`
+
+| Field | Detail |
+|-------|--------|
+| Intent | JVM compiler daemon が wire レベルで解釈不能な reply を返したことを表す sealed variant |
+| Requirements | 1.1, 1.2, 1.3, 1.5 |
+
+**Responsibilities & Constraints**
+
+- `BackendUnavailable` の sub-variant として **fallback-eligible** の性質を継承
+- `detail: String` には判定根拠（"malformed reply: ..."、 "truncated reply: wanted=X got=Y"、 "unexpected reply type: ..." など、 既存 detail 文と互換）を保持
+- 旧 `BackendUnavailable.Other` から **置き換え** て使う（receive 側の wire-related 失敗のみ。 send-side や connect-fatal は引き続き `Other`）
+
+**Dependencies**
+
+- Inbound: `mapFrameErrorToReceiveError` / `mapReplyToOutcome` (P0)
+- Outbound: `isFallbackEligible`, `formatCompileError`, `reportFallback` (P0)
+
+**Contracts**: State [x]
+
+##### State Management
+
+- 不変 data class、 `detail` のみ
+- 既存の `BackendUnavailable.Other` と同じ fallback eligibility（`isFallbackEligible` は `BackendUnavailable` 一括で true）
+
+#### `NativeCompileError.BackendUnavailable.WireMismatch`
+
+JVM 側と field/契約完全同形。 詳細省略。
+
+### kolt.build.daemon / kolt.build.nativedaemon (backends)
+
+#### `DaemonCompilerBackend.compile` (modified)
+
+| Field | Detail |
+|-------|--------|
+| Intent | wire-mismatch 検出時に `Message.Shutdown` を best-effort 送信してから WireMismatch を返す |
+| Requirements | 1.1, 1.2, 1.3, 2.1, 2.2, 2.3 |
+
+**Responsibilities & Constraints**
+
+- 既存の `connectOrSpawn` → `sendRequest` → `receiveReply` → `mapReplyToOutcome` フローは維持
+- `receiveReply` の `Err(FrameError.*)`、 または `mapReplyToOutcome` が WireMismatch を返すと判明した時点で **Err を返す前に** `connection.sendRequest(Message.Shutdown)` を呼ぶ（戻り値は warn-log するだけ）
+- Shutdown 送信は connection が閉じられる前に行う（`connection.use { ... }` の中で）
+- 同期待ちしない（Shutdown 送信完了即 return）
+
+**Dependencies**
+
+- Inbound: `FallbackCompilerBackend.compile` (P0)
+- Outbound: `DaemonConnection.sendRequest(Message.Shutdown)` (P0), `eprintln` warn (P1)
+- External: なし
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+override fun compile(request: CompileRequest): Result<CompileOutcome, CompileError>
+```
+
+- Preconditions: 既存どおり（`connectOrSpawn` が成功するか failover）
+- Postconditions:
+  - 戻り値が `Err(BackendUnavailable.WireMismatch)` のとき、 同じ open connection 上で `Message.Shutdown` 送信が試行されている（成功/失敗は問わず）
+  - Shutdown 送信失敗時は stderr に 1 行 warn が出る
+- Invariants: connection が `use` ブロック内でクローズされる（既存どおり）
+
+##### Implementation Notes
+
+- Integration: 既存 `mapFrameErrorToReceiveError` / `mapReplyToOutcome` の変位振替で十分。 `compile` 本体での新規分岐は最小限
+- Code shape：既存の早期 return パターンを保ったまま Shutdown 送信を `connection.use { ... }` 内で挟むため、 戻り値計算と Shutdown 送信を分離する。 擬似コード：
+
+  ```kotlin
+  connection.use {
+    val sendErr = it.sendRequest(wire).getError()
+    if (sendErr != null) return Err(mapFrameErrorToSendError(sendErr))
+
+    val reply = it.receiveReply()
+    val replyErr = reply.getError()
+    val mapped: Result<CompileOutcome, CompileError> =
+      if (replyErr != null) Err(mapFrameErrorToReceiveError(replyErr))
+      else mapReplyToOutcome(reply.get()!!)
+
+    // Shutdown 送信は use ブロックを抜ける前、 戻り値確定後に実施
+    val errored = mapped.getError()
+    if (errored is CompileError.BackendUnavailable.WireMismatch) {
+      it.sendRequest(Message.Shutdown).getError()?.let { sendErr ->
+        eprintln("warning: failed to send Shutdown to stale daemon: $sendErr")
+      }
+    }
+    return mapped
+  }
+  ```
+
+- Validation: `FakeConnection` を拡張し、 `lastSent` リスト化または `sentShutdown: Boolean` フラグで Shutdown 送信を観測
+- Risks:
+  - daemon が Shutdown 受信後すぐ socket を閉じない可能性 → 次回 `connectOrSpawn` の既存 retry budget が吸収（design §System Flows 参照）
+  - send 自体が即時失敗するケース（broken pipe）→ 既に R2.2 で warn + 続行を規定
+  - early return を残したまま Shutdown を `use` 外に書く実装ミス → 上記 pseudocode の構造を pin して防ぐ
+
+#### `NativeDaemonBackend.compile` (modified)
+
+JVM 側と完全同形。 wire 型のみ `kolt.nativedaemon.wire.Message.Shutdown` に差し替え。 詳細省略。
+
+### kolt.build (StaleDaemonNotice)
+
+#### `StaleDaemonNotice` (new)
+
+| Field | Detail |
+|-------|--------|
+| Intent | 1 process（= 1 invocation）あたり最大 1 回だけ stale-daemon 通知を stderr に出す |
+| Requirements | 3.1, 3.2, 3.3, 4.3 |
+
+**Responsibilities & Constraints**
+
+- mutable flag を保持し、 最初の `emit` 呼び出しでのみ stderr 1 行書き出し
+- 同一 compile pass 内で JVM 由来 / native 由来どちらの WireMismatch も区別なく 1 回でカウント
+- スコープは「1 compile pass」。 `kolt build --watch` / `kolt test --watch` のように 1 process が複数 compile pass を回すケースに備え、 各 compile pass の開始時点で `reset()` を呼ぶ責務を caller (`BuildCommands` の watch loop / 単発 build entry) に持たせる
+- 単発 build (`kolt build` / `kolt test` の non-watch) でも各 compile entry 開始時に `reset()` を呼んで OK（process が新しいので flag は false 始まりだが、 idempotent な reset で実装の単純性を優先）
+- 通知メッセージのテンプレート：`"warning: stale {label} detected ({detail}); recycling — this build runs as subprocess, the next build will spawn a fresh daemon"`
+  - `label`：`"compiler daemon"`（JVM）または `"native compiler daemon"`（native）
+  - `detail`：`WireMismatch.detail` をそのまま埋め込み
+
+**Dependencies**
+
+- Inbound: `reportFallback`, `reportNativeFallback` (P0)
+- Outbound: `kolt.infra.eprintln` (P0)
+
+**Contracts**: Service [x] / State [x]
+
+##### Service Interface
+
+```kotlin
+object StaleDaemonNotice {
+  fun emit(label: String, detail: String, sink: (String) -> Unit = ::eprintln): Boolean
+  fun reset()
+}
+```
+
+- Preconditions: なし
+- Postconditions:
+  - 初回呼び出し時：`sink` に 1 行書き出し、 flag を立て、 `true` を返す
+  - 同 compile pass 内 2 回目以降（`reset` を挟まない）：何も書かず `false` を返す
+- Invariants: `emit` 呼び出し間で `reset` がない限り、 flag は単調に true へ遷移
+
+##### State Management
+
+- State model: `private var emitted: Boolean = false`
+- Lifecycle: 各 compile pass entry が `reset()` を呼んでから compile を開始する。 process exit でも当然リセットされる
+- Persistence & consistency: in-memory only
+- Concurrency strategy: kolt CLI は単一スレッドの compile orchestration のため synchronization 不要。 将来並列化が入る場合は `atomicfu` 等で保護を検討（現状は不要）
+
+**Caller integration**
+
+- `BuildCommands` の build entry（`doBuild` / `doTest` 等）が compile invocation の **直前** に `StaleDaemonNotice.reset()` を呼ぶ
+- `--watch` ループでは「ファイル変更検知 → compile 1 回」の各サイクルで reset を 1 回呼ぶ。 これにより watch セッション中の各 compile pass で最大 1 行の通知が出る
+- 単発 build entry でも同じ呼び出しを統一的に行う（idempotent）
+
+### kolt.build (reporters, modified)
+
+#### `reportFallback` (modified)
+
+| Field | Detail |
+|-------|--------|
+| Intent | WireMismatch を `StaleDaemonNotice` に分岐し、 既存 generic warning と二重出力させない |
+| Requirements | 3.1 |
+
+**Responsibilities & Constraints**
+
+- `when (err)` に `is CompileError.BackendUnavailable.WireMismatch -> StaleDaemonNotice.emit("compiler daemon", err.detail, sink)` を **`BackendUnavailable.Other` より前に** 配置
+- `BackendUnavailable.Other` 既存分岐は変更なし（precondition 失敗等の他経路に残る）
+
+##### Implementation Notes
+
+- Integration: sink 引数を `StaleDaemonNotice.emit` に渡せば、 既存の `eprintln` デフォルトとテスト時の collector 注入が両立
+- Validation: `FallbackReporterTest` に WireMismatch ケースと、 既存 Other ケースが従来どおり出ることのアサート両方を追加
+- Risks: なし
+
+#### `reportNativeFallback` (modified)
+
+JVM 側と同形。 `StaleDaemonNotice.emit("native compiler daemon", ...)` を呼ぶ。
+
+## Error Handling
+
+### Error Strategy
+
+- **wire レベルの不整合**：新 variant `BackendUnavailable.WireMismatch` で表面化、 backend が Shutdown を送り、 reporter が 1 行通知、 fallback wrapper が subprocess へ
+- **Shutdown 送信失敗**：warn-log のみ、 build は継続。 `BackendUnavailable.WireMismatch` 戻り値は変えない
+- **既存の `BackendUnavailable.Other`**：precondition 失敗、 connect 失敗、 send 失敗等は **WireMismatch 経路には乗らない**（R1.5 の境界）
+- **`CompilationFailed` / `NoCommand`**：これまで通り fallback 対象外、 影響なし
+
+### Error Categories and Responses
+
+| カテゴリ | 該当 | 振る舞い |
+|----|----|----|
+| wire incompatibility | `FrameError.*` on receive、 unexpected reply variant | `WireMismatch(detail)` → Shutdown 送信 → reporter → 1 行 stderr → fallback |
+| Shutdown send failure | `connection.sendRequest(Shutdown)` の `Err(FrameError.*)` | `eprintln("warning: failed to send Shutdown to stale daemon: ...")` のみ、 build 続行 |
+| 他の `BackendUnavailable` | precondition / connect / send 既存 | 既存 `reportFallback` の generic warning |
+| `InternalMisuse` | sealed family の incoming variant 不整合等 | 既存どおり error-level log（kolt 自身のバグ） |
+
+### Monitoring
+
+- 観測可能性は stderr の通知 1 行のみ。 構造化ログ・テレメトリは対象外（kolt は CLI ツールで daemon ヘルス telemetry を持たない）
+- 同 invocation で 2 回目以降の WireMismatch が **silent** になるため、 デバッグ時のため backend 側で `eprintln` の trace を追加することは検討可（design 段階では追加しない、 必要なら follow-up issue）
+
+## Testing Strategy
+
+要件の AC を直接テスト項目に落とす。 既存の `DaemonCompilerBackendTest` 系統と `FallbackReporterTest` 系統に追加する形で書く（new file の必要は最小限）。
+
+### Unit Tests
+
+1. **`DaemonCompilerBackendTest`：FrameError.Malformed → WireMismatch + Shutdown 送信**（R1.1 / 1.2 / 2.1）
+   - `FakeConnection` の `reply = Err(FrameError.Malformed("..."))`
+   - 戻り値が `Err(BackendUnavailable.WireMismatch(...))` であること
+   - `FakeConnection.lastSent`（または専用フラグ）に `Message.Shutdown` が記録されていること
+2. **`DaemonCompilerBackendTest`：FrameError.{Eof,Truncated,Transport} → WireMismatch**（R1.1）
+   - 各 variant ごとに reply を Err にして上記同様
+3. **`DaemonCompilerBackendTest`：unexpected reply variant → WireMismatch + Shutdown**（R1.3 / 2.1）
+   - `reply = Ok(Message.Pong)` 等
+4. **`DaemonCompilerBackendTest`：Shutdown send failure → warn-log + 戻り値 WireMismatch**（R2.2）
+   - `FakeConnection.sendResult` を 2 回目だけ Err にする工夫、 stderr collector で warn-line 検証
+5. **`NativeDaemonBackendTest`：上記 4 項目の native ミラー**（R1.4）
+6. **`StaleDaemonNoticeTest`：emit は初回 true, 2 回目以降 false**（R3.2 / R4.3）
+   - reset 後再度 true になること
+7. **`FallbackReporterTest`：WireMismatch → 専用文言、 generic warning は出ない**（R3.1）
+8. **`NativeFallbackReporterTest`：上記 native ミラー**
+
+### Integration Tests
+
+9. **`StaleDaemonRecycleIT`：古い wire を返す fake daemon → 1 build 目で WireMismatch 通知 → 2 build 目で fresh spawn**（R5.1 end-to-end、 initial PR scope）
+   - ハーネスは既存 `MultiShapeDaemonTestCoverageIT` の env-gated パターンを踏襲し、 false-RED を回避
+   - fake daemon は `kolt.infra.net` の UnixSocket primitive を使い、 期待外 reply（例：JSON `{"type":"Pong"}` を `Compile` リクエストに返す）を書き戻す軽量 server を test fixture として実装
+   - assertion 観点：(1) 1 build 目の stderr に stale-daemon 通知 1 行が出ること、 (2) 1 build 目が subprocess fallback で正常完了すること、 (3) 2 build 目（fake server を停止した後の通常 daemon 起動）が fresh daemon 経路を通ること
+   - 親 kolt との実行時 path 切り分けは memory `feedback_bootstrap_gated_test.md` の bootstrap-gated パターンに従う
+
+### E2E / Manual
+
+10. dogfood：v0.18.0 の daemon を立てた状態で kolt を v0.18.1 に上げ、 `kolt build` を実行。 stderr 1 行出ること、 2 回目で daemon が新しく立つことを `kolt daemon stop` 経由で目視確認
+
+## Optional Sections
+
+### Migration Strategy
+
+破壊的変更なし。 `BackendUnavailable.WireMismatch` 追加は既存 caller（`isFallbackEligible`、 `formatCompileError`、 `reportFallback`、 `reportNativeFallback`）の when 網羅性を高めるための **追加** であり、 既存挙動を変えない。 ADR 0016 §5 / ADR 0024 §7 にこの新 variant の意味を 1〜2 行で追記する（task 内で実施）。
+
+### Performance & Scalability
+
+性能影響なし。 wire-mismatch は古い daemon が残っているときだけ発生する希少パスで、 通常時の compile flow には 1 行たりとも追加されない。 通知メッセージは `eprintln` 1 回で sub-millisecond。
+
+## Supporting References
+
+- gap analysis：`research.md` §3 (Option C) と §5 (Key decisions / Research items) を参照
+- 関連 ADR：ADR 0001 (Result vs exceptions)、 ADR 0016 §3/§5 (JVM daemon fallback policy)、 ADR 0024 §1/§7 (native daemon symmetry, fallback)
+- 関連 issue：#379 (本機能)、 #376 (precursor wire change)

--- a/.kiro/specs/379-auto-restart-stale-daemon/requirements.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/requirements.md
@@ -1,0 +1,77 @@
+# Requirements Document
+
+## Introduction
+
+#376 で daemon の wire 形式が変わったあと、 旧バージョンの daemon プロセスが UNIX socket を握ったまま生き残ると、 新しい kolt クライアントは reply を decode できず subprocess fallback に落ちる。 build 自体は成功するため一見気付かないが、 古い daemon は socket を解放しないので **以降の build も毎回 fallback** し、 daemon の高速化メリットが沈黙のうちに失われる。 ユーザーが手動で `kolt daemon stop` を打たない限り回復しない。
+
+本機能は、 kolt の native クライアントが「daemon からの reply を解釈できない」という事象を *precondition mismatch* として扱う動作を導入する。 具体的には、 best-effort で `Message.Shutdown` を送り、 ユーザーには stderr に 1 行だけ知らせ、 当該 build は既存の subprocess fallback で完了させる。 次回の `kolt build` / `kolt test` は通常通り fresh daemon を起動して走る。 JVM コンパイラ daemon と native コンパイラ daemon の両 backend で同じ振る舞いをする。
+
+## Boundary Context
+
+- **In scope**:
+  - daemon 由来の reply を解釈できない事象を検出するクライアント側の振る舞い（ JVM daemon backend と native daemon backend の両方）
+  - 当該 daemon への best-effort な `Message.Shutdown` 送信
+  - ユーザーへの stderr 1 行通知
+  - 当該 build を既存の subprocess fallback 経路で完走させること
+- **Out of scope**:
+  - daemon 側の変更（ `Shutdown` 処理は既存。本機能では daemon 側コードを触らない）
+  - 一般的な daemon ヘルス監視（ハング、 OOM、 応答遅延などは対象外）
+  - 当該 build を新規起動した daemon に対して再試行すること
+  - JVM 以外のクライアント経路（本機能は native client `kolt.kexe` のみ）
+- **Adjacent expectations**:
+  - 既存の `FallbackCompilerBackend` / `FallbackNativeCompilerBackend` は in-flight compile を本機能から従来通り受け取り、その動作は変えない
+  - 次回 invocation で fresh daemon を起こすのは、 既存の daemon spawn / socket precondition ロジックに依存する。 本機能は「古い daemon に socket を手放させる契機を作る」までを担当する
+  - 検出トリガーは #376 で生じた wire 互換性ギャップの *再発防止* ではなく、 *既に動いている古い daemon との遭遇時の救済* である
+
+## Requirements
+
+### Requirement 1: Detect daemon-reply incompatibility on the kolt native client
+
+**Objective:** As a kolt user who has just upgraded across a daemon wire change, I want the kolt native client to recognize when a still-running old daemon replies with something the new client cannot use, so that I am not silently locked into subprocess fallback for every subsequent build.
+
+#### Acceptance Criteria
+
+1. If the kolt native client cannot read a complete, well-formed reply frame from a connected daemon (e.g., truncated bytes, premature connection close, transport error mid-frame), then the kolt native client shall treat the situation as a daemon-reply incompatibility.
+2. If the kolt native client reads a complete reply frame but cannot deserialize its payload — whether the variant is unknown or the field shape does not match — then the kolt native client shall treat the situation as a daemon-reply incompatibility.
+3. If the kolt native client deserializes a reply variant that does not correspond to the request just sent on the same connection, then the kolt native client shall treat the situation as a daemon-reply incompatibility.
+4. The kolt native client shall apply this detection identically for builds that target a JVM compiler daemon and for builds that target a native compiler daemon.
+5. While operating against any other daemon error class (e.g., precondition failure, hang, OOM, transport timeout outside reply read), the kolt native client shall not enter the auto-recycle path defined by this feature.
+
+### Requirement 2: Best-effort daemon shutdown on incompatibility
+
+**Objective:** As a kolt user, I want the offending daemon to be asked to stop as part of detection, so that the next build can spawn a fresh daemon instead of contending for the same socket.
+
+#### Acceptance Criteria
+
+1. When the kolt native client classifies a reply as incompatible per Requirement 1, the kolt native client shall send `Message.Shutdown` to that daemon on the still-open connection before completing the in-flight compile.
+2. If the `Message.Shutdown` send itself fails (e.g., the connection has already been closed from the daemon side), then the kolt native client shall record a warn-level log entry describing the send failure and shall continue the in-flight compile.
+3. The kolt native client shall not wait synchronously for the daemon to confirm or perform shutdown before returning to the build orchestration path.
+
+### Requirement 3: Notify the user once per invocation
+
+**Objective:** As a kolt user whose build silently fell back to subprocess, I want a short stderr line on that build so that I can see why the daemon was bypassed and trust that my next build will be daemon-fast again.
+
+#### Acceptance Criteria
+
+1. When the kolt native client triggers the auto-recycle path during a `kolt build` / `kolt test` invocation, the kolt native client shall write exactly one stderr line that identifies the situation as a stale daemon being recycled.
+2. While a single `kolt build` / `kolt test` invocation is running, the kolt native client shall emit at most one such stderr line even if subsequent compiles within the same invocation would also encounter an incompatible reply.
+3. The kolt native client shall emit the stderr line regardless of the user's verbosity setting, because the message is a user-actionable signal rather than diagnostic output.
+
+### Requirement 4: Complete the in-flight compile via subprocess fallback
+
+**Objective:** As a kolt user, I want the build that triggered the recycle to still finish, so that the upgrade-related daemon mismatch costs me at most a one-time slow build, not a failed build.
+
+#### Acceptance Criteria
+
+1. When the kolt native client triggers the auto-recycle path, the kolt native client shall complete the in-flight compile via the existing subprocess fallback path.
+2. The kolt native client shall not retry the in-flight compile against a freshly spawned daemon.
+3. While a single `kolt build` / `kolt test` invocation is running, the kolt native client shall enter the auto-recycle path at most once. Subsequent compiles in the same invocation that meet Requirement 1 conditions shall fall back to subprocess silently without re-sending `Message.Shutdown` or re-emitting the stderr line.
+
+### Requirement 5: Subsequent invocations land on a fresh daemon
+
+**Objective:** As a kolt user, I want my next `kolt build` / `kolt test` after the recycle to run on a clean daemon, so that the cost of the upgrade-related mismatch is bounded to the single build that triggered the detection.
+
+#### Acceptance Criteria
+
+1. When the auto-recycle path has fired in invocation A and the offending daemon has released its socket before invocation B starts, the kolt native client shall spawn a fresh daemon during invocation B as it would when no daemon were running at all.
+2. If the offending daemon has not yet released its socket by the time invocation B starts, then the kolt native client shall behave as it does under the existing socket-occupied precondition. This feature shall not introduce new socket-occupied semantics.

--- a/.kiro/specs/379-auto-restart-stale-daemon/research.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/research.md
@@ -1,0 +1,229 @@
+# Gap Analysis — 379-auto-restart-stale-daemon
+
+要件と既存コードベースの突き合わせ。 設計判断のための情報整理であり最終決定ではない。
+
+## 1. Current State Investigation
+
+### 1.1 関連モジュールとレイヤ
+
+```
+kolt.cli.BuildCommands
+    └─ resolveCompilerBackend / resolveNativeCompilerBackend
+        └─ FallbackCompilerBackend(primary = daemonBackend, fallback = subprocessBackend, onFallback)
+            ├─ primary: DaemonCompilerBackend / NativeDaemonBackend
+            │     └─ DaemonConnection / NativeDaemonConnection
+            │           └─ FrameCodec.{writeFrame, readFrame}
+            │                 └─ FrameError(Eof|Truncated|Malformed|Transport)
+            └─ fallback: KotlincSubprocessBackend / NativeSubprocessBackend
+```
+
+JVM 側と native 側はパッケージごと **完全な並行構造**：
+
+| 役割 | JVM 側 | Native 側 |
+|---|---|---|
+| Backend | `kolt.build.daemon.DaemonCompilerBackend` | `kolt.build.nativedaemon.NativeDaemonBackend` |
+| Connection iface | `DaemonConnection` | `NativeDaemonConnection` |
+| Wire | `kolt.daemon.wire.{Message, FrameCodec, FrameError}` | `kolt.nativedaemon.wire.{Message, FrameCodec, FrameError}` |
+| Fallback wrapper | `FallbackCompilerBackend` | `FallbackNativeCompilerBackend` |
+| Error type | `CompileError` | `NativeCompileError` |
+| Reporter | `reportFallback` | `reportNativeFallback` |
+| Shutdown helper | `sendShutdown` (DaemonCommands.kt:139) | `sendNativeShutdown` (DaemonCommands.kt:153) |
+
+### 1.2 Compile flow（両 backend 共通）
+
+`DaemonCompilerBackend.compile()` (`src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt:72-89`)：
+
+```kotlin
+val connection = connectOrSpawn().getOrElse { return Err(it) }
+connection.use {
+  val sendErr = it.sendRequest(wire).getError()
+  if (sendErr != null) return Err(mapFrameErrorToSendError(sendErr))
+  val reply = it.receiveReply()
+  val replyErr = reply.getError()
+  if (replyErr != null) return Err(mapFrameErrorToReceiveError(replyErr))
+  return mapReplyToOutcome(reply.get()!!)
+}
+```
+
+`NativeDaemonBackend.compile()` (`src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt:76-93`) は構造が同一で、 wire 型が `kolt.nativedaemon.wire.Message` (`NativeCompile` / `NativeCompileResult` / `Ping` / `Pong` / `Shutdown`)。
+
+### 1.3 既存のエラーマッピング
+
+`mapFrameErrorToReceiveError(err: FrameError)` (`DaemonCompilerBackend.kt:225-237` および `NativeDaemonBackend.kt:235-247`)：
+
+| FrameError 変体 | 現行マッピング |
+|---|---|
+| `Eof` | `BackendUnavailable.Other("daemon closed connection before replying")` |
+| `Truncated(w, g)` | `BackendUnavailable.Other("truncated reply: wanted=$w got=$g")` |
+| `Malformed(reason)` | `BackendUnavailable.Other("malformed reply: $reason")` |
+| `Transport(cause)` | `BackendUnavailable.Other("receive failed: ${describe(cause)}")` |
+
+`mapReplyToOutcome(reply: Message)` (`DaemonCompilerBackend.kt:239-263` / `NativeDaemonBackend.kt:249-270`) は `Message.Compile|Ping|Pong|Shutdown`（期待外の variant）を `BackendUnavailable.Other("unexpected reply type: ${reply::class.simpleName}")` に落とす。
+
+`FrameCodec.readFrame()` (`src/nativeMain/kotlin/kolt/daemon/wire/FrameCodec.kt:56-88`) は内部で `kotlinx.serialization` の `decodeFromString` を呼び、 `SerializationException` を catch して `Malformed` に正規化する。 つまり「未知の variant」「フィールド不整合」もすべて `Malformed` として client に届く。
+
+### 1.4 `FallbackCompilerBackend` 経路
+
+`src/nativeMain/kotlin/kolt/build/FallbackCompilerBackend.kt:14-20`：
+
+```kotlin
+override fun compile(request): Result<CompileOutcome, CompileError> {
+  val primaryResult = primary.compile(request)
+  val primaryError = primaryResult.getError() ?: return primaryResult
+  if (!isFallbackEligible(primaryError)) return Err(primaryError)
+  onFallback(primaryError)
+  return fallback.compile(request)
+}
+```
+
+`isFallbackEligible` は `BackendUnavailable.*` と `InternalMisuse` を true、 `CompilationFailed` / `NoCommand` を false。 すなわち上記の「malformed reply」「unexpected reply type」全部が **fallback-eligible** で、 現状は subprocess に静かに fallback している。
+
+`onFallback = ::reportFallback` (`BuildCommands.kt:1462,1504`)。 `reportFallback` (`FallbackReporter.kt:6-24`) は variant 別に "warning: compiler daemon unavailable (..), falling back to subprocess compile" を 1 行 stderr に出す。 つまり **`Malformed` を含む wire 系の不整合でもユーザは generic な "daemon unavailable" 警告しか見ない**。
+
+### 1.5 既存の Shutdown 送信経路
+
+`kolt daemon stop` 用：
+
+- `sendShutdown(socketPath)` (`DaemonCommands.kt:139-147`) — **新規** に `UnixSocket.connect(path)` してから `JvmFrameCodec.writeFrame(socket, JvmMessage.Shutdown)`、close
+- `sendNativeShutdown(socketPath)` (`DaemonCommands.kt:153-161`) — 同じ shape
+
+これらは **socket path から再接続** する設計。 #379 の要件 (R2.1: "on the still-open connection") は **すでに開いている `DaemonConnection` 上で** Shutdown を送る必要があり、 既存ヘルパーはそのまま流用できない。
+
+ただし `DaemonConnection.sendRequest(message)` は `Message` を任意に投げられるので、 `DaemonConnection` 上に薄い `sendShutdown()` を生やすか、 backend 内で既存の `sendRequest(Message.Shutdown)` を直に呼ぶだけで足りる。
+
+### 1.6 Backend 構築点
+
+`BuildCommands.kt:1459-1463 / 1501-1505`：
+
+```kotlin
+return FallbackCompilerBackend(
+  primary = daemonBackendFactory(setup, pluginJars),
+  fallback = subprocessBackend,
+  onFallback = ::reportFallback,
+)
+```
+
+新しい "auto-recycle" のシグナルは `onFallback` の引数を経由して `reportFallback` に届ける、 もしくは `FallbackCompilerBackend` の外側に新たな decorator を被せる、 どちらの選択肢もここから差し込める。
+
+## 2. Requirement-to-Asset Map
+
+| Req | 必要な能力 | 既存資産 | Gap |
+|---|---|---|---|
+| R1.1 frame-layer 失敗検出 | `FrameError.*` の判定 | `FrameError.{Eof,Truncated,Malformed,Transport}` 既存（FrameCodec.kt:12-20） | ✅ 既存 |
+| R1.2 payload deserialize 失敗 | 失敗時の通知 | `FrameCodec.readFrame` が `SerializationException` を catch して `Malformed` に正規化 | ✅ 既存（`Malformed` に集約） |
+| R1.3 reply variant mismatch | request 送信種別と reply variant の対応検査 | `mapReplyToOutcome` で「期待外 variant」を `BackendUnavailable.Other("unexpected reply type: ...")` に落としている | 🔶 Constraint：今は string detail に埋もれていて型で識別できない |
+| R1.4 JVM / native 両 backend で同一 | 並行構造あり | `kolt.build.{daemon,nativedaemon}` の二重実装 | ✅ ミラー対応で OK |
+| R1.5 他 daemon error class は対象外 | precondition 失敗等は別経路 | `formatDaemonPreconditionWarning` 経路は `subprocessBackend` を直返し（BuildCommands.kt:1448-1450） | ✅ 既存（混線しない） |
+| R2.1 開いた connection 上で `Shutdown` 送信 | live connection への `Message.Shutdown` write | `DaemonConnection.sendRequest(Message)` は任意の `Message` を投げられる | 🚧 Missing：使い方を backend `compile()` 内に追加 |
+| R2.2 send 失敗時に warn-log し継続 | warn-level logger | `eprintln` のみ（dedicated logger なし） | 🔶 Constraint：log facility は eprintln + ステータスメッセージで十分 |
+| R2.3 同期待ちしない | – | 既に `connection.use { ... }` で抜けるパターン | ✅ 既存 |
+| R3.1 stderr 1 行通知 | dedicated message | `reportFallback` が generic warning を 1 行出している | 🚧 Missing：stale-daemon 専用メッセージと既存 generic warning の二重出力抑止 |
+| R3.2 1 invocation 1 回 | 一度限りガード | invocation-スコープの状態は現在ない（CLI は 1 process / 1 invocation） | 🚧 Missing：process-global flag または higher-level scope が必要 |
+| R3.3 verbosity に関わらず出す | – | `eprintln` は無条件出力 | ✅ 既存（verbosity システム自体未実装） |
+| R4.1 in-flight build を fallback で完走 | `FallbackCompilerBackend` 経由 | 既存どおり | ✅ 既存 |
+| R4.2 fresh daemon に対する再試行はしない | – | `FallbackCompilerBackend` は subprocess 1 回のみ | ✅ 既存 |
+| R4.3 invocation 中 1 回限り | once-per-invocation ガード | R3.2 と同じ機構 | 🚧 Missing |
+| R5.1 次回起動で fresh daemon | 既存 `connectOrSpawn` の再試行で実現 | `connectOrSpawn` は ENOENT/ECONNREFUSED を retry し socket がなければ spawn | ✅ 既存（古い daemon が socket 解放 → 自動 spawn） |
+| R5.2 socket-occupied 時の挙動 | 既存挙動を維持 | `mapFatalConnectError` 経路 | ✅ 既存 |
+
+### Complexity 信号
+
+- **Algorithmic**: 単純（型ベースの分岐 + 1 回限りガード）
+- **External integration**: なし（daemon side は不変）
+- **Workflow**: 既存の compile flow に 1 ステップ（Shutdown 送信）追加 + 1 つの新エラー variant
+- **Cross-cutting**: 「invocation 中 1 回限り」のガードがやや交差的
+
+## 3. Implementation Approach Options
+
+### Option A: 新エラー variant + backend 内インライン Shutdown
+
+新しく `CompileError.BackendUnavailable.WireMismatch(reason)` と `NativeCompileError.BackendUnavailable.WireMismatch(reason)` を追加し、 `mapFrameErrorToReceiveError` と `mapReplyToOutcome` で wire 系の失敗（`FrameError.*` の全変体 + 期待外 variant）をこの新 variant に振り替える。 backend の `compile()` 内で当該 variant を返す **直前に** `connection.sendRequest(Message.Shutdown)` を best-effort 実行（戻り値は warn-log するだけ）。 `FallbackReporter` を WireMismatch だけ別メッセージ（stale daemon 通知）に分岐させる。 once-per-invocation ガードは `reportFallback` 側の process-global flag。
+
+**変更ファイル想定**:
+- `kolt/build/CompilerBackend.kt` / `kolt/build/NativeCompilerBackend.kt`（variant 追加 + `isFallbackEligible` map）
+- `kolt/build/daemon/DaemonCompilerBackend.kt` / `kolt/build/nativedaemon/NativeDaemonBackend.kt`（mapFrameErrorToReceiveError / mapReplyToOutcome 拡張、 Shutdown 送信ステップ）
+- `kolt/build/FallbackReporter.kt` / `kolt/build/NativeFallbackReporter.kt`（WireMismatch 分岐 + 1 回限りガード）
+- 新規 test: `DaemonCompilerBackendWireMismatchTest`, `NativeDaemonBackendWireMismatchTest`, `FallbackReporterStaleDaemonTest` ほか
+
+**Trade-offs**:
+- ✅ wire-mismatch シグナルが Result chain に乗るので test と将来の telemetry が容易
+- ✅ JVM/native の対称性を保つ
+- ✅ 既存 `FallbackCompilerBackend` を変更しない（onFallback 経由でメッセージは出る）
+- ❌ sealed error 階層に新 variant を追加（小規模だが API surface 変更）
+- ❌ once-per-invocation flag が process-global（ただし CLI は 1 process / 1 invocation なので自然）
+
+### Option B: 外側 decorator `RecyclingDaemonBackend`
+
+`DaemonCompilerBackend` をラップする `RecyclingDaemonBackend(inner, recycleSink)` を新設。 `inner.compile()` を呼び、 結果が `BackendUnavailable.Other` で detail が wire-mismatch を示すなら別途 socket を再接続し `Shutdown` を投げる。 `DaemonCompilerBackend` 自体は無改造。
+
+**Trade-offs**:
+- ✅ エラー階層を変えない
+- ❌ live connection への access がない → 別接続を張るしかなく R2.1 の "still-open connection" 文言とずれる（古い daemon は read-side が壊れていても accept が生きている可能性が高いが保証はない）
+- ❌ 「wire mismatch」を `BackendUnavailable.Other.detail` の文字列マッチで検出することになり脆弱
+- ❌ 結局 once-per-invocation ガードを別途必要とする
+
+### Option C（recommended）: Hybrid — backend 内に変位 variant + reporter 側に policy
+
+Option A の core（新 variant + backend 内インライン Shutdown）に、 once-per-invocation ガードは `reportFallback` / `reportNativeFallback` の中で持つ（あるいは小さな `RecycleNotifier` モジュールに切り出す）。 backend は **検出と Shutdown 送信** だけを担い、 **ユーザ通知の重複抑止** は reporter 層が責任を持つ。 この分離は steering structure.md の "Explicit fallback policy" 原則とも整合する（fallback policy は明示的に上層に集約）。
+
+**Trade-offs**:
+- ✅ 検出（backend）／通知ポリシー（reporter）／状態（reporter or 専用モジュール）の責務分離
+- ✅ unit test しやすい（backend は Result の variant、 reporter は flag を観測）
+- ✅ Option A 比で追加するピースは小さい
+- ❌ Option A より動く部品は 1 段多い
+
+## 4. Effort & Risk
+
+- **Effort**: **M (3–7 days)**
+  - 6–8 ファイルへの並行変更（JVM/native）+ 同数の新規テスト
+  - 新エラー variant の sealed 階層への追加とエラーマッピング 4 箇所の更新
+  - `FallbackReporter` / `NativeFallbackReporter` の 1 回限りガード
+  - end-to-end IT は既存 `MultiShapeDaemonTestCoverageIT` パターン流用で書けるが古い daemon を擬する fixture 整備が必要
+
+- **Risk**: **Low**
+  - 既存パターンの拡張のみ（sealed variant 追加、 並行ミラー、 fallback wrapper）
+  - 新規依存なし、 daemon-side コード触らず、 socket protocol 不変
+  - 最悪のリグレッション = 「auto-recycle が発火しない」だけ → 既存 fallback で通常 build 成功
+
+## 5. Recommendations for Design Phase
+
+### Preferred approach
+**Option C** — backend 内で wire-mismatch を新エラー variant として表面化し、 reporter 層で 1 回限りガードと専用 stderr メッセージを担当する。
+
+### Key decisions（design 段階で確定すべき）
+1. **新 variant の名前と shape**：`CompileError.BackendUnavailable.WireMismatch(kind: Kind, detail: String)` か単純な `WireMismatch(detail: String)` か。 `kind = Frame|Payload|VariantMismatch` を持たせると test が見通し良くなる
+2. **`DaemonConnection.sendShutdown()` を生やすか、 既存 `sendRequest(Message.Shutdown)` を直接呼ぶか**：前者は意図が明確、 後者は API surface が小さい
+3. **Once-per-invocation ガードの置き場所**：
+   - `reportFallback` 内に `private var emitted = false`（最も小さい）
+   - 専用 `RecycleNotifier` シングルトン（テスト分離に有利）
+   - `FallbackCompilerBackend` のコンストラクタ引数で渡す（DI 的、 でも policy が wrapper に漏れる）
+4. **stale-daemon stderr 文言**：既存 `reportFallback` は "warning: compiler daemon unavailable, falling back to subprocess compile"。 新メッセージは「古い daemon を見つけたので restart する」「今回の build は subprocess」という 2 点を 1 行で。 例： `warning: stale compiler daemon detected (<reason>), recycled — this build runs as subprocess; the next build will spawn a fresh daemon` の前後で短縮検討
+5. **既存 generic fallback warning の抑止**：`WireMismatch` のときは generic 警告を出さず stale-daemon メッセージだけ。 同 invocation の 2 回目以降の WireMismatch は両方とも silent
+6. **テスト戦略**：
+   - unit: backend が WireMismatch 時に `connection.sendRequest(Message.Shutdown)` を呼ぶこと、 send 失敗時も build を続行すること（FakeConnection 拡張）
+   - unit: reporter が 1 invocation で 1 回しかメッセージを出さないこと（flag 注入）
+   - IT: 既存 `MultiShapeDaemonTestCoverageIT` / `DaemonIntegrationTest` 系統に「古い wire を返す fake daemon を立てて kolt build → stderr 検査」を追加検討（ただし複雑化するなら unit + 限定的 IT で十分）
+
+### Research items to carry forward
+- **Once-per-invocation ガードを process-global flag で済ませる正当性**：kolt CLI が 1 process / 1 invocation である事実を ADR/コメントとして固定するか、 構造化されたスコープを導入するか
+- **`MultiShapeDaemonTestCoverageIT` で stale-daemon 経路をどこまで再現できるか**：既存ハーネスは fresh daemon 前提で組まれているため、 古いバージョンの jar を差し込む or fake daemon server を別途立てる手立てが必要
+- **`WireMismatch.kind` を持たせた場合、 `mapReplyToOutcome` の "unexpected reply type" を `Kind.VariantMismatch` に分類するか、 別変位として保つか**：要件 R1.3 はあくまで "treat as incompatibility" なので一括でよいが、 telemetry 余地は残しておく価値がある
+- **ADR 0016 / ADR 0024 の更新範囲**：本変更は §7 "fallback" 周りの policy を踏み込むので、 ADR 末尾に "Wire-mismatch auto-recycle" 節を追記する価値がある
+
+---
+
+## Design Synthesis Outcomes (2026-05-05)
+
+### 1. Generalization
+- 5 つの requirement は「detection (R1) → action (R2) → notification (R3) → disposition (R4) → continuity (R5)」の同一 lifecycle として表現できる。 design では各 phase を 1 component が担い、 横断 state（once-per-invocation flag）だけ単独 module 化（`StaleDaemonNotice`）
+- JVM/native 並行 backend は wire 型の sealed family が異なるため共通化せず、 既存の対称ミラーで一貫させる（ADR 0024 §1 の方針踏襲）
+
+### 2. Build vs. Adopt
+- **Adopt**：`Message.Shutdown` 送信は既存 `connection.sendRequest(Message)` を再利用、 path 経由再接続の `sendShutdown` ヘルパーは目的が異なるため流用しない
+- **Adopt**：`isFallbackEligible(BackendUnavailable) -> true` は既存網羅で WireMismatch も自動カバー、 追加分岐不要
+- **Build**：`StaleDaemonNotice` は最小 module（flag + emit + reset）として新設。 既存 reporter に flag 直書きする案も検討したが、 JVM/native 両 reporter から共有されるため独立 module の方が test/責務とも明快
+
+### 3. Simplification
+- `WireMismatch.Kind = Frame|Payload|VariantMismatch` の sealed sub-hierarchy は **採らず**、 単一 `WireMismatch(detail: String)` で十分。 detail 文字列は既存 `Other(detail)` と互換の人間可読形式でテスト時に substring 検証できる。 telemetry が必要になれば pre-v1 で variant 化可能
+- `DaemonConnection.sendShutdown()` 専用メソッドは追加せず、 既存 `sendRequest(Message.Shutdown)` を直接呼ぶ。 API surface 最小化 + 意図はコメントで明示
+- 新規 decorator class（`RecyclingDaemonBackend` など）は採らず、 backend 内インライン処理で完結。 sealed error 階層を通じて signal が伝わるので decorator の indirection は冗長

--- a/.kiro/specs/379-auto-restart-stale-daemon/spec.json
+++ b/.kiro/specs/379-auto-restart-stale-daemon/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "379-auto-restart-stale-daemon",
+  "created_at": "2026-05-05T16:59:29Z",
+  "updated_at": "2026-05-06T00:34:39Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
@@ -1,0 +1,88 @@
+# Implementation Plan
+
+## 1. Foundation: WireMismatch error variant
+
+- [ ] 1.1 (P) JVM 側エラー sealed 階層に WireMismatch 変位を追加
+  - `BackendUnavailable` sealed に `WireMismatch(detail: String)` を sibling として追加し、 既存の `Other` 等とは別 case として扱えるようにする
+  - `formatCompileError` で WireMismatch を `"error: $context wire mismatch: ${detail}"` 形式に整形する分岐を追加
+  - `isFallbackEligible` は `BackendUnavailable` 一括で true を返すため変更不要だが、 `when` 網羅性が新 variant でも維持されることをコンパイル通過で確認
+  - 観測可能な完了状態：JVM 側 unit test で `WireMismatch("any-detail")` が `BackendUnavailable` 系として扱われ、 `formatCompileError` から期待文字列が返ること
+  - _Requirements: 1.1, 1.2, 1.3, 1.5_
+  - _Boundary: kolt.build.CompilerBackend (JVM error sealed)_
+
+- [ ] 1.2 (P) Native 側エラー sealed 階層に WireMismatch 変位を追加
+  - `NativeCompileError.BackendUnavailable` sealed に `WireMismatch(detail: String)` を追加
+  - `formatNativeCompileError` で同形の分岐を追加
+  - `isNativeFallbackEligible` は変更不要、 網羅性のみ確認
+  - 観測可能な完了状態：native 側 unit test で `WireMismatch` が JVM 側と対称な振る舞いを示すこと
+  - _Requirements: 1.4_
+  - _Boundary: kolt.build.NativeCompilerBackend (native error sealed)_
+
+## 2. Core: detection, Shutdown send, notification module
+
+- [ ] 2.1 (P) JVM compiler daemon backend で wire 不整合を検出し Shutdown を best-effort 送信
+  - `mapFrameErrorToReceiveError` で受信側 `FrameError.{Eof, Truncated, Malformed, Transport}` を WireMismatch に振替（送信側 mapping は不変）
+  - `mapReplyToOutcome` で期待外 reply variant（`Compile` / `Ping` / `Pong` / `Shutdown` 受信）を WireMismatch に振替
+  - `compile()` 内で「戻り値が WireMismatch の場合のみ、 同じ open connection 上で `Message.Shutdown` を送信」する経路を追加。 `connection.use { ... }` を抜ける前に行い、 send が失敗したら `eprintln` で warn-line を 1 行出して続行
+  - 戻り値の早期 return は維持しつつ、 戻り値計算を一旦変数に束ねてから Shutdown 送信→return の順で組み立てる（design.md の pseudocode を踏襲）
+  - 観測可能な完了状態：FakeConnection を使った unit test で、 (a) FrameError.* 全 4 変位が `Err(BackendUnavailable.WireMismatch)` を返す、 (b) 期待外 variant が同じく WireMismatch を返す、 (c) WireMismatch 経路で `lastSent` 末尾が `Message.Shutdown` になっている、 (d) Shutdown 送信が失敗するスタブで stderr に warn-line が出て build が続行する、 の 4 項目すべて green
+  - _Requirements: 1.1, 1.2, 1.3, 1.5, 2.1, 2.2, 2.3_
+  - _Boundary: kolt.build.daemon.DaemonCompilerBackend_
+  - _Depends: 1.1_
+
+- [ ] 2.2 (P) Native compiler daemon backend で同様の検出と Shutdown 送信
+  - `kolt.build.nativedaemon.NativeDaemonBackend` で 2.1 と同形の改修を施す（wire 型は `kolt.nativedaemon.wire.Message.Shutdown`）
+  - 観測可能な完了状態：native 版 unit test で 2.1 と同 4 項目が green
+  - _Requirements: 1.4, 2.1, 2.2, 2.3_
+  - _Boundary: kolt.build.nativedaemon.NativeDaemonBackend_
+  - _Depends: 1.2_
+
+- [ ] 2.3 (P) StaleDaemonNotice モジュールで compile-pass スコープ 1 回限り通知を実装
+  - 新規 `kolt.build.StaleDaemonNotice` を `object` として作成。 `emit(label, detail, sink)` と `reset()` を public API として公開（`reset` は test だけでなく caller integration からも呼ばれるため public）
+  - `emit` は flag が false のとき stderr に `"warning: stale {label} detected ({detail}); recycling — this build runs as subprocess, the next build will spawn a fresh daemon"` を 1 行書き、 flag を立てて true を返す。 すでに true なら何も書かず false を返す
+  - `reset()` は flag を false に戻す
+  - 観測可能な完了状態：unit test で (a) reset 直後の最初の emit が true を返し sink に 1 行届く、 (b) 同 cycle の 2 回目 emit は false を返し sink には何も追加されない、 (c) reset を挟むと再び true で 1 行届く、 が green
+  - _Requirements: 3.1, 3.2, 3.3, 4.3_
+  - _Boundary: kolt.build.StaleDaemonNotice_
+
+## 3. Wiring: reporter dispatch and entry-point reset
+
+- [ ] 3.1 (P) JVM fallback reporter から StaleDaemonNotice にディスパッチ
+  - `reportFallback` の `when (err)` に `is CompileError.BackendUnavailable.WireMismatch` 分岐を **既存 `BackendUnavailable.Other` より前** に追加し、 `StaleDaemonNotice.emit("compiler daemon", err.detail, sink)` を呼ぶ
+  - 既存の generic warning（`Other` 含む）は WireMismatch には流れないことを確認
+  - 観測可能な完了状態：FallbackReporterTest に「WireMismatch を渡すと stale-daemon 通知が出て、 generic warning が出ない」「他の variant 渡し時は従来どおりの文言が出る」の 2 ケースを追加し green
+  - _Requirements: 3.1_
+  - _Boundary: kolt.build.FallbackReporter_
+  - _Depends: 1.1, 2.3_
+
+- [ ] 3.2 (P) Native fallback reporter から StaleDaemonNotice にディスパッチ
+  - `reportNativeFallback` に同形の分岐を追加（label は `"native compiler daemon"`）
+  - 観測可能な完了状態：NativeFallbackReporterTest に対応 2 ケースを追加し green
+  - _Requirements: 3.1_
+  - _Boundary: kolt.build.NativeFallbackReporter_
+  - _Depends: 1.2, 2.3_
+
+- [ ] 3.3 (P) BuildCommands の compile pass entry に StaleDaemonNotice.reset() を挿入
+  - `doBuildInner` / `doTestInner` の compile invocation 直前で `StaleDaemonNotice.reset()` を 1 回呼ぶ。 watch 経路も同関数を再呼び出しする構造のため、 同関数冒頭に reset を置けば single-shot と watch 両方をカバーする想定。 実装時にコールパスを grep で確認し、 別経路があればそこにも reset を挿入する
+  - reset は idempotent なので「念のため複数箇所に呼ぶ」コストは無視できる。 ただし対称性のため 1 関数につき 1 箇所に統一する
+  - 観測可能な完了状態：`grep -n "StaleDaemonNotice.reset" src/nativeMain/kotlin/kolt/cli/BuildCommands.kt` で挿入箇所が確認でき、 各 compile invocation の前に reset が走ることが目視 + 後続 IT (4.1) で検証される
+  - _Requirements: 3.2, 4.3_
+  - _Boundary: kolt.cli.BuildCommands_
+  - _Depends: 2.3_
+
+## 4. Validation: end-to-end test and ADR
+
+- [ ] 4.1 古い daemon 模擬による end-to-end IT
+  - `src/nativeTest/kotlin/kolt/cli/StaleDaemonRecycleIT.kt` を新規作成し、 既存 `MultiShapeDaemonTestCoverageIT` の env-gated パターン（false-RED 回避）と memory `feedback_bootstrap_gated_test.md` の bootstrap-gated パターンを踏襲
+  - `kolt.infra.net` の UnixSocket primitive で、 受信した Compile に対し `Message.Pong` 等の期待外 reply を JSON 直書きで返すフェイク server を fixture として実装
+  - シナリオ：(1) フェイク server を立てて socket path に bind、 (2) その path を daemon socket として `kolt build` を 1 回走らせる、 (3) フェイク server を停止し、 (4) もう 1 回 `kolt build` を走らせる
+  - 観測可能な完了状態：assertion で (a) 1 回目の stderr に stale-daemon 通知が 1 行ある、 (b) 1 回目の build が exit code 0 で完了している（subprocess fallback で）、 (c) 2 回目の build が「fresh daemon を spawn した」または「subprocess に再 fallback した」のいずれか（フェイク server が解放した socket 状態に依存して `connectOrSpawn` の通常経路を通ることを確認）、 (d) 2 回目の stderr に stale-daemon 通知が出ない、 の 4 点が green
+  - _Requirements: 4.1, 4.2, 5.1, 5.2_
+  - _Boundary: kolt.cli (integration test only)_
+
+- [ ] 4.2 (P) ADR 0016 と ADR 0024 に Wire-mismatch auto-recycle 節を追記
+  - ADR 0016（JVM daemon fallback policy）末尾に「Wire-mismatch auto-recycle」短節（5–7 行）を追加し、 #379 の動機・トリガー・once-per-compile-pass policy・Shutdown best-effort を 1 文ずつまとめる
+  - ADR 0024（native daemon symmetry）にも同節を追加（JVM 版を参照する形で短く）
+  - 観測可能な完了状態：両 ADR の末尾に該当節が存在し、 既存の「fallback policy」記述（§5 / §7）から 1 行で参照されていること
+  - _Requirements: 1.5, 2.1, 3.1, 4.3_
+  - _Boundary: docs/adr_

--- a/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
@@ -55,7 +55,7 @@
   - _Boundary: kolt.build.FallbackReporter_
   - _Depends: 1.1, 2.3_
 
-- [ ] 3.2 (P) Native fallback reporter から StaleDaemonNotice にディスパッチ
+- [x] 3.2 (P) Native fallback reporter から StaleDaemonNotice にディスパッチ
   - `reportNativeFallback` に同形の分岐を追加（label は `"native compiler daemon"`）
   - 観測可能な完了状態：NativeFallbackReporterTest に対応 2 ケースを追加し green
   - _Requirements: 3.1_

--- a/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
@@ -2,7 +2,7 @@
 
 ## 1. Foundation: WireMismatch error variant
 
-- [ ] 1.1 (P) JVM 側エラー sealed 階層に WireMismatch 変位を追加
+- [x] 1.1 (P) JVM 側エラー sealed 階層に WireMismatch 変位を追加
   - `BackendUnavailable` sealed に `WireMismatch(detail: String)` を sibling として追加し、 既存の `Other` 等とは別 case として扱えるようにする
   - `formatCompileError` で WireMismatch を `"error: $context wire mismatch: ${detail}"` 形式に整形する分岐を追加
   - `isFallbackEligible` は `BackendUnavailable` 一括で true を返すため変更不要だが、 `when` 網羅性が新 variant でも維持されることをコンパイル通過で確認

--- a/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
@@ -80,7 +80,7 @@
   - _Requirements: 4.1, 4.2, 5.1, 5.2_
   - _Boundary: kolt.cli (integration test only)_
 
-- [ ] 4.2 (P) ADR 0016 と ADR 0024 に Wire-mismatch auto-recycle 節を追記
+- [x] 4.2 (P) ADR 0016 と ADR 0024 に Wire-mismatch auto-recycle 節を追記
   - ADR 0016（JVM daemon fallback policy）末尾に「Wire-mismatch auto-recycle」短節（5–7 行）を追加し、 #379 の動機・トリガー・once-per-compile-pass policy・Shutdown best-effort を 1 文ずつまとめる
   - ADR 0024（native daemon symmetry）にも同節を追加（JVM 版を参照する形で短く）
   - 観測可能な完了状態：両 ADR の末尾に該当節が存在し、 既存の「fallback policy」記述（§5 / §7）から 1 行で参照されていること

--- a/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
@@ -20,7 +20,7 @@
 
 ## 2. Core: detection, Shutdown send, notification module
 
-- [ ] 2.1 (P) JVM compiler daemon backend で wire 不整合を検出し Shutdown を best-effort 送信
+- [x] 2.1 (P) JVM compiler daemon backend で wire 不整合を検出し Shutdown を best-effort 送信
   - `mapFrameErrorToReceiveError` で受信側 `FrameError.{Eof, Truncated, Malformed, Transport}` を WireMismatch に振替（送信側 mapping は不変）
   - `mapReplyToOutcome` で期待外 reply variant（`Compile` / `Ping` / `Pong` / `Shutdown` 受信）を WireMismatch に振替
   - `compile()` 内で「戻り値が WireMismatch の場合のみ、 同じ open connection 上で `Message.Shutdown` を送信」する経路を追加。 `connection.use { ... }` を抜ける前に行い、 send が失敗したら `eprintln` で warn-line を 1 行出して続行

--- a/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
@@ -62,7 +62,7 @@
   - _Boundary: kolt.build.NativeFallbackReporter_
   - _Depends: 1.2, 2.3_
 
-- [ ] 3.3 (P) BuildCommands の compile pass entry に StaleDaemonNotice.reset() を挿入
+- [x] 3.3 (P) BuildCommands の compile pass entry に StaleDaemonNotice.reset() を挿入
   - `doBuildInner` / `doTestInner` の compile invocation 直前で `StaleDaemonNotice.reset()` を 1 回呼ぶ。 watch 経路も同関数を再呼び出しする構造のため、 同関数冒頭に reset を置けば single-shot と watch 両方をカバーする想定。 実装時にコールパスを grep で確認し、 別経路があればそこにも reset を挿入する
   - reset は idempotent なので「念のため複数箇所に呼ぶ」コストは無視できる。 ただし対称性のため 1 関数につき 1 箇所に統一する
   - 観測可能な完了状態：`grep -n "StaleDaemonNotice.reset" src/nativeMain/kotlin/kolt/cli/BuildCommands.kt` で挿入箇所が確認でき、 各 compile invocation の前に reset が走ることが目視 + 後続 IT (4.1) で検証される

--- a/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
@@ -72,7 +72,7 @@
 
 ## 4. Validation: end-to-end test and ADR
 
-- [ ] 4.1 古い daemon 模擬による end-to-end IT
+- [x] 4.1 古い daemon 模擬による end-to-end IT
   - `src/nativeTest/kotlin/kolt/cli/StaleDaemonRecycleIT.kt` を新規作成し、 既存 `MultiShapeDaemonTestCoverageIT` の env-gated パターン（false-RED 回避）と memory `feedback_bootstrap_gated_test.md` の bootstrap-gated パターンを踏襲
   - `kolt.infra.net` の UnixSocket primitive で、 受信した Compile に対し `Message.Pong` 等の期待外 reply を JSON 直書きで返すフェイク server を fixture として実装
   - シナリオ：(1) フェイク server を立てて socket path に bind、 (2) その path を daemon socket として `kolt build` を 1 回走らせる、 (3) フェイク server を停止し、 (4) もう 1 回 `kolt build` を走らせる

--- a/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
@@ -47,7 +47,7 @@
 
 ## 3. Wiring: reporter dispatch and entry-point reset
 
-- [ ] 3.1 (P) JVM fallback reporter から StaleDaemonNotice にディスパッチ
+- [x] 3.1 (P) JVM fallback reporter から StaleDaemonNotice にディスパッチ
   - `reportFallback` の `when (err)` に `is CompileError.BackendUnavailable.WireMismatch` 分岐を **既存 `BackendUnavailable.Other` より前** に追加し、 `StaleDaemonNotice.emit("compiler daemon", err.detail, sink)` を呼ぶ
   - 既存の generic warning（`Other` 含む）は WireMismatch には流れないことを確認
   - 観測可能な完了状態：FallbackReporterTest に「WireMismatch を渡すと stale-daemon 通知が出て、 generic warning が出ない」「他の variant 渡し時は従来どおりの文言が出る」の 2 ケースを追加し green

--- a/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
@@ -30,7 +30,7 @@
   - _Boundary: kolt.build.daemon.DaemonCompilerBackend_
   - _Depends: 1.1_
 
-- [ ] 2.2 (P) Native compiler daemon backend で同様の検出と Shutdown 送信
+- [x] 2.2 (P) Native compiler daemon backend で同様の検出と Shutdown 送信
   - `kolt.build.nativedaemon.NativeDaemonBackend` で 2.1 と同形の改修を施す（wire 型は `kolt.nativedaemon.wire.Message.Shutdown`）
   - 観測可能な完了状態：native 版 unit test で 2.1 と同 4 項目が green
   - _Requirements: 1.4, 2.1, 2.2, 2.3_

--- a/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
@@ -10,7 +10,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 1.5_
   - _Boundary: kolt.build.CompilerBackend (JVM error sealed)_
 
-- [ ] 1.2 (P) Native 側エラー sealed 階層に WireMismatch 変位を追加
+- [x] 1.2 (P) Native 側エラー sealed 階層に WireMismatch 変位を追加
   - `NativeCompileError.BackendUnavailable` sealed に `WireMismatch(detail: String)` を追加
   - `formatNativeCompileError` で同形の分岐を追加
   - `isNativeFallbackEligible` は変更不要、 網羅性のみ確認

--- a/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
+++ b/.kiro/specs/379-auto-restart-stale-daemon/tasks.md
@@ -37,7 +37,7 @@
   - _Boundary: kolt.build.nativedaemon.NativeDaemonBackend_
   - _Depends: 1.2_
 
-- [ ] 2.3 (P) StaleDaemonNotice モジュールで compile-pass スコープ 1 回限り通知を実装
+- [x] 2.3 (P) StaleDaemonNotice モジュールで compile-pass スコープ 1 回限り通知を実装
   - 新規 `kolt.build.StaleDaemonNotice` を `object` として作成。 `emit(label, detail, sink)` と `reset()` を public API として公開（`reset` は test だけでなく caller integration からも呼ばれるため public）
   - `emit` は flag が false のとき stderr に `"warning: stale {label} detected ({detail}); recycling — this build runs as subprocess, the next build will spawn a fresh daemon"` を 1 行書き、 flag を立てて true を返す。 すでに true なら何も書かず false を返す
   - `reset()` は flag を false に戻す

--- a/docs/adr/0016-warm-jvm-compiler-daemon.md
+++ b/docs/adr/0016-warm-jvm-compiler-daemon.md
@@ -14,6 +14,7 @@ date: 2026-04-14
 - The daemon is the default compile backend from day one (`FallbackCompilerBackend(DaemonCompilerBackend, SubprocessCompilerBackend)`). `--no-daemon` bypasses it per invocation. Only `BackendUnavailable` / `InternalMisuse` trigger fallback; `CompilationFailed` does not. (§5)
 - Cold-spawn connect budget is 10s (was 3s through 2026-04-30). Budget covers cold spawn only — warm reconnects short-circuit before the retry loop and are unaffected. (§5)
 - `kolt-compiler-daemon/` is an independent Gradle build included via `includeBuild`, not a subproject, to allow separate distribution per ADR 0018. (§6)
+- A reply the client cannot decode (`FrameError.*`, payload deserialize failure, or unexpected reply variant) raises `BackendUnavailable.WireMismatch`; the client sends `Message.Shutdown` best-effort, prints one stderr line via `StaleDaemonNotice`, falls back to subprocess for the in-flight compile, and lets the next invocation spawn a fresh daemon (introduced in #379). (§7)
 
 ## Context and Problem Statement
 
@@ -95,9 +96,15 @@ The opt-in plan (ship as `kolt build --daemon`, flip default after spikes #88–
 
 Cold-spawn connect budget: `DaemonCompilerBackend.CONNECT_TOTAL_BUDGET_MS = 10_000`. The 3s default shipped with #14 false-positively fell back on cold-cache CI (#310): the §2 cold-start figure (~2.6s) plus the WSL2/CI 9p stat-storm outlier (~3.3s, see Benchmark notes) routinely cleared 3s before the daemon listened. The retry loop runs only after a spawn — warm reconnects succeed on the first `connector()` call and never enter `retryConnect()` — so the headroom is invisible to dev-loop builds. Cost: when the daemon is genuinely broken, fallback now takes up to ~10s per build; this is paid once because subsequent builds still re-spawn rather than wait, but the failure mode is louder than before.
 
+Wire-incompatibility from a stale daemon left over across a kolt upgrade is treated as a distinct fallback case — see §7.
+
 ### §6 Independent Gradle build via includeBuild
 
 `kolt-compiler-daemon/` is an independent Gradle build included from the root via `includeBuild`, not `include`. `./gradlew build` rebuilds both via an explicit `dependsOn`; `DaemonJarResolver.kt` never sees a stale jar. This boundary enables the distribution plan in ADR 0018 and keeps the native/JVM build split clean.
+
+### §7 Wire-mismatch auto-recycle (introduced in #379)
+
+A daemon reply the client cannot consume — frame decode failure (`FrameError.{Eof,Truncated,Malformed,Transport}`), payload deserialize failure, or a reply variant that does not match the request — is classified as `CompileError.BackendUnavailable.WireMismatch(detail)`, a sibling of `BackendUnavailable.Other` under the same fallback-eligible umbrella defined in §5. On classification, the client sends `Message.Shutdown` on the still-open connection before closing it; if that send itself fails, `eprintln` writes one warn line and the build continues. `StaleDaemonNotice` writes one stderr line per compile pass identifying the stale daemon, suppressing duplicates within the same `kolt build` / `kolt test` invocation. The in-flight compile completes through the existing `FallbackCompilerBackend` subprocess path; the next invocation reaches `connectOrSpawn` normally and spawns a fresh daemon once the recycled one has released its socket. No daemon-side change is required.
 
 ## Benchmark results — Scaling (#96, 2026-04-14)
 

--- a/docs/adr/0024-native-compiler-daemon.md
+++ b/docs/adr/0024-native-compiler-daemon.md
@@ -13,6 +13,7 @@ date: 2026-04-19
 - Wire protocol reuses ADR 0016's frame format (u32 length + JSON) with a new `NativeCompile { args: List<String> }` / `NativeCompileResult { exitCode: Int, stderr: String }` message pair. Args are passed as a flat list; no structured compilation API exists for native. (§4)
 - Both build stages (library and link) go through the daemon; the client calls it twice per build as it currently calls `konanc` twice. (§5)
 - IC flags (`-Xenable-incremental-compilation`, `-Xic-cache-dir`) pass through as konanc args; the daemon does not manage IC state. (§6)
+- A reply the client cannot decode raises `NativeCompileError.BackendUnavailable.WireMismatch`; the client sends `Message.Shutdown` best-effort, prints one stderr line via `StaleDaemonNotice`, falls back to the `konanc` subprocess for the in-flight stage, and lets the next invocation spawn a fresh daemon (introduced in #379). (§9)
 
 ## Context and Problem Statement
 
@@ -97,9 +98,15 @@ IC flags (`-Xenable-incremental-compilation`, `-Xic-cache-dir`) are part of the 
 
 `FallbackCompilerBackend(NativeDaemonBackend, NativeSubprocessBackend)` — same pattern as ADR 0016 §5. On any daemon failure (connect refused, spawn failure, unexpected disconnect), the client falls back to the existing `konanc` subprocess path. `CompileError.CompilationFailed` does not trigger fallback.
 
+Wire-incompatibility from a stale daemon left over across a kolt upgrade is treated as a distinct fallback case — see §9.
+
 ### §8 Daemon jar
 
 `kolt-native-daemon/` is a new module: an independent Gradle build included via `includeBuild`, same pattern as `kolt-compiler-daemon/`.
+
+### §9 Wire-mismatch auto-recycle (introduced in #379)
+
+A daemon reply the client cannot consume — frame decode failure (`FrameError.{Eof,Truncated,Malformed,Transport}`), payload deserialize failure, or a reply variant that does not match the request — is classified as `NativeCompileError.BackendUnavailable.WireMismatch(detail)`, a sibling under the same fallback-eligible umbrella as §7. On classification, the client sends `kolt.nativedaemon.wire.Message.Shutdown` on the still-open connection before closing it; if that send itself fails, `eprintln` writes one warn line and the build continues. `StaleDaemonNotice` writes one stderr line per compile pass identifying the stale native daemon, suppressing duplicates within the same `kolt build` / `kolt test` invocation. The in-flight stage (library or link) completes through `FallbackNativeCompilerBackend` against the existing `konanc` subprocess path; the next invocation reaches `connectOrSpawn` normally and spawns a fresh native daemon once the recycled one has released its socket. No daemon-side change is required, and the once-per-pass notification is shared with the JVM daemon path so a mixed JVM+native build emits at most one stale-daemon line per pass.
 
 ## Consequences
 

--- a/src/nativeMain/kotlin/kolt/build/CompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/CompilerBackend.kt
@@ -43,6 +43,11 @@ sealed interface CompileError {
 
     data object PopenFailed : BackendUnavailable
 
+    // Receive-side wire incompatibility (frame error or unexpected reply variant).
+    // Carries fallback eligibility from BackendUnavailable; the auto-recycle path
+    // owns Shutdown send and stale-daemon notification (ADR 0016 §5).
+    data class WireMismatch(val detail: String) : BackendUnavailable
+
     data class Other(val detail: String) : BackendUnavailable
   }
 
@@ -93,6 +98,8 @@ fun formatCompileError(error: CompileError, context: String): String =
     is CompileError.BackendUnavailable.PopenFailed -> "error: failed to start $context process"
     is CompileError.BackendUnavailable.WaitFailed -> "error: failed waiting for $context process"
     is CompileError.BackendUnavailable.SignalKilled -> "error: $context process was killed"
+    is CompileError.BackendUnavailable.WireMismatch ->
+      "error: $context wire mismatch: ${error.detail}"
     is CompileError.BackendUnavailable.Other ->
       "error: $context backend unavailable: ${error.detail}"
     is CompileError.NoCommand -> "error: no command to execute"

--- a/src/nativeMain/kotlin/kolt/build/FallbackReporter.kt
+++ b/src/nativeMain/kotlin/kolt/build/FallbackReporter.kt
@@ -10,6 +10,11 @@ fun reportFallback(err: CompileError, sink: (String) -> Unit = ::eprintln) {
     is CompileError.BackendUnavailable.SignalKilled,
     is CompileError.BackendUnavailable.PopenFailed ->
       sink("warning: compiler daemon unavailable, falling back to subprocess compile")
+    is CompileError.BackendUnavailable.WireMismatch ->
+      // stub branch overridden by reporter task
+      sink(
+        "warning: compiler daemon unavailable (${err.detail}), falling back to subprocess compile"
+      )
     is CompileError.BackendUnavailable.Other ->
       sink(
         "warning: compiler daemon unavailable (${err.detail}), falling back to subprocess compile"

--- a/src/nativeMain/kotlin/kolt/build/FallbackReporter.kt
+++ b/src/nativeMain/kotlin/kolt/build/FallbackReporter.kt
@@ -11,10 +11,7 @@ fun reportFallback(err: CompileError, sink: (String) -> Unit = ::eprintln) {
     is CompileError.BackendUnavailable.PopenFailed ->
       sink("warning: compiler daemon unavailable, falling back to subprocess compile")
     is CompileError.BackendUnavailable.WireMismatch ->
-      // stub branch overridden by reporter task
-      sink(
-        "warning: compiler daemon unavailable (${err.detail}), falling back to subprocess compile"
-      )
+      StaleDaemonNotice.emit("compiler daemon", err.detail, sink)
     is CompileError.BackendUnavailable.Other ->
       sink(
         "warning: compiler daemon unavailable (${err.detail}), falling back to subprocess compile"

--- a/src/nativeMain/kotlin/kolt/build/NativeCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/NativeCompilerBackend.kt
@@ -41,6 +41,11 @@ sealed interface NativeCompileError {
 
     data object PopenFailed : BackendUnavailable
 
+    // Receive-side wire incompatibility (frame error or unexpected reply variant).
+    // Carries fallback eligibility from BackendUnavailable; the auto-recycle path
+    // owns Shutdown send and stale-daemon notification (ADR 0024 §7).
+    data class WireMismatch(val detail: String) : BackendUnavailable
+
     data class Other(val detail: String) : BackendUnavailable
   }
 
@@ -68,6 +73,8 @@ fun formatNativeCompileError(error: NativeCompileError, context: String): String
     is NativeCompileError.BackendUnavailable.WaitFailed ->
       "error: failed waiting for $context process"
     is NativeCompileError.BackendUnavailable.SignalKilled -> "error: $context process was killed"
+    is NativeCompileError.BackendUnavailable.WireMismatch ->
+      "error: $context wire mismatch: ${error.detail}"
     is NativeCompileError.BackendUnavailable.Other ->
       "error: $context backend unavailable: ${error.detail}"
     is NativeCompileError.NoCommand -> "error: no command to execute"

--- a/src/nativeMain/kotlin/kolt/build/NativeFallbackReporter.kt
+++ b/src/nativeMain/kotlin/kolt/build/NativeFallbackReporter.kt
@@ -17,10 +17,7 @@ fun reportNativeFallback(err: NativeCompileError, sink: (String) -> Unit = ::epr
     is NativeCompileError.BackendUnavailable.PopenFailed ->
       sink("warning: native compiler daemon unavailable, falling back to subprocess compile")
     is NativeCompileError.BackendUnavailable.WireMismatch ->
-      // stub branch overridden by reporter task
-      sink(
-        "warning: native compiler daemon unavailable (${err.detail}), falling back to subprocess compile"
-      )
+      StaleDaemonNotice.emit("native compiler daemon", err.detail, sink)
     is NativeCompileError.BackendUnavailable.Other ->
       sink(
         "warning: native compiler daemon unavailable (${err.detail}), falling back to subprocess compile"

--- a/src/nativeMain/kotlin/kolt/build/NativeFallbackReporter.kt
+++ b/src/nativeMain/kotlin/kolt/build/NativeFallbackReporter.kt
@@ -16,6 +16,11 @@ fun reportNativeFallback(err: NativeCompileError, sink: (String) -> Unit = ::epr
     is NativeCompileError.BackendUnavailable.SignalKilled,
     is NativeCompileError.BackendUnavailable.PopenFailed ->
       sink("warning: native compiler daemon unavailable, falling back to subprocess compile")
+    is NativeCompileError.BackendUnavailable.WireMismatch ->
+      // stub branch overridden by reporter task
+      sink(
+        "warning: native compiler daemon unavailable (${err.detail}), falling back to subprocess compile"
+      )
     is NativeCompileError.BackendUnavailable.Other ->
       sink(
         "warning: native compiler daemon unavailable (${err.detail}), falling back to subprocess compile"

--- a/src/nativeMain/kotlin/kolt/build/StaleDaemonNotice.kt
+++ b/src/nativeMain/kotlin/kolt/build/StaleDaemonNotice.kt
@@ -1,0 +1,23 @@
+package kolt.build
+
+import kolt.infra.eprintln
+
+// Once-per-compile-pass guard for stale-daemon stderr notice.
+// Caller (BuildCommands) calls reset() at each compile pass entry; reporters call emit().
+object StaleDaemonNotice {
+  private var emitted: Boolean = false
+
+  fun emit(label: String, detail: String, sink: (String) -> Unit = ::eprintln): Boolean {
+    if (emitted) return false
+    emitted = true
+    sink(
+      "warning: stale $label detected ($detail); recycling — " +
+        "this build runs as subprocess, the next build will spawn a fresh daemon"
+    )
+    return true
+  }
+
+  fun reset() {
+    emitted = false
+  }
+}

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
@@ -13,6 +13,7 @@ import kolt.daemon.wire.FrameCodec
 import kolt.daemon.wire.FrameError
 import kolt.daemon.wire.Message
 import kolt.infra.ProcessError
+import kolt.infra.eprintln
 import kolt.infra.net.UnixSocket
 import kolt.infra.net.UnixSocketError
 import kolt.infra.spawnDetached
@@ -45,6 +46,7 @@ internal constructor(
   private val clockMs: () -> Long = ::monotonicMs,
   private val sleeper: (Int) -> Unit = defaultSleeper,
   private val onSpawn: () -> Unit = {},
+  private val warnSink: (String) -> Unit = ::eprintln,
 ) : CompilerBackend {
 
   constructor(
@@ -83,8 +85,20 @@ internal constructor(
       if (sendErr != null) return Err(mapFrameErrorToSendError(sendErr))
       val reply = it.receiveReply()
       val replyErr = reply.getError()
-      if (replyErr != null) return Err(mapFrameErrorToReceiveError(replyErr))
-      return mapReplyToOutcome(reply.get()!!)
+      val mapped: Result<CompileOutcome, CompileError> =
+        if (replyErr != null) Err(mapFrameErrorToReceiveError(replyErr))
+        else mapReplyToOutcome(reply.get()!!)
+
+      // Wire-mismatch auto-recycle (ADR 0016 §5): nudge the stale daemon to release
+      // its socket so the next invocation lands on a fresh one. Best-effort — a send
+      // failure is logged but does not change the returned error.
+      val errored = mapped.getError()
+      if (errored is CompileError.BackendUnavailable.WireMismatch) {
+        it.sendRequest(Message.Shutdown).getError()?.let { shutdownErr ->
+          warnSink("warning: failed to send Shutdown to stale daemon: $shutdownErr")
+        }
+      }
+      return mapped
     }
   }
 
@@ -225,15 +239,15 @@ internal fun mapFrameErrorToSendError(err: FrameError): CompileError =
 internal fun mapFrameErrorToReceiveError(err: FrameError): CompileError =
   when (err) {
     is FrameError.Eof ->
-      CompileError.BackendUnavailable.Other("daemon closed connection before replying")
+      CompileError.BackendUnavailable.WireMismatch("daemon closed connection before replying")
     is FrameError.Truncated ->
-      CompileError.BackendUnavailable.Other(
+      CompileError.BackendUnavailable.WireMismatch(
         "truncated reply: wanted=${err.wantedBytes} got=${err.gotBytes}"
       )
     is FrameError.Malformed ->
-      CompileError.BackendUnavailable.Other("malformed reply: ${err.reason}")
+      CompileError.BackendUnavailable.WireMismatch("malformed reply: ${err.reason}")
     is FrameError.Transport ->
-      CompileError.BackendUnavailable.Other("receive failed: ${describe(err.cause)}")
+      CompileError.BackendUnavailable.WireMismatch("receive failed: ${describe(err.cause)}")
   }
 
 internal fun mapReplyToOutcome(reply: Message): Result<CompileOutcome, CompileError> =
@@ -258,7 +272,9 @@ internal fun mapReplyToOutcome(reply: Message): Result<CompileOutcome, CompileEr
     is Message.Pong,
     is Message.Shutdown ->
       Err(
-        CompileError.BackendUnavailable.Other("unexpected reply type: ${reply::class.simpleName}")
+        CompileError.BackendUnavailable.WireMismatch(
+          "unexpected reply type: ${reply::class.simpleName}"
+        )
       )
   }
 

--- a/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
@@ -16,6 +16,7 @@ import kolt.build.NativeCompilerBackend
 import kolt.build.daemon.isRetryableConnectError
 import kolt.build.daemon.monotonicMs
 import kolt.infra.ProcessError
+import kolt.infra.eprintln
 import kolt.infra.net.UnixSocket
 import kolt.infra.net.UnixSocketError
 import kolt.infra.spawnDetached
@@ -51,6 +52,7 @@ internal constructor(
   private val clockMs: () -> Long = ::monotonicMs,
   private val sleeper: (Int) -> Unit = defaultNativeDaemonSleeper,
   private val onSpawn: () -> Unit = {},
+  private val warnSink: (String) -> Unit = ::eprintln,
 ) : NativeCompilerBackend {
 
   constructor(
@@ -87,8 +89,20 @@ internal constructor(
       if (sendErr != null) return Err(mapFrameErrorToSendError(sendErr))
       val reply = it.receiveReply()
       val replyErr = reply.getError()
-      if (replyErr != null) return Err(mapFrameErrorToReceiveError(replyErr))
-      return mapReplyToOutcome(reply.get()!!)
+      val mapped: Result<NativeCompileOutcome, NativeCompileError> =
+        if (replyErr != null) Err(mapFrameErrorToReceiveError(replyErr))
+        else mapReplyToOutcome(reply.get()!!)
+
+      // Wire-mismatch auto-recycle (ADR 0024 §7): nudge the stale daemon to release
+      // its socket so the next invocation lands on a fresh one. Best-effort — a send
+      // failure is logged but does not change the returned error.
+      val errored = mapped.getError()
+      if (errored is NativeCompileError.BackendUnavailable.WireMismatch) {
+        it.sendRequest(Message.Shutdown).getError()?.let { shutdownErr ->
+          warnSink("warning: failed to send Shutdown to stale daemon: $shutdownErr")
+        }
+      }
+      return mapped
     }
   }
 
@@ -235,15 +249,17 @@ internal fun mapFrameErrorToSendError(err: FrameError): NativeCompileError =
 internal fun mapFrameErrorToReceiveError(err: FrameError): NativeCompileError =
   when (err) {
     is FrameError.Eof ->
-      NativeCompileError.BackendUnavailable.Other("native daemon closed connection before replying")
+      NativeCompileError.BackendUnavailable.WireMismatch(
+        "native daemon closed connection before replying"
+      )
     is FrameError.Truncated ->
-      NativeCompileError.BackendUnavailable.Other(
+      NativeCompileError.BackendUnavailable.WireMismatch(
         "truncated reply: wanted=${err.wantedBytes} got=${err.gotBytes}"
       )
     is FrameError.Malformed ->
-      NativeCompileError.BackendUnavailable.Other("malformed reply: ${err.reason}")
+      NativeCompileError.BackendUnavailable.WireMismatch("malformed reply: ${err.reason}")
     is FrameError.Transport ->
-      NativeCompileError.BackendUnavailable.Other("receive failed: ${describe(err.cause)}")
+      NativeCompileError.BackendUnavailable.WireMismatch("receive failed: ${describe(err.cause)}")
   }
 
 internal fun mapReplyToOutcome(reply: Message): Result<NativeCompileOutcome, NativeCompileError> =
@@ -263,7 +279,7 @@ internal fun mapReplyToOutcome(reply: Message): Result<NativeCompileOutcome, Nat
     is Message.Pong,
     is Message.Shutdown ->
       Err(
-        NativeCompileError.BackendUnavailable.Other(
+        NativeCompileError.BackendUnavailable.WireMismatch(
           "unexpected reply type: ${reply::class.simpleName}"
         )
       )

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -368,6 +368,7 @@ private fun doBuildInner(
   profile: Profile,
   quietUpToDate: Boolean = false,
 ): Result<BuildResult, Int> {
+  StaleDaemonNotice.reset()
   val startMark = TimeSource.Monotonic.markNow()
   val config =
     loadProjectConfig().getOrElse {
@@ -1001,6 +1002,7 @@ private fun doTestInner(
   cliSysProps: List<Pair<String, String>>,
   lock: LockHandle,
 ): Result<Unit, Int> {
+  StaleDaemonNotice.reset()
   val config =
     loadProjectConfig().getOrElse {
       return Err(it)

--- a/src/nativeTest/kotlin/kolt/build/CompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/CompilerBackendTest.kt
@@ -1,0 +1,37 @@
+package kolt.build
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class CompilerBackendWireMismatchTest {
+
+  @Test
+  fun wireMismatchIsBackendUnavailable() {
+    val variant: CompileError = CompileError.BackendUnavailable.WireMismatch("foo")
+    assertIs<CompileError.BackendUnavailable>(variant)
+  }
+
+  @Test
+  fun wireMismatchIsFallbackEligible() {
+    assertTrue(isFallbackEligible(CompileError.BackendUnavailable.WireMismatch("foo")))
+  }
+
+  @Test
+  fun formatCompileErrorRendersWireMismatchDetail() {
+    val message = formatCompileError(CompileError.BackendUnavailable.WireMismatch("foo"), "compile")
+    assertTrue(message.contains("wire mismatch"), "expected 'wire mismatch' in: $message")
+    assertTrue(message.contains("foo"), "expected detail 'foo' in: $message")
+  }
+
+  @Test
+  fun formatCompileErrorWireMismatchMatchesTemplate() {
+    val message =
+      formatCompileError(
+        CompileError.BackendUnavailable.WireMismatch("malformed reply"),
+        "compilation",
+      )
+    assertEquals("error: compilation wire mismatch: malformed reply", message)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/build/FallbackReporterTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/FallbackReporterTest.kt
@@ -1,10 +1,23 @@
 package kolt.build
 
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FallbackReporterTest {
+
+  @BeforeTest
+  fun setUp() {
+    StaleDaemonNotice.reset()
+  }
+
+  @AfterTest
+  fun tearDown() {
+    StaleDaemonNotice.reset()
+  }
 
   private fun capture(err: CompileError): List<String> {
     val out = mutableListOf<String>()
@@ -18,6 +31,31 @@ class FallbackReporterTest {
     assertEquals(1, messages.size)
     assertTrue(messages.single().startsWith("warning: "))
     assertTrue(messages.single().contains("connect refused"))
+  }
+
+  @Test
+  fun wireMismatchRoutesThroughStaleDaemonNotice() {
+    val messages = capture(CompileError.BackendUnavailable.WireMismatch("malformed reply"))
+    assertEquals(1, messages.size, "WireMismatch should produce exactly one stderr line")
+    val line = messages.single()
+    assertTrue(line.contains("stale"), "expected stale-daemon wording, got: $line")
+    assertTrue(line.contains("compiler daemon"), "expected label 'compiler daemon', got: $line")
+    assertTrue(line.contains("malformed reply"), "expected detail 'malformed reply', got: $line")
+    assertFalse(
+      line.contains("warning: compiler daemon unavailable"),
+      "WireMismatch should not fall through to the generic warning, got: $line",
+    )
+  }
+
+  @Test
+  fun backendUnavailableOtherStillEmitsLegacyGenericWarning() {
+    val messages = capture(CompileError.BackendUnavailable.Other("foo"))
+    assertEquals(1, messages.size)
+    val line = messages.single()
+    assertEquals(
+      "warning: compiler daemon unavailable (foo), falling back to subprocess compile",
+      line,
+    )
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/build/NativeCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/NativeCompilerBackendTest.kt
@@ -1,7 +1,9 @@
 package kolt.build
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 // Pins `isNativeFallbackEligible` — the single point of truth for which
@@ -44,5 +46,37 @@ class NativeCompilerBackendTest {
   fun noCommandIsNotFallbackEligible() {
     // If there's no konanc binary to fall back to, retrying is pointless.
     assertFalse(isNativeFallbackEligible(NativeCompileError.NoCommand))
+  }
+}
+
+class NativeCompilerBackendWireMismatchTest {
+
+  @Test
+  fun wireMismatchIsBackendUnavailable() {
+    val variant: NativeCompileError = NativeCompileError.BackendUnavailable.WireMismatch("foo")
+    assertIs<NativeCompileError.BackendUnavailable>(variant)
+  }
+
+  @Test
+  fun wireMismatchIsFallbackEligible() {
+    assertTrue(isNativeFallbackEligible(NativeCompileError.BackendUnavailable.WireMismatch("foo")))
+  }
+
+  @Test
+  fun formatNativeCompileErrorRendersWireMismatchDetail() {
+    val message =
+      formatNativeCompileError(NativeCompileError.BackendUnavailable.WireMismatch("foo"), "compile")
+    assertTrue(message.contains("wire mismatch"), "expected 'wire mismatch' in: $message")
+    assertTrue(message.contains("foo"), "expected detail 'foo' in: $message")
+  }
+
+  @Test
+  fun formatNativeCompileErrorWireMismatchMatchesTemplate() {
+    val message =
+      formatNativeCompileError(
+        NativeCompileError.BackendUnavailable.WireMismatch("malformed reply"),
+        "compilation",
+      )
+    assertEquals("error: compilation wire mismatch: malformed reply", message)
   }
 }

--- a/src/nativeTest/kotlin/kolt/build/NativeFallbackReporterTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/NativeFallbackReporterTest.kt
@@ -1,10 +1,23 @@
 package kolt.build
 
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class NativeFallbackReporterTest {
+
+  @BeforeTest
+  fun setUp() {
+    StaleDaemonNotice.reset()
+  }
+
+  @AfterTest
+  fun tearDown() {
+    StaleDaemonNotice.reset()
+  }
 
   private fun capture(err: NativeCompileError): List<String> {
     val messages = mutableListOf<String>()
@@ -33,6 +46,34 @@ class NativeFallbackReporterTest {
   fun backendUnavailableOtherIncludesDetail() {
     val out = capture(NativeCompileError.BackendUnavailable.Other("connect refused")).single()
     assertTrue(out.contains("connect refused"), "expected detail in warning: $out")
+  }
+
+  @Test
+  fun wireMismatchRoutesThroughStaleDaemonNotice() {
+    val messages = capture(NativeCompileError.BackendUnavailable.WireMismatch("malformed reply"))
+    assertEquals(1, messages.size, "WireMismatch should produce exactly one stderr line")
+    val line = messages.single()
+    assertTrue(line.contains("stale"), "expected stale-daemon wording, got: $line")
+    assertTrue(
+      line.contains("native compiler daemon"),
+      "expected label 'native compiler daemon', got: $line",
+    )
+    assertTrue(line.contains("malformed reply"), "expected detail 'malformed reply', got: $line")
+    assertFalse(
+      line.contains("warning: native compiler daemon unavailable"),
+      "WireMismatch should not fall through to the generic warning, got: $line",
+    )
+  }
+
+  @Test
+  fun backendUnavailableOtherStillEmitsLegacyGenericWarning() {
+    val messages = capture(NativeCompileError.BackendUnavailable.Other("foo"))
+    assertEquals(1, messages.size)
+    val line = messages.single()
+    assertEquals(
+      "warning: native compiler daemon unavailable (foo), falling back to subprocess compile",
+      line,
+    )
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/build/StaleDaemonNoticeTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/StaleDaemonNoticeTest.kt
@@ -1,0 +1,83 @@
+package kolt.build
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class StaleDaemonNoticeTest {
+
+  @BeforeTest
+  fun setUp() {
+    StaleDaemonNotice.reset()
+  }
+
+  @AfterTest
+  fun tearDown() {
+    StaleDaemonNotice.reset()
+  }
+
+  private fun MutableList<String>.collector(): (String) -> Unit = { add(it) }
+
+  @Test
+  fun firstEmitReturnsTrueAndWritesOneLine() {
+    val sink = mutableListOf<String>()
+    val emitted = StaleDaemonNotice.emit("compiler daemon", "malformed reply", sink.collector())
+
+    assertTrue(emitted, "first emit should return true")
+    assertEquals(1, sink.size, "first emit should write exactly one line")
+    val line = sink.single()
+    assertTrue(
+      line.contains("compiler daemon"),
+      "expected message to contain label 'compiler daemon', got: $line",
+    )
+    assertTrue(
+      line.contains("malformed reply"),
+      "expected message to contain detail 'malformed reply', got: $line",
+    )
+    assertTrue(
+      line.startsWith("warning: stale "),
+      "expected message to start with 'warning: stale ', got: $line",
+    )
+    assertTrue(line.contains("recycling"), "expected message to mention recycling, got: $line")
+  }
+
+  @Test
+  fun secondEmitReturnsFalseAndWritesNothing() {
+    val sink = mutableListOf<String>()
+    StaleDaemonNotice.emit("compiler daemon", "malformed reply", sink.collector())
+    val sizeAfterFirst = sink.size
+
+    val emittedAgain =
+      StaleDaemonNotice.emit("native compiler daemon", "other detail", sink.collector())
+
+    assertFalse(emittedAgain, "second emit should return false")
+    assertEquals(sizeAfterFirst, sink.size, "second emit should not append to sink")
+  }
+
+  @Test
+  fun resetRestoresFirstEmitBehaviour() {
+    val sink = mutableListOf<String>()
+    StaleDaemonNotice.emit("compiler daemon", "first detail", sink.collector())
+    StaleDaemonNotice.emit("compiler daemon", "ignored detail", sink.collector())
+    val sizeBeforeReset = sink.size
+
+    StaleDaemonNotice.reset()
+    val emittedAfterReset =
+      StaleDaemonNotice.emit("native compiler daemon", "second detail", sink.collector())
+
+    assertTrue(emittedAfterReset, "emit after reset should return true")
+    assertEquals(sizeBeforeReset + 1, sink.size, "emit after reset should write one new line")
+    val newLine = sink.last()
+    assertTrue(
+      newLine.contains("native compiler daemon"),
+      "expected new line to contain new label, got: $newLine",
+    )
+    assertTrue(
+      newLine.contains("second detail"),
+      "expected new line to contain new detail, got: $newLine",
+    )
+  }
+}

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
@@ -24,13 +24,21 @@ private class FakeConnection(
   val reply: Result<Message, FrameError> =
     Ok(Message.CompileResult(exitCode = 0, diagnostics = emptyList(), stdout = "", stderr = "")),
   val sendResult: Result<Unit, FrameError> = Ok(Unit),
+  // Per-call override: index 0 = first sendRequest, index 1 = second, etc.
+  // null entries fall through to sendResult.
+  private val sendResults: List<Result<Unit, FrameError>?> = emptyList(),
 ) : DaemonConnection {
-  var lastSent: Message? = null
+  val sent: MutableList<Message> = mutableListOf()
+  val lastSent: Message?
+    get() = sent.lastOrNull()
+
   var closed = false
 
   override fun sendRequest(message: Message): Result<Unit, FrameError> {
-    lastSent = message
-    return sendResult
+    val index = sent.size
+    sent += message
+    val override = sendResults.getOrNull(index)
+    return override ?: sendResult
   }
 
   override fun receiveReply(): Result<Message, FrameError> = reply
@@ -60,6 +68,7 @@ private fun newBackend(
   spawner: DaemonSpawner = { _, _ -> Ok(Unit) },
   clock: FakeClock = FakeClock(),
   pluginJars: Map<String, List<String>> = emptyMap(),
+  warnSink: (String) -> Unit = {},
 ): DaemonCompilerBackend =
   DaemonCompilerBackend(
     javaBin = "/opt/jdk/bin/java",
@@ -73,6 +82,7 @@ private fun newBackend(
     spawner = spawner,
     clockMs = clock.clock,
     sleeper = clock.sleeper,
+    warnSink = warnSink,
   )
 
 class DaemonCompilerBackendHappyPathTest {
@@ -481,16 +491,56 @@ class DaemonCompilerBackendConnectAndSpawnTest {
 class DaemonCompilerBackendReplyMappingTest {
 
   @Test
-  fun unexpectedReplyTypeIsMappedToBackendUnavailable() {
-    val fake = FakeConnection(reply = Ok(Message.Pong))
+  fun sendSerializationFailureIsInternalMisuse() {
+    val fake = FakeConnection(sendResult = Err(FrameError.Malformed("not serialisable")))
     val backend = newBackend(connector = { Ok(fake) })
     val err = assertNotNull(backend.compile(sampleRequest()).getError())
-    val unavailable = assertIs<CompileError.BackendUnavailable.Other>(err)
-    assertTrue(unavailable.detail.contains("Pong"))
+    val misuse = assertIs<CompileError.InternalMisuse>(err)
+    assertTrue(misuse.detail.contains("serialise"))
+  }
+}
+
+class DaemonCompilerBackendWireMismatchTest {
+
+  @Test
+  fun eofOnReadMapsToWireMismatchAndSendsShutdown() {
+    val fake = FakeConnection(reply = Err(FrameError.Eof))
+    val backend = newBackend(connector = { Ok(fake) })
+    val err = assertNotNull(backend.compile(sampleRequest()).getError())
+    val mismatch = assertIs<CompileError.BackendUnavailable.WireMismatch>(err)
+    assertTrue(
+      mismatch.detail.contains("daemon closed connection before replying"),
+      "detail mismatch: ${mismatch.detail}",
+    )
+    assertEquals(2, fake.sent.size, "expected Compile then Shutdown, got ${fake.sent}")
+    assertIs<Message.Compile>(fake.sent[0])
+    assertEquals(Message.Shutdown, fake.sent[1])
   }
 
   @Test
-  fun transportErrorOnReadMapsToBackendUnavailable() {
+  fun truncatedOnReadMapsToWireMismatchAndSendsShutdown() {
+    val fake = FakeConnection(reply = Err(FrameError.Truncated(wantedBytes = 16, gotBytes = 7)))
+    val backend = newBackend(connector = { Ok(fake) })
+    val err = assertNotNull(backend.compile(sampleRequest()).getError())
+    val mismatch = assertIs<CompileError.BackendUnavailable.WireMismatch>(err)
+    assertTrue(mismatch.detail.contains("truncated reply"), "detail mismatch: ${mismatch.detail}")
+    assertEquals(2, fake.sent.size)
+    assertEquals(Message.Shutdown, fake.sent[1])
+  }
+
+  @Test
+  fun malformedOnReadMapsToWireMismatchAndSendsShutdown() {
+    val fake = FakeConnection(reply = Err(FrameError.Malformed("unknown discriminator")))
+    val backend = newBackend(connector = { Ok(fake) })
+    val err = assertNotNull(backend.compile(sampleRequest()).getError())
+    val mismatch = assertIs<CompileError.BackendUnavailable.WireMismatch>(err)
+    assertTrue(mismatch.detail.contains("malformed reply"), "detail mismatch: ${mismatch.detail}")
+    assertEquals(2, fake.sent.size)
+    assertEquals(Message.Shutdown, fake.sent[1])
+  }
+
+  @Test
+  fun transportErrorOnReadMapsToWireMismatchAndSendsShutdown() {
     val fake =
       FakeConnection(
         reply =
@@ -498,25 +548,74 @@ class DaemonCompilerBackendReplyMappingTest {
       )
     val backend = newBackend(connector = { Ok(fake) })
     val err = assertNotNull(backend.compile(sampleRequest()).getError())
-    val unavailable = assertIs<CompileError.BackendUnavailable.Other>(err)
-    assertTrue(unavailable.detail.contains("Connection reset"))
+    val mismatch = assertIs<CompileError.BackendUnavailable.WireMismatch>(err)
+    assertTrue(mismatch.detail.contains("Connection reset"), "detail mismatch: ${mismatch.detail}")
+    assertEquals(2, fake.sent.size)
+    assertEquals(Message.Shutdown, fake.sent[1])
   }
 
   @Test
-  fun eofOnReadMapsToBackendUnavailable() {
-    val fake = FakeConnection(reply = Err(FrameError.Eof))
+  fun unexpectedReplyVariantMapsToWireMismatchAndSendsShutdown() {
+    val fake = FakeConnection(reply = Ok(Message.Pong))
     val backend = newBackend(connector = { Ok(fake) })
     val err = assertNotNull(backend.compile(sampleRequest()).getError())
-    assertIs<CompileError.BackendUnavailable.Other>(err)
+    val mismatch = assertIs<CompileError.BackendUnavailable.WireMismatch>(err)
+    assertTrue(
+      mismatch.detail.contains("unexpected reply type"),
+      "detail mismatch: ${mismatch.detail}",
+    )
+    assertTrue(mismatch.detail.contains("Pong"), "detail mismatch: ${mismatch.detail}")
+    assertEquals(2, fake.sent.size, "expected Compile then Shutdown, got ${fake.sent}")
+    assertEquals(Message.Shutdown, fake.sent[1])
   }
 
   @Test
-  fun sendSerializationFailureIsInternalMisuse() {
-    val fake = FakeConnection(sendResult = Err(FrameError.Malformed("not serialisable")))
-    val backend = newBackend(connector = { Ok(fake) })
+  fun shutdownSendFailureLogsWarningAndStillReturnsWireMismatch() {
+    val warnings = mutableListOf<String>()
+    val fake =
+      FakeConnection(
+        reply = Err(FrameError.Eof),
+        // First sendRequest (Compile) succeeds; second (Shutdown) fails.
+        sendResults =
+          listOf(Ok(Unit), Err(FrameError.Transport(UnixSocketError.SendFailed(32, "Broken pipe")))),
+      )
+    val backend = newBackend(connector = { Ok(fake) }, warnSink = { warnings += it })
     val err = assertNotNull(backend.compile(sampleRequest()).getError())
-    val misuse = assertIs<CompileError.InternalMisuse>(err)
-    assertTrue(misuse.detail.contains("serialise"))
+    assertIs<CompileError.BackendUnavailable.WireMismatch>(err)
+    assertEquals(2, fake.sent.size, "Shutdown send must still be attempted")
+    assertEquals(Message.Shutdown, fake.sent[1])
+    assertTrue(
+      warnings.any { it.contains("failed to send Shutdown") },
+      "expected warn-line about failed Shutdown send, got: $warnings",
+    )
+  }
+
+  @Test
+  fun happyPathDoesNotSendShutdown() {
+    val fake = FakeConnection()
+    val backend = newBackend(connector = { Ok(fake) })
+    backend.compile(sampleRequest())
+    assertEquals(1, fake.sent.size, "happy path must send only Compile, got ${fake.sent}")
+    assertIs<Message.Compile>(fake.sent[0])
+  }
+
+  @Test
+  fun compilationFailedDoesNotSendShutdown() {
+    val fake =
+      FakeConnection(
+        reply =
+          Ok(
+            Message.CompileResult(
+              exitCode = 1,
+              diagnostics = emptyList(),
+              stdout = "",
+              stderr = "compile error",
+            )
+          )
+      )
+    val backend = newBackend(connector = { Ok(fake) })
+    backend.compile(sampleRequest())
+    assertEquals(1, fake.sent.size, "compilation failure must not trigger Shutdown")
   }
 }
 

--- a/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
@@ -21,13 +21,21 @@ private class FakeConnection(
   val reply: Result<Message, FrameError> =
     Ok(Message.NativeCompileResult(exitCode = 0, stderr = "")),
   val sendResult: Result<Unit, FrameError> = Ok(Unit),
+  // Per-call override: index 0 = first sendRequest, index 1 = second, etc.
+  // null entries fall through to sendResult.
+  private val sendResults: List<Result<Unit, FrameError>?> = emptyList(),
 ) : NativeDaemonConnection {
-  var lastSent: Message? = null
+  val sent: MutableList<Message> = mutableListOf()
+  val lastSent: Message?
+    get() = sent.lastOrNull()
+
   var closed = false
 
   override fun sendRequest(message: Message): Result<Unit, FrameError> {
-    lastSent = message
-    return sendResult
+    val index = sent.size
+    sent += message
+    val override = sendResults.getOrNull(index)
+    return override ?: sendResult
   }
 
   override fun receiveReply(): Result<Message, FrameError> = reply
@@ -47,6 +55,7 @@ private fun newBackend(
   spawner: NativeDaemonSpawner = { _, _ -> Ok(Unit) },
   clock: FakeClock = FakeClock(),
   onSpawn: () -> Unit = {},
+  warnSink: (String) -> Unit = {},
 ): NativeDaemonBackend =
   NativeDaemonBackend(
     javaBin = "/opt/jdk/bin/java",
@@ -61,6 +70,7 @@ private fun newBackend(
     clockMs = clock.clock,
     sleeper = clock.sleeper,
     onSpawn = onSpawn,
+    warnSink = warnSink,
   )
 
 private val sampleArgs =
@@ -191,17 +201,6 @@ class NativeDaemonBackendHappyPathTest {
   }
 
   @Test
-  fun unexpectedReplyTypeBecomesBackendUnavailable() {
-    val fake = FakeConnection(reply = Ok(Message.Pong))
-    val backend = newBackend(connector = { Ok(fake) })
-
-    val err = backend.compile(sampleArgs).getError()
-
-    val unavailable = assertIs<NativeCompileError.BackendUnavailable.Other>(err)
-    assertTrue(unavailable.detail.contains("unexpected reply type"))
-  }
-
-  @Test
   fun sendErrorMalformedMapsToInternalMisuse() {
     val fake = FakeConnection(sendResult = Err(FrameError.Malformed("oversize body")))
     val backend = newBackend(connector = { Ok(fake) })
@@ -211,19 +210,116 @@ class NativeDaemonBackendHappyPathTest {
     val misuse = assertIs<NativeCompileError.InternalMisuse>(err)
     assertTrue(misuse.detail.contains("oversize body"))
   }
+}
+
+class NativeDaemonBackendWireMismatchTest {
 
   @Test
-  fun receiveErrorTransportMapsToBackendUnavailable() {
+  fun eofOnReadMapsToWireMismatchAndSendsShutdown() {
+    val fake = FakeConnection(reply = Err(FrameError.Eof))
+    val backend = newBackend(connector = { Ok(fake) })
+    val err = assertNotNull(backend.compile(sampleArgs).getError())
+    val mismatch = assertIs<NativeCompileError.BackendUnavailable.WireMismatch>(err)
+    assertTrue(
+      mismatch.detail.contains("native daemon closed connection before replying"),
+      "detail mismatch: ${mismatch.detail}",
+    )
+    assertEquals(2, fake.sent.size, "expected NativeCompile then Shutdown, got ${fake.sent}")
+    assertIs<Message.NativeCompile>(fake.sent[0])
+    assertEquals(Message.Shutdown, fake.sent[1])
+  }
+
+  @Test
+  fun truncatedOnReadMapsToWireMismatchAndSendsShutdown() {
+    val fake = FakeConnection(reply = Err(FrameError.Truncated(wantedBytes = 16, gotBytes = 7)))
+    val backend = newBackend(connector = { Ok(fake) })
+    val err = assertNotNull(backend.compile(sampleArgs).getError())
+    val mismatch = assertIs<NativeCompileError.BackendUnavailable.WireMismatch>(err)
+    assertTrue(mismatch.detail.contains("truncated reply"), "detail mismatch: ${mismatch.detail}")
+    assertEquals(2, fake.sent.size)
+    assertEquals(Message.Shutdown, fake.sent[1])
+  }
+
+  @Test
+  fun malformedOnReadMapsToWireMismatchAndSendsShutdown() {
+    val fake = FakeConnection(reply = Err(FrameError.Malformed("unknown discriminator")))
+    val backend = newBackend(connector = { Ok(fake) })
+    val err = assertNotNull(backend.compile(sampleArgs).getError())
+    val mismatch = assertIs<NativeCompileError.BackendUnavailable.WireMismatch>(err)
+    assertTrue(mismatch.detail.contains("malformed reply"), "detail mismatch: ${mismatch.detail}")
+    assertEquals(2, fake.sent.size)
+    assertEquals(Message.Shutdown, fake.sent[1])
+  }
+
+  @Test
+  fun transportErrorOnReadMapsToWireMismatchAndSendsShutdown() {
     val fake =
       FakeConnection(
         reply =
           Err(FrameError.Transport(UnixSocketError.RecvFailed(errno = 5, message = "I/O error")))
       )
     val backend = newBackend(connector = { Ok(fake) })
+    val err = assertNotNull(backend.compile(sampleArgs).getError())
+    val mismatch = assertIs<NativeCompileError.BackendUnavailable.WireMismatch>(err)
+    assertTrue(mismatch.detail.contains("I/O error"), "detail mismatch: ${mismatch.detail}")
+    assertEquals(2, fake.sent.size)
+    assertEquals(Message.Shutdown, fake.sent[1])
+  }
 
-    val err = backend.compile(sampleArgs).getError()
+  @Test
+  fun unexpectedReplyVariantMapsToWireMismatchAndSendsShutdown() {
+    val fake = FakeConnection(reply = Ok(Message.Pong))
+    val backend = newBackend(connector = { Ok(fake) })
+    val err = assertNotNull(backend.compile(sampleArgs).getError())
+    val mismatch = assertIs<NativeCompileError.BackendUnavailable.WireMismatch>(err)
+    assertTrue(
+      mismatch.detail.contains("unexpected reply type"),
+      "detail mismatch: ${mismatch.detail}",
+    )
+    assertTrue(mismatch.detail.contains("Pong"), "detail mismatch: ${mismatch.detail}")
+    assertEquals(2, fake.sent.size, "expected NativeCompile then Shutdown, got ${fake.sent}")
+    assertEquals(Message.Shutdown, fake.sent[1])
+  }
 
-    assertIs<NativeCompileError.BackendUnavailable.Other>(err)
+  @Test
+  fun shutdownSendFailureLogsWarningAndStillReturnsWireMismatch() {
+    val warnings = mutableListOf<String>()
+    val fake =
+      FakeConnection(
+        reply = Err(FrameError.Eof),
+        // First sendRequest (NativeCompile) succeeds; second (Shutdown) fails.
+        sendResults =
+          listOf(Ok(Unit), Err(FrameError.Transport(UnixSocketError.SendFailed(32, "Broken pipe")))),
+      )
+    val backend = newBackend(connector = { Ok(fake) }, warnSink = { warnings += it })
+    val err = assertNotNull(backend.compile(sampleArgs).getError())
+    assertIs<NativeCompileError.BackendUnavailable.WireMismatch>(err)
+    assertEquals(2, fake.sent.size, "Shutdown send must still be attempted")
+    assertEquals(Message.Shutdown, fake.sent[1])
+    assertTrue(
+      warnings.any { it.contains("failed to send Shutdown") },
+      "expected warn-line about failed Shutdown send, got: $warnings",
+    )
+  }
+
+  @Test
+  fun happyPathDoesNotSendShutdown() {
+    val fake = FakeConnection()
+    val backend = newBackend(connector = { Ok(fake) })
+    backend.compile(sampleArgs)
+    assertEquals(1, fake.sent.size, "happy path must send only NativeCompile, got ${fake.sent}")
+    assertIs<Message.NativeCompile>(fake.sent[0])
+  }
+
+  @Test
+  fun compilationFailedDoesNotSendShutdown() {
+    val fake =
+      FakeConnection(
+        reply = Ok(Message.NativeCompileResult(exitCode = 1, stderr = "error: source error"))
+      )
+    val backend = newBackend(connector = { Ok(fake) })
+    backend.compile(sampleArgs)
+    assertEquals(1, fake.sent.size, "compilation failure must not trigger Shutdown")
   }
 }
 

--- a/src/nativeTest/kotlin/kolt/cli/StaleDaemonRecycleIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/StaleDaemonRecycleIT.kt
@@ -1,0 +1,506 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package kolt.cli
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.build.daemon.projectHashOf
+import kolt.infra.eprintln
+import kolt.infra.executeCommand
+import kolt.infra.fileExists
+import kolt.infra.net.SUN_PATH_CAPACITY
+import kolt.infra.net.fillSockaddrUn
+import kolt.infra.readFileAsString
+import kolt.infra.writeFileAsString
+import kotlin.concurrent.AtomicInt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.StableRef
+import kotlinx.cinterop.ULongVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.asStableRef
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.staticCFunction
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
+import platform.linux.sockaddr_un
+import platform.posix.AF_UNIX
+import platform.posix.ECONNABORTED
+import platform.posix.EINTR
+import platform.posix.PATH_MAX
+import platform.posix.SOCK_STREAM
+import platform.posix.accept
+import platform.posix.bind
+import platform.posix.errno
+import platform.posix.getcwd
+import platform.posix.getenv
+import platform.posix.listen
+import platform.posix.mkdtemp
+import platform.posix.pthread_create
+import platform.posix.pthread_join
+import platform.posix.recv
+import platform.posix.send
+import platform.posix.sockaddr
+import platform.posix.socket
+import platform.posix.unlink
+
+private const val GATE_ENV = "KOLT_DAEMON_JAR"
+// Distinct from the top-level `FIXTURE_KOTLIN_VERSION` const in
+// MultiShapeDaemonTestCoverageIT so this file's private const does not
+// collide at link time.
+private const val STALE_FIXTURE_KOTLIN_VERSION = "2.3.20"
+
+// Single literal "$" token for use inside the bash heredoc raw strings so
+// `$?` is not interpreted as a Kotlin template lookup.
+private const val D = "$"
+
+class StaleDaemonRecycleIT {
+
+  // R4.1, R4.2, R5.1, R5.2: stale daemon at the project's daemon socket
+  // path replies with a frame the new client cannot use. The first build
+  // must surface the recycle notice and complete via subprocess fallback;
+  // the second build (after the fake server has released the socket)
+  // must run cleanly with no recycle notice.
+  @Test
+  fun staleDaemonReplyTriggersRecycleAndNextBuildSpawnsFresh() {
+    if (!ensureGateOrSkip()) return
+
+    val fixtureDir = scaffoldFixtureWithStaleSocket()
+    val daemonDir = expectedDaemonDir(fixtureDir, STALE_FIXTURE_KOTLIN_VERSION)
+    val socketPath = "$daemonDir/jvm-compiler-daemon-noplugins.sock"
+
+    ensureDir(daemonDir)
+    val server =
+      FakeStaleDaemonServer.bind(socketPath).getOrElse {
+        fail("FakeStaleDaemonServer.bind($socketPath) failed: $it")
+      }
+
+    var firstStderr = ""
+    var firstExit = -1
+    var secondStderr = ""
+    var secondExit = -1
+    try {
+      firstExit = runKoltBuild(fixtureDir, "b1")
+      firstStderr = readOptional(fixtureDir, "b1.stderr") ?: ""
+    } finally {
+      server.close()
+    }
+
+    secondExit = runKoltBuild(fixtureDir, "b2")
+    secondStderr = readOptional(fixtureDir, "b2.stderr") ?: ""
+
+    val firstStdout = readOptional(fixtureDir, "b1.stdout") ?: ""
+    val secondStdout = readOptional(fixtureDir, "b2.stdout") ?: ""
+
+    // (a) 1st build emits the stale-daemon recycle notice.
+    assertTrue(
+      firstStderr.contains("stale compiler daemon detected"),
+      "expected stale-daemon notice on 1st build stderr; got stderr=$firstStderr",
+    )
+    assertTrue(
+      firstStderr.contains("recycling"),
+      "expected 'recycling' word in 1st build stderr; got stderr=$firstStderr",
+    )
+
+    // (b) 1st build completes via subprocess fallback with exit 0.
+    assertEquals(
+      0,
+      firstExit,
+      "1st build must exit 0 via subprocess fallback; stdout=$firstStdout stderr=$firstStderr",
+    )
+
+    // (c) 2nd build completes cleanly. Whether it spawns a fresh daemon
+    // or falls back to subprocess depends on socket-release timing, so
+    // assert exit-0 only — implementation details (daemon vs subprocess)
+    // are intentionally not pinned (design.md §System Flows R5).
+    assertEquals(0, secondExit, "2nd build must exit 0; stdout=$secondStdout stderr=$secondStderr")
+
+    // (d) 2nd build does NOT re-emit the recycle notice. The flag is
+    // reset per compile pass, but a fresh daemon (or fresh subprocess
+    // path) should not trip the wire-mismatch detector again.
+    assertFalse(
+      secondStderr.contains("stale compiler daemon detected"),
+      "2nd build must not re-emit stale-daemon notice; got stderr=$secondStderr",
+    )
+  }
+}
+
+// ---------- Gate / harness ----------
+
+// Module-level so a single skip notice covers every @Test in this class
+// across the JVM lifetime, mirroring MultiShapeDaemonTestCoverageIT.
+private var skipNoticePrinted = false
+
+private fun ensureGateOrSkip(): Boolean {
+  val raw = getenv(GATE_ENV)?.toKString()
+  if (raw.isNullOrEmpty()) {
+    if (!skipNoticePrinted) {
+      skipNoticePrinted = true
+      eprintln("StaleDaemonRecycleIT: skipped (set $GATE_ENV to a daemon thin jar to enable)")
+    }
+    return false
+  }
+  if (!fileExists(raw)) {
+    fail("$GATE_ENV points to non-existent path: $raw")
+  }
+  return true
+}
+
+private fun locateKoltKexe(): String {
+  val cwd =
+    currentWorkingDir() ?: error("StaleDaemonRecycleIT: getcwd() failed; cannot locate kolt.kexe")
+  val candidates = listOf("$cwd/build/debug/kolt.kexe", "$cwd/build/release/kolt.kexe")
+  return candidates.firstOrNull { fileExists(it) }
+    ?: error(
+      "StaleDaemonRecycleIT: kolt.kexe not built; run `kolt build` first. " +
+        "Looked under: $candidates"
+    )
+}
+
+private fun currentWorkingDir(): String? = memScoped {
+  val buf = allocArray<ByteVar>(PATH_MAX)
+  getcwd(buf, PATH_MAX.toULong())?.toKString()
+}
+
+private fun createTempDir(prefix: String): String {
+  val template = "/tmp/${prefix}XXXXXX"
+  val buf = template.encodeToByteArray().copyOf(template.length + 1)
+  buf.usePinned { pinned ->
+    val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed for prefix '$prefix'")
+    return result.toKString()
+  }
+}
+
+private fun scaffoldFixtureWithStaleSocket(): String {
+  val dir = createTempDir("kolt-it-stale-")
+  writeFileAsString("$dir/kolt.toml", FIXTURE_TOML).getOrElse {
+    error("write kolt.toml: ${it.path}")
+  }
+  val mainDir = "$dir/src/main/kotlin"
+  executeCommand(listOf("mkdir", "-p", mainDir)).getOrElse { error("mkdir main: $it") }
+  writeFileAsString("$mainDir/Main.kt", FIXTURE_MAIN).getOrElse {
+    error("write Main.kt: ${it.path}")
+  }
+  return dir
+}
+
+private fun ensureDir(path: String) {
+  executeCommand(listOf("mkdir", "-p", path)).getOrElse { error("mkdir -p $path: $it") }
+}
+
+// Mirrors KoltPaths.daemonDir layout: `$HOME/.kolt/daemon/<projectHash>/<kotlinVersion>`.
+// Pinning the algorithm here means a drift in production projectHashOf or
+// path layout fails this test loud rather than silently bypassing the
+// fake server.
+private fun expectedDaemonDir(absProjectPath: String, kotlinVersion: String): String {
+  val home = getenv("HOME")?.toKString() ?: fail("HOME env var not set; cannot resolve daemon dir")
+  val projectHash = projectHashOf(absProjectPath)
+  return "$home/.kolt/daemon/$projectHash/$kotlinVersion"
+}
+
+private fun runKoltBuild(fixtureDir: String, fileStem: String): Int {
+  val kolt = locateKoltKexe()
+  val daemonJar =
+    getenv(GATE_ENV)?.toKString()
+      ?: error("$GATE_ENV must be set when runKoltBuild runs (gate already passed)")
+  val script =
+    """
+        set -u
+        cd "$fixtureDir"
+        "$kolt" build > $fileStem.stdout 2> $fileStem.stderr
+        echo $D? > $fileStem.exit
+        """
+      .trimIndent()
+  executeCommand(listOf("bash", "-c", script), extraEnv = mapOf(GATE_ENV to daemonJar)).getOrElse {
+    // executeCommand returns Err for any non-zero exit including the kolt
+    // exit code — we proceed and read the exit-code file harness wrote.
+  }
+  val raw =
+    readFileAsString("$fixtureDir/$fileStem.exit").getOrElse {
+      error("missing $fixtureDir/$fileStem.exit — harness did not record an exit code")
+    }
+  return raw.trim().toIntOrNull()
+    ?: error("could not parse exit code from $fixtureDir/$fileStem.exit: '$raw'")
+}
+
+private fun readOptional(dir: String, name: String): String? {
+  val path = "$dir/$name"
+  if (!fileExists(path)) return null
+  return readFileAsString(path).getOrElse {
+    return null
+  }
+}
+
+// ---------- Fake stale daemon ----------
+
+// Minimal AF_UNIX server that accepts one connection at a time, reads
+// one Compile frame (4-byte big-endian length + JSON body), then writes
+// back a frame whose JSON body is `{"type":"Pong"}`. The new client
+// successfully decodes the reply but classifies the unexpected variant
+// as a wire mismatch (DaemonCompilerBackend.mapReplyToOutcome).
+//
+// Patterned on UnixEchoServer (kolt.infra.net.testfixture) but tailored
+// to a request/reply wire instead of read-until-EOF echo. Lives inline
+// per the IT boundary: no shared fixture module is added.
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+private class FakeStaleDaemonServer
+private constructor(
+  private val socketPath: String,
+  private val listenFd: Int,
+  private val workerThread: ULong,
+  private val workerRef: StableRef<FakeServerState>,
+  private val state: FakeServerState,
+) : AutoCloseable {
+  private var closed = false
+
+  override fun close() {
+    if (closed) return
+    closed = true
+    state.shutdown.value = 1
+    // close(listenFd) will not unblock a thread parked in accept(). Force
+    // an extra accept() return by self-connecting; the worker re-checks
+    // the shutdown flag on the next loop iteration and exits.
+    selfConnectToWakeAccept(socketPath)
+    pthread_join(workerThread, null)
+    workerRef.dispose()
+    platform.posix.close(listenFd)
+    unlink(socketPath)
+  }
+
+  companion object {
+    private const val BACKLOG = 8
+
+    fun bind(socketPath: String): Result<FakeStaleDaemonServer, String> {
+      val pathBytes = socketPath.encodeToByteArray()
+      if (pathBytes.size >= SUN_PATH_CAPACITY) {
+        return Err("path exceeds sun_path capacity ($SUN_PATH_CAPACITY): $socketPath")
+      }
+
+      // A previous test run or an external daemon may have left a socket
+      // file at this path; unlink it so bind() can succeed.
+      unlink(socketPath)
+
+      val fd = socket(AF_UNIX, SOCK_STREAM, 0)
+      if (fd < 0) return Err("socket() failed errno=$errno")
+
+      val bindErr = doBindAndListen(fd, socketPath, pathBytes)
+      if (bindErr != null) return Err(bindErr)
+
+      val workerState = FakeServerState(listenFd = fd, shutdown = AtomicInt(0))
+      val ref = StableRef.create(workerState)
+
+      var createdThread: ULong = 0uL
+      var createRc = 0
+      memScoped {
+        val threadVar = alloc<ULongVar>()
+        createRc =
+          pthread_create(
+            threadVar.ptr.reinterpret(),
+            null,
+            staticCFunction(::fakeServerWorkerMain),
+            ref.asCPointer(),
+          )
+        if (createRc == 0) {
+          createdThread = threadVar.value
+        }
+      }
+      if (createRc != 0) {
+        ref.dispose()
+        platform.posix.close(fd)
+        unlink(socketPath)
+        return Err("pthread_create failed rc=$createRc")
+      }
+
+      return Ok(
+        FakeStaleDaemonServer(
+          socketPath = socketPath,
+          listenFd = fd,
+          workerThread = createdThread,
+          workerRef = ref,
+          state = workerState,
+        )
+      )
+    }
+
+    private fun doBindAndListen(fd: Int, path: String, pathBytes: ByteArray): String? = memScoped {
+      val addr = alloc<sockaddr_un>()
+      val addrLen = fillSockaddrUn(addr, pathBytes)
+      if (bind(fd, addr.ptr.reinterpret<sockaddr>(), addrLen) != 0) {
+        val e = errno
+        platform.posix.close(fd)
+        return@memScoped "bind($path) failed errno=$e"
+      }
+      if (listen(fd, BACKLOG) != 0) {
+        val e = errno
+        platform.posix.close(fd)
+        unlink(path)
+        return@memScoped "listen($path) failed errno=$e"
+      }
+      null
+    }
+
+    private fun selfConnectToWakeAccept(path: String) {
+      val fd = socket(AF_UNIX, SOCK_STREAM, 0)
+      if (fd < 0) return
+      memScoped {
+        val addr = alloc<sockaddr_un>()
+        val addrLen = fillSockaddrUn(addr, path.encodeToByteArray())
+        platform.posix.connect(fd, addr.ptr.reinterpret<sockaddr>(), addrLen)
+      }
+      platform.posix.close(fd)
+    }
+  }
+}
+
+internal class FakeServerState(val listenFd: Int, val shutdown: AtomicInt)
+
+// JSON body of the unexpected-variant reply. The new client decodes this
+// successfully, but `mapReplyToOutcome` classifies a Pong response to a
+// Compile request as `BackendUnavailable.WireMismatch`.
+private val PONG_JSON_BODY: ByteArray = "{\"type\":\"Pong\"}".encodeToByteArray()
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+private fun fakeServerWorkerMain(arg: COpaquePointer?): COpaquePointer? {
+  if (arg == null) return null
+  val state = arg.asStableRef<FakeServerState>().get()
+  while (true) {
+    if (state.shutdown.value != 0) return null
+    val clientFd = accept(state.listenFd, null, null)
+    if (clientFd < 0) {
+      val e = errno
+      if (e == EINTR || e == ECONNABORTED) continue
+      return null
+    }
+    if (state.shutdown.value != 0) {
+      platform.posix.close(clientFd)
+      return null
+    }
+    handleClient(clientFd)
+    platform.posix.close(clientFd)
+  }
+}
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+private fun handleClient(fd: Int) {
+  // Read the 4-byte big-endian length prefix.
+  val header = recvExactBytes(fd, 4) ?: return
+  val len =
+    ((header[0].toInt() and 0xff) shl 24) or
+      ((header[1].toInt() and 0xff) shl 16) or
+      ((header[2].toInt() and 0xff) shl 8) or
+      (header[3].toInt() and 0xff)
+  if (len < 0 || len > 64 * 1024 * 1024) return
+  // Drain the request body so the kernel side has nothing held; we do
+  // not deserialise — any Compile JSON is fine.
+  recvExactBytes(fd, len) ?: return
+
+  val body = PONG_JSON_BODY
+  val replyHeader = ByteArray(4)
+  val bodyLen = body.size
+  replyHeader[0] = ((bodyLen ushr 24) and 0xff).toByte()
+  replyHeader[1] = ((bodyLen ushr 16) and 0xff).toByte()
+  replyHeader[2] = ((bodyLen ushr 8) and 0xff).toByte()
+  replyHeader[3] = (bodyLen and 0xff).toByte()
+  if (!sendAllBytes(fd, replyHeader)) return
+  sendAllBytes(fd, body)
+
+  // The new client may follow the WireMismatch reply by sending a
+  // best-effort Shutdown frame on the same connection. Drain whatever
+  // arrives until the peer half-closes so the writer never sees
+  // EPIPE / SIGPIPE before our close().
+  drainUntilEof(fd)
+}
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+private fun recvExactBytes(fd: Int, n: Int): ByteArray? {
+  if (n == 0) return ByteArray(0)
+  val buf = ByteArray(n)
+  var offset = 0
+  buf.usePinned { pinned ->
+    while (offset < n) {
+      val got = recv(fd, pinned.addressOf(offset), (n - offset).convert(), 0)
+      if (got < 0L) {
+        val e = errno
+        if (e == EINTR) continue
+        return null
+      }
+      if (got == 0L) return null
+      offset += got.toInt()
+    }
+  }
+  return buf
+}
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+private fun sendAllBytes(fd: Int, data: ByteArray): Boolean {
+  if (data.isEmpty()) return true
+  var offset = 0
+  data.usePinned { pinned ->
+    while (offset < data.size) {
+      val n = send(fd, pinned.addressOf(offset), (data.size - offset).convert(), 0)
+      if (n < 0L) {
+        val e = errno
+        if (e == EINTR) continue
+        return false
+      }
+      if (n == 0L) return false
+      offset += n.toInt()
+    }
+  }
+  return true
+}
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+private fun drainUntilEof(fd: Int) {
+  val buf = ByteArray(4096)
+  buf.usePinned { pinned ->
+    while (true) {
+      val got = recv(fd, pinned.addressOf(0), buf.size.convert(), 0)
+      if (got < 0L) {
+        val e = errno
+        if (e == EINTR) continue
+        return
+      }
+      if (got == 0L) return
+    }
+  }
+}
+
+// ---------- Fixture sources ----------
+
+private val FIXTURE_TOML =
+  """
+        name = "stale-daemon-recycle-it"
+        version = "0.0.1"
+        kind = "lib"
+
+        [kotlin]
+        version = "$STALE_FIXTURE_KOTLIN_VERSION"
+
+        [build]
+        target = "jvm"
+        jvm_target = "21"
+        sources = ["src/main/kotlin"]
+        """
+    .trimIndent()
+
+private val FIXTURE_MAIN =
+  """
+        package stale.daemon.recycle.it
+
+        fun greet(): String = "hello-stale-daemon"
+        """
+    .trimIndent()


### PR DESCRIPTION
After #376 a daemon left from before the wire change keeps owning its socket, the new client silently falls back to subprocess on every build, and `kolt daemon stop` is the only way out. This change makes the native client treat a wire-incompatible reply as a precondition mismatch: best-effort `Message.Shutdown` on the still-open connection, one stderr line per compile pass via `StaleDaemonNotice`, and the in-flight build completes through the existing subprocess fallback. The next invocation reaches `connectOrSpawn` normally and lands on a fresh daemon.

Both daemon backends carry symmetric changes: a new `BackendUnavailable.WireMismatch(detail)` variant on each error sealed family, the same `compile()` body shape (Implementation Notes pseudocode in design.md is the contract), and reporters dispatching to `StaleDaemonNotice.emit("compiler daemon" | "native compiler daemon", ...)`. ADR 0016 §7 and ADR 0024 §9 capture the policy.

Where to look:

- `DaemonCompilerBackend.compile` / `NativeDaemonBackend.compile` — the pseudocode keeps Shutdown send inside the `connection.use { }` block; an implementer who lifts the early `return Err` outside the block would silently skip Shutdown send and tests would still see WireMismatch in the return value but not on the wire. The `FakeConnection.sent` ordering assertions pin this.
- `StaleDaemonNotice` is a process-global singleton; per-pass scoping comes from `BuildCommands.{doBuildInner, doTestInner}` calling `reset()` on entry. `--watch` cycles through `doBuildInner` so each cycle resets naturally; the `doTest → doTestInner → doBuildInner` chain calls `reset()` twice per `kolt test`, which is harmless because `reset()` is idempotent.
- `warnSink` is on the internal constructor only; public secondary constructors of both backends are unchanged.
- `StaleDaemonRecycleIT` is bootstrap-gated on `KOLT_DAEMON_JAR` and silent-skips when unset (per `feedback_bootstrap_gated_test.md`). It binds an AF_UNIX server at the production socket path and replies with `{"type":"Pong"}` to exercise the variant-mismatch arm of `mapReplyToOutcome`.

Spec at `.kiro/specs/379-auto-restart-stale-daemon/`.