### PR TITLE
Drop daemon kolt.toml re-parse for plugin translation (#159)

### DIFF
--- a/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
+++ b/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
@@ -64,6 +64,7 @@ interface IncrementalCompiler {
 
 data class IcRequest(
     val projectId: String,        // stable, caller-derived hash
+    val projectRoot: Path,        // source for `LanguageVersionTranslator` (§9)
     val sources: List<Path>,      // full source set
     val classpath: List<Path>,    // deps + stdlib, full
     val outputDir: Path,
@@ -131,11 +132,11 @@ Self-heal wipes `workingDir` before retrying so the next request does not read t
 
 ### §9 Plugin and compilerArguments plumbing: inside the adapter
 
-`IcRequest` does not carry `pluginClasspaths` or `compilerOptions`. The adapter reads `kolt.toml` `[kotlin.plugins]` from `projectRoot` directly and translates to `JvmCompilerArguments`. Plugin jars load into the same classloader hierarchy as `kotlin-build-tools-impl`.
+`IcRequest` does not carry `pluginClasspaths` or `compilerOptions`. The native client owns `kolt.toml` `[kotlin.plugins]`: it filters enabled aliases and resolves each to a jar path before launching the daemon, then ships the resulting `Map<alias, List<jarPath>>` over `--plugin-jars`. The adapter consumes that map directly via `PluginTranslator` and translates to `JvmCompilerArguments`. Plugin jars load into the same classloader hierarchy as `kotlin-build-tools-impl`.
 
 Plugin passthrough mechanism (post-#148): the adapter emits `-Xplugin=<jar>` tokens via `CommonToolArguments.applyArgumentStrings`, not the structured `CommonCompilerArguments.COMPILER_PLUGINS` key. The structured key was added only in BTA 2.3.20 and rejects assignment on 2.3.0 / 2.3.10 impls even with an empty list. `applyArgumentStrings` is the passthrough surface present across the full 2.3.x family. Call order is load-bearing: `applyArgumentStrings` must precede any structured `set(...)` call because it resets non-mentioned arguments to parser defaults. See `spike/bta-compat-138/REPORT.md` for the empirical record.
 
-Passing plugin settings through `IcRequest` (option b) would force daemon core to carry fields whose shape is dictated by BTA's `JvmCompilerArguments` — the adapter boundary leaking by a different door. The tradeoff is one extra `kolt.toml` parse on the JVM side, accepted as the lesser cost.
+Passing plugin settings through `IcRequest` (option b) would force daemon core to carry fields whose shape is dictated by BTA's `JvmCompilerArguments` — the adapter boundary leaking by a different door. The pre-resolved `Map<alias, List<jarPath>>` shape passed via `--plugin-jars` is wire-friendly (string keys, path lists) and never references BTA types, so the invariant holds without daemon core needing to understand `kolt.toml` semantics.
 
 ### §10 Rollout: default-on from day one
 
@@ -154,7 +155,7 @@ IC is the default compile path from the first B-2 release. No opt-in flag, no `k
 **Negative**
 - `@ExperimentalBuildToolsApi` is load-bearing. BTA surface can change on any minor compiler release. Mitigated by version pinning and the adapter integration test that exercises the cold-then-incremental cycle on every build.
 - `~/.kolt/daemon/ic/` accumulates state without a reaper (resolved: #125/PR #126 `cdf5da9` ships a reaper for non-current `<kotlinVersion>` segments and dangling projectId dirs).
-- The JVM adapter parses `kolt.toml` a second time to extract plugin settings (accepted duplication; avoidable if it gets out of hand).
+- The JVM adapter still parses `kolt.toml` once for `LanguageVersionTranslator`. Plugin settings stopped being parsed JVM-side once `--plugin-jars` carried pre-resolved jars (resolved: #159).
 - Classpath snapshot cost was ~310 ms per request before caching (resolved: #127 `ClasspathSnapshotCache` caches snapshots keyed by `(path, mtime, size)` in `<icRoot>/<kotlinVersion>/classpath-snapshots/`).
 
 ### Confirmation

--- a/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
@@ -55,13 +55,9 @@ import org.jetbrains.kotlin.buildtools.api.trackers.BuildMetricsCollector
 class BtaIncrementalCompiler
 private constructor(
   private val toolchain: KotlinToolchains,
-  // Maps a kolt.toml [kotlin.plugins] alias (e.g. "serialization") to the plugin jar
-  // classpath on disk. Injected at construction time so daemon startup owns
-  // the policy (walk a plugin-jars directory, read from --plugin-jars CLI,
-  // etc.) and :ic stays a pure translator. B-2a defaults this to an empty-
-  // result resolver — the translation path is still exercised end to end,
-  // and real plugin jar delivery is wired in daemon core later (B-2b/B-2c).
-  private val pluginJarResolver: (alias: String) -> List<Path>,
+  // Pre-resolved per ADR 0019 §9; daemon hands `--plugin-jars` through
+  // unchanged.
+  private val pluginJars: Map<String, List<Path>>,
   // ADR 0019 §7 observability: adapter-level counters are recorded here.
   // Defaults to no-op so tests that only care about the Result<,> shape
   // stay terse; Main wires `StderrIcMetricsSink` in production so
@@ -179,7 +175,7 @@ private constructor(
     // #162: language/api-version args must ride the same applyArgumentStrings
     // batch as plugin args — the reset-to-default behavior documented above
     // would wipe whichever translator fed an earlier call.
-    val translatedPluginArgs = PluginTranslator.translate(request.projectRoot, pluginJarResolver)
+    val translatedPluginArgs = PluginTranslator.translate(pluginJars)
     val translatedLanguageArgs = LanguageVersionTranslator.translate(request.projectRoot)
     val freeArgs = translatedPluginArgs + translatedLanguageArgs
     if (freeArgs.isNotEmpty()) {
@@ -438,13 +434,7 @@ private constructor(
     // Result returned to daemon core rather than throwing.
     fun create(
       btaImplJars: List<Path>,
-      // Defaults to an empty-result resolver: every plugin alias maps to
-      // an empty classpath, which collapses to no `-Xplugin=` freeArg
-      // emitted. Production daemon startup overrides this with a
-      // resolver that looks up the `pluginJars` map passed through
-      // `--plugin-jars`; tests that do not exercise plugin delivery
-      // rely on this default.
-      pluginJarResolver: (alias: String) -> List<Path> = { _ -> emptyList() },
+      pluginJars: Map<String, List<Path>> = emptyMap(),
       metrics: IcMetricsSink = NoopIcMetricsSink,
       // ADR 0019 §Negative follow-up (#127): shared directory for cached
       // ClasspathEntrySnapshot files. When null, a temp directory is used
@@ -474,7 +464,7 @@ private constructor(
         Ok(
           BtaIncrementalCompiler(
             toolchain = toolchain,
-            pluginJarResolver = pluginJarResolver,
+            pluginJars = pluginJars,
             metrics = metrics,
             classpathSnapshotCache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics),
             shrunkSnapshotCache = effectiveShrunkCache,

--- a/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/IncrementalCompiler.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/IncrementalCompiler.kt
@@ -10,22 +10,16 @@ import java.nio.file.Path
 // Import of a BTA type anywhere outside the ic subproject is an ADR 0019 violation
 // and is enforced by human review per issue #112 acceptance criterion 2.
 //
-// IcRequest deliberately does not carry compilerArguments / pluginClasspaths /
-// pluginOptions — those are translated inside the adapter from kolt.toml [kotlin.plugins]
-// (ADR 0019 §9). Keeping the translation inside the adapter preserves the
-// "daemon core carries no BTA-shaped fields" invariant.
+// IcRequest carries no BTA-shaped fields per ADR 0019 §9; plugin jars
+// arrive via the daemon-level `--plugin-jars` map and translate inside
+// the adapter.
 interface IncrementalCompiler {
   fun compile(request: IcRequest): Result<IcResponse, IcError>
 }
 
 data class IcRequest(
   val projectId: String,
-  // The project root directory (containing `kolt.toml`). The adapter reads the
-  // TOML file directly to translate plugin settings per ADR 0019 §9; this is
-  // the only way the @ExperimentalBuildToolsApi shape of plugin arguments
-  // stays out of daemon core. ADR §3's original data class did not list
-  // projectRoot, but §9 implicitly requires it — this is a minor inter-
-  // section fix, not a scope widening.
+  // Source for `LanguageVersionTranslator` reading `[kotlin]` per ADR 0019 §9.
   val projectRoot: Path,
   val sources: List<Path>,
   val classpath: List<Path>,

--- a/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/PluginTranslator.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/PluginTranslator.kt
@@ -1,71 +1,18 @@
 package kolt.daemon.ic
 
-import com.akuleshov7.ktoml.Toml
-import com.akuleshov7.ktoml.TomlInputConfig
-import java.nio.file.Files
 import java.nio.file.Path
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 
-// Translates a project's `kolt.toml` [kotlin.plugins] section into the `-Xplugin=<path>`
-// freeArgs list that `BtaIncrementalCompiler` pushes through
-// `CommonToolArguments.applyArgumentStrings`. Lives inside the adapter per
-// ADR 0019 §9 so daemon core never carries a BTA-shaped `pluginClasspaths`
-// field.
+// Emits one `-Xplugin=<jar>` per supplied jar, in map iteration order, for
+// `CommonToolArguments.applyArgumentStrings` consumption (ADR 0019 §9).
 //
-// Why freeArgs and not the structured `COMPILER_PLUGINS` key: the structured
-// key was introduced in BTA 2.3.20. The daemon supports the full 2.3.x line
-// per ADR 0022 §3; `-Xplugin=` + `applyArgumentStrings` is the one passthrough
-// mechanism present across the family (the same mechanism 2.3.20's own
-// `Kotlin230AndBelowWrapper` uses internally to shuttle arguments into a
-// pre-2.3.20 impl). Verdict source: `spike/bta-compat-138/REPORT.md` §"Plugin-passthrough spike:
-// GREEN".
-//
-// Plugin-id aliasing dropped: with `-Xplugin=`, kotlinc reads the plugin
-// identity from the jar's `META-INF/services/org.jetbrains.kotlin.compiler.
-// plugin.CompilerPluginRegistrar` descriptor. The translator only needs to
-// forward resolved jar paths; the alias→id map the 2.3.20 adapter needed is
-// no longer load-bearing.
-//
-// The translator is a pure function over (projectRoot, jarResolver). Making
-// the jar resolver injectable keeps the unit tests independent of any real
-// plugin jars on disk, and lets daemon startup wire in a real resolver that
-// reads from `pluginJars: Map<alias, List<path>>` delivered alongside
-// `--compiler-jars`.
+// `-Xplugin=` is the passthrough surface present across the full BTA 2.3.x
+// family; the structured `CommonCompilerArguments.COMPILER_PLUGINS` key was
+// added only in 2.3.20 and rejects assignment on earlier impls. Plugin
+// identity comes from the jar's
+// `META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar`
+// descriptor — the alias map's keys are not load-bearing here.
 object PluginTranslator {
 
-  /**
-   * Parse `projectRoot/kolt.toml`, pick the enabled `[kotlin.plugins]` entries, ask [jarResolver]
-   * for the classpath of each, and emit one `-Xplugin=<path>` argument per resolved jar. Resolver
-   * order is preserved.
-   *
-   * Non-existent `kolt.toml`, absent `[kotlin.plugins]` section, entries set to `false`, and
-   * resolver returns that are empty for an enabled alias all collapse to an empty output. The
-   * resolver is not called when the parsed map is empty.
-   */
-  fun translate(projectRoot: Path, jarResolver: (alias: String) -> List<Path>): List<String> {
-    val tomlFile = projectRoot.resolve("kolt.toml")
-    if (!Files.isRegularFile(tomlFile)) return emptyList()
-    val enabledAliases = parseEnabledPluginAliases(tomlFile)
-    return enabledAliases.flatMap { alias -> jarResolver(alias).map { jar -> "-Xplugin=$jar" } }
-  }
-
-  private fun parseEnabledPluginAliases(tomlFile: Path): List<String> {
-    val raw = Files.readString(tomlFile)
-    val decoded =
-      Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = true))
-        .decodeFromString(KoltConfigPluginsView.serializer(), raw)
-    return decoded.kotlin.plugins.filterValues { it }.keys.toList()
-  }
-
-  @Serializable
-  private data class KoltConfigPluginsView(
-    // Only the [kotlin.plugins] section matters to this translator;
-    // `ignoreUnknownNames` lets every other kolt.toml field pass through
-    // without a schema definition.
-    @SerialName("kotlin") val kotlin: KotlinView = KotlinView()
-  ) {
-    @Serializable
-    data class KotlinView(@SerialName("plugins") val plugins: Map<String, Boolean> = emptyMap())
-  }
+  fun translate(pluginJars: Map<String, List<Path>>): List<String> =
+    pluginJars.values.flatMap { jars -> jars.map { "-Xplugin=$it" } }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaIncrementalCompilerColdPathTest.kt
@@ -4,7 +4,6 @@ package kolt.daemon.ic
 
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
-import com.github.michaelbull.result.mapBoth
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
@@ -169,111 +168,6 @@ class BtaIncrementalCompilerColdPathTest {
     assertTrue(
       !joined.contains("kotlinc reported COMPILATION_ERROR"),
       "stub fallback must not fire when real diagnostics were captured, got:\n$joined",
-    )
-  }
-
-  // Acceptance criterion 4 of issue #112: a kolt.toml with one enabled plugin
-  // entry must drive the translation path all the way through to the BTA layer,
-  // even if the actual plugin jars cannot be resolved or the compile fails at
-  // plugin load. This test proves that (a) the injected resolver is consulted,
-  // and (b) the adapter still reaches BtaIncrementalCompiler.executeCompile's
-  // session.executeOperation() call — i.e. the translation is wired through
-  // to the compile operation, not short-circuited before BTA sees it.
-  //
-  // A fake plugin alias is used so the test stays independent of whether a
-  // real kotlinx-serialization-compiler-plugin jar is resolvable in the Gradle
-  // test task's environment. Real plugin validation (actually compiling a
-  // @Serializable class) is B-2c's scope.
-  @Test
-  fun `kotlin_plugins section in kolt_toml reaches the compile path via the resolver`() {
-    val workRoot = Files.createTempDirectory("bta-plugins-")
-    workRoot
-      .resolve("kolt.toml")
-      .writeText(
-        """
-            name = "demo"
-            version = "0.1.0"
-
-            [kotlin]
-            version = "2.3.20"
-
-            [kotlin.plugins]
-            serialization = true
-
-            [build]
-            target = "jvm"
-            main = "fixture.Main"
-            sources = ["."]
-            """
-          .trimIndent()
-      )
-    workRoot
-      .resolve("Main.kt")
-      .writeText(
-        """
-            package fixture
-            object Main {
-                fun greeting(): String = "hi"
-            }
-            """
-          .trimIndent()
-      )
-    val outputDir = workRoot.resolve("classes").apply { createDirectories() }
-    val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
-    val workingDir = projectStateDir.resolve("main").apply { createDirectories() }
-
-    val resolverCalls = mutableListOf<String>()
-    val compiler =
-      BtaIncrementalCompiler.create(
-          btaImplJars = btaImplJars,
-          pluginJarResolver = { alias ->
-            resolverCalls += alias
-            // Return an empty classpath on purpose: the point of this test is
-            // to prove the translation path is reached, not to successfully
-            // load a real plugin. Post-#148 the translator collapses an
-            // empty resolution to zero `-Xplugin=` freeArgs, so the compile
-            // simply proceeds without the plugin attached. The assertion
-            // that matters here is that the resolver was consulted at all.
-            emptyList()
-          },
-        )
-        .getOrElse { fail("failed to load BTA toolchain: $it") }
-
-    val result =
-      compiler.compile(
-        IcRequest(
-          projectId = "plugin-path-smoke",
-          projectRoot = workRoot,
-          sources = listOf(workRoot.resolve("Main.kt")),
-          classpath = fixtureClasspath,
-          outputDir = outputDir,
-          workingDir = workingDir,
-        )
-      )
-
-    // Primary assertion: the injected resolver was consulted for the
-    // `serialization` alias. Without this, the translation path never
-    // reached BTA; the compile outcome is a secondary signal.
-    assertEquals(
-      listOf("serialization"),
-      resolverCalls,
-      "expected PluginTranslator to consult the resolver for the `serialization` alias",
-    )
-
-    // Secondary assertion: the compile reaches a well-formed Result<,>
-    // (Ok or Err) — i.e., the adapter did not crash on a thrown exception
-    // when handed an empty-classpath plugin. Either outcome is acceptable
-    // because B-2a only requires that the translation path is exercised.
-    val outcome =
-      result.mapBoth(success = { "SUCCESS" }, failure = { err -> "Err(${err::class.simpleName})" })
-    // This assert is documentation for a future reader: both outcomes are
-    // legal. A test failure would mean `compile` threw past the adapter,
-    // which IS an ADR 0019 §7 invariant violation.
-    assertTrue(
-      outcome == "SUCCESS" ||
-        outcome == "Err(CompilationFailed)" ||
-        outcome == "Err(InternalError)",
-      "unexpected compile outcome: $outcome",
     )
   }
 

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
@@ -14,25 +14,14 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
-// ADR 0019 Follow-ups + B-2c: resolves spike #104 O.Q. 6 residual risk.
-// Drives BtaIncrementalCompiler end-to-end through a **real** compiler
-// plugin (`kotlinx.serialization`) so the adapter's plugin jar delivery,
-// PluginTranslator wiring, and BTA's plugin loading have all been
-// exercised on the happy path before B-2 is declared done.
+// End-to-end test through the **real** kotlinx.serialization compiler plugin.
 //
-// The test asserts two structural facts:
-//   1. A `@Serializable` data class compiles without error.
-//   2. The kotlinx.serialization compiler plugin ran during the compile
-//      — evidenced by the generated `$Companion` / `$serializer` symbol
-//      inside the produced .class file, which the plugin synthesises
-//      and is never present in plain kotlinc output.
-//
-// The second assertion is the load-bearing one: without it, a regression
-// that silently skipped plugin attachment (e.g. the pluginJarResolver
-// returning empty, or PluginTranslator's alias map losing the
-// `serialization` entry) could still pass the compile because
-// `@Serializable` is a harmless annotation on its own. The serializer
-// symbol only exists if the plugin actually transformed the AST.
+// The load-bearing assertion is the generated `$serializer` nested class:
+// without it, a silently-skipped plugin attachment (empty `pluginJars`,
+// translator dropping the `serialization` entry, or BTA refusing the jar)
+// would still pass the compile because `@Serializable` is a harmless
+// annotation on its own. The serializer symbol only exists if the plugin
+// actually transformed the AST.
 class BtaSerializationPluginTest {
 
   private val btaImplJars: List<Path> = systemClasspath("kolt.ic.btaImplClasspath")
@@ -62,40 +51,12 @@ class BtaSerializationPluginTest {
     val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
     val workingDir = projectStateDir.resolve("main").apply { createDirectories() }
 
-    val resolverCalls = mutableListOf<String>()
     val compiler =
       BtaIncrementalCompiler.create(
           btaImplJars = btaImplJars,
-          pluginJarResolver = { alias ->
-            resolverCalls.add(alias)
-            if (alias == "serialization") serializationPluginJars else emptyList()
-          },
+          pluginJars = mapOf("serialization" to serializationPluginJars),
         )
         .getOrElse { fail("failed to load BTA toolchain: $it") }
-
-    // kolt.toml enables the serialization plugin so PluginTranslator
-    // picks it up on its normal reading path — the test is not
-    // bypassing the translator, it is going through it.
-    workRoot
-      .resolve("kolt.toml")
-      .writeText(
-        """
-            name = "demo"
-            version = "0.1.0"
-
-            [kotlin]
-            version = "2.3.20"
-
-            [kotlin.plugins]
-            serialization = true
-
-            [build]
-            target = "jvm"
-            main = "fixture.Payload"
-            sources = ["."]
-            """
-          .trimIndent()
-      )
 
     compiler
       .compile(
@@ -109,11 +70,6 @@ class BtaSerializationPluginTest {
         )
       )
       .getOrElse { fail("expected successful compile of @Serializable fixture, got: $it") }
-
-    assertTrue(
-      resolverCalls.contains("serialization"),
-      "PluginTranslator must have consulted the resolver for `serialization`, got: $resolverCalls",
-    )
 
     val classFiles = outputDir.walk().filter { it.extension == "class" }.toList()
     assertTrue(
@@ -201,9 +157,7 @@ class BtaSerializationPluginTest {
     val compiler =
       BtaIncrementalCompiler.create(
           btaImplJars = btaImplJars,
-          pluginJarResolver = { alias ->
-            if (alias == "serialization") serializationPluginJars else emptyList()
-          },
+          pluginJars = mapOf("serialization" to serializationPluginJars),
         )
         .getOrElse { fail("failed to load BTA toolchain: $it") }
 

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/PluginTranslatorTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/PluginTranslatorTest.kt
@@ -1,213 +1,63 @@
 package kolt.daemon.ic
 
-import java.nio.file.Files
 import java.nio.file.Path
-import kotlin.io.path.writeText
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-// Unit tests for the kolt.toml [kotlin.plugins] → freeArgs translation path.
-// Issue #148 flipped the translator output from the structured
-// `COMPILER_PLUGINS` shape (2.3.20-only) to CLI-style `-Xplugin=<jar>` strings
-// fed through `CommonToolArguments.applyArgumentStrings`. The latter works
-// against every 2.3.x BTA impl the daemon supports — see
-// spike/bta-compat-138/REPORT.md.
-//
-// Plugin-id aliasing is no longer needed: kotlinc discovers the plugin via
-// the jar's `META-INF/services/.../CompilerPluginRegistrar` service
-// descriptor, so the translator just passes through resolved jar paths.
+// Unit tests for the plugin-jar map -> `-Xplugin=<jar>` freeArgs translation.
+// See `PluginTranslator.kt` for why `-Xplugin=` is the chosen passthrough
+// surface (BTA 2.3.x family compatibility).
 class PluginTranslatorTest {
 
-  private val baseToml =
-    """
-        name = "demo"
-        version = "0.1.0"
-
-        [kotlin]
-        version = "2.3.20"
-
-        [build]
-        target = "jvm"
-        main = "demo.Main"
-        sources = ["src/main/kotlin"]
-    """
-      .trimIndent()
-
   @Test
-  fun `missing kolt_toml yields an empty plugin list`() {
-    val projectRoot = Files.createTempDirectory("plugin-translator-empty-")
-    val args =
-      PluginTranslator.translate(
-        projectRoot = projectRoot,
-        jarResolver = { _ -> error("resolver must not be called when no plugins section") },
-      )
-    assertTrue(args.isEmpty(), "no kolt.toml → no plugin args, got $args")
+  fun `empty map yields no plugin args`() {
+    assertTrue(PluginTranslator.translate(emptyMap()).isEmpty())
   }
 
   @Test
-  fun `kolt_toml with no plugins section yields an empty list`() {
-    val projectRoot = Files.createTempDirectory("plugin-translator-no-section-")
-    projectRoot.resolve("kolt.toml").writeText(baseToml)
-    val args =
-      PluginTranslator.translate(
-        projectRoot = projectRoot,
-        jarResolver = { _ -> error("resolver must not be called when plugins map is empty") },
-      )
-    assertTrue(args.isEmpty())
-  }
-
-  @Test
-  fun `serialization plugin entry emits one -Xplugin= arg per resolved jar`() {
-    val projectRoot = Files.createTempDirectory("plugin-translator-serialization-")
-    projectRoot
-      .resolve("kolt.toml")
-      .writeText(
-        baseToml +
-          """
-
-                [kotlin.plugins]
-                serialization = true
-            """
-            .trimIndent()
-      )
-    val fakeJar = Path.of("/fake/kotlinx-serialization-compiler-plugin.jar")
-    val resolved = mutableListOf<String>()
-
-    val args =
-      PluginTranslator.translate(
-        projectRoot = projectRoot,
-        jarResolver = { name ->
-          resolved += name
-          if (name == "serialization") listOf(fakeJar) else emptyList()
-        },
-      )
-
+  fun `single alias emits one -Xplugin= arg per resolved jar`() {
+    val jar = Path.of("/fake/kotlinx-serialization-compiler-plugin.jar")
     assertEquals(
-      listOf("serialization"),
-      resolved,
-      "resolver should be asked once for the serialization plugin",
+      listOf("-Xplugin=$jar"),
+      PluginTranslator.translate(mapOf("serialization" to listOf(jar))),
     )
-    assertEquals(listOf("-Xplugin=$fakeJar"), args)
   }
 
   @Test
-  fun `disabled plugin entry is skipped entirely`() {
-    val projectRoot = Files.createTempDirectory("plugin-translator-disabled-")
-    projectRoot
-      .resolve("kolt.toml")
-      .writeText(
-        baseToml +
-          """
-
-                [kotlin.plugins]
-                serialization = false
-            """
-            .trimIndent()
-      )
-    val args =
-      PluginTranslator.translate(
-        projectRoot = projectRoot,
-        jarResolver = { _ -> error("resolver must not be called for disabled plugin") },
-      )
-    assertTrue(args.isEmpty())
-  }
-
-  // #65 native client wiring: allopen / noarg must also translate through
-  // the same passthrough path. The translator is alias-agnostic now — it
-  // only trusts the resolver — so this test pins the "resolver gets asked"
-  // behaviour for all three known aliases.
-  @Test
-  fun `allopen plugin entry emits -Xplugin= passthrough args`() {
-    val projectRoot = Files.createTempDirectory("plugin-translator-allopen-")
-    projectRoot
-      .resolve("kolt.toml")
-      .writeText(
-        baseToml +
-          """
-
-                [kotlin.plugins]
-                allopen = true
-            """
-            .trimIndent()
-      )
-    val fakeJar = Path.of("/fake/allopen-compiler-plugin.jar")
-    val args =
-      PluginTranslator.translate(
-        projectRoot = projectRoot,
-        jarResolver = { name -> if (name == "allopen") listOf(fakeJar) else emptyList() },
-      )
-    assertEquals(listOf("-Xplugin=$fakeJar"), args)
-  }
-
-  @Test
-  fun `noarg plugin entry emits -Xplugin= passthrough args`() {
-    val projectRoot = Files.createTempDirectory("plugin-translator-noarg-")
-    projectRoot
-      .resolve("kolt.toml")
-      .writeText(
-        baseToml +
-          """
-
-                [kotlin.plugins]
-                noarg = true
-            """
-            .trimIndent()
-      )
-    val fakeJar = Path.of("/fake/noarg-compiler-plugin.jar")
-    val args =
-      PluginTranslator.translate(
-        projectRoot = projectRoot,
-        jarResolver = { name -> if (name == "noarg") listOf(fakeJar) else emptyList() },
-      )
-    assertEquals(listOf("-Xplugin=$fakeJar"), args)
-  }
-
-  @Test
-  fun `multi-jar resolution emits one arg per jar preserving resolver order`() {
-    val projectRoot = Files.createTempDirectory("plugin-translator-multijar-")
-    projectRoot
-      .resolve("kolt.toml")
-      .writeText(
-        baseToml +
-          """
-
-                [kotlin.plugins]
-                serialization = true
-            """
-            .trimIndent()
-      )
+  fun `multi-jar value emits one arg per jar preserving order`() {
     val jars =
       listOf(
         Path.of("/fake/kotlinx-serialization-compiler-plugin.jar"),
         Path.of("/fake/kotlinx-serialization-compiler-plugin-embeddable.jar"),
       )
-    val args = PluginTranslator.translate(projectRoot = projectRoot, jarResolver = { _ -> jars })
-    assertEquals(jars.map { "-Xplugin=$it" }, args)
+    assertEquals(
+      jars.map { "-Xplugin=$it" },
+      PluginTranslator.translate(mapOf("serialization" to jars)),
+    )
   }
 
+  // Production upstream (`PluginJarFetcher` in the native client) fails before
+  // the daemon request is built if a plugin jar cannot be fetched, so the map
+  // never carries an empty list for an alias in practice. This test pins the
+  // boundary case: if it does happen (tests, future rewiring) the translator
+  // emits no `-Xplugin=` entries rather than a malformed one.
   @Test
-  fun `empty resolver result for an enabled plugin produces no args`() {
-    // Production upstream (`PluginJarFetcher` in the CLI) fails before the
-    // daemon request is built if a plugin jar cannot be fetched, so the
-    // resolver never returns an empty list for an enabled alias in
-    // practice. This test pins the boundary case: if it does happen
-    // (test mocks, future resolver rewiring) the translator emits no
-    // `-Xplugin=` entries rather than a malformed one.
-    val projectRoot = Files.createTempDirectory("plugin-translator-unresolved-")
-    projectRoot
-      .resolve("kolt.toml")
-      .writeText(
-        baseToml +
-          """
+  fun `empty value list for an alias produces no args`() {
+    assertTrue(PluginTranslator.translate(mapOf("serialization" to emptyList())).isEmpty())
+  }
 
-                [kotlin.plugins]
-                serialization = true
-            """
-            .trimIndent()
-      )
-    val args =
-      PluginTranslator.translate(projectRoot = projectRoot, jarResolver = { _ -> emptyList() })
-    assertTrue(args.isEmpty())
+  // Iteration order matters: BTA's `applyArgumentStrings` consumes freeArgs
+  // positionally, so two aliases must keep the map's declaration order.
+  @Test
+  fun `multi-alias map preserves declaration order across aliases`() {
+    val allopen = Path.of("/fake/allopen-compiler-plugin.jar")
+    val noarg = Path.of("/fake/noarg-compiler-plugin.jar")
+    assertEquals(
+      listOf("-Xplugin=$allopen", "-Xplugin=$noarg"),
+      PluginTranslator.translate(
+        linkedMapOf("allopen" to listOf(allopen), "noarg" to listOf(noarg))
+      ),
+    )
   }
 }

--- a/kolt-jvm-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
+++ b/kolt-jvm-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
@@ -98,12 +98,6 @@ fun main(args: Array<String>) {
   // "observability via metrics" rule from forking into two sinks.
   val metrics = StderrIcMetricsSink()
 
-  // ADR 0019 §9: translate the CLI-supplied alias→classpath map into the
-  // resolver signature BtaIncrementalCompiler expects. Unknown aliases
-  // return `emptyList()` so PluginTranslator can surface a plugin-not-
-  // found error at compile time rather than failing daemon startup.
-  val pluginJarResolver: (String) -> List<Path> = { alias -> cli.pluginJars[alias] ?: emptyList() }
-
   // Shared across daemon lifetimes via `<icRoot>/<kotlinVersion>/shrunk-snapshots/`.
   // The directory is created lazily inside `storeIfNew`, so daemon startup
   // does not depend on writable disk for the cache itself.
@@ -116,7 +110,7 @@ fun main(args: Array<String>) {
   val adapter =
     BtaIncrementalCompiler.create(
         btaImplJars = cli.btaImplJars.map { it.toPath() },
-        pluginJarResolver = pluginJarResolver,
+        pluginJars = cli.pluginJars,
         metrics = metrics,
         classpathSnapshotsDir =
           IcStateLayout.classpathSnapshotsDirFor(cli.icRoot, KOLT_DAEMON_KOTLIN_VERSION),

--- a/kolt-jvm-compiler-daemon/src/main/kotlin/kolt/daemon/server/DaemonServer.kt
+++ b/kolt-jvm-compiler-daemon/src/main/kotlin/kolt/daemon/server/DaemonServer.kt
@@ -243,9 +243,9 @@ class DaemonServer(
     // legacy `-Xplugin=...` plugin args into `extraArgs` for the
     // subprocess fallback path, which execs raw kotlinc and needs
     // them. The daemon path uses structured channels instead:
-    // - plugins flow through `--plugin-jars` → `pluginJarResolver` →
-    //   `PluginTranslator` → `COMPILER_PLUGINS` (BTA's structured
-    //   plugin list).
+    // - plugins flow through `--plugin-jars` → `pluginJars` →
+    //   `PluginTranslator` → `-Xplugin=<jar>` freeArgs forwarded into
+    //   BTA via `applyArgumentStrings` (ADR 0019 §9, post-#148).
     // - jvm target is hard-coded by the daemon's BTA setup.
     // Honouring `extraArgs` here would re-attach `-Xplugin=` as a
     // free-text compiler arg on top of the structured `CompilerPlugin`


### PR DESCRIPTION
The native side already filters enabled `[kotlin.plugins]` aliases and ships the resolved jar paths via `--plugin-jars`, so the daemon's re-parse was redundant. After re-reading the code I left a comment on #159 narrowing the scope from `M` to `S` and dropping the proposed `--enabled-plugins` flag (the existing `--plugin-jars` already encodes "enabled").

Reviewer focus:

- `PluginTranslator.translate` is now a one-liner over the wire-supplied map. The end-to-end iteration order chain — `fetchEnabledPluginJars` (`linkedMapOf`) → `mapValues` → wire serialization → daemon `parsePluginJars` (`linkedMapOf`) → `translate` — is what keeps `applyArgumentStrings` ordering deterministic. The new `multi-alias map preserves declaration order` unit test pins the translator end of that chain.
- `BtaIncrementalCompilerColdPathTest`'s plugin-path smoke is gone. Without the resolver hook there was no signal that wouldn't pass with `translate` stubbed to `emptyList()`. `BtaSerializationPluginTest`'s `\$serializer.class` assertion is the load-bearing coverage.
- ADR 0019 §9 prose was rewritten ("adapter consumes wire-friendly map" instead of "adapter reads kolt.toml"). §3's `IcRequest` example gained `projectRoot` since it has been load-bearing for `LanguageVersionTranslator` for a while and was inconsistently absent from the spec block.
- `LanguageVersionTranslator` still parses `kolt.toml`, so `IcRequest.projectRoot` and the daemon's ktoml dependency stay. Filed as a follow-up.

Dogfood: rebuilt `kolt-jvm-compiler-daemon` (which has `[kotlin.plugins] serialization = true`) through the modified daemon jar; plugin path exercised end to end.