### PR TITLE
Drop daemon kolt.toml re-parse for language version translation (#399)

### DIFF
--- a/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
+++ b/docs/adr/0019-incremental-build-kotlin-build-tools-api.md
@@ -64,7 +64,7 @@ interface IncrementalCompiler {
 
 data class IcRequest(
     val projectId: String,        // stable, caller-derived hash
-    val projectRoot: Path,        // source for `LanguageVersionTranslator` (§9)
+    val projectRoot: Path,        // identifies the project source tree for the IcReaper breadcrumb (§5)
     val sources: List<Path>,      // full source set
     val classpath: List<Path>,    // deps + stdlib, full
     val outputDir: Path,
@@ -132,11 +132,11 @@ Self-heal wipes `workingDir` before retrying so the next request does not read t
 
 ### §9 Plugin and compilerArguments plumbing: inside the adapter
 
-`IcRequest` does not carry `pluginClasspaths` or `compilerOptions`. The native client owns `kolt.toml` `[kotlin.plugins]`: it filters enabled aliases and resolves each to a jar path before launching the daemon, then ships the resulting `Map<alias, List<jarPath>>` over `--plugin-jars`. The adapter consumes that map directly via `PluginTranslator` and translates to `JvmCompilerArguments`. Plugin jars load into the same classloader hierarchy as `kotlin-build-tools-impl`.
+`IcRequest` does not carry `pluginClasspaths` or `compilerOptions`. The native client owns `kolt.toml`: it parses `[kotlin.plugins]` and `[kotlin]`, ships the resolved plugin-jar map via `--plugin-jars`, and ships the user's declared language/compiler version pair via `--kotlin-language-version` / `--kotlin-compiler-version`. The adapter's `PluginTranslator` and `LanguageVersionTranslator` consume those wire-supplied values directly; neither reads `kolt.toml`. Plugin jars load into the same classloader hierarchy as `kotlin-build-tools-impl`.
 
-Plugin passthrough mechanism (post-#148): the adapter emits `-Xplugin=<jar>` tokens via `CommonToolArguments.applyArgumentStrings`, not the structured `CommonCompilerArguments.COMPILER_PLUGINS` key. The structured key was added only in BTA 2.3.20 and rejects assignment on 2.3.0 / 2.3.10 impls even with an empty list. `applyArgumentStrings` is the passthrough surface present across the full 2.3.x family. Call order is load-bearing: `applyArgumentStrings` must precede any structured `set(...)` call because it resets non-mentioned arguments to parser defaults. See `spike/bta-compat-138/REPORT.md` for the empirical record.
+Plugin passthrough mechanism (post-#148): the adapter emits `-Xplugin=<jar>` tokens via `CommonToolArguments.applyArgumentStrings`, not the structured `CommonCompilerArguments.COMPILER_PLUGINS` key. The structured key was added only in BTA 2.3.20 and rejects assignment on 2.3.0 / 2.3.10 impls even with an empty list. `applyArgumentStrings` is the passthrough surface present across the full 2.3.x family. Call order is load-bearing: `applyArgumentStrings` must precede any structured `set(...)` call because it resets non-mentioned arguments to parser defaults. `LanguageVersionTranslator` rides the same single `applyArgumentStrings` batch — splitting into a second call would wipe the plugin freeArgs. See `spike/bta-compat-138/REPORT.md` for the empirical record.
 
-Passing plugin settings through `IcRequest` (option b) would force daemon core to carry fields whose shape is dictated by BTA's `JvmCompilerArguments` — the adapter boundary leaking by a different door. The pre-resolved `Map<alias, List<jarPath>>` shape passed via `--plugin-jars` is wire-friendly (string keys, path lists) and never references BTA types, so the invariant holds without daemon core needing to understand `kolt.toml` semantics.
+Passing translation inputs through `IcRequest` (option b) would force daemon core to carry fields whose shape is dictated by BTA's `JvmCompilerArguments` — the adapter boundary leaking by a different door. The wire-supplied shape (string keys, path lists, raw version strings) is BTA-neutral and lets daemon core stay free of `kolt.toml` semantics.
 
 ### §10 Rollout: default-on from day one
 
@@ -155,7 +155,7 @@ IC is the default compile path from the first B-2 release. No opt-in flag, no `k
 **Negative**
 - `@ExperimentalBuildToolsApi` is load-bearing. BTA surface can change on any minor compiler release. Mitigated by version pinning and the adapter integration test that exercises the cold-then-incremental cycle on every build.
 - `~/.kolt/daemon/ic/` accumulates state without a reaper (resolved: #125/PR #126 `cdf5da9` ships a reaper for non-current `<kotlinVersion>` segments and dangling projectId dirs).
-- The JVM adapter still parses `kolt.toml` once for `LanguageVersionTranslator`. Plugin settings stopped being parsed JVM-side once `--plugin-jars` carried pre-resolved jars (resolved: #159).
+- The JVM adapter parsed `kolt.toml` for plugin and language-version translation; both call sites stopped parsing once the values reached the adapter via wire flags (resolved: #159 plugins, #399 language version).
 - Classpath snapshot cost was ~310 ms per request before caching (resolved: #127 `ClasspathSnapshotCache` caches snapshots keyed by `(path, mtime, size)` in `<icRoot>/<kotlinVersion>/classpath-snapshots/`).
 
 ### Confirmation

--- a/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/BtaIncrementalCompiler.kt
@@ -58,6 +58,9 @@ private constructor(
   // Pre-resolved per ADR 0019 §9; daemon hands `--plugin-jars` through
   // unchanged.
   private val pluginJars: Map<String, List<Path>>,
+  // Wire-supplied per ADR 0019 §9; daemon hands raw values through unchanged.
+  private val kotlinLanguageVersion: String?,
+  private val kotlinCompilerVersion: String?,
   // ADR 0019 §7 observability: adapter-level counters are recorded here.
   // Defaults to no-op so tests that only care about the Result<,> shape
   // stay terse; Main wires `StderrIcMetricsSink` in production so
@@ -172,11 +175,12 @@ private constructor(
     // with `'moduleName' is null!` at `IncrementalJvmCompilerRunnerBase.makeServices`.
     // The structured `set(...)` calls therefore come AFTER the
     // passthrough so their values survive into the final compile.
-    // #162: language/api-version args must ride the same applyArgumentStrings
+    // Language/api-version args must ride the same applyArgumentStrings
     // batch as plugin args — the reset-to-default behavior documented above
     // would wipe whichever translator fed an earlier call.
     val translatedPluginArgs = PluginTranslator.translate(pluginJars)
-    val translatedLanguageArgs = LanguageVersionTranslator.translate(request.projectRoot)
+    val translatedLanguageArgs =
+      LanguageVersionTranslator.translate(kotlinLanguageVersion, kotlinCompilerVersion)
     val freeArgs = translatedPluginArgs + translatedLanguageArgs
     if (freeArgs.isNotEmpty()) {
       builder.compilerArguments.applyArgumentStrings(freeArgs)
@@ -435,6 +439,8 @@ private constructor(
     fun create(
       btaImplJars: List<Path>,
       pluginJars: Map<String, List<Path>> = emptyMap(),
+      kotlinLanguageVersion: String? = null,
+      kotlinCompilerVersion: String? = null,
       metrics: IcMetricsSink = NoopIcMetricsSink,
       // ADR 0019 §Negative follow-up (#127): shared directory for cached
       // ClasspathEntrySnapshot files. When null, a temp directory is used
@@ -465,6 +471,8 @@ private constructor(
           BtaIncrementalCompiler(
             toolchain = toolchain,
             pluginJars = pluginJars,
+            kotlinLanguageVersion = kotlinLanguageVersion,
+            kotlinCompilerVersion = kotlinCompilerVersion,
             metrics = metrics,
             classpathSnapshotCache = ClasspathSnapshotCache(toolchain, snapshotsDir, metrics),
             shrunkSnapshotCache = effectiveShrunkCache,

--- a/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/IncrementalCompiler.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/IncrementalCompiler.kt
@@ -19,7 +19,7 @@ interface IncrementalCompiler {
 
 data class IcRequest(
   val projectId: String,
-  // Source for `LanguageVersionTranslator` reading `[kotlin]` per ADR 0019 §9.
+  // Identifies the project source tree for the IcReaper breadcrumb (§5).
   val projectRoot: Path,
   val sources: List<Path>,
   val classpath: List<Path>,

--- a/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/LanguageVersionTranslator.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/main/kotlin/kolt/daemon/ic/LanguageVersionTranslator.kt
@@ -1,44 +1,13 @@
 package kolt.daemon.ic
 
-import com.akuleshov7.ktoml.Toml
-import com.akuleshov7.ktoml.TomlInputConfig
-import java.nio.file.Files
-import java.nio.file.Path
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-// #162: when `[kotlin] compiler` pins a kotlinc newer than `[kotlin] version`
-// (e.g. compiler=2.3.20 / version=2.1.0 to let 2.1-language projects run on the
-// daemon), emit `-language-version` / `-api-version` freeArgs so the compile
-// targets `version`, not `compiler`. Collapses to an empty list whenever the
-// two match (or `compiler` is unset) — keeps the common case warning-free.
-//
-// Runs in the same `applyArgumentStrings` batch as PluginTranslator output:
-// the BTA ordering invariant (see BtaIncrementalCompiler header comment) resets
-// every argument the call does not mention, so splitting these into a second
-// applyArgumentStrings would wipe the plugin freeArgs. Daemon core stays free
-// of a BTA-shaped `compilerArguments` field per ADR 0019 §3; the adapter reads
-// `kolt.toml` directly here for the same reason PluginTranslator does.
+// kotlinc rejects patch-level values: `-api-version 2.1.0` →
+// `Unknown -api-version value: 2.1.0`. Language/API surface is addressed by
+// `major.minor` only.
 object LanguageVersionTranslator {
 
-  fun translate(projectRoot: Path): List<String> {
-    val tomlFile = projectRoot.resolve("kolt.toml")
-    if (!Files.isRegularFile(tomlFile)) return emptyList()
-    val view =
-      Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = true))
-        .decodeFromString(KotlinView.serializer(), Files.readString(tomlFile))
-    val version = view.kotlin.version ?: return emptyList()
-    val compiler = view.kotlin.compiler ?: return emptyList()
-    if (compiler == version) return emptyList()
-    // kotlinc rejects patch-level values: `-api-version 2.1.0` →
-    // `Unknown -api-version value: 2.1.0`. Language/API surface is
-    // addressed by `major.minor` only.
+  fun translate(version: String?, compiler: String?): List<String> {
+    if (version == null || compiler == null || version == compiler) return emptyList()
     val surface = version.split('.').take(2).joinToString(".")
     return listOf("-language-version", surface, "-api-version", surface)
-  }
-
-  @Serializable
-  private data class KotlinView(@SerialName("kotlin") val kotlin: Section = Section()) {
-    @Serializable data class Section(val version: String? = null, val compiler: String? = null)
   }
 }

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/BtaSerializationPluginTest.kt
@@ -123,7 +123,7 @@ class BtaSerializationPluginTest {
     )
   }
 
-  // #162 single-batch invariant guard. When both PluginTranslator and
+  // Single-batch invariant guard. When both PluginTranslator and
   // LanguageVersionTranslator return non-empty lists, BtaIncrementalCompiler
   // must pass their concatenation to `applyArgumentStrings` in a *single*
   // call — two sequential calls would reset the earlier batch's args back
@@ -154,38 +154,18 @@ class BtaSerializationPluginTest {
     val projectStateDir = workRoot.resolve("ic").apply { createDirectories() }
     val workingDir = projectStateDir.resolve("main").apply { createDirectories() }
 
+    // version=2.1.0 with compiler=2.3.20 makes LanguageVersionTranslator emit
+    // `-language-version 2.1 -api-version 2.1`; PluginTranslator emits
+    // `-Xplugin=<serialization jar>`. The batch invariant is that both sets
+    // survive into the compile.
     val compiler =
       BtaIncrementalCompiler.create(
           btaImplJars = btaImplJars,
           pluginJars = mapOf("serialization" to serializationPluginJars),
+          kotlinLanguageVersion = "2.1.0",
+          kotlinCompilerVersion = "2.3.20",
         )
         .getOrElse { fail("failed to load BTA toolchain: $it") }
-
-    // version=2.1.0 with compiler=2.3.20 makes LanguageVersionTranslator
-    // emit `-language-version 2.1.0 -api-version 2.1.0`; plugin translator
-    // emits `-Xplugin=<serialization jar>`. The batch invariant is that
-    // both sets survive into the compile.
-    workRoot
-      .resolve("kolt.toml")
-      .writeText(
-        """
-            name = "demo"
-            version = "0.1.0"
-
-            [kotlin]
-            version = "2.1.0"
-            compiler = "2.3.20"
-
-            [kotlin.plugins]
-            serialization = true
-
-            [build]
-            target = "jvm"
-            main = "fixture.Payload"
-            sources = ["."]
-            """
-          .trimIndent()
-      )
 
     compiler
       .compile(

--- a/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/LanguageVersionTranslatorTest.kt
+++ b/kolt-jvm-compiler-daemon/ic/src/test/kotlin/kolt/daemon/ic/LanguageVersionTranslatorTest.kt
@@ -1,84 +1,38 @@
 package kolt.daemon.ic
 
-import java.nio.file.Files
-import kotlin.io.path.writeText
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class LanguageVersionTranslatorTest {
 
-  private val baseToml =
-    """
-        name = "demo"
-        version = "0.1.0"
-
-        [build]
-        target = "jvm"
-        main = "demo.Main"
-        sources = ["src/main/kotlin"]
-    """
-      .trimIndent()
-
   @Test
-  fun `missing kolt_toml yields no args`() {
-    val projectRoot = Files.createTempDirectory("lang-translator-empty-")
-    assertTrue(LanguageVersionTranslator.translate(projectRoot).isEmpty())
+  fun `both null yields no args`() {
+    assertTrue(LanguageVersionTranslator.translate(version = null, compiler = null).isEmpty())
   }
 
   @Test
-  fun `compiler unset yields no args`() {
-    val projectRoot = Files.createTempDirectory("lang-translator-unset-")
-    projectRoot
-      .resolve("kolt.toml")
-      .writeText(
-        """
-            $baseToml
+  fun `null version yields no args`() {
+    assertTrue(LanguageVersionTranslator.translate(version = null, compiler = "2.3.20").isEmpty())
+  }
 
-            [kotlin]
-            version = "2.1.0"
-            """
-          .trimIndent()
-      )
-    assertTrue(LanguageVersionTranslator.translate(projectRoot).isEmpty())
+  @Test
+  fun `null compiler yields no args`() {
+    assertTrue(LanguageVersionTranslator.translate(version = "2.1.0", compiler = null).isEmpty())
   }
 
   @Test
   fun `compiler equal to version yields no args`() {
-    val projectRoot = Files.createTempDirectory("lang-translator-equal-")
-    projectRoot
-      .resolve("kolt.toml")
-      .writeText(
-        """
-            $baseToml
-
-            [kotlin]
-            version = "2.3.20"
-            compiler = "2.3.20"
-            """
-          .trimIndent()
-      )
-    assertTrue(LanguageVersionTranslator.translate(projectRoot).isEmpty())
+    assertTrue(
+      LanguageVersionTranslator.translate(version = "2.3.20", compiler = "2.3.20").isEmpty()
+    )
   }
 
   @Test
-  fun `compiler higher than version emits language and api flags pinned to version`() {
-    val projectRoot = Files.createTempDirectory("lang-translator-higher-")
-    projectRoot
-      .resolve("kolt.toml")
-      .writeText(
-        """
-            $baseToml
-
-            [kotlin]
-            version = "2.1.0"
-            compiler = "2.3.20"
-            """
-          .trimIndent()
-      )
+  fun `differing version and compiler emit language and api flags pinned to version surface`() {
     assertEquals(
       listOf("-language-version", "2.1", "-api-version", "2.1"),
-      LanguageVersionTranslator.translate(projectRoot),
+      LanguageVersionTranslator.translate(version = "2.1.0", compiler = "2.3.20"),
     )
   }
 }

--- a/kolt-jvm-compiler-daemon/kolt.lock
+++ b/kolt-jvm-compiler-daemon/kolt.lock
@@ -3,10 +3,6 @@
   "kotlin": "2.3.20",
   "jvm_target": "25",
   "dependencies": {
-    "com.akuleshov7:ktoml-core": {
-      "version": "0.7.1",
-      "sha256": "c22cb661eefc75e30007a1b08d37c4e93a157f7f3a950a478251632c0af6050d"
-    },
     "com.michael-bull.kotlin-result:kotlin-result": {
       "version": "2.3.1",
       "sha256": "96289c225b06d20156a0695432afc104f187ab68c84e9b8bed7af573e5194c83"
@@ -36,14 +32,9 @@
       "sha256": "90c554e254623cc49de7ae4c7c932a86287795e45875c47e1937c29c297eff02",
       "test": true
     },
-    "org.jetbrains.kotlinx:kotlinx-datetime-jvm": {
-      "version": "0.7.1-0.6.x-compat",
-      "sha256": "cf9cdf7b3074044657a1a80bc1bb5280b58545a967ac7fe42b1aa3cf93305714",
-      "transitive": true
-    },
     "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm": {
-      "version": "1.9.0",
-      "sha256": "1f0afa172110e45a7231ef1b44ae8fd84c1ebaff96f3fc3ad68ef8c48120b59c",
+      "version": "1.7.3",
+      "sha256": "f0adde45864144475385cf4aa7e0b7feb27f61fcf9472665ed98cc971b06b1eb",
       "transitive": true
     },
     "org.jetbrains.kotlinx:kotlinx-serialization-json": {

--- a/kolt-jvm-compiler-daemon/kolt.toml
+++ b/kolt-jvm-compiler-daemon/kolt.toml
@@ -20,7 +20,6 @@ test_sources = ["src/test/kotlin", "ic/src/test/kotlin"]
 "org.jetbrains.kotlin:kotlin-build-tools-api" = "2.3.20"
 "org.jetbrains.kotlinx:kotlinx-serialization-json" = "1.7.3"
 "com.michael-bull.kotlin-result:kotlin-result" = "2.3.1"
-"com.akuleshov7:ktoml-core" = "0.7.1"
 
 [test-dependencies]
 "org.junit.jupiter:junit-jupiter" = "5.11.3"

--- a/kolt-jvm-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
+++ b/kolt-jvm-compiler-daemon/src/main/kotlin/kolt/daemon/Main.kt
@@ -57,6 +57,10 @@ internal data class CliArgs(
   // the no-op path in that case. The daemon is the sole consumer;
   // resolving these jars is the native client's responsibility.
   val pluginJars: Map<String, List<Path>>,
+  // ADR 0019 §9: user-declared `[kotlin] version` / `compiler` from the
+  // native client. Either may be null when the user did not declare it.
+  val kotlinLanguageVersion: String?,
+  val kotlinCompilerVersion: String?,
 )
 
 internal sealed interface CliError {
@@ -111,6 +115,8 @@ fun main(args: Array<String>) {
     BtaIncrementalCompiler.create(
         btaImplJars = cli.btaImplJars.map { it.toPath() },
         pluginJars = cli.pluginJars,
+        kotlinLanguageVersion = cli.kotlinLanguageVersion,
+        kotlinCompilerVersion = cli.kotlinCompilerVersion,
         metrics = metrics,
         classpathSnapshotsDir =
           IcStateLayout.classpathSnapshotsDirFor(cli.icRoot, KOLT_DAEMON_KOTLIN_VERSION),
@@ -167,6 +173,8 @@ internal fun parseArgs(args: Array<String>): Result<CliArgs, CliError> {
   var btaImplJars: String? = null
   var icRoot: String? = null
   var pluginJarsRaw: String? = null
+  var kotlinLanguageVersion: String? = null
+  var kotlinCompilerVersion: String? = null
   var i = 0
   while (i < args.size) {
     when (args[i]) {
@@ -190,6 +198,14 @@ internal fun parseArgs(args: Array<String>): Result<CliArgs, CliError> {
         pluginJarsRaw = args.getOrNull(i + 1)
         i += 2
       }
+      "--kotlin-language-version" -> {
+        kotlinLanguageVersion = args.getOrNull(i + 1)
+        i += 2
+      }
+      "--kotlin-compiler-version" -> {
+        kotlinCompilerVersion = args.getOrNull(i + 1)
+        i += 2
+      }
       else -> return Err(CliError.UnknownFlag(args[i]))
     }
   }
@@ -209,7 +225,17 @@ internal fun parseArgs(args: Array<String>): Result<CliArgs, CliError> {
           return Err(it)
         },
       )
-  return Ok(CliArgs(Path.of(socketPath), cjars, bjars, icRootPath, pluginJars))
+  return Ok(
+    CliArgs(
+      socketPath = Path.of(socketPath),
+      compilerJars = cjars,
+      btaImplJars = bjars,
+      icRoot = icRootPath,
+      pluginJars = pluginJars,
+      kotlinLanguageVersion = kotlinLanguageVersion,
+      kotlinCompilerVersion = kotlinCompilerVersion,
+    )
+  )
 }
 
 // Parses `alias=cp[;alias=cp]` where each `cp` is a File.pathSeparator-joined

--- a/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/MainCliArgsTest.kt
+++ b/kolt-jvm-compiler-daemon/src/test/kotlin/kolt/daemon/MainCliArgsTest.kt
@@ -246,6 +246,39 @@ class MainCliArgsTest {
   }
 
   @Test
+  fun kotlinLanguageAndCompilerVersionDefaultToNull() {
+    val result =
+      parseArgs(
+        arrayOf("--socket", "/tmp/s", "--compiler-jars", "/a.jar", "--bta-impl-jars", "/b.jar")
+      )
+    val cli = assertNotNull(result.get())
+    assertEquals(null, cli.kotlinLanguageVersion)
+    assertEquals(null, cli.kotlinCompilerVersion)
+  }
+
+  @Test
+  fun kotlinLanguageAndCompilerVersionParsedAsRawStrings() {
+    val result =
+      parseArgs(
+        arrayOf(
+          "--socket",
+          "/tmp/s",
+          "--compiler-jars",
+          "/a.jar",
+          "--bta-impl-jars",
+          "/b.jar",
+          "--kotlin-language-version",
+          "2.1.0",
+          "--kotlin-compiler-version",
+          "2.3.20",
+        )
+      )
+    val cli = assertNotNull(result.get())
+    assertEquals("2.1.0", cli.kotlinLanguageVersion)
+    assertEquals("2.3.20", cli.kotlinCompilerVersion)
+  }
+
+  @Test
   fun unknownFlagRejected() {
     val result =
       parseArgs(

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
@@ -41,6 +41,8 @@ internal constructor(
   private val socketPath: String,
   private val logPath: String? = null,
   private val pluginJars: Map<String, List<String>> = emptyMap(),
+  private val kotlinLanguageVersion: String? = null,
+  private val kotlinCompilerVersion: String? = null,
   private val connector: DaemonConnector = defaultDaemonConnector,
   private val spawner: DaemonSpawner = defaultDaemonSpawner,
   private val clockMs: () -> Long = ::monotonicMs,
@@ -57,6 +59,8 @@ internal constructor(
     socketPath: String,
     logPath: String? = null,
     pluginJars: Map<String, List<String>> = emptyMap(),
+    kotlinLanguageVersion: String? = null,
+    kotlinCompilerVersion: String? = null,
     onSpawn: () -> Unit = {},
   ) : this(
     javaBin = javaBin,
@@ -66,6 +70,8 @@ internal constructor(
     socketPath = socketPath,
     logPath = logPath,
     pluginJars = pluginJars,
+    kotlinLanguageVersion = kotlinLanguageVersion,
+    kotlinCompilerVersion = kotlinCompilerVersion,
     connector = defaultDaemonConnector,
     spawner = defaultDaemonSpawner,
     onSpawn = onSpawn,
@@ -154,6 +160,14 @@ internal constructor(
     if (pluginJars.isNotEmpty()) {
       add("--plugin-jars")
       add(pluginJars.entries.joinToString(";") { (alias, cp) -> "$alias=${cp.joinToString(":")}" })
+    }
+    if (kotlinLanguageVersion != null) {
+      add("--kotlin-language-version")
+      add(kotlinLanguageVersion)
+    }
+    if (kotlinCompilerVersion != null) {
+      add("--kotlin-compiler-version")
+      add(kotlinCompilerVersion)
     }
   }
 

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -1422,7 +1422,8 @@ internal fun resolveCompilerBackend(
   bundledKotlinVersion: String = BUNDLED_DAEMON_KOTLIN_VERSION,
   pluginJars: Map<String, List<String>> = emptyMap(),
   daemonDirCreator: (String) -> Result<Unit, MkdirFailed> = ::ensureDirectoryRecursive,
-  daemonBackendFactory: (DaemonSetup, Map<String, List<String>>) -> CompilerBackend =
+  daemonBackendFactory:
+    (DaemonSetup, Map<String, List<String>>, String?, String?) -> CompilerBackend =
     ::createDaemonBackend,
   warningSink: (String) -> Unit = ::eprintln,
   preconditionResolver:
@@ -1459,7 +1460,8 @@ internal fun resolveCompilerBackend(
   }
 
   return FallbackCompilerBackend(
-    primary = daemonBackendFactory(setup, pluginJars),
+    primary =
+      daemonBackendFactory(setup, pluginJars, config.kotlin.version, config.kotlin.compiler),
     fallback = subprocessBackend,
     onFallback = ::reportFallback,
   )
@@ -1521,12 +1523,17 @@ internal fun createNativeDaemonBackend(setup: NativeDaemonSetup): NativeCompiler
 internal fun createDaemonBackend(
   setup: DaemonSetup,
   pluginJars: Map<String, List<String>>,
+  kotlinLanguageVersion: String?,
+  kotlinCompilerVersion: String?,
 ): CompilerBackend {
-  // Plugin jars are baked into the daemon at spawn time. A fingerprint
-  // in the socket name forces a new daemon when the plugin set changes.
-  val fp = pluginsFingerprint(pluginJars)
-  val socketPath = applyPluginsFingerprintToFile(setup.socketPath, fp)
-  val logPath = applyPluginsFingerprintToFile(setup.logPath, fp)
+  // Plugin jars and the user's `[kotlin]` version pair are baked into the
+  // daemon at spawn time. A fingerprint in the socket name forces a new
+  // daemon when any of those inputs change so a stale daemon does not
+  // emit obsolete `-Xplugin=` / `-language-version` args for a refreshed
+  // request.
+  val fp = daemonInputsFingerprint(pluginJars, kotlinLanguageVersion, kotlinCompilerVersion)
+  val socketPath = applyDaemonInputsFingerprintToFile(setup.socketPath, fp)
+  val logPath = applyDaemonInputsFingerprintToFile(setup.logPath, fp)
   return DaemonCompilerBackend(
     javaBin = setup.javaBin,
     daemonLaunchArgs = setup.daemonLaunchArgs,
@@ -1535,21 +1542,30 @@ internal fun createDaemonBackend(
     socketPath = socketPath,
     logPath = logPath,
     pluginJars = pluginJars,
+    kotlinLanguageVersion = kotlinLanguageVersion,
+    kotlinCompilerVersion = kotlinCompilerVersion,
     onSpawn = { eprintln("starting compiler daemon...") },
   )
 }
 
-// Inner classpath order is significant (BTA plugin classpath order).
-internal fun pluginsFingerprint(pluginJars: Map<String, List<String>>): String {
-  if (pluginJars.isEmpty()) return "noplugins"
-  val canonical =
+// Inner classpath order is significant (BTA plugin classpath order). Alias
+// order is normalised to keep the fingerprint stable across map iteration
+// orders.
+internal fun daemonInputsFingerprint(
+  pluginJars: Map<String, List<String>>,
+  kotlinLanguageVersion: String?,
+  kotlinCompilerVersion: String?,
+): String {
+  val pluginsCanonical =
     pluginJars.entries
       .sortedBy { it.key }
       .joinToString(";") { (alias, cp) -> "$alias=${cp.joinToString(":")}" }
+  val canonical =
+    "plugins=$pluginsCanonical|lang=${kotlinLanguageVersion ?: ""}|cc=${kotlinCompilerVersion ?: ""}"
   return kolt.infra.sha256Hex(canonical.encodeToByteArray()).take(8)
 }
 
-internal fun applyPluginsFingerprintToFile(path: String, fingerprint: String): String {
+internal fun applyDaemonInputsFingerprintToFile(path: String, fingerprint: String): String {
   val slash = path.lastIndexOf('/')
   val dir = if (slash >= 0) path.substring(0, slash + 1) else ""
   val name = if (slash >= 0) path.substring(slash + 1) else path

--- a/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
@@ -107,9 +107,9 @@ internal fun stopProjectDaemons(
 // JVM daemon socket = `jvm-compiler-daemon.sock` (unfingerprinted, possible on old disks)
 // or `jvm-compiler-daemon-<fingerprint>.sock` (#138). `native-compiler-daemon.sock` starts with
 // `native-` and is explicitly excluded. The fingerprint segment must be
-// non-empty — `jvm-compiler-daemon-.sock` is not something `applyPluginsFingerprintToFile`
-// can emit today, but the length check keeps the predicate strict against
-// a future refactor.
+// non-empty — `jvm-compiler-daemon-.sock` is not something
+// `applyDaemonInputsFingerprintToFile` can emit today, but the length check
+// keeps the predicate strict against a future refactor.
 internal fun isJvmDaemonSocket(name: String): Boolean =
   name == "jvm-compiler-daemon.sock" ||
     (name.startsWith("jvm-compiler-daemon-") &&

--- a/src/nativeMain/kotlin/kolt/resolve/PluginJarFetcher.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/PluginJarFetcher.kt
@@ -164,8 +164,8 @@ fun fetchPluginJar(
  * Batch variant used by the compile path callers. Iterates enabled aliases in declaration order and
  * fetches each plugin jar; aborts on the first error so a missing jar does not silently produce a
  * half-plugged plugin set. Returns a LinkedHashMap to preserve iteration order for the
- * `pluginsFingerprint` helper in BuildCommands, which sorts internally but benefits from a stable
- * input for diffing.
+ * `daemonInputsFingerprint` helper in BuildCommands, which sorts internally but benefits from a
+ * stable input for diffing.
  */
 fun fetchEnabledPluginJars(
   plugins: Map<String, Boolean>,

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
@@ -68,6 +68,8 @@ private fun newBackend(
   spawner: DaemonSpawner = { _, _ -> Ok(Unit) },
   clock: FakeClock = FakeClock(),
   pluginJars: Map<String, List<String>> = emptyMap(),
+  kotlinLanguageVersion: String? = null,
+  kotlinCompilerVersion: String? = null,
   warnSink: (String) -> Unit = {},
 ): DaemonCompilerBackend =
   DaemonCompilerBackend(
@@ -78,6 +80,8 @@ private fun newBackend(
     socketPath = "/tmp/kolt-daemon-test.sock",
     logPath = "/tmp/kolt-daemon-test.log",
     pluginJars = pluginJars,
+    kotlinLanguageVersion = kotlinLanguageVersion,
+    kotlinCompilerVersion = kotlinCompilerVersion,
     connector = connector,
     spawner = spawner,
     clockMs = clock.clock,
@@ -352,8 +356,8 @@ class DaemonCompilerBackendConnectAndSpawnTest {
     assertEquals("serialization=/kt/lib/ser1.jar:/kt/lib/ser2.jar", argv[flagIdx + 1])
   }
 
-  // #65: multiple aliases joined with ';'. Iteration order matters —
-  // a non-LinkedHashMap would break pluginsFingerprint stability.
+  // Multiple aliases joined with ';'. Iteration order matters — a
+  // non-LinkedHashMap would break daemonInputsFingerprint stability.
   @Test
   fun spawnArgvSerialisesMultiplePluginsSemicolonSeparated() {
     var captured: List<String>? = null
@@ -383,6 +387,70 @@ class DaemonCompilerBackendConnectAndSpawnTest {
     val flagIdx = argv.indexOf("--plugin-jars")
     assertTrue(flagIdx >= 0, "spawnArgv must include --plugin-jars, got: $argv")
     assertEquals("serialization=/p/ser.jar;allopen=/p/open.jar", argv[flagIdx + 1])
+  }
+
+  @Test
+  fun spawnArgvOmitsKotlinVersionFlagsWhenBothNull() {
+    var captured: List<String>? = null
+    var attempt = 0
+    val connector: DaemonConnector = { path ->
+      attempt++
+      if (attempt == 1) {
+        Err(UnixSocketError.ConnectFailed(path, platform.posix.ENOENT, "No such file"))
+      } else {
+        Ok(FakeConnection())
+      }
+    }
+    val backend =
+      newBackend(
+        connector = connector,
+        spawner = { argv, _ ->
+          captured = argv
+          Ok(Unit)
+        },
+      )
+
+    backend.compile(sampleRequest())
+
+    val argv = assertNotNull(captured)
+    assertFalse(
+      argv.contains("--kotlin-language-version") || argv.contains("--kotlin-compiler-version"),
+      "spawnArgv must omit kotlin version flags when both are null, got: $argv",
+    )
+  }
+
+  @Test
+  fun spawnArgvEmitsKotlinVersionFlagsWhenSet() {
+    var captured: List<String>? = null
+    var attempt = 0
+    val connector: DaemonConnector = { path ->
+      attempt++
+      if (attempt == 1) {
+        Err(UnixSocketError.ConnectFailed(path, platform.posix.ENOENT, "No such file"))
+      } else {
+        Ok(FakeConnection())
+      }
+    }
+    val backend =
+      newBackend(
+        connector = connector,
+        spawner = { argv, _ ->
+          captured = argv
+          Ok(Unit)
+        },
+        kotlinLanguageVersion = "2.1.0",
+        kotlinCompilerVersion = "2.3.20",
+      )
+
+    backend.compile(sampleRequest())
+
+    val argv = assertNotNull(captured)
+    val langIdx = argv.indexOf("--kotlin-language-version")
+    val ccIdx = argv.indexOf("--kotlin-compiler-version")
+    assertTrue(langIdx >= 0, "spawnArgv must include --kotlin-language-version, got: $argv")
+    assertTrue(ccIdx >= 0, "spawnArgv must include --kotlin-compiler-version, got: $argv")
+    assertEquals("2.1.0", argv[langIdx + 1])
+    assertEquals("2.3.20", argv[ccIdx + 1])
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ResolveCompilerBackendTest.kt
@@ -56,7 +56,7 @@ class ResolveCompilerBackendTest {
           error("must not resolve preconditions when useDaemon=false")
         },
         daemonDirCreator = { error("must not create daemon dir when useDaemon=false") },
-        daemonBackendFactory = { _, _ ->
+        daemonBackendFactory = { _, _, _, _ ->
           error("must not construct daemon backend when useDaemon=false")
         },
         warningSink = { warnings.add(it) },
@@ -91,7 +91,7 @@ class ResolveCompilerBackendTest {
           )
         },
         daemonDirCreator = { error("must not create daemon dir after precondition failure") },
-        daemonBackendFactory = { _, _ ->
+        daemonBackendFactory = { _, _, _, _ ->
           error("must not construct daemon backend after precondition failure")
         },
         warningSink = { warnings.add(it) },
@@ -124,7 +124,7 @@ class ResolveCompilerBackendTest {
           Ok(okSetup)
         },
         daemonDirCreator = { Ok(Unit) },
-        daemonBackendFactory = { _, _ -> daemonSentinel },
+        daemonBackendFactory = { _, _, _, _ -> daemonSentinel },
         warningSink = { error("happy path must not warn") },
       )
 
@@ -144,7 +144,7 @@ class ResolveCompilerBackendTest {
         absProjectPath = absProject,
         preconditionResolver = { _, _, _, _ -> Err(DaemonPreconditionError.DaemonJarMissing) },
         daemonDirCreator = { error("must not create daemon dir after precondition failure") },
-        daemonBackendFactory = { _, _ ->
+        daemonBackendFactory = { _, _, _, _ ->
           error("must not construct daemon backend after precondition failure")
         },
         warningSink = { warnings.add(it) },
@@ -178,7 +178,7 @@ class ResolveCompilerBackendTest {
           )
         },
         daemonDirCreator = { error("must not create daemon dir after precondition failure") },
-        daemonBackendFactory = { _, _ ->
+        daemonBackendFactory = { _, _, _, _ ->
           error("must not construct daemon backend after precondition failure")
         },
         warningSink = { warnings.add(it) },
@@ -213,7 +213,7 @@ class ResolveCompilerBackendTest {
         absProjectPath = absProject,
         preconditionResolver = { _, _, _, _ -> Ok(okSetup) },
         daemonDirCreator = { Err(MkdirFailed(okSetup.daemonDir)) },
-        daemonBackendFactory = { _, _ ->
+        daemonBackendFactory = { _, _, _, _ ->
           error("must not construct daemon backend after mkdir failure")
         },
         warningSink = { warnings.add(it) },
@@ -241,7 +241,7 @@ class ResolveCompilerBackendTest {
         pluginJars = pluginJars,
         preconditionResolver = { _, _, _, _ -> Ok(okSetup) },
         daemonDirCreator = { Ok(Unit) },
-        daemonBackendFactory = { _, jars ->
+        daemonBackendFactory = { _, jars, _, _ ->
           capturedPluginJars = jars
           daemonSentinel
         },
@@ -273,7 +273,7 @@ class ResolveCompilerBackendTest {
           assertEquals(okSetup.daemonDir, dir)
           Ok(Unit)
         },
-        daemonBackendFactory = { setup, _ ->
+        daemonBackendFactory = { setup, _, _, _ ->
           createdFrom = setup
           daemonSentinel
         },
@@ -288,40 +288,65 @@ class ResolveCompilerBackendTest {
   }
 
   @Test
-  fun pluginsFingerprintIsStableForSamePluginMap() {
-    val a = pluginsFingerprint(mapOf("serialization" to listOf("/k/lib/ser.jar")))
-    val b = pluginsFingerprint(mapOf("serialization" to listOf("/k/lib/ser.jar")))
+  fun daemonInputsFingerprintIsStableForSameInputs() {
+    val a =
+      daemonInputsFingerprint(mapOf("serialization" to listOf("/k/lib/ser.jar")), "2.1.0", "2.3.20")
+    val b =
+      daemonInputsFingerprint(mapOf("serialization" to listOf("/k/lib/ser.jar")), "2.1.0", "2.3.20")
     assertEquals(a, b)
   }
 
   @Test
-  fun pluginsFingerprintIsOrderInsensitiveOnAliases() {
-    val a = pluginsFingerprint(linkedMapOf("a" to listOf("/x"), "b" to listOf("/y")))
-    val b = pluginsFingerprint(linkedMapOf("b" to listOf("/y"), "a" to listOf("/x")))
+  fun daemonInputsFingerprintIsOrderInsensitiveOnAliases() {
+    val a =
+      daemonInputsFingerprint(linkedMapOf("a" to listOf("/x"), "b" to listOf("/y")), null, null)
+    val b =
+      daemonInputsFingerprint(linkedMapOf("b" to listOf("/y"), "a" to listOf("/x")), null, null)
     assertEquals(a, b)
   }
 
   @Test
-  fun pluginsFingerprintChangesWhenAClasspathChanges() {
-    val a = pluginsFingerprint(mapOf("serialization" to listOf("/k/lib/ser-2.0.jar")))
-    val b = pluginsFingerprint(mapOf("serialization" to listOf("/k/lib/ser-2.1.jar")))
-    assertTrue(a != b, "version bump should change fingerprint, both=$a")
+  fun daemonInputsFingerprintChangesWhenAClasspathChanges() {
+    val a =
+      daemonInputsFingerprint(mapOf("serialization" to listOf("/k/lib/ser-2.0.jar")), null, null)
+    val b =
+      daemonInputsFingerprint(mapOf("serialization" to listOf("/k/lib/ser-2.1.jar")), null, null)
+    assertTrue(a != b, "plugin classpath change should change fingerprint, both=$a")
   }
 
   @Test
-  fun pluginsFingerprintEmptyMapHasFixedMarker() {
-    assertEquals("noplugins", pluginsFingerprint(emptyMap()))
+  fun daemonInputsFingerprintChangesWhenLanguageVersionChanges() {
+    val a = daemonInputsFingerprint(emptyMap(), "2.0.0", "2.3.20")
+    val b = daemonInputsFingerprint(emptyMap(), "2.1.0", "2.3.20")
+    assertTrue(a != b, "language version change must spawn a new daemon, both=$a")
   }
 
   @Test
-  fun applyPluginsFingerprintInsertsBeforeExtension() {
+  fun daemonInputsFingerprintChangesWhenCompilerVersionChanges() {
+    val a = daemonInputsFingerprint(emptyMap(), "2.1.0", "2.3.10")
+    val b = daemonInputsFingerprint(emptyMap(), "2.1.0", "2.3.20")
+    assertTrue(a != b, "compiler version change must spawn a new daemon, both=$a")
+  }
+
+  @Test
+  fun daemonInputsFingerprintDistinguishesNullFromEmpty() {
+    // Defensive: an empty-string version field must not collide with the
+    // null (unset) case. Both serialise into the canonical string but the
+    // hash should differ once either grows a value.
+    val nullPair = daemonInputsFingerprint(emptyMap(), null, null)
+    val withLang = daemonInputsFingerprint(emptyMap(), "2.1.0", null)
+    assertTrue(nullPair != withLang, "presence of language version must perturb the fingerprint")
+  }
+
+  @Test
+  fun applyDaemonInputsFingerprintInsertsBeforeExtension() {
     assertEquals(
       "/fake/daemon/dir/jvm-compiler-daemon-abcd1234.sock",
-      applyPluginsFingerprintToFile("/fake/daemon/dir/jvm-compiler-daemon.sock", "abcd1234"),
+      applyDaemonInputsFingerprintToFile("/fake/daemon/dir/jvm-compiler-daemon.sock", "abcd1234"),
     )
     assertEquals(
       "/fake/daemon/dir/jvm-compiler-daemon-abcd1234.log",
-      applyPluginsFingerprintToFile("/fake/daemon/dir/jvm-compiler-daemon.log", "abcd1234"),
+      applyDaemonInputsFingerprintToFile("/fake/daemon/dir/jvm-compiler-daemon.log", "abcd1234"),
     )
   }
 


### PR DESCRIPTION
Mirrors #159 for the second translator. Native parses `[kotlin]` version/compiler from `kolt.toml` and ships them as raw `--kotlin-language-version` / `--kotlin-compiler-version` flags on daemon spawn; `LanguageVersionTranslator` becomes a pure function over the pair. The daemon's last `kolt.toml` read is gone and `com.akuleshov7:ktoml-core` drops out of the daemon's `[dependencies]`.

Reviewer focus:

- The version pair joined the daemon socket fingerprint. Pre-#399 the daemon re-read `kolt.toml` per request, so a project editing `[kotlin] version` was picked up without a daemon recycle. Post-#399 the field is fixed at spawn time — without the fingerprint extension a stale daemon would emit obsolete `-language-version` args for a refreshed request. `pluginsFingerprint` is renamed to `daemonInputsFingerprint` and now hashes `(plugins, languageVersion, compilerVersion)` together. Two new tests pin the language- and compiler-version diff cases.
- The `daemonBackendFactory` lambda widened from `(DaemonSetup, Map) -> CompilerBackend` to a 4-arg shape. Six existing test mocks updated to `(_, _, _, _)`. A small `data class DaemonInputs(plugins, langVersion, compilerVersion)` is the natural follow-up to keep the lambda 2-arity and to consolidate the fingerprint formula at the same boundary — out of scope here.
- `DaemonCompilerBackend` got positive+negative `spawnArgv` tests for the two new flags (memory `feedback_daemon_canary_pattern.md` — a positive-only test would miss a `if (… != null)` guard regression).
- `IcRequest.projectRoot` stays. Only consumer left is the `BtaIncrementalCompiler` IcReaper breadcrumb (`request.projectRoot.toString()` written to `projectStateDir/project.path`). `IncrementalCompiler.kt` and ADR §3's `IcRequest` example comment updated to reflect that.
- ADR 0019 §9 prose: rewrote to "neither translator reads kolt.toml". §Negative bullet now annotates plugin removal as #159 and language-version removal as #399.

Dogfood: rebuilt `kolt-jvm-compiler-daemon` (its kolt.toml has `version = "2.3.20"`, no `compiler`) through the modified daemon — passes; the language path stays a no-op as expected, plugin path still works.