### PR TITLE
Add [tools] section for project-pinned executable jars

### DIFF
--- a/.kiro/specs/341-tools-section/design.md
+++ b/.kiro/specs/341-tools-section/design.md
@@ -1,0 +1,793 @@
+# Design Document — `[tools]` Section for Project-Pinned Executable Jars
+
+## Overview
+
+`[tools]` セクションは「プロジェクトに紐付くが、 プロジェクト本体の依存ではない」 runnable jar (ktlint / detekt 等) を kolt.toml に alias + Maven coordinates で宣言できるようにする機能である。 kolt は jar を **アプリの classpath とは隔離された** per-alias cache に解決し、 SHA-256 を含む形で kolt.lock に pin し、 ユーザーの呼び出し時に bootstrap JDK で `java -jar` 起動して引数を verbatim 透過する。
+
+**Purpose**: This feature delivers per-project runnable-jar tooling to kolt users, avoiding both `[dependencies]` の classpath 汚染 と global install の版 drift。
+
+**Users**: Kotlin 開発者で、 ktlint / detekt のような jar ツールをチームで共通 pin したいケース。
+
+**Impact**: kolt.toml schema に新セクション、 kolt.lock format に additive な `tools_bundles` field、 CLI に `kolt tool run` subcommand を追加する。 ADR 0028 §3 凍結面が拡張される (本設計の commit と同時に ADR 改訂を land させる)。
+
+### Goals
+
+- alias + coordinates の `[tools]` 宣言を kolt.toml で受理し、 alias 文法と orchestration ガードレールを parse-time に loud reject する
+- `kolt tool run <alias> [args]` で per-alias cache に解決した runnable jar を `java -jar` で起動、 引数 verbatim 透過、 exit code そのまま伝播
+- 解決済 coordinates と SHA-256 を kolt.lock に pin し、 lockfile と kolt.toml の矛盾は loud reject (silent overwrite しない)
+- jar 起動失敗を **resolve / Main-Class / launch** の 3 系統に cause-distinguishable に surface する (kolt 自身の exit code で識別可能)
+- bootstrap JDK 経路で起動 (host PATH の `java` には依存しない)
+
+### Non-Goals
+
+- `[hooks]` (#119) との連携。 `[hooks]` が landing したら別 spec で扱う
+- distribution-zip / launcher-script 形式のツール (kotlinc-style)
+- 短縮構文 (`ktlint = "1.3.1"`) と組み込み name → coords レジストリ
+- グローバルインストール (`~/.kolt/bin/`)
+- ツールごとに別 JDK version を要求する schema (将来 v1.1 以降の additive 拡張対象)
+- 依存性のある jar (transitive を必要とするツール) のサポート — fat-jar / runnable jar のみ
+
+## Boundary Commitments
+
+### This Spec Owns
+
+- kolt.toml の `[tools.<alias>]` schema 定義と parse・validation
+- alias 文法 (regex) と orchestration field 拒否ルール
+- `~/.kolt/tools/bundles/<alias>/<version>/` 配下の per-alias cache layout
+- kolt.lock の `tools_bundles` field 形と round-trip serialization
+- `kolt tool run <alias> [-- args...]` CLI surface とその dispatch
+- jar 起動失敗の cause-distinguishable な exit code mapping (`ToolError` sealed)
+- `META-INF/MANIFEST.MF` からの Main-Class 抽出 (libarchive cinterop)
+- 起動 JDK の選択 (v1 は bootstrap JDK 固定)
+
+### Out of Boundary
+
+- `[dependencies]` / `[test-dependencies]` / `[classpaths]` 配下の解決経路 (本 spec は触らない)
+- daemon (JVM / native) 関連の挙動 (本 spec のツール起動は subprocess、 daemon は使わない)
+- bootstrap JDK 自体の provisioning (`ensureBootstrapJavaBin` を adopt するだけで、 install logic 変更なし)
+- Maven repo の URL 構築・SHA-256 検証 primitives (`kolt.resolve` 既存 API を adopt)
+- 既存 `~/.kolt/tools/<filename>` flat layout (kolt-internal 用 ktfmt / junit-console。 本 spec は別 layout `~/.kolt/tools/bundles/` を新設して衝突回避)
+- `[hooks]` (#119) integration、 lifecycle event 自動連携
+- ツールごと JDK pin / native ツール起動 / Windows 対応
+
+### Allowed Dependencies
+
+- **Upstream (この spec が依存)**:
+  - `kolt.config` (RawKoltConfig 拡張、 KoltPaths 拡張)
+  - `kolt.resolve` (`BundleResolver` の transitive-skip 起動経路、 `Lockfile` field 拡張、 `Coordinate`、 path/URL builder、 SHA-256 verify)
+  - `kolt.tool` (toolchain JDK provisioning — `ensureBootstrapJavaBin`)
+  - `kolt.infra` (`Process.executeCommand`、 file I/O)
+  - libarchive cinterop (zip read for MANIFEST.MF)
+- **Downstream (この spec を消費)**:
+  - `kolt.cli.ToolCommands` (本 spec が新設、 `Main.kt` から dispatch)
+- 違反禁止: `kolt.usertool` から `kolt.cli` への依存 (cli → build → resolve の方向逆転)、 `kolt.usertool` から daemon backend への依存
+
+### Revalidation Triggers
+
+ADR 0028 §3 凍結面に同時に複数 surface を加えるため、 以下のいずれかが変わったら依存 spec / consumer を revalidate する必要がある:
+
+- alias 文法 regex の変更 (現在の宣言を無効化する narrow は不可)
+- `tools_bundles` lockfile field 形の変更 (additive 以外)
+- `~/.kolt/tools/bundles/<alias>/<version>/` cache layout の変更
+- `kolt tool run` CLI surface の変更 (subcommand 形 / `--`-passthrough 規約)
+- `ToolError` exit code mapping の変更 (user 契約)
+- bootstrap JDK fallback ポリシー変更 (例: ツールごと JDK pin 導入)
+
+## Architecture
+
+### Existing Architecture Analysis
+
+kolt は **native-first CLI + JVM sidecar daemon** 構成。 user-facing binary は `kolt.kexe` (Kotlin/Native linuxX64)。 既存依存解決 (`kolt.resolve`) は POM + Gradle metadata + transitive fixpoint + SHA-256 verify を備え、 `BundleResolver` は `[classpaths.<name>]` 用に bundle isolation 経路 (子 graph を独立 fixpoint 化) を提供している。 lockfile (`kolt.lock`) は v4 JSON で、 nested map (`classpathBundles: Map<String, Map<String, LockEntry>>`) の precedent を持つ。 JDK 取り扱いは `kolt.tool` で `ensureBootstrapJavaBin` (固定 version 25) と `ensureJdkBins(version)` の 2 経路。 jar 起動は既に `executeCommand(args, extraEnv)` で subprocess fork、 引数 verbatim、 exit code propagation が確立済 (ktfmt / junit-console / daemon jar 起動で再利用中)。
+
+`kolt.tool` package 名は既存で **toolchain provisioning 専用** (kotlinc / JDK / konanc / kolt-internal 用 `ensureTool`)。 本 spec の新コードは package `kolt.usertool` に置き、 命名衝突を避ける (`[tools]` config section 名と package 名は直交、 内部実装で混同しない)。
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+    subgraph cli[kolt.cli]
+        Main[Main.kt]
+        ToolCommands[ToolCommands]
+    end
+    subgraph usertool[kolt.usertool]
+        ToolSection[ToolSection]
+        ToolSectionParse[ToolSectionParse]
+        ToolResolution[ToolResolution]
+        ToolLauncher[ToolLauncher]
+        ToolError[ToolError]
+    end
+    subgraph config[kolt.config]
+        RawKoltConfig[RawKoltConfig]
+        KoltPaths[KoltPaths]
+    end
+    subgraph resolve[kolt.resolve]
+        BundleResolver[BundleResolver]
+        Lockfile[Lockfile]
+        Coordinate[Coordinate]
+    end
+    subgraph tool[kolt.tool]
+        BootstrapJdk[BootstrapJdk]
+    end
+    subgraph infra[kolt.infra]
+        Process[Process]
+        Libarchive[libarchive cinterop]
+    end
+
+    Main --> ToolCommands
+    ToolCommands --> ToolSection
+    ToolCommands --> ToolResolution
+    ToolCommands --> ToolLauncher
+    ToolCommands --> ToolError
+    ToolSection --> RawKoltConfig
+    ToolSectionParse --> RawKoltConfig
+    ToolResolution --> BundleResolver
+    ToolResolution --> Lockfile
+    ToolResolution --> Coordinate
+    ToolResolution --> KoltPaths
+    ToolLauncher --> BootstrapJdk
+    ToolLauncher --> Process
+    ToolLauncher --> Libarchive
+    ToolLauncher --> KoltPaths
+```
+
+**Architecture Integration**:
+
+- **Selected pattern**: layered native-first CLI、 cli → usertool → (config / resolve / tool / infra)。 既存の cli → build → resolve 方向と整合
+- **Domain boundaries**: `kolt.usertool` は jar 取得 + 起動 のみ。 orchestration / lifecycle 連携は明示的に持たず、 R7 の境界をパッケージ境界として表現
+- **Existing patterns preserved**: `BundleResolver` の bundle-isolation 経路、 `LockEntry(version, sha256, ...)` schema、 `executeCommand(args, env)` launch、 `Result<V, E>` error handling
+- **New components rationale**: ToolSectionParse は ktoml AST レベルの strict-key 検証が必要 (R7.1/R7.2)、 ToolLauncher は libarchive 経路での MANIFEST.MF 読みが新規 (R5.2)
+- **Steering compliance**: ADR 0001 (Result-based error handling)、 ADR 0017 (bootstrap JDK)、 ADR 0028 §3 (凍結面追加)、 ADR 0031 (libarchive 採用) に準拠
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|---|---|---|---|
+| CLI | `kolt.kexe` Kotlin/Native linuxX64 | `kolt tool run <alias>` dispatch | `Main.kt` の `when` に case 追加 |
+| Config schema | ktoml-core 0.7.x | `[tools]` table parse | `ignoreUnknownNames=true` 既定。 strict-key validation は AST scan で別経路 |
+| Resolution | `kolt.resolve.BundleResolver` (kotlin-result 2.x) | transitive-skip mode で単一 jar 解決 + SHA-256 verify | 既存 fixpointResolve に childLookup={emptyList} を渡して transitive 抑止 |
+| Lockfile | kotlinx.serialization JSON v4 | `tools_bundles` field 追加 | additive。 `classpathBundles` と同 nested 形 |
+| Cache | `~/.kolt/tools/bundles/<alias>/<version>/<filename>` | per-alias 隔離 layout | 既存 `~/.kolt/tools/<filename>` flat (kolt-internal 用) と分離 |
+| JDK | bootstrap JDK 25 (`ensureBootstrapJavaBin`) | jar 起動の `java` 解決 | v1 は固定。 ツールごと JDK pin は将来 |
+| Process | `kolt.infra.Process.executeCommand` | fork/execvp + 引数 verbatim + exit code 透過 | 既存 |
+| Manifest read | libarchive cinterop (ADR 0031) | jar 内 `META-INF/MANIFEST.MF` から Main-Class 抽出 | zip read API を utility 関数に薄く wrap |
+
+## File Structure Plan
+
+### Directory Structure
+
+```
+src/nativeMain/kotlin/kolt/usertool/
+├── ToolSection.kt              # KoltConfig.tools の公開型 (ToolSection, ToolEntry)
+├── ToolSectionParse.kt         # ktoml deserialize + AST strict-key check + alias regex
+├── ToolResolution.kt           # BundleResolver 連携 (transitive-skip) + cache layout + lockfile pin/read
+├── ToolLauncher.kt             # libarchive で MANIFEST 読 + bootstrap JDK 解決 + executeCommand
+└── ToolError.kt                # sealed class、 cause-distinguishable な exit code mapping
+
+src/nativeMain/kotlin/kolt/cli/
+└── ToolCommands.kt             # `doTool(args)` 関数: `kolt tool run <alias> [-- args...]` dispatch
+
+src/nativeTest/kotlin/kolt/usertool/
+├── ToolSectionParseTest.kt     # alias 文法 / orchestration field reject / coords 形 round-trip
+├── ToolResolutionTest.kt       # cache hit / miss / SHA-256 mismatch / lockfile round-trip
+├── ToolLauncherTest.kt         # MANIFEST 読 / Main-Class missing / non-runnable jar / JDK missing
+└── ToolErrorTest.kt            # exit code mapping coverage
+
+src/nativeTest/kotlin/kolt/cli/
+└── ToolCommandsTest.kt         # `--`-passthrough / unknown alias / 引数 verbatim
+```
+
+### Modified Files
+
+- `src/nativeMain/kotlin/kolt/config/Config.kt`
+  - `RawKoltConfig` に `tools: Map<String, RawToolEntry>?` field 追加 (ktoml deserialize)
+  - `KoltConfig` に `tools: Map<String, ToolEntry>` field 追加 (validated)
+  - `validateConfig` chain に `validateToolSection` 呼び出しを追加
+- `src/nativeMain/kotlin/kolt/config/KoltPaths.kt`
+  - `fun toolsBundleDir(alias: String, version: String): String`
+  - `fun toolsBundleJarPath(alias: String, version: String, fileName: String): String`
+- `src/nativeMain/kotlin/kolt/resolve/Lockfile.kt`
+  - `Lockfile` data class に `toolsBundles: Map<String, Map<String, LockEntry>> = emptyMap()` 追加
+  - `LockfileJson` 拡張、 `parseLockfile` / `serializeLockfile` round-trip 対応
+- `src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt`
+  - transitive-skip 起動経路を export (内部関数 `resolveSingleArtifact` か、 既存 `resolveBundle` に `transitive: Boolean = true` flag を追加)
+- `src/nativeMain/kotlin/kolt/cli/Main.kt`
+  - `when (filteredArgs[0])` に `"tool"` case 追加
+  - `printUsage()` に `kolt tool run <alias> [-- args...]` の help text 追加
+- `src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt`
+  - `doUpdateInner` を [tools] にも対応するよう拡張 (`config.tools` を seed として `BundleResolver.resolveSingleArtifact` を回し、 `Lockfile.toolsBundles` を rewrite)。 R4.3 の唯一の更新経路
+- `src/nativeMain/kotlin/kolt/cli/ExitCode.kt`
+  - `EXIT_TOOL_ERROR = 7` の追加 (jar 起動の失敗系 — Main-Class missing / non-runnable / JDK unavailable)
+- `src/nativeTest/kotlin/kolt/resolve/LockfileTest.kt`
+  - `toolsBundles` round-trip テストを既存 `classpathBundles` テスト構造に揃えて追加
+
+### New Tests Outside `usertool/`
+
+- `src/nativeTest/kotlin/kolt/config/ToolSectionConfigTest.kt`
+  - `KoltConfig.tools` が parse 結果に正しく反映されること、 重複 alias の reject
+
+## System Flows
+
+### `kolt tool run <alias>` 起動フロー
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant Main as Main
+    participant TC as ToolCommands
+    participant TR as ToolResolution
+    participant BR as BundleResolver
+    participant TL as ToolLauncher
+    participant LA as libarchive
+    participant BJ as BootstrapJdk
+    participant P as Process
+
+    U->>Main: kolt tool run ktlint --reporter plain
+    Main->>TC: doTool(args)
+    TC->>TC: parse alias and passthrough args
+    TC->>TR: ensureTool(alias)
+    alt cache hit and lockfile pin matches
+        TR-->>TC: jarPath
+    else miss or first run
+        TR->>BR: resolveSingleArtifact(coords)
+        BR->>BR: download and verify SHA-256
+        BR-->>TR: artifact
+        TR->>TR: write tools_bundles to lockfile
+        TR-->>TC: jarPath
+    end
+    TC->>TL: launch(jarPath, args)
+    TL->>LA: readManifest(jarPath)
+    LA-->>TL: Main-Class
+    alt Main-Class found
+        TL->>BJ: ensureBootstrapJavaBin
+        BJ-->>TL: javaBin
+        TL->>P: executeCommand java -jar jarPath args
+        P-->>TL: exitCode
+        TL-->>TC: ExitCode of tool
+        TC-->>U: stdout and stderr passthrough; exit
+    else Main-Class missing
+        TL-->>TC: ToolError MainClassMissing
+        TC-->>U: stderr message; exit non-zero
+    end
+```
+
+**Key decisions**:
+- cache hit / miss の分岐は `ToolResolution.ensureTool` 内で完結。 lockfile が pin を持っていてかつ cache に jar があれば fully offline
+- `MainClassMissing` は libarchive で MANIFEST 読了後の synchronous な失敗 — JVM 起動前に検出するため、 「JVM が起動して 1 で死ぬ」 brittle path に依存しない
+- 起動失敗 (TR / TL) 系の kolt-side exit code は `ToolError` enum で識別可能。 ツール実行成功時の exit code はツール自身の値をそのまま透過 (kolt は overlay しない)
+
+### kolt.toml load 時の `[tools]` validation
+
+```mermaid
+graph TD
+    Start[Read kolt toml] --> Decode[ktoml decode RawKoltConfig]
+    Decode --> AstScan[Read TomlNode tree for tools subtree]
+    AstScan --> KeyCheck{Each entry's keys subset of allowlist coords}
+    KeyCheck -- no --> RejectKey[Reject: orchestration field present]
+    KeyCheck -- yes --> AliasCheck{alias matches regex}
+    AliasCheck -- no --> RejectAlias[Reject: alias grammar violation]
+    AliasCheck -- yes --> CoordsCheck{coords parses as group artifact version classifier}
+    CoordsCheck -- no --> RejectCoords[Reject: coords malformed]
+    CoordsCheck -- yes --> DupCheck{alias unique}
+    DupCheck -- no --> RejectDup[Reject: duplicate alias]
+    DupCheck -- yes --> Accept[Accept entry into KoltConfig tools]
+```
+
+**Key decisions**:
+- ktoml の global `ignoreUnknownNames=true` を維持しつつ、 `[tools]` subtree だけ AST scan で strict-key check する 2 段構え
+- 失敗箇所はすべて kolt.toml load の早期で検出され、 build / resolve に進む前に loud reject される
+
+## Requirements Traceability
+
+| Req | Summary | Components | Interfaces | Flows |
+|---|---|---|---|---|
+| 1.1 | `[tools.<alias>]` parse | RawKoltConfig, ToolSection, ToolSectionParse | `parseToolSection(raw): Result<Map<String, ToolEntry>, ToolError>` | toml load |
+| 1.2 | coords 形 (`group:artifact:version[:classifier]`) parse | ToolSectionParse, Coordinate | `parseCoordsString(s): Result<(Coordinate, Classifier?), ToolError>` | toml load |
+| 1.3 | alias 文法違反 reject | ToolSectionParse | alias regex `^[a-z][a-z0-9_-]{0,63}$` | toml load |
+| 1.4 | coords 不正 reject | ToolSectionParse | `parseCoordsString` 失敗を ToolError.MalformedCoords | toml load |
+| 1.5 | alias 重複 reject | ToolSectionParse | RawToolEntry deserialize 後の alias key 衝突 detect | toml load |
+| 2.1 | alias 起動 + 引数 verbatim | ToolCommands, ToolLauncher | `doTool(args)`, `launch(jarPath, args, env)` | invoke |
+| 2.2 | exit code propagation | ToolLauncher, Process | `executeCommand` の戻り value をそのまま return | invoke |
+| 2.3 | 未知 alias reject | ToolCommands | `KoltConfig.tools.lookup(alias)` 失敗 → ToolError.UnknownAlias | invoke |
+| 2.4 | app classpath 非汚染 | ToolResolution | per-alias cache + 独立 BundleResolver pass、 [dependencies] 経路非経由 | invoke |
+| 3.1 | 初回 fetch + cache 格納 | ToolResolution, BundleResolver | `ensureTool(alias)` 内 cache miss 経路 | invoke |
+| 3.2 | cache hit でネット skip | ToolResolution | jar path 存在 + lockfile pin match で download skip | invoke |
+| 3.3 | integrity 失敗 → 停止 | ToolResolution, BundleResolver | `ResolveError.Sha256Mismatch` を `ToolError.IntegrityMismatch` に lift | invoke |
+| 3.4 | 取得不能 → 停止 | ToolResolution, BundleResolver | `downloadFromRepositories` 失敗を `ToolError.ResolveFailed` に lift | invoke |
+| 4.1 | lockfile 記録 | ToolResolution, Lockfile | `Lockfile.toolsBundles` write | invoke (cache miss) |
+| 4.2 | lockfile pin 優先 | ToolResolution | lockfile load 時 pinned coords を取り、 toml の宣言と独立に jar 取得 | invoke |
+| 4.3 | toml/lock 矛盾 → loud | ToolResolution | 宣言 coords ≠ pinned coords ≠ user 明示更新 → ToolError.LockfileMismatch (kolt update 案内) | invoke |
+| 4.4 | 再現情報 | Lockfile | `LockEntry(version, sha256, ...)` 既存形 | invoke |
+| 5.1 | Main-Class で起動 | ToolLauncher | libarchive で MANIFEST.MF を読み Main-Class を抽出、 `java -jar` 起動 | invoke |
+| 5.2 | Main-Class missing → loud | ToolLauncher | MANIFEST 不在 / Main-Class attribute 不在 → ToolError.MainClassMissing | invoke |
+| 5.3 | 非 runnable 形 reject | ToolLauncher | jar の zip magic bytes 検査 + libarchive open 失敗 → ToolError.NotRunnableJar | invoke |
+| 5.4 | cause-distinguishable surface | ToolError | sealed class + 各 variant に固有 exit code (10..14) | invoke |
+| 6.1 | JDK 決定論 | ToolLauncher, BootstrapJdk | `ensureBootstrapJavaBin` 固定経路、 host PATH 非依存 | invoke |
+| 6.2 | JDK 不在 → loud | ToolLauncher, BootstrapJdk | `BootstrapJdkInstallFailed` を `ToolError.JdkUnavailable` に lift | invoke |
+| 6.3 | JDK 出所の事後確認 | ToolLauncher | verbose flag (`KOLT_VERBOSE=1` 等) で起動時に JDK path を stderr 1 行出力、 失敗 message にも含める | invoke |
+| 7.1 | depends-on reject | ToolSectionParse | strict-key check (allowlist `{coords}`) | toml load |
+| 7.2 | args = [...] reject | ToolSectionParse | strict-key check (allowlist `{coords}`) | toml load |
+| 7.3 | tool 固有 subcommand 非生成 | ToolCommands | dispatch は `tool run` のみ。 alias 名は subcommand に昇格しない | (設計上の不在) |
+| 7.4 | lifecycle 連携なし | ToolResolution, ToolLauncher | `kolt build` / `kolt test` の経路から `[tools]` を呼ばない (本 spec はそのコードを書かない) | (設計上の不在) |
+
+## Components and Interfaces
+
+| Component | Domain | Intent | Req Coverage | Key Dependencies (P0/P1) | Contracts |
+|---|---|---|---|---|---|
+| ToolSection | usertool / config | KoltConfig 内の `[tools]` 公開型 | 1.1, 1.2 | RawKoltConfig (P0) | State |
+| ToolSectionParse | usertool / config | strict-key + alias regex + coords parse | 1.1〜1.5, 7.1, 7.2 | ktoml-core (P0), Coordinate (P0) | Service |
+| ToolResolution | usertool / resolve | per-alias jar 解決 + cache + lockfile pin | 2.4, 3.1〜3.4, 4.1〜4.4 | BundleResolver (P0), Lockfile (P0), KoltPaths (P0) | Service, State |
+| ToolLauncher | usertool / launch | MANIFEST 読 + JDK 解決 + jar 起動 | 2.1, 2.2, 5.1〜5.4, 6.1〜6.3 | libarchive cinterop (P0), BootstrapJdk (P0), Process (P0) | Service |
+| ToolError | usertool / error | cause-distinguishable な失敗 sealed type | 3.3, 3.4, 4.3, 5.2, 5.3, 5.4, 6.2 | (既存型のみ参照) | State |
+| ToolCommands | cli | `kolt tool run` dispatch | 2.1〜2.3, 7.3 | KoltConfig (P0), ToolResolution (P0), ToolLauncher (P0) | Service |
+
+### usertool / config
+
+#### ToolSection
+
+| Field | Detail |
+|---|---|
+| Intent | KoltConfig 内の `[tools]` 公開型 (validated、 immutable) |
+| Requirements | 1.1, 1.2 |
+
+**Responsibilities & Constraints**
+
+- `KoltConfig.tools: Map<String, ToolEntry>` を保持 (alias → entry)
+- `ToolEntry(coords: Coordinate, classifier: String?)` の不変性
+- 重複 alias は parse 段階で排除済 — このコンポーネントには到達しない
+- 空 `[tools]` テーブルは empty map として表現 (`[tools]` 自体未宣言と区別不要)
+
+**Dependencies**
+
+- Inbound: `KoltConfig`、 `ToolCommands` (lookup)、 `ToolResolution` (coords 取得)
+- External: なし
+
+**Contracts**: State [x]
+
+##### State Management
+
+```kotlin
+data class ToolEntry(
+    val coords: Coordinate,
+    val classifier: String?,
+)
+
+// KoltConfig 拡張: val tools: Map<String, ToolEntry>
+```
+
+- State model: immutable map、 KoltConfig インスタンスごとに固定
+- Persistence: kolt.toml に source-of-truth、 lockfile に pin 情報
+- Concurrency: read-only
+
+**Implementation Notes**
+
+- Integration: `Config.kt` の `KoltConfig` と `RawKoltConfig` 両方に additive、 既存 field の順序は保つ
+- Validation: 本コンポーネントは validated 結果を保持するだけ。 validation logic は `ToolSectionParse` 側
+- Risks: なし
+
+#### ToolSectionParse
+
+| Field | Detail |
+|---|---|
+| Intent | `[tools]` の strict-key 検証、 alias 文法、 coords 形検証 |
+| Requirements | 1.1, 1.2, 1.3, 1.4, 1.5, 7.1, 7.2 |
+
+**Responsibilities & Constraints**
+
+- ktoml で deserialize した `RawKoltConfig.tools: Map<String, RawToolEntry>?` を受け取り、 validated `Map<String, ToolEntry>` を返す
+- alias regex `^[a-z][a-z0-9_-]{0,63}$` で照合 (lowercase 始まり、 文字種制限、 64 字以下)
+- `RawToolEntry` には `coords` のほか、 既知 orchestration field (`dependsOn` / `args` / `main`) を **明示的に nullable で宣言**しておき、 deserialize 後に「いずれかが non-null なら reject」する。 R7 が要求するのは「**例:** depends-on / **例:** args = [...] のような orchestration field の reject」であり、 unknown field 全般の strict reject まで要求しないので、 ktoml の global `ignoreUnknownNames=true` をそのまま使う既存 pattern と整合
+- coords 文字列を `parseCoordsString` で `(Coordinate, classifier?)` に分解
+- 重複 alias は ktoml が detect (TOML spec で table key 重複は parse error)、 ここではすでに表面化していない前提
+
+**Dependencies**
+
+- Inbound: `Config.parseConfig` の validation chain
+- Outbound: `ToolSection` (validated 結果を返す)
+- External: ktoml-core (TomlNode AST scan)、 `kolt.resolve.Coordinate` (parse 補助)
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+sealed class ToolSectionParseError {
+    data class ForbiddenField(val alias: String, val field: String) : ToolSectionParseError()
+    data class InvalidAlias(val alias: String, val reason: String) : ToolSectionParseError()
+    data class MalformedCoords(val alias: String, val coords: String, val reason: String) : ToolSectionParseError()
+    data class DuplicateAlias(val alias: String) : ToolSectionParseError()
+    data class MissingCoords(val alias: String) : ToolSectionParseError()
+}
+
+@Serializable
+data class RawToolEntry(
+    val coords: String? = null,
+    @SerialName("depends-on") val dependsOn: String? = null,
+    val args: List<String>? = null,
+    val main: String? = null,
+)
+
+fun parseToolSection(
+    rawTools: Map<String, RawToolEntry>?,
+): Result<Map<String, ToolEntry>, ToolSectionParseError>
+
+private val ALIAS_REGEX = Regex("""^[a-z][a-z0-9_-]{0,63}$""")
+
+fun parseCoordsString(s: String): Result<Pair<Coordinate, String?>, String>
+```
+
+- Preconditions: `rawTools` は ktoml で `tools` table を deserialize した中間表現
+- Postconditions: 成功時、 alias 重複なし・全 entry が validated・forbidden field 不在・coords parse 済
+- Invariants: 失敗時の error は alias と field を pinpoint できる (debug 容易性)
+
+**Implementation Notes**
+
+- Integration: `Config.parseConfig()` の validation chain で `validateToolSection` を呼ぶ。 既存 `validateBundleReferences` の隣に並べる pattern。 `Config.parseConfig` の signature は touch せず、 既存 `RawKoltConfig` deserialize 結果のみで完結する
+- Validation: `RawToolEntry` の forbidden field (`dependsOn`, `args`, `main`) を post-deserialize で逐次 nullability check、 non-null なら `ForbiddenField` を返す。 `coords` 不在は `MissingCoords`、 alias regex は `ALIAS_REGEX.matchEntire(alias)` で照合
+- Risks: 将来的に新 orchestration field (`hooks`, `before`, `after` 等) が追加されるシナリオで、 declared でない field は ktoml の `ignoreUnknownNames=true` で silently strip される。 ADR 0028 §3 の additive-only 制約により、 そのリスクは limited (新 field の意図的 reject は新 PR で `RawToolEntry` に nullable 追加で対応可能)
+
+### usertool / resolve
+
+#### ToolResolution
+
+| Field | Detail |
+|---|---|
+| Intent | per-alias jar 解決・cache・lockfile pin の orchestration |
+| Requirements | 2.4, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4 |
+
+**Responsibilities & Constraints**
+
+- alias から coords を取り、 cache (`~/.kolt/tools/bundles/<alias>/<version>/<filename>`) に jar が存在しかつ lockfile の pin と SHA-256 一致なら **そのまま path を返す** (network skip)
+- cache miss だが lockfile に pin がある場合、 pin の coords / SHA-256 に従って jar を取得 (transitive-skip 経路)、 SHA-256 verify、 cache に格納
+- lockfile に pin あり、 toml に宣言なし (orphan) は本 spec では起動時 lookup miss として扱い、 R2.3 の UnknownAlias path に乗る (orphan pin の cleanup は別 spec)
+- **`kolt tool run` 経路では新規 lockfile 書き込みを行わない**。 toml の coords と lockfile pin が **不一致 (group:artifact:version[:classifier] のいずれかが異なる)** の場合、 R4.3 に従い **loud reject**。 stderr message は `tool '<alias>': lockfile pin '<pinned-coords>' differs from kolt.toml '<toml-coords>'. Run \`kolt update\` to refresh tool pins.` で固定
+- 初回 (lockfile に該当 alias の pin が存在しない) の場合は `kolt update` を打つことなく `kolt tool run` 経路でも write-through を許可 (lockfile が育つ初回と「明示的 update を求められる更新」は区別)
+- 既存 `kolt update` (`DependencyCommands.kt` `doUpdateInner`) を本 spec で **拡張**し、 `[dependencies]` と `[tools]` の両方を re-resolve・lockfile 更新する。 ユーザーが `[tools]` の coords を編集した場合の正規 update path はこの単一 command に集約する
+
+**Dependencies**
+
+- Inbound: `ToolCommands.doTool`
+- Outbound: `BundleResolver` (resolveSingleArtifact transitive=skip)、 `Lockfile` (read/write)、 `KoltPaths` (cache layout)
+- External: file I/O (`kolt.infra`)
+
+**Contracts**: Service [x], State [x]
+
+##### Service Interface
+
+```kotlin
+sealed class ToolResolutionError {
+    data class ResolveFailed(val alias: String, val coords: Coordinate, val attempts: List<String>) : ToolResolutionError()
+    data class IntegrityMismatch(val alias: String, val coords: Coordinate, val expected: String, val actual: String) : ToolResolutionError()
+    data class LockfileMismatch(val alias: String, val tomlCoords: Coordinate, val lockedCoords: Coordinate) : ToolResolutionError()
+    data class CachePathFailed(val alias: String, val cause: String) : ToolResolutionError()
+}
+
+fun ensureTool(
+    alias: String,
+    entry: ToolEntry,
+    paths: KoltPaths,
+    lockfile: Lockfile,
+    netDeps: ResolverDeps,
+): Result<ToolJarHandle, ToolResolutionError>
+
+data class ToolJarHandle(
+    val jarPath: String,
+    val resolvedCoords: Coordinate,
+    val classifier: String?,
+    val lockfileChanged: Boolean,
+)
+```
+
+- Preconditions: `entry` は validated、 `paths.toolsBundleDir(alias, version)` は computable
+- Postconditions: 成功時 `jarPath` は存在し SHA-256 検証済。 `lockfileChanged=true` なら呼び出し側が `serializeLockfile` で再 persist する責務を持つ
+- Invariants: cache hit path では network 一切叩かない。 SHA-256 mismatch で auto-refetch しない (loud fail)
+
+##### State Management
+
+- State model: immutable per call、 cache file system が事実上の state
+- Persistence: `~/.kolt/tools/bundles/<alias>/<version>/<filename>`、 `kolt.lock` の `tools_bundles`
+- Concurrency: 並列 alias 起動は cache file レベルで idempotent (同一 SHA-256 を書き込むだけ)。 同一 alias の並列 first-fetch は temp file + atomic rename pattern を踏襲 (`BundleResolver.materialiseBundleJarsFromLock` 既存)
+
+**Implementation Notes**
+
+- Integration: 既存 `BundleResolver.resolveBundle` に transitive-skip mode を expose (内部関数を `internal` から `public` に上げる、 もしくは新 `resolveSingleArtifact` ラッパー追加)。 `Lockfile.toolsBundles` field 拡張は additive、 既存 round-trip テストを extend
+- Validation: SHA-256 verify は `ResolverDeps.computeSha256(filePath)` を adopt
+- Risks: lockfile の atomic write は `[dependencies]` 経路と共有 — `[tools]` だけ別 write 経路にすると競合が起きる。 既存 `serializeLockfile` 単一経路に集約する
+
+### usertool / launch
+
+#### ToolLauncher
+
+| Field | Detail |
+|---|---|
+| Intent | jar の MANIFEST 読 + bootstrap JDK 解決 + `java -jar` 起動 |
+| Requirements | 2.1, 2.2, 5.1, 5.2, 5.3, 5.4, 6.1, 6.2, 6.3 |
+
+**Responsibilities & Constraints**
+
+- jar (zip) を libarchive で open、 `META-INF/MANIFEST.MF` entry を read、 `Main-Class:` 行を抽出
+- libarchive open 失敗 (zip magic mismatch、 truncated 等) は `NotRunnableJar` (R5.3)
+- MANIFEST.MF 不在、 もしくは `Main-Class:` 行不在は `MainClassMissing` (R5.2)
+- `ensureBootstrapJavaBin(paths)` で `java` path を取得、 `BootstrapJdkInstallFailed` を `JdkUnavailable` に lift (R6.2)
+- `executeCommand(listOf(javaBin, "-jar", jarPath, *args), env)` で起動、 exit code をそのまま return (R2.2)
+- `KOLT_VERBOSE=1` 等の env で起動時に「`tool=<alias> jdk=<javaBin> jar=<jarPath>`」を stderr に 1 行出力 (R6.3)
+
+**Dependencies**
+
+- Inbound: `ToolCommands.doTool`
+- Outbound: `kolt.infra.Process.executeCommand`
+- External: libarchive cinterop (zip read)、 `kolt.tool.BootstrapJdk.ensureBootstrapJavaBin`
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+sealed class ToolLaunchError {
+    data class NotRunnableJar(val alias: String, val jarPath: String, val reason: String) : ToolLaunchError()
+    data class MainClassMissing(val alias: String, val jarPath: String) : ToolLaunchError()
+    data class JdkUnavailable(val cause: String) : ToolLaunchError()
+    data class LaunchFailed(val alias: String, val cause: String) : ToolLaunchError()
+}
+
+fun launch(
+    alias: String,
+    jarHandle: ToolJarHandle,
+    args: List<String>,
+    paths: KoltPaths,
+    env: Map<String, String>,
+): Result<Int, ToolLaunchError>
+
+internal fun readMainClassFromJar(jarPath: String): Result<String, ToolLaunchError>
+```
+
+- Preconditions: `jarHandle.jarPath` は存在しかつ SHA-256 検証済 (`ToolResolution` 完了後)
+- Postconditions: 成功時 exit code はツール自身の値 (kolt は overlay しない)。 失敗時は loud かつ identifiable
+- Invariants: stdout / stderr は子プロセスから直接 inherit (kolt は buffer しない)。 SIGINT / SIGTERM はツールに伝播
+
+**Implementation Notes**
+
+- Integration: libarchive read API は `ADR 0031` の archive_read_open_filename + iterate header pattern を踏襲 — 既存 `kolt.infra` 内に zip read utility を追加 (新 file `kolt/infra/JarManifest.kt` か `ToolLauncher.kt` 内 internal 関数)。 設計上は ToolLauncher 内 internal で十分
+- Validation: pre-launch で zip open + MANIFEST 読了するため、 `java -jar` 起動後の brittle stderr scrape に頼らない
+- Risks:
+  - jar が **valid zip だが MANIFEST.MF が空 / 改行混乱**: `Main-Class:` 行抽出は spec 準拠の line-folded format (RFC) を簡易対応、 fold/continuation handling は将来拡張余地として認識
+  - SIGINT propagation は `executeCommand` の fork/execvp で標準的に動くはず — 既存 ktfmt / junit-console 経路で動作実績あり
+
+### usertool / error
+
+#### ToolError
+
+| Field | Detail |
+|---|---|
+| Intent | resolve / launch / parse 失敗を 1 系統に集約、 cause-distinguishable な exit code mapping |
+| Requirements | 3.3, 3.4, 4.3, 5.2, 5.3, 5.4, 6.2 |
+
+**Responsibilities & Constraints**
+
+- `ToolSectionParseError` / `ToolResolutionError` / `ToolLaunchError` を 1 つの top-level sealed class `ToolError` に lift (互いに直交)
+- `toExitCode(): Int` で kolt 既存の `ExitCode.kt` の semantic 分類 (`EXIT_CONFIG_ERROR=2`, `EXIT_DEPENDENCY_ERROR=3`, 新設 `EXIT_TOOL_ERROR=7`) に揃えて返す。 R5.4 の cause-distinguishable は **stderr の構造化メッセージ** で担保 (`tool <alias>: <variant>: <detail>` の prefix を variant ごとに固定) — exit code が変種ごとに異なる必要はない
+- ツール自身の exit code (jarHandle launch 成功時) は `Result.Ok(Int)` で別経路に流れる — `ToolError` には乗らない
+
+**Dependencies**
+
+- Inbound: `ToolCommands` (top-level error handler)
+- Outbound: なし
+
+**Contracts**: State [x]
+
+##### State Management
+
+```kotlin
+sealed class ToolError {
+    abstract val message: String
+    abstract fun toExitCode(): Int
+
+    data class Parse(val cause: ToolSectionParseError) : ToolError()
+    data class Resolve(val cause: ToolResolutionError) : ToolError()
+    data class Launch(val cause: ToolLaunchError) : ToolError()
+    data class UnknownAlias(val alias: String, val knownAliases: List<String>) : ToolError()
+}
+```
+
+| variant | exit code (`ExitCode.kt`) | stderr prefix | trigger |
+|---|---|---|---|
+| Parse.\* | `EXIT_CONFIG_ERROR = 2` | `tool '<alias>': parse error: ...` | toml load 段階 (R1.3〜1.5, R7.1〜7.2) |
+| Resolve.ResolveFailed | `EXIT_DEPENDENCY_ERROR = 3` | `tool '<alias>': resolve failed: ...` | network 取得不能 (R3.4) |
+| Resolve.IntegrityMismatch | `EXIT_DEPENDENCY_ERROR = 3` | `tool '<alias>': integrity mismatch: expected <sha> got <sha>` | SHA-256 mismatch (R3.3) |
+| Resolve.LockfileMismatch | `EXIT_DEPENDENCY_ERROR = 3` | `tool '<alias>': lockfile pin '<pinned>' differs from kolt.toml '<toml>'. Run \`kolt update\` to refresh tool pins.` | toml/lock 矛盾 (R4.3) |
+| Launch.NotRunnableJar | `EXIT_TOOL_ERROR = 7` (新設) | `tool '<alias>': not a runnable jar (<reason>)` | 非 runnable 形 (R5.3) |
+| Launch.MainClassMissing | `EXIT_TOOL_ERROR = 7` | `tool '<alias>': Main-Class missing in MANIFEST.MF` | Main-Class 不在 (R5.2) |
+| Launch.JdkUnavailable | `EXIT_TOOL_ERROR = 7` | `tool '<alias>': JDK unavailable: ...` | JDK 不在 (R6.2) |
+| UnknownAlias | `EXIT_CONFIG_ERROR = 2` | `tool '<alias>': not declared in [tools]. Known aliases: ...` | alias not in `[tools]` (R2.3) |
+
+- `EXIT_TOOL_ERROR = 7` は `ExitCode.kt` 既存の `EXIT_LOCK_TIMEOUT = 6` の次の slot に追加 (`EXIT_COMMAND_NOT_FOUND = 127` とは衝突しない)
+- R5.4 の cause-distinguishable surface は **stderr prefix が variant ごとに固定** であることで担保。 exit code は kolt 全体の semantic 分類 (config / dep / tool) を維持し、 「resolver 失敗なら 3」「launch 失敗なら 7」 の既存 user mental model を壊さない
+- ADR 0028 §3 凍結面追加は `EXIT_TOOL_ERROR = 7` の 1 行のみ (10..16 を新規予約しない)
+
+### cli
+
+#### ToolCommands
+
+| Field | Detail |
+|---|---|
+| Intent | `kolt tool run <alias> [-- args...]` の dispatch |
+| Requirements | 2.1, 2.2, 2.3, 7.3 |
+
+**Responsibilities & Constraints**
+
+- subcommand 第 2 引数が `run` でなければ usage 表示 + non-zero (R7.3 — `tool` に他の subcommand を作らない、 ただし v1 後の `tool list` 等は将来 follow-up)
+- 第 3 引数を alias として lookup、 KoltConfig.tools にあれば ensureTool → launch、 なければ UnknownAlias
+- alias 後の引数は verbatim 透過 — `--` 区切りは optional (`kolt tool run ktlint -F` も `kolt tool run ktlint -- -F` も等価)。 既存 `doTest` の precedent と整合
+- exit code は launch 成功時はツール自身の値、 ToolError 系は `toExitCode()`
+
+**Dependencies**
+
+- Inbound: `Main.kt` の `when` dispatch
+- Outbound: `KoltConfig.tools`、 `ToolResolution`、 `ToolLauncher`、 `ToolError`
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+fun doTool(args: List<String>): Result<Int, Int>
+```
+
+- Preconditions: `args` は `Main.kt` で `tool` case に dispatch された残りの引数列
+- Postconditions: 成功時 `Result.Ok(toolExitCode)`、 失敗時 `Result.Err(toolErrorExitCode)`
+- Invariants: stdout / stderr は子プロセスから inherit、 kolt 自身は ToolError 時のみ stderr に 1 行 message を書く
+
+**Implementation Notes**
+
+- Integration: `Main.kt` の `when (filteredArgs[0]) { ... "tool" -> doTool(filteredArgs.drop(1)) }` で接続
+- Validation: alias lookup miss は kolt-known alias 一覧を stderr に出して helpful にする (`Did you mean: ktfmt`)
+- Risks: `kolt tool run --version` のような奇妙な alias (regex で reject されるが、 user が `--version` を alias と prtend したい場合) は alias-as-flag という unusual case。 alias regex の lowercase letter 始まり制約で自然に弾かれる
+
+## Data Models
+
+### kolt.toml schema (`[tools]`)
+
+```toml
+[tools.ktlint]
+coords = "com.pinterest.ktlint:ktlint-cli:1.3.1:all"
+
+[tools.detekt]
+coords = "io.gitlab.arturbosch.detekt:detekt-cli:1.23.6"
+```
+
+**Validation rules**:
+
+- `[tools]` は空 table 可 (entry なし) — `[tools]` 自体不在と等価扱い (R1 の最低 acceptance criteria は entry がある場合の振る舞い)
+- 各 entry は **`coords` のみ** (allowlist)。 他 key (`depends-on`, `args`, `main`, `version` 単独など) は loud reject (R7.1, R7.2)
+- alias は `^[a-z][a-z0-9_-]{0,63}$` (R1.3)
+- `coords` 文字列 grammar: `<group>:<artifact>:<version>[:<classifier>]`
+  - `<group>`、 `<artifact>` は 1 字以上、 ASCII letters / digits / `-` / `_` / `.`
+  - `<version>` は 1 字以上、 任意の non-empty (Maven version は厳密 grammar を持たないため、 kolt は基本的に opaque 扱い)
+  - `<classifier>` は optional、 同上の charset
+  - 構文逸脱は `MalformedCoords` (R1.4)
+
+### kolt.lock schema 拡張
+
+```json
+{
+  "version": 4,
+  "kotlin": "2.3.0",
+  "jvm_target": "25",
+  "dependencies": { ... },
+  "classpath_bundles": { ... },
+  "tools_bundles": {
+    "ktlint": {
+      "com.pinterest.ktlint:ktlint-cli:all": {
+        "version": "1.3.1",
+        "sha256": "..."
+      }
+    },
+    "detekt": {
+      "io.gitlab.arturbosch.detekt:detekt-cli": {
+        "version": "1.23.6",
+        "sha256": "..."
+      }
+    }
+  }
+}
+```
+
+- `tools_bundles` は `Map<alias, Map<group:artifact[:classifier], LockEntry>>` (R4.1, R4.4)
+- inner key 形は `classpath_bundles` の precedent と整合 (`group:artifact` で transitive=false 固定、 classifier は suffix で含める)
+- 既存 v4 lockfile に対し additive — version bump 不要。 既存 lockfile を読むときは `tools_bundles` 不在 = empty map (R4 backward compatible)
+- ADR 0028 §3 lockfile-format-stable の **additive 規則** に準拠
+
+### Cache layout
+
+```
+~/.kolt/tools/bundles/
+├── ktlint/
+│   └── 1.3.1/
+│       └── ktlint-cli-1.3.1-all.jar
+└── detekt/
+    └── 1.23.6/
+        └── detekt-cli-1.23.6.jar
+```
+
+- 既存 `~/.kolt/tools/<filename>` flat layout (kolt-internal 用 ktfmt / junit-console 等) と分離 — `bundles/` subdir で衝突回避
+- jar filename は `<artifact>-<version>[-<classifier>].jar` (Maven Central path 規則そのまま)
+- 削除は `kolt cache clean` 等 (現状 `[dependencies]` 経路に同名 command 既存) と統合可能だが、 本 spec は cache 削除 UX を扱わない (out of boundary)
+
+## Error Handling
+
+### Error Strategy
+
+- すべての failable path は `Result<V, E>` を返す。 例外を throw しない (ADR 0001 準拠)
+- `ToolError` sealed が top-level error envelope。 各 sub-error type は cause を保持し、 `toExitCode()` で kolt 自身の exit code を返す
+- ツール自身の exit code は `ToolError` には乗せず、 `Result.Ok(Int)` の Int として propagate
+
+### Error Categories and Responses
+
+- **Parse** (R1, R7): exit 10、 stderr に「`kolt.toml [tools.<alias>] error: <reason>`」を 1 行
+- **Resolve** (R3, R4): exit 11/12/13、 stderr に「`tool <alias>: resolve failed`」+ 詳細 (試行 repo 一覧 / SHA mismatch)
+- **Launch** (R5, R6): exit 14/15、 stderr に「`tool <alias>: <reason>`」+ jar path / JDK path
+- **UnknownAlias** (R2.3): exit 16、 stderr に「`tool <alias>: not declared in [tools]`」+ 既知 alias 一覧
+- **ツール自身の non-zero exit**: kolt は overlay しない、 ツールの値そのまま
+
+### Monitoring
+
+- `KOLT_VERBOSE=1` で起動時に「`tool=<alias> jdk=<javaBin> jar=<jarPath>`」を stderr に 1 行 (R6.3)
+- 失敗時 message は ADR 0001 の「actionable error」原則に従い、 修復手順 (例: 「run `kolt update --tools` to refresh lockfile」) を提示
+
+## Testing Strategy
+
+### Unit Tests (`src/nativeTest/kotlin/kolt/usertool/`)
+
+- `ToolSectionParseTest`:
+  - alias regex 適合 / 不適合 (1.3) — lowercase 始まり、 64 字超過、 special char
+  - coords 形 valid / invalid (1.2, 1.4) — classifier 有無、 group 欠落、 version 欠落
+  - strict-key reject (7.1, 7.2) — `depends-on`、 `args`、 `main` 等の不正 field 検出
+  - 重複 alias は ktoml が parse error として上げることを assert (1.5)
+- `ToolErrorTest`:
+  - 各 variant の `toExitCode()` 値が固定 (5.4 の cause-distinguishable surface)
+- `ToolLauncherTest`:
+  - libarchive で MANIFEST.MF 抽出 OK の jar fixture (5.1)
+  - MANIFEST 不在の zip fixture → `MainClassMissing` (5.2)
+  - 非 zip ファイル → `NotRunnableJar` (5.3)
+
+### Integration Tests
+
+- `ToolResolutionTest`:
+  - cache miss で BundleResolver 経路に分岐 (3.1)
+  - cache hit + lockfile pin match で download skip (3.2)
+  - SHA-256 mismatch で `IntegrityMismatch` (3.3)
+  - 取得不能 (mock 404) で `ResolveFailed` (3.4)
+  - lockfile 書き込み round-trip (4.1, 4.4) — `LockfileTest` の `classpathBundles` round-trip と同 pattern
+  - toml/lock 矛盾の loud reject (4.3)
+- `ToolCommandsTest`:
+  - `kolt tool run <alias> --foo bar` で alias 後の引数が verbatim (2.1)
+  - `kolt tool run <alias> -- --opt val` (`--`-passthrough) (2.1)
+  - 未知 alias で `UnknownAlias` exit code 16 (2.3)
+  - exit code 透過 (2.2) — モック jar が exit 42 → kolt も 42
+
+### E2E (`src/nativeTest/kotlin/kolt/cli/` または `kolt-toml` fixture)
+
+- 実 jar (例: 小さな `printArgs.jar` を test fixture に commit) を `[tools]` に宣言、 引数透過と exit code 透過を end-to-end 確認 (2.1, 2.2, 5.1)
+
+### CI integration
+
+- `kolt test` で全 nativeTest が走る既存パターンに乗せる
+- self-host smoke (existing `self-host-post` job) には影響なし — `[tools]` を kolt 自身は宣言しない (kolt の dogfood 対象は別 issue で検討)
+
+## Migration Strategy
+
+ADR 0028 §3 に従い、 lockfile schema は additive (`tools_bundles` 不在時は empty map として読む) — 既存 lockfile は無修正で動作する。
+
+kolt.toml も additive — `[tools]` 不在時は `KoltConfig.tools = emptyMap()` として動く。
+
+ADR 改訂 (本 design と同 PR で land):
+- §3 に「`[tools]` toml section の additive 規則」「`tools_bundles` lockfile field の additive 規則」「`kolt tool run` CLI surface の凍結」「`~/.kolt/tools/bundles/<alias>/<version>/` cache layout の凍結」「`EXIT_TOOL_ERROR = 7` の凍結」を 1 セクションで追記
+- `kolt update` の scope 拡張 ([dependencies] + [tools] 双方を扱う) も §3 の同セクションに記載
+- §3 既存の `~/.kolt/toolchains/{jdk|kotlinc|konanc}/` 凍結に並べる形
+
+## Open Questions / Risks
+
+- libarchive cinterop の zip read 経路 (header iterate + entry data read) が ADR 0031 の extraction 経路と reuse できるか — 採用前に 30 分 spike で確認、 必要なら `kolt.infra` に薄い `readJarManifest(path: String): Result<String, JarReadError>` utility を切り出す。 spike 不可なら fallback として bootstrap JDK の `<javaBin>../jar -tf` ＋ `unzip`-via-libarchive 既存経路でも実装可能
+- alias と既存 kolt subcommand 名 (`build`, `test`, `run`, ...) の衝突防止 — alias regex が lowercase letter 始まり 64 字以下を許すため、 user が `build` を alias にすることは可能。 これは `kolt build` ではなく `kolt tool run build` で起動するため衝突しない設計だが、 confusion 回避のため alias 文法 doc に注意書き
+- `kolt tool` の sub-action として `run` 以外 (`list`、 `clear-cache`) を将来追加するときの surface freeze — 本 spec は `run` のみ ship、 他 sub-action は ADR 0028 §3 凍結対象外として後続 spec で扱う
+- forbidden field 一覧 (`dependsOn`, `args`, `main`) は v1 時点の orchestration ガードレール。 将来 R7 の意図に反する新 field 名が現れたら、 PR で `RawToolEntry` に nullable 追加して reject 範囲を広げる運用 (additive)

--- a/.kiro/specs/341-tools-section/requirements.md
+++ b/.kiro/specs/341-tools-section/requirements.md
@@ -1,0 +1,147 @@
+# Requirements Document
+
+## Project Description (Input)
+
+Issue #341: Add `[tools]` section for project-pinned executable jars
+
+ktlint や detekt のような runnable jar ツールは、現状ユーザーが手作業で取得している。`dependencies` に列挙するとアプリの classpath を汚染し、build 出力にも漏れる。グローバルインストールではプロジェクトごとの pin ができず、チームメンバー間で版が drift する。「プロジェクトに紐付くがプロジェクトの依存ではない」というカテゴリが欠けている — npm の `devDependencies` が同じ形を解いている。
+
+`kolt.toml` に `[tools]` テーブルを追加する。各エントリは alias と Maven coordinates だけ。string 短縮形なし、組み込みの name → coords レジストリなし。kolt は jar をアプリ classpath に**載らない** cache に解決して、`java -jar` で起動する。引数は npx スタイルでそのまま透過する。
+
+ガードレール（non-goals）: エントリ間の参照は不可（`depends-on` なし）。ツールごとの kolt subcommand は作らない（`kolt lint` のような）。エントリ内でのコマンドライン構築は不可（`args = [...]` なし）。`[tools]` は jar 取得 + 起動のみで、orchestration はしない。
+
+### Done when
+
+- `kolt.toml` が `[tools]` を受け付ける（`alias = { coords = "group:artifact:version[:classifier]" }`）
+- `kolt-<surface> <alias> <args...>` が解決・キャッシュ・jar の Main-Class を `java -jar` で起動する
+- 解決された coordinates は lockfile に pin される（ファイル位置は ADR で TBD）。チーム全員が同じ jar を実行する
+- v1 では Main-Class manifest を持つ runnable jar のみサポート。それ以外の形は resolve / launch 時に loud に失敗する
+- cache hit はネットワーク不要、`kolt build` の offline-when-possible 挙動に揃える
+
+### Out of scope
+
+- `[hooks]` 連携（`[hooks]` が landing したら follow-up #119）
+- distribution-zip + launcher-script ツール（kotlinc 系）
+- plugin classpath 組み立て（detekt plugin、ktlint ruleset）
+- 短縮構文（`ktlint = "1.3.1"`）と組み込み name → coords マッピング
+- グローバルインストール（`~/.kolt/bin/`、別議論）
+
+### Open questions to resolve in design.md (= ADR-equivalent)
+
+これら 8 項目は ADR 0028 §3 の凍結面を同時に拡張するため、design.md でまとめて決め切る:
+
+- **CLI surface.** `kolt-x ktlint check`（separate binary）vs `kolt tool run ktlint check`（subcommand）。どちらも ADR 0028 §3 の凍結対象 — ship でゲートが閉じる
+- **Coordinate shape and transitives.** `coords` 文字列に classifier を含めるか（`group:artifact:version:classifier` — `ktlint-cli:1.3.1:all` に必要）、それとも `classifier` を別フィールドにするか。fat-jar tool は transitive 不要のため、resolve-and-skip vs main-classifier-only fetch も同じ判断に乗る
+- **Lockfile placement.** 既存 `kolt.lock` vs 別ファイル
+- **Alias grammar.** regex を up-front で pin する。ADR 0028 §3 の additive-only schema 制約により、後から narrow するのは痛い
+- **Launch JDK.** デフォルトは bootstrap JDK（`~/.kolt/toolchains/jdk/<version>/`、ADR 0017 §1）か。ツールが project の Kotlin JDK target と独立に JDK を要求できるかも open
+- **Cache layout.** `~/.kolt/tools/<alias>/<version>/` か coords-hashed か。ship で ADR 0028 §3 凍結に乗る
+- **Failure exit codes.** resolve failure / Main-Class missing / checksum mismatch を別々の exit code にするか — `install.sh` の粒度に揃える
+- **§3 update.** ADR draft で §3 を拡張し、新 toml section / CLI surface / cache layout を凍結面に含める
+
+### Implementation strategy
+
+ユーザーと 2026-05-08 に合意したハイブリッド方針: 単一 SDD で 8 項目の設計判断を ADR 相当の design.md に集約 → tasks.md で 3〜4 phase に自然に分割（schema parse + alias validation / resolve + cache / launch + lockfile / failure exit code surface）。
+
+### Milestone
+
+現状 v1.0 milestone（Issue 末尾「v1 inclusion is open. v1.1 is acceptable as fallback」）。最終配置は design.md の scope freeze で決定する。
+
+### Related
+
+- Issue #119 — `[hooks]` 議論（将来の連携対象）
+- Issue #28 — `kolt init` / `new`（closed、共有 CLI surface 判断の前例）
+- ADR 0017 — bootstrap JDK provisioning（§1 を launch JDK default に流用）
+- ADR 0025 — library artifact layout（cache layout の前例）
+- ADR 0028 — v1 release policy §3（本機能が凍結面を拡張する）
+
+## Introduction
+
+`[tools]` セクションは「プロジェクトに紐付くが、プロジェクト本体の依存ではない」ツール (ktlint / detekt のような runnable jar) を、 alias + Maven coordinates で kolt.toml に宣言できるようにする機能である。 kolt はそれらを **アプリの classpath とは分離された** cache に解決し、 lockfile で pin し、 ユーザーの呼び出し時に `java -jar` で起動する。 引数は変更せずそのまま透過し、 ツールの終了コードもそのまま返す。 npm の `devDependencies` + `npx` に相当するカテゴリを kolt に持ち込むことが狙いで、 `[dependencies]` への手作業列挙、 グローバルインストールの版 drift、 手作業 jar 取得をすべて置き換える。
+
+本機能は jar 取得・キャッシュ・起動だけを担い、 orchestration（ツール間依存、 ツール固有の kolt subcommand、 エントリ内でのコマンドライン構築）は明示的に持たない。 `[hooks]` (#119) との連携は、 `[hooks]` が landing した後の follow-up で扱う。
+
+## Boundary Context
+
+- **In scope**: `[tools]` テーブルの parse と validation、 alias による起動、 引数の verbatim 透過、 解決済 jar の cache、 lockfile への pin、 起動失敗の cause-distinguishable な surface、 v1 で Main-Class manifest を持つ runnable jar のみサポートすること
+- **Out of scope**: `[hooks]` (#119) との連携、 distribution-zip + launcher-script 形式のツール、 ツールの plugin classpath 組み立て、 `ktlint = "1.3.1"` のような短縮構文と name→coords レジストリ、 グローバルインストール (`~/.kolt/bin/`)、 ツール間 orchestration 機能 (depends-on, ツール固有 kolt subcommand, エントリ内 args 構築)
+- **Adjacent expectations**: Maven coordinates の解決には kolt の既存依存解決経路を再利用すること、 ツール起動 JDK は kolt の JDK provisioning (ADR 0017 §1) と同じ管理対象であること、 lockfile 形式は kolt の既存 lockfile (kolt.lock) と互換に整合させること。 これらの具体的な束ね方 (CLI surface, coords 文字列形状, lockfile 配置, alias regex, JDK 既定, cache layout, exit code 粒度) は design.md で決定し、 ADR 0028 §3 の凍結面に組み込む
+
+## Requirements
+
+### Requirement 1: `[tools]` テーブルの宣言と parse
+
+**Objective:** kolt ユーザーとして、 プロジェクト固有の runnable jar ツールを kolt.toml に宣言したい。 そうすればチーム全員が同じ kolt.toml + lockfile から同一のツールを起動できる。
+
+#### Acceptance Criteria
+
+1. When `kolt.toml` が `[tools.<alias>]` 形式のエントリを含むとき、 kolt shall そのエントリを (alias, coords) のペアとして parse して内部設定に取り込む
+2. When エントリの `coords` 値が `group:artifact:version` または `group:artifact:version:classifier` の形であるとき、 kolt shall その coordinates を Maven coordinates として受理する
+3. If エントリの `alias` がプロジェクトで定義する alias 文法に違反しているとき、 kolt shall 違反した alias と期待される文法を提示して `kolt.toml` の load を失敗させる
+4. If エントリの `coords` 値が group / artifact / version を欠くなど未定義の形であるとき、 kolt shall 該当 alias と coords の値を提示して `kolt.toml` の load を失敗させる
+5. If 同一の `alias` が `[tools]` 配下に複数回宣言されているとき、 kolt shall 衝突した alias を提示して `kolt.toml` の load を失敗させる
+
+### Requirement 2: alias による起動と引数の verbatim 透過
+
+**Objective:** kolt ユーザーとして、 宣言したツールを alias でそのまま呼びたい。 そうすれば npx 相当の体験で、 引数を覚え直したりラッパーシェルを書く必要がない。
+
+#### Acceptance Criteria
+
+1. When ユーザーが宣言済の `<alias>` を引数 `<args...>` 付きで呼び出したとき、 kolt shall その alias に紐付く jar を起動して `<args...>` を変更せず透過する
+2. The kolt shall 起動したツールの終了 exit code をそのまま呼び出し側に返す
+3. If ユーザーが `[tools]` に宣言されていない alias を呼び出したとき、 kolt shall 未知 alias であることと、 既知 alias の一覧を表示して non-zero で終了する
+4. The kolt shall ツール起動時にプロジェクトの application classpath、 `[dependencies]`、 build 出力に対してそのツールの依存性を混入させない
+
+### Requirement 3: 解決と cache（offline-when-possible）
+
+**Objective:** kolt ユーザーとして、 同じツールを 2 回目以降はネットワークなしで起動したい。 そうすれば CI / 機内 / オフライン開発でも安定して走る。
+
+#### Acceptance Criteria
+
+1. When ある alias が初めて呼び出されて cache 上に該当 jar が存在しないとき、 kolt shall 宣言された coordinates から jar を取得して cache に格納してから起動する
+2. When ある alias が呼び出されて cache 上に該当 jar が存在するとき、 kolt shall ネットワークアクセスなしで cache から jar を起動する
+3. If cache 上の jar が integrity check (期待 checksum との一致) を満たさないとき、 kolt shall 該当 alias と検出した不整合を提示して non-zero で終了し、 自動で再取得は行わない
+4. If リモートから jar を取得できず cache 上にも該当 jar がないとき、 kolt shall 解決失敗の原因 (取得対象 coordinates と試行先) を提示して non-zero で終了する
+
+### Requirement 4: lockfile による pin とチーム間整合性
+
+**Objective:** kolt ユーザーとして、 ツールの版もアプリ依存と同じ「kolt.toml + lockfile」契約で固定したい。 そうすればチームメンバー間で版が drift しない。
+
+#### Acceptance Criteria
+
+1. When ある alias の coordinates が初めて解決されたとき、 kolt shall 解決後の具体 coordinates を kolt の lockfile に記録する
+2. When `[tools]` の宣言と lockfile の pin の両方が存在するとき、 kolt shall lockfile の pin を優先してその通りに jar を起動する
+3. If `[tools]` の coordinates と lockfile の pin が矛盾していて、 ユーザーが明示的に lockfile 更新を指示していないとき、 kolt shall 矛盾箇所と取るべき手順 (例: lockfile 更新コマンド) を提示して non-zero で終了する
+4. The kolt shall lockfile の pin に再現に必要な情報 (具体 version と integrity 識別子) を含める
+
+### Requirement 5: サポートされる jar 形状
+
+**Objective:** kolt ユーザーとして、 サポート対象 jar とそうでない jar の境界を明確にしたい。 そうすれば想定外の形を渡したときに沈黙で誤動作せず、 直すべき箇所がすぐ分かる。
+
+#### Acceptance Criteria
+
+1. When `[tools]` で参照された jar が `MANIFEST.MF` に有効な `Main-Class` を持つとき、 kolt shall その `Main-Class` を `java -jar` 経路で起動する
+2. If `[tools]` で参照された jar が `Main-Class` を持たない、 または `Main-Class` が解決できないとき、 kolt shall 該当 alias と原因を提示して non-zero で終了する
+3. If `[tools]` で参照された artifact が runnable jar 以外の形 (distribution zip、 launcher script bundle 等) であるとき、 kolt shall サポート対象外であることを提示して non-zero で終了する
+4. The kolt shall ツールの起動失敗を「resolve 失敗」「Main-Class なし / 解決不可」「integrity check 失敗」のように cause-distinguishable な surface (exit code もしくは構造化メッセージ) で返す
+
+### Requirement 6: ツール実行用 JDK の前提
+
+**Objective:** kolt ユーザーとして、 ツール起動に使う JDK の出処を予測可能にしたい。 そうすればホスト環境に依存しないチーム共通の挙動が得られる。
+
+#### Acceptance Criteria
+
+1. When 同じ kolt.toml + lockfile + 同じ kolt version でツールを起動するとき、 kolt shall ツール jar の起動に同じ JDK 環境を決定論的に選択し、 host の PATH 偶然や非宣言の環境変数差に依存しない
+2. If 起動に必要な JDK が利用できないとき、 kolt shall 期待された JDK の出所と取るべき手順を提示して non-zero で終了する
+3. The kolt shall ツール起動に実際に使った JDK の出所を、 ユーザーが事後に確認できる形 (ログ / verbose 出力 / 失敗時メッセージのいずれか) で提供する
+
+### Requirement 7: orchestration を持たない境界
+
+**Objective:** kolt メンテナーとして、 `[tools]` の責務を「jar 取得 + 起動」に厳しく限定したい。 そうすれば将来 `[hooks]` (#119) や別のスコープ追加が来たときに、 既存の `[tools]` 契約と競合しない。
+
+#### Acceptance Criteria
+
+1. If `[tools]` エントリにツール間の依存関係を表すフィールド (例: `depends-on`) が含まれているとき、 kolt shall そのフィールドが `[tools]` の対象外であることを提示して `kolt.toml` の load を失敗させる
+2. If `[tools]` エントリにエントリ内コマンドライン構築を表すフィールド (例: `args = [...]`) が含まれているとき、 kolt shall そのフィールドが `[tools]` の対象外であることを提示して `kolt.toml` の load を失敗させる
+3. The kolt shall `[tools]` のエントリに対してツール固有の kolt subcommand (例: `kolt lint`) を自動生成しない
+4. The kolt shall `[tools]` 経由のツール起動を、 `kolt build` / `kolt test` / その他の kolt lifecycle event の前後に自動で挿入しない (連携が必要なら別機能 / 別 toml セクションで導入する)

--- a/.kiro/specs/341-tools-section/research.md
+++ b/.kiro/specs/341-tools-section/research.md
@@ -1,0 +1,233 @@
+# Gap Analysis: 341-tools-section
+
+調査日: 2026-05-08
+
+## Analysis Summary
+
+- `[tools]` の **大半は既存 infrastructure の composition** で実現できる。 jar download/cache (`ensureTool`)、 process spawn + arg passthrough + exit code propagation (`executeCommand`)、 JDK 解決 (`ensureBootstrapJavaBin` / `ensureJdkBins`)、 lockfile schema (`classpathBundles` の nested Map precedent)、 SHA-256 verification (`ResolveError.Sha256Mismatch`) はすべて存在する
+- **新規実装が必要な箇所は限定的**: schema parse + validation, alias 文法, lockfile への `toolsBundles` field 追加, Main-Class 検証経路、 cause-distinguishable な exit code mapping
+- **package name の潜在衝突**: 既存の `kolt.tool` package は **toolchain provisioning** (kotlinc / JDK / konanc / 内部 jar の `ensureTool`) を担う。 `[tools]` config section の新規コードは別 package に置く必要がある (例: `kolt.toolsection` / `kolt.usertool`)。 命名は design.md で確定
+- **ADR 0028 §3 凍結面の影響**: schema は additive-only。 alias 文法、 coords 形状、 lockfile format、 cache layout、 CLI surface はすべて ship で凍結。 後から narrow できないので、 design.md で一括で決定する
+- **推奨 implementation 戦略**: Option C (Hybrid) — 既存の `BundleResolver` パターンを踏襲して `[classpaths]` と並ぶ第三の bundle カテゴリとして実装、 + alias-による起動経路と Main-Class 検証経路だけ新規。 effort M (3〜7 日)、 risk Low-Medium
+
+## 1. Current State Investigation
+
+### 1.1 設定 parse (`kolt.config`)
+
+| 要素 | ファイル / 型 | 役割 |
+|---|---|---|
+| schema 中間型 | `Config.kt` `RawKoltConfig` | ktoml `@Serializable`、 `ignoreUnknownNames = true` |
+| schema 公開型 | `Config.kt` `KoltConfig` | validated、 immutable |
+| validation chain | `Config.kt` `validateKind` / `validateTarget` / `validateMainFqn` / `validateProjectRelativePath` / `validateBundleReferences` ほか | parse 後に直列で走る |
+| 既存 nested table 例 | `[classpaths.<name>]` (Map) | `[tools.<alias>]` の precedent |
+| 既存 path 計算 | `KoltPaths.kt` `cacheBase = "$home/.kolt/cache"`, `jdkPath`, `javaBin` | tools 専用 path もここに置く |
+
+**新セクション追加で触るファイル**: `Config.kt` (`RawKoltConfig`, `KoltConfig`, validation 1 件追加), `KoltPaths.kt` (cache path)
+
+### 1.2 依存解決と Maven coords (`kolt.resolve`)
+
+| 要素 | 場所 | 注意点 |
+|---|---|---|
+| 座標型 | `Dependency.kt` `Coordinate(group, artifact, version)` | **classifier フィールドなし**。 classifier は `buildMavenUrl(..., classifier)` で URL builder に渡される |
+| URL/path builder | `Dependency.kt` `buildMavenUrl`, `buildCachePath`, `buildSourcesCachePath` | classifier 別に関数分離している慣例 |
+| 解決 kernel | `Resolution.kt` `fixpointResolve()` | childLookup callback 注入式。 children を空にすれば single-jar 解決 |
+| transitive 解決 | `TransitiveResolver.kt` `resolveTransitive()` / `downloadFromRepositories()` / `materialize()` | repo iterate + 404 fallthrough、 download 後 SHA-256 verify |
+| bundle 解決 | `BundleResolver.kt` `resolveBundle()` / `materialiseBundleJarsFromLock()` | bundle isolation の precedent |
+| 失敗型 | `Resolver.kt` `ResolveError` enum (含む `Sha256Mismatch`) | 新たな失敗種は enum 拡張で済む |
+
+**新セクション追加で触るファイル**: `Resolver.kt` (`buildLockfileFromResolved` に tool 経路追加), 新 file `ToolResolver.kt`、 もしくは `BundleResolver.kt` を再利用
+
+### 1.3 lockfile (`kolt.lock`)
+
+| 要素 | 場所 | 注意点 |
+|---|---|---|
+| 形式 | JSON (kotlinx.serialization)。 v4 (ADR 0005, redirect_target 追加) | 単一ファイル precedent |
+| 公開型 | `Lockfile.kt` `Lockfile(version, kotlin, jvmTarget, dependencies, classpathBundles)` | nested Map (`Map<String, Map<String, LockEntry>>`) 既存 |
+| entry 型 | `LockEntry(version, sha256, transitive=false, test=false, redirectTarget=null)` | tools 用に追加 field 必要なし |
+| serialize | `LockfileJson` (private) + `serializeLockfile()` (alphabetic sort) | round-trip テスト前例あり |
+| version mismatch | `LockfileError.UnsupportedVersion` | parse 前段で reject |
+
+**選択肢**: (a) `Lockfile.classpathBundles` と並べて `toolsBundles: Map<String, Map<String, LockEntry>>` を additive 追加 (recommended、 single atomic write 維持)、 (b) 別ファイル `kolt-tools.lock` を新設 (concern 分離、 ただし atomic 性低下)
+
+### 1.4 JDK 取り扱い (`kolt.tool`、 `kolt.build.daemon`)
+
+| 要素 | 場所 | 役割 |
+|---|---|---|
+| toolchain JDK | `ToolchainManager.kt` `ensureJdkBins(version, paths): Result<JdkBins, ToolchainError>` | 任意 version の JDK を install/検証 |
+| bootstrap JDK | `BootstrapJdk.kt` `BOOTSTRAP_JDK_VERSION = "25"` + `ensureBootstrapJavaBin(paths)` | daemon 起動用、 user 設定で override 不可 |
+| JDK path 規則 | `KoltPaths.kt` `jdkPath(version) = "$toolchainsDir/jdk/$version"`, `javaBin(version)` | ADR 0017 §1 |
+
+**結論**: `[tools]` の launch JDK 既定を bootstrap JDK にする場合、 `ensureBootstrapJavaBin` を流用するだけで済む (新規実装ゼロ)。 「ツールごとに別 JDK version を要求できる」を v1 で許すなら schema 拡張 + `ensureJdkBins(version, ...)` 流用
+
+### 1.5 既存の jar 実行経路 (`kolt.tool` の `ToolManager`、 `kolt.build`、 `kolt.infra`)
+
+| 要素 | 場所 | 役割 |
+|---|---|---|
+| jar download + cache | `ToolManager.kt` `ensureTool(paths, spec): Result<String, String>` | jar を Maven Central から取得して `~/.kolt/tools/<filename>` に置く。 path を返す |
+| 既存 spec 例 | `ToolManager.kt` `KTFMT_SPEC`, `CONSOLE_LAUNCHER_SPEC` | runnable jar の established precedent |
+| jar 起動 | `Process.kt` `executeCommand(args, extraEnv): Result<Int, ProcessError>` | fork/execvp、 引数 verbatim、 exit code そのまま返す |
+| 起動例 | `Formatter.kt` `formatCommand(...)` (ktfmt)、 `TestRunner.kt` `testRunCommand(...)` (junit) | `java [-D...] -jar <path> <args...>` の組み立て precedent |
+| daemon jar 起動 | `NativeDaemonBackend.kt` `java -cp <classpath> <Main> --socket <path>` | 別経路 (classpath 起動) — `[tools]` には不要 |
+| process error 型 | `Process.kt` `ProcessError` sealed (`EmptyArgs / ForkFailed / WaitFailed / NonZeroExit / SignalKilled / PopenFailed`) | exit code propagation の足場 |
+
+**結論**: `ensureTool` + `executeCommand` の組み合わせで、 `[tools]` の launch 部分は ktfmt / junit と同じ既存パターンに完全一致できる
+
+### 1.6 CLI surface dispatch (`kolt.cli`)
+
+| 要素 | 場所 | 役割 |
+|---|---|---|
+| dispatch | `Main.kt` `when(filteredArgs[0]) { ... }` (15+ subcommand) | 新 subcommand は case 1 件 + 関数 1 件 |
+| arg parser | `Main.kt` `parseKoltArgs(argList)` | global flag + `--` 後 verbatim passthrough |
+| nested subcommand pattern | `doToolchain(args)` (`install/list/remove`)、 `doDaemon(args)` (`stop/reap`) | `kolt tool run <alias>` パターンの precedent |
+| separate binary precedent | `kolt-jvm-compiler-daemon` / `kolt-native-compiler-daemon` (sidecars) | user-facing binary としての precedent はない |
+
+**結論**: subcommand 案 (`kolt tool run ...` / 新 top-level `kolt tool ...`) は既存パターンと natural fit。 separate binary 案 (`kolt-x`) は user-facing には前例ゼロ — 採るなら新規 build target を kolt-toml 自己ホストで定義する必要があり、 release tarball の packaging (ADR 0018) と install.sh も拡張必要
+
+## 2. Requirements Feasibility Analysis
+
+### 2.1 Requirement → Asset Map
+
+| Req | 必要な技術要素 | 既存資産 | gap tag |
+|---|---|---|---|
+| R1.1 (`[tools]` parse) | ktoml deserialize の Map field | `RawKoltConfig` の `[classpaths]` field 形 | **Reusable** |
+| R1.2 (coords 形状) | `group:artifact:version[:classifier]` parse | `parseCoordinate(...)` (classifier なし) | **Constraint**: 既存 `Coordinate` に classifier がない。 design で「coords 文字列に classifier を含めるか / 別 field か」を決める必要 |
+| R1.3 (alias 文法) | regex validation | `validateMainFqn` / `validateBundleReferences` の precedent | **Missing**: alias 専用 validator は新規。 regex は design で確定 |
+| R1.4 (coords 不正 reject) | parse 後 reject | `Config.kt` validation chain | **Reusable** |
+| R1.5 (alias 重複 reject) | duplicate key 検知 | ktoml の重複キー → `SerializationException` | **Reusable** (ktoml の動作に依存) |
+| R2.1 (alias 起動 + arg verbatim) | subcommand dispatch + `executeCommand` | `Main.kt` + `executeCommand` | **Reusable** |
+| R2.2 (exit code propagation) | `executeCommand` の戻り | `ProcessError.NonZeroExit(exitCode)` | **Reusable** |
+| R2.3 (未知 alias) | dispatch 内 alias lookup | 新規 (`KoltConfig.tools` map lookup) | **Missing (trivial)** |
+| R2.4 (app classpath 非汚染) | tool jar を `[dependencies]` 経路に通さない | `BundleResolver` の isolation pattern | **Reusable** |
+| R3.1 (初回 fetch + cache 格納) | jar download + path 返却 | `ensureTool(paths, spec)` | **Reusable** (ただし alias-名で path 計算する必要 — design に依存) |
+| R3.2 (cache hit でネット skip) | 既存 cache existence check | `ensureTool` 内に既存 | **Reusable** |
+| R3.3 (integrity check 失敗 → 停止) | SHA-256 verify | `ResolveError.Sha256Mismatch` | **Reusable** |
+| R3.4 (取得不能 → 停止) | repo download fail | `downloadFromRepositories` | **Reusable** |
+| R4.1 (lockfile 記録) | `Lockfile` 拡張 | `classpathBundles` の precedent | **Reusable** + extension |
+| R4.2 (lockfile pin 優先) | lockfile load → resolved 上書き | bundle 経路の `materialiseBundleJarsFromLock` | **Reusable** |
+| R4.3 (toml と lock 矛盾 → loud) | mismatch detection | `Resolver` の lockChanged compute | **Constraint**: 既存はサイレント overwrite。 `[tools]` は loud reject (新挙動) — design で `kolt update` 等の指示文言を確定 |
+| R4.4 (再現情報) | `LockEntry` の version + sha256 | 既存 entry にあり | **Reusable** |
+| R5.1 (Main-Class で起動) | `java -jar <path>` で JVM が manifest 読む | `executeCommand` で実現 | **Reusable** |
+| R5.2 (Main-Class 不在 reject) | 起動失敗 detect | JVM が exit code 1 + stderr「no main manifest attribute」を出す | **Missing**: kolt 側でこれを認識して cause-distinguishable に分類するロジック新規 (pre-launch で manifest を読むか、 post-launch で stderr / exit code を classify するか — design で決定) |
+| R5.3 (非 runnable 形 reject) | distribution zip / launcher script | 現状なし | **Missing**: 形検出ロジック新規 (pre-launch で magic-byte / extension check) |
+| R5.4 (cause-distinguishable surface) | 失敗種の分類 | `ProcessError` + `ResolveError` enum 拡張 | **Reusable** + extension |
+| R6.1 (JDK 決定論) | bootstrap JDK fallback | `ensureBootstrapJavaBin` | **Reusable**、 ただし「ツールごとに別 JDK」を v1 で許すかは design 判断 |
+| R6.2 (JDK 不在 → loud) | 失敗 surface | `ToolchainError` + `BootstrapJdkInstallFailed` | **Reusable** |
+| R6.3 (JDK 出所の事後確認) | log / verbose 出力 | 既存 daemon 経路で precedent あり | **Reusable** |
+| R7.1〜7.2 (orchestration field reject) | 未知 field の strict reject | 現状 ktoml は `ignoreUnknownNames=true` | **Constraint**: 全体 default が「ignore unknown」なので、 `[tools]` 配下だけ strict にする必要。 design で「専用 strict deserializer」を組むか、 「validation 段階で blacklist field を明示 reject」するか決定 |
+| R7.3 (subcommand 自動生成しない) | dispatch 設計 | 単に実装しないだけ | **Trivial** |
+| R7.4 (lifecycle 自動連携しない) | build/test 経路から外す | 単に実装しないだけ | **Trivial** |
+
+### 2.2 既存 codebase との非自明な constraint
+
+- **`Coordinate` に classifier フィールドがない** — coords 文字列に classifier を含める設計 (`group:artifact:version:classifier`) を採るなら、 schema 表面と内部型の不一致を design で documented (parser が string → `(Coordinate, classifier?)` に分解) する必要
+- **既存 `~/.kolt/tools/` flat layout** — `ensureTool` は `~/.kolt/tools/<filename>` (filename はツール固有)。 `[tools]` がそのまま使うと、 ktfmt / junit-console と user tool の path collision が起き得る。 design で `~/.kolt/tools/<alias>/<version>/` のような nested layout に切るか、 flat 維持で命名衝突を許さない alias 文法を pin するか決定
+- **ktoml `ignoreUnknownNames = true`** が global default — `[tools]` の orchestration ガードレール (R7.1, R7.2) をどう実装するか。 専用 strict serializer か、 validation で blacklist 列挙か、 design 判断
+- **lockfile silent overwrite vs loud** — 既存 `[dependencies]` は toml の宣言と lockfile の差分を silent に取り込む。 `[tools]` で R4.3 を loud にするには新挙動。 design で `[tools]` の「lock 出力モード」をどう trigger するか (例: 専用 `kolt update` flag vs 自動再解決) を確定
+
+### 2.3 Research Needed (design 段階で深掘り)
+
+- **Main-Class 検証の実装手段**: jar (=zip) から `META-INF/MANIFEST.MF` を読む native 経路 (libarchive cinterop は ADR 0031 で導入済 — extraction だけでなく zip read API があるか) vs JVM 起動して exit code/stderr 分類
+- **alias 文法 regex** の妥当性 — Cargo の crate name 規則 (`[a-zA-Z][a-zA-Z0-9_-]*`)、 npm package 名規則あたりを比較し、 pinned regex を design で決める
+- **CLI surface の `--`-passthrough 方針** — `kolt tool run ktlint --reporter=plain` を `--` 必須にするか optional にするか。 既存 `doTest` の `--` 区切り precedent との整合
+- **`KOLT_TOOL_ARGS` の env 透過** — `executeCommand(args, extraEnv)` の `extraEnv` をどこまで埋めるか (project-root, build-dir 等を `[hooks]` 系で渡す既存議論 #119 と整合させる)
+- **fat-jar tool で transitives を skip するか / main-classifier だけ取るか** — `fixpointResolve` の childLookup を空 callback にする vs 別 path、 影響範囲は `TransitiveResolver`
+
+## 3. Implementation Approach Options
+
+### Option A: 既存 component を最大限拡張 (BundleResolver 全乗り)
+
+**やり方**: `[tools]` を `[classpaths]` の第三カテゴリとして扱う。 `BundleResolver.resolveBundle()` の childLookup を「transitive を取らない (children=[])」にして tool 専用 entry point を `BundleResolver.kt` 内に追加。 lockfile は `Lockfile.classpathBundles` と並ぶ `toolsBundles` を additive 追加。 CLI は `Main.kt` に `tool` case + `doTool(args)` 関数 1 件追加。 launch は `ensureTool` のジェネリック化 + `executeCommand` 流用
+
+**変更ファイル**:
+- `kolt.config.Config.kt` (RawKoltConfig + KoltConfig + validation)
+- `kolt.resolve.BundleResolver.kt` (tool resolver entry point 追加 + transitive=false mode)
+- `kolt.resolve.Lockfile.kt` (`toolsBundles` field 追加)
+- `kolt.tool.ToolManager.kt` (`ensureTool` を spec ジェネリックに)
+- `kolt.cli.Main.kt` (`tool` case 追加) + 新 file `ToolCommands.kt`
+- `kolt.config.KoltPaths.kt` (tool cache path)
+
+**Trade-offs**:
+- ✅ 新 file 最少 (1〜2)、 既存 test 資産再利用 (round-trip lockfile test の precedent)
+- ✅ ADR 上は既存 §3 凍結面の **拡張** で済み、 新セクションが少ない
+- ❌ `BundleResolver` が「app classpath bundle (`[classpaths]`)」「user tool bundle (`[tools]`)」の双方を担うことで責務肥大、 single-responsibility が薄れる
+- ❌ `[tools]` の orchestration-not-allowed 性 (R7) と `[classpaths]` の自由形 schema が同居して読みにくい
+
+### Option B: 新 component を別 package で分離
+
+**やり方**: 新 package `kolt.toolsection`/`kolt.usertool` を作り、 schema parse / resolve / launch を全て新規。 `kolt.tool` (toolchain) と命名衝突を避ける。 lockfile は別ファイル `kolt-tools.lock` を新設
+
+**変更ファイル**:
+- 既存変更は最小: `kolt.config.Config.kt` (`tools` field 追加だけ)、 `kolt.cli.Main.kt` (case 追加)
+- 新規 multiple files: `kolt.toolsection.{ToolSection.kt, ToolResolver.kt, ToolLauncher.kt, ToolsLockfile.kt}` 等
+
+**Trade-offs**:
+- ✅ 責務分離が明確、 R7 の orchestration-not-allowed 境界をパッケージ境界で表現
+- ✅ test isolation が高い
+- ❌ 新規ファイル多 (5〜6)、 既存 `BundleResolver` / `Lockfile` の round-trip test 資産が再利用しづらい
+- ❌ 別 lockfile (`kolt-tools.lock`) は atomic 性低下、 `kolt update` の意味論が複雑化、 ADR 0028 §3 の lockfile-format-stable 凍結面を **2 ファイル** に拡張する負担 (面が増えるとデフォ deprecation budget も増える)
+
+### Option C: ハイブリッド (推奨)
+
+**やり方**:
+- **Schema / lockfile / cache layout** は **既存 infrastructure 拡張** (Option A 寄り):
+  - `RawKoltConfig.tools` を additive 追加
+  - `Lockfile.toolsBundles` を additive 追加 (single file 維持)
+  - cache は `~/.kolt/tools/<alias>/<version>/<artifact>-<version>[-<classifier>].jar` で nested に切る (既存の `~/.kolt/cache/` と user `~/.kolt/tools/` の慣例を踏襲しつつ衝突回避)
+- **CLI dispatch / Main-Class 検証 / orchestration ガードレール** は **新規ファイル** (Option B 寄り) — 別 package `kolt.usertool` (仮)
+  - `ToolCommands.kt` (CLI dispatch)
+  - `ToolLauncher.kt` (Main-Class 検証 + java -jar 起動 + JDK 解決 wiring)
+  - `ToolValidation.kt` (alias regex、 orchestration field の blacklist reject)
+- **解決経路** は `BundleResolver.resolveBundle()` を transitive=false モードで呼ぶ (もしくは `TransitiveResolver` の薄い wrapper を新規作る) — design で確定
+- **launch JDK** は v1 では bootstrap JDK 固定 (`ensureBootstrapJavaBin` 流用、 schema 拡張なし)。 ツールごとの JDK pin は v1.1 以降の additive に倒す
+
+**Trade-offs**:
+- ✅ schema / lockfile / cache の凍結面は既存パターンに乗り、 ADR 0028 §3 への新セクション追加が最小
+- ✅ `[tools]` 固有の振る舞い (Main-Class 検証、 orchestration reject、 user-facing CLI surface) は新 package で隔離 — R7 の境界をコードで表現できる
+- ✅ effort は M (3〜7 日)、 risk Low-Medium
+- ❌ 「拡張」と「新規」の境界線が design で正確に引かれていないと、 担当が曖昧になる
+
+## 4. Effort & Risk
+
+| 領域 | Effort | 備考 |
+|---|---|---|
+| Schema parse + alias validation (R1, R7.1〜7.2) | S (1〜2 日) | ktoml + 既存 validation chain にのる。 strict mode の orchestration reject だけ新規 |
+| Resolve + cache (R3) | S-M (2〜3 日) | `BundleResolver` の transitive-skip variant を作る or 既存に flag。 cache layout 設計込み |
+| Lockfile pin + 矛盾検知 (R4) | S (1〜2 日) | `toolsBundles` field 追加 + bundle 経路の lockChanged 流用、 R4.3 (loud reject) は新挙動 |
+| Launch + Main-Class 検証 (R2, R5) | M (2〜3 日) | `executeCommand` 流用は trivial だが、 R5.2/R5.3 の cause-distinguishable 分類が新規。 jar manifest pre-read か post-launch classify かの design 判断次第 |
+| JDK 経路 (R6) | S (0.5〜1 日) | bootstrap JDK 流用なら最小。 ツール JDK pin を v1 で許すなら + S |
+| CLI dispatch + help (R2.1, R7.3) | S (0.5〜1 日) | `Main.kt` case 追加 + 新 `doTool` 関数 |
+| Test (round-trip lockfile, parse rejection, e2e launch) | S-M (2〜3 日) | nativeTest 既存パターン踏襲 |
+| ADR 起草 + §3 update | S (1 日) | design.md と並行 |
+
+**Total: M (5〜10 日)**
+
+**Risk: Low-Medium**
+
+- Low 側: 既存 infrastructure (download / cache / SHA-256 / launch / lockfile) が established で、 Kotlin/Native 上での動作実績あり
+- Medium 側:
+  - Main-Class 検証経路の design 選択が未確定 (pre-read vs post-classify) — 実装複雑度に直接影響
+  - ADR 0028 §3 凍結面に **同時に複数追加** (toml schema + CLI surface + lockfile field + cache layout) — 1 つでも narrow が必要になると post-v1 で痛い、 design.md で全部きっちり pin する必要
+  - alias 文法と既存 `[classpaths]` / `[dependencies]` 名と衝突しないかは grep + spike 必要
+
+## 5. Recommendations for Design Phase
+
+### 5.1 Preferred approach
+- **Option C (Hybrid)** で進める。 既存 infra は拡張、 新挙動 (Main-Class 検証、 orchestration reject、 user CLI surface) は別 package に隔離
+
+### 5.2 Key decisions to lock in design.md (= ADR-equivalent, ADR 0028 §3 凍結対象)
+
+1. **CLI surface**: `kolt tool run <alias> [args]` (subcommand、 既存 `doTest` の `--`-passthrough と整合) を **強く推奨**。 separate binary は user-facing precedent ゼロでコスト高
+2. **Coords shape**: `group:artifact:version[:classifier]` 文字列形 (issue body のまま) を採用、 内部 parse で `(Coordinate, classifier?)` に分解。 schema 表面は単純維持
+3. **Lockfile**: 既存 `kolt.lock` に additive (`toolsBundles: Map<String, Map<String, LockEntry>>`) — `classpathBundles` precedent
+4. **Alias regex**: `^[a-zA-Z][a-zA-Z0-9_-]{0,63}$` あたりが Cargo precedent と整合 — design で正式 pin
+5. **Launch JDK**: v1 は bootstrap JDK 固定 (schema 拡張なし)。 ツールごと JDK pin は v1.1 以降に follow-up
+6. **Cache layout**: `~/.kolt/tools/<alias>/<version>/<filename>` nested layout — 既存 `~/.kolt/tools/` flat (kolt-internal 用) と区別しつつ衝突を避ける
+7. **Failure exit codes**: 既存 `ProcessError` / `ResolveError` を流用しつつ、 user-facing には 3 段階くらいで分類 (resolve fail / Main-Class issue / launch fail) — `install.sh` 粒度に揃える
+8. **§3 update**: 上記 1〜7 を全部 §3 凍結面に組み込む単一 ADR 改訂 (新 ADR ではなく ADR 0028 §3 拡張) を design.md で起草
+
+### 5.3 Research items to carry forward (design 中に深掘り)
+
+- jar の `META-INF/MANIFEST.MF` を Kotlin/Native から読む手段 (libarchive cinterop が zip read をサポートするか / `unzip -p` shell out をどう廃するか / 単に JVM 起動の exit code + stderr で post-classify するか)
+- ktoml で「ある table 配下だけ unknown field を strict reject する」モードの組み立て方 (config-level override が可能か、 専用 deserializer 必要か)
+- `kolt tool run` 経路で `[tools]` 未宣言 alias を呼ぶときの error message と類似 alias 提案 (既存 `kolt fmt --check` 等の precedent と整合)
+- 既存 `kolt.tool` package 命名と衝突しない新 package 名 (`kolt.usertool` / `kolt.toolsection` / `kolt.runtool` 候補) — 命名は design で確定、 影響は小

--- a/.kiro/specs/341-tools-section/spec.json
+++ b/.kiro/specs/341-tools-section/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "341-tools-section",
+  "created_at": "2026-05-07T15:51:23Z",
+  "updated_at": "2026-05-07T16:52:23Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -163,7 +163,7 @@
   - _Requirements: 2.1, 2.2, 5.1_
   - _Boundary: ToolCommands E2E_
 
-- [ ] 7.2 (P) `kolt.usertool` が build / test lifecycle に連携していないことを assert する guard test を追加
+- [x] 7.2 (P) `kolt.usertool` が build / test lifecycle に連携していないことを assert する guard test を追加
   - `src/nativeMain/kotlin/kolt/build/` および `src/nativeMain/kotlin/kolt/cli/BuildCommands.kt` / `TestCommands.kt` (もしくはそれに準ずる existing build/test entry) の source 全文を grep し、 `kolt.usertool` を import / 参照していないことを assert (precedent: `DriftGuardsTest` 既存 sweep pattern)
   - 「build/test 経路から `[tools]` の hook が刺さっていない」ことを compile-time + grep で 2 重に保証
   - 観測完了条件: 新 guard test が green で、 将来誰かが build/test 経路から `kolt.usertool` を呼び出す変更を入れたら test が RED になる

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -1,0 +1,179 @@
+# Implementation Plan
+
+> 注: 本機能は kolt の v1.0 milestone 候補で、 ADR 0028 §3 凍結面に新たに `[tools]` schema / `tools_bundles` lockfile field / `kolt tool run` CLI surface / `~/.kolt/tools/bundles/<alias>/<version>/` cache layout / `EXIT_TOOL_ERROR = 7` を加える。 Task 7.2 で ADR 改訂を land させ、 Task 7.1 までで実装を完結させる。
+>
+> TDD 方針: 各実装サブタスクは「test を先行で書き、 implementation を完成させる」を 1 task 内 atomic に行う (memory `feedback_tdd_red_green_atomic.md` 準拠)。 RED-only commit を残さない。
+
+## 1. Foundation: lockfile / paths / exit code 拡張
+
+- [ ] 1.1 (P) Lockfile に `tools_bundles` field を additive 追加
+  - `Lockfile` data class に `toolsBundles: Map<String, Map<String, LockEntry>> = emptyMap()` を `classpathBundles` の隣に追加
+  - `LockfileJson` の snake_case マッピングと `parseLockfile` / `serializeLockfile` を round-trip 対応に拡張
+  - 既存 lockfile (`tools_bundles` 不在) を読めることを `LockfileTest` の既存 `classpathBundles` round-trip pattern で assert
+  - 観測完了条件: 新 round-trip テストで `tools_bundles` を含む lockfile を serialize → parse して同一値が返り、 既存 lockfile (tools_bundles 不在) を読むと empty map が返る
+  - _Requirements: 4.1, 4.4_
+  - _Boundary: Lockfile_
+
+- [ ] 1.2 (P) KoltPaths に tool cache 専用 path helper を追加
+  - `toolsBundleDir(alias: String, version: String): String` で `~/.kolt/tools/bundles/<alias>/<version>/` を計算
+  - `toolsBundleJarPath(alias: String, version: String, fileName: String): String` で配下の jar path
+  - 既存 `~/.kolt/tools/<filename>` (kolt-internal flat layout) と path 衝突しないこと unit test で確認
+  - 観測完了条件: 同一 alias + 異なる version で別ディレクトリが返り、 既存 `KoltPaths` の他 helper と並んで使える
+  - _Requirements: 3.1, 3.2_
+  - _Boundary: KoltPaths_
+
+- [ ] 1.3 (P) ExitCode.kt に `EXIT_TOOL_ERROR = 7` を追加
+  - 既存 `EXIT_LOCK_TIMEOUT = 6` の次の slot に const 追加、 命名は kolt 既存 semantic (BUILD/CONFIG/DEPENDENCY/TEST/FORMAT/LOCK_TIMEOUT) に並べる
+  - 既存 exit code 値 (0/1/2/3/4/5/6/127) と非衝突であることをテストで assert (mechanical sweep)
+  - 観測完了条件: `EXIT_TOOL_ERROR = 7` を import して使えるようになり、 `ExitCode.kt` の他 const と整合
+  - _Requirements: 5.4_
+  - _Boundary: ExitCode_
+
+## 2. Schema parse: `[tools]` の types と validation
+
+- [ ] 2.1 `parseCoordsString` utility を新設
+  - `group:artifact:version[:classifier]` 文字列を `(Coordinate, classifier?)` に分解
+  - group / artifact が ASCII letters/digits/`-`/`_`/`.`、 version が non-empty、 classifier 同 charset で optional
+  - 構文逸脱は `Result.Err(reason: String)` を返し、 alias 文脈は呼び出し側で添える
+  - 観測完了条件: unit test で `"a.b:c:1.0"` / `"a.b:c:1.0:cls"` の両形が成功、 group 欠落・version 欠落・空文字は loud に Err を返す
+  - _Requirements: 1.2_
+  - _Boundary: ToolSectionParse_
+
+- [ ] 2.2 `RawToolEntry` / `ToolEntry` / `KoltConfig.tools` field を追加
+  - `RawToolEntry(coords: String?, dependsOn: String?, args: List<String>?, main: String?)` で `@SerialName("depends-on")` 付きの 4 field を nullable 宣言
+  - `ToolEntry(coords: Coordinate, classifier: String?)` を public validated 型として導入
+  - `RawKoltConfig.tools: Map<String, RawToolEntry>?` と `KoltConfig.tools: Map<String, ToolEntry>` を additive 追加 (既存 field 順序を保つ)
+  - 観測完了条件: `[tools.foo] coords = "a:b:1.0"` だけを書いた kolt.toml が parse 通り、 `KoltConfig.tools["foo"]?.coords` が `Coordinate("a", "b", "1.0")` を返す
+  - _Requirements: 1.1_
+  - _Boundary: ToolSection, RawKoltConfig, KoltConfig_
+
+- [ ] 2.3 `ToolSectionParse.parseToolSection` を実装
+  - alias を `^[a-z][a-z0-9_-]{0,63}$` の regex で照合、 違反は `InvalidAlias`
+  - `RawToolEntry.dependsOn` / `args` / `main` のいずれかが non-null なら `ForbiddenField` で reject
+  - `coords` が null なら `MissingCoords`、 `parseCoordsString` 失敗は `MalformedCoords`
+  - 重複 alias は ktoml の TOML spec 準拠 parse error に乗る (本コンポーネントには到達しない) — 動作確認テストを追加
+  - 観測完了条件: unit test で alias `Foo` / 65 字 / `args = []` / `depends-on = "..."` / `main = "..."` / `coords` 不在の各 case が指定された error variant を返す
+  - _Requirements: 1.3, 1.4, 1.5, 7.1, 7.2_
+  - _Boundary: ToolSectionParse_
+
+- [ ] 2.4 `Config.parseConfig` の validation chain に `validateToolSection` を組み込む
+  - 既存 `validateBundleReferences` の隣に `validateToolSection` を呼び出し、 失敗は `Config.parseConfig` の Err 経路に乗せる
+  - parse 結果の `KoltConfig.tools` が `RawKoltConfig.tools` の validated 像になっていることを Config 全体テストで確認
+  - 観測完了条件: `[tools]` 含む実 kolt.toml fixture が `loadProjectConfig()` で正常 parse され、 forbidden field 入りの fixture は load 段階で Err を返す
+  - _Requirements: 1.1, 1.3, 1.4, 7.1, 7.2_
+  - _Boundary: Config.parseConfig_
+
+## 3. Error type: `ToolError` sealed の集約
+
+- [ ] 3.1 `ToolError` sealed top-level + `ToolSectionParseError` / `ToolResolutionError` / `ToolLaunchError` sealed sub-types を作成
+  - 各 sub-error は design.md の State Management 表に従い variant 毎の data class を持つ (`Parse`, `Resolve`, `Launch`, `UnknownAlias`)
+  - `toExitCode(): Int` を `EXIT_CONFIG_ERROR=2` / `EXIT_DEPENDENCY_ERROR=3` / `EXIT_TOOL_ERROR=7` に振り分け
+  - `formatStderr(): String` で variant ごとに `tool '<alias>': <variant>: <detail>` の prefix を固定 (R5.4 cause-distinguishable)
+  - `LockfileMismatch` の message は `tool '<alias>': lockfile pin '<pinned>' differs from kolt.toml '<toml>'. Run \`kolt update\` to refresh tool pins.` で固定
+  - 観測完了条件: 各 variant の `toExitCode()` 値と `formatStderr()` 文字列を unit test で全網羅、 `EXIT_TOOL_ERROR=7` を経由する変種は 3 つだけ (NotRunnableJar / MainClassMissing / JdkUnavailable) であることを assert
+  - _Requirements: 2.3, 3.3, 3.4, 4.3, 5.2, 5.3, 5.4, 6.2_
+  - _Boundary: ToolError_
+
+## 4. Resolve: BundleResolver 拡張 と ToolResolution
+
+- [ ] 4.1 `BundleResolver.resolveSingleArtifact` (transitive-skip mode) を expose
+  - 既存 `resolveBundle` の childLookup を `{ emptyList() }` に固定する薄い wrapper を導入、 もしくは既存 internal 関数を `internal` から `internal kolt.usertool` に open
+  - 単一 coordinate を受け取り、 transitive を fetch せず POM + jar を返す経路にする
+  - 既存 `[classpaths]` 経路に regression が出ないことを既存 BundleResolver テストで担保
+  - 観測完了条件: 単一 `Coordinate("a","b","1.0")` を渡したテストで POM+jar の 2 entry のみ返り、 transitive 列が emptyList であることを assert
+  - _Requirements: 2.4, 3.1_
+  - _Boundary: BundleResolver_
+
+- [ ] 4.2 `ToolResolution.ensureTool` の happy-path (cache + first fetch + lockfile write-through) を実装
+  - alias から `ToolEntry` を引き、 `paths.toolsBundleJarPath` 配下に jar が存在し lockfile pin の `version` / `sha256` と一致するなら network skip
+  - lockfile に該当 alias の pin 不在 (初回) は `BundleResolver.resolveSingleArtifact` で fetch、 SHA-256 verify、 cache に格納、 lockfile に新 pin を書き戻す (R3.1, R4.1)
+  - cache miss だが lockfile pin あり の場合、 pin の coords / SHA-256 に従って fetch・verify (R4.2)
+  - 観測完了条件: cache hit テストで network mock が呼ばれない、 cache miss テストで lockfile に新 entry が書かれて round-trip 成立
+  - _Requirements: 2.4, 3.1, 3.2, 4.1, 4.2, 4.4_
+  - _Boundary: ToolResolution_
+  - _Depends: 1.1, 1.2, 2.2, 3.1, 4.1_
+
+- [ ] 4.3 `ToolResolution.ensureTool` の failure-path (mismatch / integrity / network) を実装
+  - toml の coords と lockfile の resolved coords が group:artifact:version[:classifier] のいずれかで不一致なら `LockfileMismatch` を返す (R4.3、 design.md 固定 message)
+  - cache 上の jar が SHA-256 mismatch なら `IntegrityMismatch` を返し、 自動 refetch しない (R3.3)
+  - network 取得不能 (全 repo 404 / 接続不能) は `ResolveFailed` を返す、 試行 repo URL を message に含める (R3.4)
+  - 観測完了条件: 各 failure case の unit test が ToolError 経路で固定 stderr prefix と exit code を返す、 SHA mismatch ケースで再 fetch が起きないことを mock で assert
+  - _Requirements: 3.3, 3.4, 4.3_
+  - _Boundary: ToolResolution_
+  - _Depends: 4.2_
+
+## 5. Launch: MANIFEST 読 と ToolLauncher
+
+- [ ] 5.1 (P) libarchive で jar (zip) MANIFEST.MF を読む utility を追加
+  - `kolt.usertool` 内 internal 関数 `readMainClassFromJar(jarPath: String): Result<String, ToolLaunchError>` を実装
+  - libarchive の `archive_read_open_filename` + entry iterate で `META-INF/MANIFEST.MF` を locate、 entry data を読み出す
+  - `Main-Class:` 行を抽出 (RFC の line-folding は v1 では非対応で十分、 spec 準拠で改行直後 SP/HT 開始は continuation として concatenate)
+  - libarchive open 失敗 (zip magic mismatch、 truncated) は `NotRunnableJar` を返す
+  - MANIFEST.MF 不在 / `Main-Class:` 行不在は `MainClassMissing` を返す
+  - 観測完了条件: fixture jar (Main-Class 有 / 無 / non-zip) の各テストで対応する Result variant が返る、 ADR 0031 既存 libarchive cinterop 経路に regression なし
+  - _Requirements: 5.1, 5.2, 5.3_
+  - _Boundary: ToolLauncher (jar manifest read sub)_
+  - _Depends: 3.1_
+
+- [ ] 5.2 `ToolLauncher.launch` で MANIFEST 検証 + bootstrap JDK + executeCommand を組む
+  - `readMainClassFromJar(jarHandle.jarPath)` を呼び、 失敗は `ToolLaunchError` (NotRunnableJar / MainClassMissing) を上に伝播
+  - `BootstrapJdk.ensureBootstrapJavaBin(paths)` を呼び、 失敗は `JdkUnavailable` に lift (R6.2)
+  - `executeCommand(listOf(javaBin, "-jar", jarPath) + args, env)` で起動、 exit code をそのまま `Result.Ok(Int)` で return (R2.1, R2.2)
+  - `KOLT_VERBOSE=1` 環境で起動時に `tool=<alias> jdk=<javaBin> jar=<jarPath>` を stderr に 1 行出力 (R6.3)
+  - 観測完了条件: fixture runnable jar (引数を echo するだけの jar) を launch して引数列が verbatim に渡り exit code がそのまま帰ってくる、 verbose 出力が想定形式で stderr に現れる
+  - _Requirements: 2.1, 2.2, 5.1, 5.2, 5.3, 6.1, 6.2, 6.3_
+  - _Boundary: ToolLauncher_
+  - _Depends: 1.2, 5.1_
+
+## 6. CLI integration: dispatch と kolt update 拡張
+
+- [ ] 6.1 `ToolCommands.doTool` で `kolt tool run <alias> [-- args...]` を dispatch
+  - 第 2 引数が `run` 以外 (もしくは欠落) なら usage 表示 + `EXIT_CONFIG_ERROR` (R7.3 — `tool` の sub-action は v1 では `run` のみ)
+  - alias を `KoltConfig.tools` で lookup、 不在なら `UnknownAlias` を返し、 既知 alias 一覧を stderr に提示 (R2.3)
+  - alias 後の引数は verbatim 透過、 `--` 区切りは optional (`kolt tool run ktlint -F` も `kolt tool run ktlint -- -F` も等価) — 既存 `doTest` の pattern と整合 (R2.1)
+  - `ensureTool` → `launch` を順に呼び、 launch 成功時はツール自身の exit code、 ToolError 経路は `toExitCode()` を返す (R2.2, R5.4)
+  - 観測完了条件: alias 後の `--reporter plain --foo bar` がそのままツールに届く E2E、 未知 alias で exit 2 と既知 alias 一覧 stderr が出る
+  - _Requirements: 2.1, 2.2, 2.3, 7.3_
+  - _Boundary: ToolCommands_
+  - _Depends: 4.2, 4.3, 5.2_
+
+- [ ] 6.2 `Main.kt` の `when (filteredArgs[0])` に `"tool"` case と printUsage を追加
+  - `"tool" -> doTool(filteredArgs.drop(1)).getOrElse { exitProcess(it) }` を既存 case 群に並べる
+  - `printUsage()` に `kolt tool run <alias> [-- args...]` の help 1 行を追加
+  - 観測完了条件: `kolt --help` 出力に新 line が含まれ、 `kolt tool run` の引数経路が他コマンドと干渉しない
+  - _Requirements: 2.1, 7.3_
+  - _Boundary: Main_
+  - _Depends: 6.1_
+
+- [ ] 6.3 (P) `doUpdateInner` を `[tools]` の re-resolve にも対応するよう拡張
+  - 既存 `[dependencies]` 経路と並べて `config.tools` を seed として `BundleResolver.resolveSingleArtifact` を回し、 `Lockfile.toolsBundles` を rewrite
+  - `kolt update` の出力に「updating tools…」段を追加、 `[tools]` が空ならスキップ
+  - 既存 `[dependencies]` の更新挙動に regression なし (既存 `DependencyCommandsTest` パス)
+  - 観測完了条件: `[tools]` の coords を編集して `kolt update` を打つと lockfile の `tools_bundles` が新 coords / SHA に置き換わる E2E、 `[dependencies]` のみのプロジェクトでは挙動不変
+  - _Requirements: 4.1, 4.3, 4.4_
+  - _Boundary: doUpdateInner_
+  - _Depends: 1.1, 2.2, 4.1_
+
+## 7. Validation: E2E と ADR 改訂
+
+- [ ] 7.1 fixture runnable jar を使った CLI E2E を追加
+  - `src/nativeTest/resources/` (もしくは既存 fixture 配置場所) に「argv を JSON で stdout に echo して exit code を引数で受け取る」極小 runnable jar を commit
+  - `kolt tool run <fixture-alias> <args...>` で argv が verbatim にツールに届くこと、 exit code がツール側の指定値そのままで返ることを assert (R2.1, R2.2, R5.1)
+  - 観測完了条件: `kolt test` で新 E2E test が green、 self-host CI (`self-host-post`) も既存通り通過
+  - _Requirements: 2.1, 2.2, 5.1_
+  - _Boundary: ToolCommands E2E_
+
+- [ ] 7.2 (P) `kolt.usertool` が build / test lifecycle に連携していないことを assert する guard test を追加
+  - `src/nativeMain/kotlin/kolt/build/` および `src/nativeMain/kotlin/kolt/cli/BuildCommands.kt` / `TestCommands.kt` (もしくはそれに準ずる existing build/test entry) の source 全文を grep し、 `kolt.usertool` を import / 参照していないことを assert (precedent: `DriftGuardsTest` 既存 sweep pattern)
+  - 「build/test 経路から `[tools]` の hook が刺さっていない」ことを compile-time + grep で 2 重に保証
+  - 観測完了条件: 新 guard test が green で、 将来誰かが build/test 経路から `kolt.usertool` を呼び出す変更を入れたら test が RED になる
+  - _Requirements: 7.4_
+  - _Boundary: DriftGuards (新規 sweep 追加)_
+
+- [ ] 7.3 ADR 0028 §3 を改訂し、 本 spec の凍結面追加を pin
+  - §3 に新セクションを追加: `[tools]` toml schema additive 規則、 `tools_bundles` lockfile field additive 規則、 `kolt tool run` CLI surface 凍結、 `~/.kolt/tools/bundles/<alias>/<version>/` cache layout 凍結、 `EXIT_TOOL_ERROR=7` 凍結、 `kolt update` の scope 拡張 ([dependencies]+[tools] 両対応) を 1 セクションに集約
+  - 既存 §3 の `~/.kolt/toolchains/{jdk|kotlinc|konanc}/` 凍結に並べる形で配置
+  - ADR Summary の bullet 1 行も追加
+  - 観測完了条件: ADR 改訂が docs/adr/0028 に commit され、 本 spec の Migration Strategy セクションが ADR の該当項に対応している
+  - _Requirements: 5.4_
+  - _Boundary: docs/adr/0028-v1-release-policy.md_

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -137,7 +137,7 @@
   - _Boundary: ToolCommands_
   - _Depends: 4.2, 4.3, 5.2_
 
-- [ ] 6.2 `Main.kt` の `when (filteredArgs[0])` に `"tool"` case と printUsage を追加
+- [x] 6.2 `Main.kt` の `when (filteredArgs[0])` に `"tool"` case と printUsage を追加
   - `"tool" -> doTool(filteredArgs.drop(1)).getOrElse { exitProcess(it) }` を既存 case 群に並べる
   - `printUsage()` に `kolt tool run <alias> [-- args...]` の help 1 行を追加
   - 観測完了条件: `kolt --help` 出力に新 line が含まれ、 `kolt tool run` の引数経路が他コマンドと干渉しない

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -56,7 +56,7 @@
   - _Requirements: 1.3, 1.4, 1.5, 7.1, 7.2_
   - _Boundary: ToolSectionParse_
 
-- [ ] 2.4 `Config.parseConfig` の validation chain に `validateToolSection` を組み込む
+- [x] 2.4 `Config.parseConfig` の validation chain に `validateToolSection` を組み込む
   - 既存 `validateBundleReferences` の隣に `validateToolSection` を呼び出し、 失敗は `Config.parseConfig` の Err 経路に乗せる
   - parse 結果の `KoltConfig.tools` が `RawKoltConfig.tools` の validated 像になっていることを Config 全体テストで確認
   - 観測完了条件: `[tools]` 含む実 kolt.toml fixture が `loadProjectConfig()` で正常 parse され、 forbidden field 入りの fixture は load 段階で Err を返す

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -76,7 +76,7 @@
 
 ## 4. Resolve: BundleResolver 拡張 と ToolResolution
 
-- [ ] 4.1 `BundleResolver.resolveSingleArtifact` (transitive-skip mode) を expose
+- [x] 4.1 `BundleResolver.resolveSingleArtifact` (transitive-skip mode) を expose
   - 既存 `resolveBundle` の childLookup を `{ emptyList() }` に固定する薄い wrapper を導入、 もしくは既存 internal 関数を `internal` から `internal kolt.usertool` に open
   - 単一 coordinate を受け取り、 transitive を fetch せず POM + jar を返す経路にする
   - 既存 `[classpaths]` 経路に regression が出ないことを既存 BundleResolver テストで担保

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -145,7 +145,7 @@
   - _Boundary: Main_
   - _Depends: 6.1_
 
-- [ ] 6.3 (P) `doUpdateInner` を `[tools]` の re-resolve にも対応するよう拡張
+- [x] 6.3 (P) `doUpdateInner` を `[tools]` の re-resolve にも対応するよう拡張
   - 既存 `[dependencies]` 経路と並べて `config.tools` を seed として `BundleResolver.resolveSingleArtifact` を回し、 `Lockfile.toolsBundles` を rewrite
   - `kolt update` の出力に「updating tools…」段を追加、 `[tools]` が空ならスキップ
   - 既存 `[dependencies]` の更新挙動に regression なし (既存 `DependencyCommandsTest` パス)

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -93,7 +93,7 @@
   - _Boundary: ToolResolution_
   - _Depends: 1.1, 1.2, 2.2, 3.1, 4.1_
 
-- [ ] 4.3 `ToolResolution.ensureTool` の failure-path (mismatch / integrity / network) を実装
+- [x] 4.3 `ToolResolution.ensureTool` の failure-path (mismatch / integrity / network) を実装
   - toml の coords と lockfile の resolved coords が group:artifact:version[:classifier] のいずれかで不一致なら `LockfileMismatch` を返す (R4.3、 design.md 固定 message)
   - cache 上の jar が SHA-256 mismatch なら `IntegrityMismatch` を返し、 自動 refetch しない (R3.3)
   - network 取得不能 (全 repo 404 / 接続不能) は `ResolveFailed` を返す、 試行 repo URL を message に含める (R3.4)

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -31,7 +31,7 @@
 
 ## 2. Schema parse: `[tools]` の types と validation
 
-- [ ] 2.1 `parseCoordsString` utility を新設
+- [x] 2.1 `parseCoordsString` utility を新設
   - `group:artifact:version[:classifier]` 文字列を `(Coordinate, classifier?)` に分解
   - group / artifact が ASCII letters/digits/`-`/`_`/`.`、 version が non-empty、 classifier 同 charset で optional
   - 構文逸脱は `Result.Err(reason: String)` を返し、 alias 文脈は呼び出し側で添える

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -6,7 +6,7 @@
 
 ## 1. Foundation: lockfile / paths / exit code 拡張
 
-- [ ] 1.1 (P) Lockfile に `tools_bundles` field を additive 追加
+- [x] 1.1 (P) Lockfile に `tools_bundles` field を additive 追加
   - `Lockfile` data class に `toolsBundles: Map<String, Map<String, LockEntry>> = emptyMap()` を `classpathBundles` の隣に追加
   - `LockfileJson` の snake_case マッピングと `parseLockfile` / `serializeLockfile` を round-trip 対応に拡張
   - 既存 lockfile (`tools_bundles` 不在) を読めることを `LockfileTest` の既存 `classpathBundles` round-trip pattern で assert

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -22,7 +22,7 @@
   - _Requirements: 3.1, 3.2_
   - _Boundary: KoltPaths_
 
-- [ ] 1.3 (P) ExitCode.kt に `EXIT_TOOL_ERROR = 7` を追加
+- [x] 1.3 (P) ExitCode.kt に `EXIT_TOOL_ERROR = 7` を追加
   - 既存 `EXIT_LOCK_TIMEOUT = 6` の次の slot に const 追加、 命名は kolt 既存 semantic (BUILD/CONFIG/DEPENDENCY/TEST/FORMAT/LOCK_TIMEOUT) に並べる
   - 既存 exit code 値 (0/1/2/3/4/5/6/127) と非衝突であることをテストで assert (mechanical sweep)
   - 観測完了条件: `EXIT_TOOL_ERROR = 7` を import して使えるようになり、 `ExitCode.kt` の他 const と整合

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -156,7 +156,7 @@
 
 ## 7. Validation: E2E と ADR 改訂
 
-- [ ] 7.1 fixture runnable jar を使った CLI E2E を追加
+- [x] 7.1 fixture runnable jar を使った CLI E2E を追加
   - `src/nativeTest/resources/` (もしくは既存 fixture 配置場所) に「argv を JSON で stdout に echo して exit code を引数で受け取る」極小 runnable jar を commit
   - `kolt tool run <fixture-alias> <args...>` で argv が verbatim にツールに届くこと、 exit code がツール側の指定値そのままで返ることを assert (R2.1, R2.2, R5.1)
   - 観測完了条件: `kolt test` で新 E2E test が green、 self-host CI (`self-host-post`) も既存通り通過
@@ -181,3 +181,4 @@
 ## Implementation Notes
 
 - 各 task の commit 前に `./scripts/fmt.sh` (もしくは `kolt fmt`) を必ず実行する。 pre-commit hook が tree 全体に対して `fmt.sh --check` を走らせるため、 staged files 外でも未 format があると commit が reject される。 implementer subagent も READY_FOR_REVIEW 前に fmt を回しておくと、 parent の commit 段階での fmt-fail retry が減る。
+- Task 7.1 の E2E は in-process dispatch + libarchive 製の fixture jar + stub `exec`/`resolveJavaBin` で実装した。 real `kolt.kexe` の subprocess fork は WSL2 9p 上で重く、 design intent (argv passthrough + exit code propagation) は `launch` の inject 点経由で完全に carry できるため。 fixture jar 自体は libarchive で書いた本物の zip + MANIFEST.MF なので、 launcher の MANIFEST 読パスは production と同じ経路を通る。 real fork/exec の経路は ToolLauncherTest と self-host smoke が引き続き cover する。

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -47,7 +47,7 @@
   - _Requirements: 1.1_
   - _Boundary: ToolSection, RawKoltConfig, KoltConfig_
 
-- [ ] 2.3 `ToolSectionParse.parseToolSection` を実装
+- [x] 2.3 `ToolSectionParse.parseToolSection` を実装
   - alias を `^[a-z][a-z0-9_-]{0,63}$` の regex で照合、 違反は `InvalidAlias`
   - `RawToolEntry.dependsOn` / `args` / `main` のいずれかが non-null なら `ForbiddenField` で reject
   - `coords` が null なら `MissingCoords`、 `parseCoordsString` 失敗は `MalformedCoords`

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -177,3 +177,7 @@
   - 観測完了条件: ADR 改訂が docs/adr/0028 に commit され、 本 spec の Migration Strategy セクションが ADR の該当項に対応している
   - _Requirements: 5.4_
   - _Boundary: docs/adr/0028-v1-release-policy.md_
+
+## Implementation Notes
+
+- 各 task の commit 前に `./scripts/fmt.sh` (もしくは `kolt fmt`) を必ず実行する。 pre-commit hook が tree 全体に対して `fmt.sh --check` を走らせるため、 staged files 外でも未 format があると commit が reject される。 implementer subagent も READY_FOR_REVIEW 前に fmt を回しておくと、 parent の commit 段階での fmt-fail retry が減る。

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -127,7 +127,7 @@
 
 ## 6. CLI integration: dispatch と kolt update 拡張
 
-- [ ] 6.1 `ToolCommands.doTool` で `kolt tool run <alias> [-- args...]` を dispatch
+- [x] 6.1 `ToolCommands.doTool` で `kolt tool run <alias> [-- args...]` を dispatch
   - 第 2 引数が `run` 以外 (もしくは欠落) なら usage 表示 + `EXIT_CONFIG_ERROR` (R7.3 — `tool` の sub-action は v1 では `run` のみ)
   - alias を `KoltConfig.tools` で lookup、 不在なら `UnknownAlias` を返し、 既知 alias 一覧を stderr に提示 (R2.3)
   - alias 後の引数は verbatim 透過、 `--` 区切りは optional (`kolt tool run ktlint -F` も `kolt tool run ktlint -- -F` も等価) — 既存 `doTest` の pattern と整合 (R2.1)

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -14,7 +14,7 @@
   - _Requirements: 4.1, 4.4_
   - _Boundary: Lockfile_
 
-- [ ] 1.2 (P) KoltPaths に tool cache 専用 path helper を追加
+- [x] 1.2 (P) KoltPaths に tool cache 専用 path helper を追加
   - `toolsBundleDir(alias: String, version: String): String` で `~/.kolt/tools/bundles/<alias>/<version>/` を計算
   - `toolsBundleJarPath(alias: String, version: String, fileName: String): String` で配下の jar path
   - 既存 `~/.kolt/tools/<filename>` (kolt-internal flat layout) と path 衝突しないこと unit test で確認

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -39,7 +39,7 @@
   - _Requirements: 1.2_
   - _Boundary: ToolSectionParse_
 
-- [ ] 2.2 `RawToolEntry` / `ToolEntry` / `KoltConfig.tools` field を追加
+- [x] 2.2 `RawToolEntry` / `ToolEntry` / `KoltConfig.tools` field を追加
   - `RawToolEntry(coords: String?, dependsOn: String?, args: List<String>?, main: String?)` で `@SerialName("depends-on")` 付きの 4 field を nullable 宣言
   - `ToolEntry(coords: Coordinate, classifier: String?)` を public validated 型として導入
   - `RawKoltConfig.tools: Map<String, RawToolEntry>?` と `KoltConfig.tools: Map<String, ToolEntry>` を additive 追加 (既存 field 順序を保つ)

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -84,7 +84,7 @@
   - _Requirements: 2.4, 3.1_
   - _Boundary: BundleResolver_
 
-- [ ] 4.2 `ToolResolution.ensureTool` の happy-path (cache + first fetch + lockfile write-through) を実装
+- [x] 4.2 `ToolResolution.ensureTool` の happy-path (cache + first fetch + lockfile write-through) を実装
   - alias から `ToolEntry` を引き、 `paths.toolsBundleJarPath` 配下に jar が存在し lockfile pin の `version` / `sha256` と一致するなら network skip
   - lockfile に該当 alias の pin 不在 (初回) は `BundleResolver.resolveSingleArtifact` で fetch、 SHA-256 verify、 cache に格納、 lockfile に新 pin を書き戻す (R3.1, R4.1)
   - cache miss だが lockfile pin あり の場合、 pin の coords / SHA-256 に従って fetch・verify (R4.2)

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -115,7 +115,7 @@
   - _Boundary: ToolLauncher (jar manifest read sub)_
   - _Depends: 3.1_
 
-- [ ] 5.2 `ToolLauncher.launch` で MANIFEST 検証 + bootstrap JDK + executeCommand を組む
+- [x] 5.2 `ToolLauncher.launch` で MANIFEST 検証 + bootstrap JDK + executeCommand を組む
   - `readMainClassFromJar(jarHandle.jarPath)` を呼び、 失敗は `ToolLaunchError` (NotRunnableJar / MainClassMissing) を上に伝播
   - `BootstrapJdk.ensureBootstrapJavaBin(paths)` を呼び、 失敗は `JdkUnavailable` に lift (R6.2)
   - `executeCommand(listOf(javaBin, "-jar", jarPath) + args, env)` で起動、 exit code をそのまま `Result.Ok(Int)` で return (R2.1, R2.2)

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -170,7 +170,7 @@
   - _Requirements: 7.4_
   - _Boundary: DriftGuards (新規 sweep 追加)_
 
-- [ ] 7.3 ADR 0028 §3 を改訂し、 本 spec の凍結面追加を pin
+- [x] 7.3 ADR 0028 §3 を改訂し、 本 spec の凍結面追加を pin
   - §3 に新セクションを追加: `[tools]` toml schema additive 規則、 `tools_bundles` lockfile field additive 規則、 `kolt tool run` CLI surface 凍結、 `~/.kolt/tools/bundles/<alias>/<version>/` cache layout 凍結、 `EXIT_TOOL_ERROR=7` 凍結、 `kolt update` の scope 拡張 ([dependencies]+[tools] 両対応) を 1 セクションに集約
   - 既存 §3 の `~/.kolt/toolchains/{jdk|kotlinc|konanc}/` 凍結に並べる形で配置
   - ADR Summary の bullet 1 行も追加

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -65,7 +65,7 @@
 
 ## 3. Error type: `ToolError` sealed の集約
 
-- [ ] 3.1 `ToolError` sealed top-level + `ToolSectionParseError` / `ToolResolutionError` / `ToolLaunchError` sealed sub-types を作成
+- [x] 3.1 `ToolError` sealed top-level + `ToolSectionParseError` / `ToolResolutionError` / `ToolLaunchError` sealed sub-types を作成
   - 各 sub-error は design.md の State Management 表に従い variant 毎の data class を持つ (`Parse`, `Resolve`, `Launch`, `UnknownAlias`)
   - `toExitCode(): Int` を `EXIT_CONFIG_ERROR=2` / `EXIT_DEPENDENCY_ERROR=3` / `EXIT_TOOL_ERROR=7` に振り分け
   - `formatStderr(): String` で variant ごとに `tool '<alias>': <variant>: <detail>` の prefix を固定 (R5.4 cause-distinguishable)

--- a/.kiro/specs/341-tools-section/tasks.md
+++ b/.kiro/specs/341-tools-section/tasks.md
@@ -104,7 +104,7 @@
 
 ## 5. Launch: MANIFEST 読 と ToolLauncher
 
-- [ ] 5.1 (P) libarchive で jar (zip) MANIFEST.MF を読む utility を追加
+- [x] 5.1 (P) libarchive で jar (zip) MANIFEST.MF を読む utility を追加
   - `kolt.usertool` 内 internal 関数 `readMainClassFromJar(jarPath: String): Result<String, ToolLaunchError>` を実装
   - libarchive の `archive_read_open_filename` + entry iterate で `META-INF/MANIFEST.MF` を locate、 entry data を読み出す
   - `Main-Class:` 行を抽出 (RFC の line-folding は v1 では非対応で十分、 spec 準拠で改行直後 SP/HT 開始は continuation として concatenate)

--- a/docs/adr/0028-v1-release-policy.md
+++ b/docs/adr/0028-v1-release-policy.md
@@ -22,6 +22,11 @@ date: 2026-04-24
 - Yank policy: shipped tags are immutable and their tarballs stay
   reachable; yank status is declared in a `YANKED` manifest that
   `install.sh` consults (§5).
+- The `[tools]` surface added in spec #341 — `[tools]` toml schema,
+  `tools_bundles` lockfile field, `kolt tool run` CLI subcommand,
+  `~/.kolt/tools/bundles/<alias>/<version>/` cache layout, and
+  `EXIT_TOOL_ERROR=7` — is v1-stable under §3, with `kolt update`
+  extended to refresh `[tools]` pins alongside `[dependencies]` (§3).
 
 ## Context and Problem Statement
 
@@ -120,6 +125,33 @@ informal decision that currently lives only in conversation.
   kolt version and rely on hits surviving patch and minor upgrades.
   The bootstrap JDK (ADR 0017 §1) shares this directory, so caching
   also warms the daemon's first run.
+- **`[tools]` surface (spec #341).** Six related surfaces ship together
+  and are jointly v1-stable:
+  - The `[tools]` `kolt.toml` section follows the additive rule: new
+    optional keys may land in any minor; the `coords` field and the
+    alias regex `^[a-z][a-z0-9_-]{0,63}$` will not change shape across
+    1.x without a major.
+  - The `tools_bundles` field in `kolt.lock` follows the additive
+    rule: presence is optional (absent = empty map); the
+    `Map<alias, Map<group:artifact[:classifier], LockEntry>>` shape
+    will not change across 1.x without a major.
+  - The `kolt tool run <alias> [-- args...]` CLI surface, including
+    the optional `--` separator after the alias and verbatim argv
+    passthrough, will not change semantics across 1.x without a
+    major. Adding new `kolt tool` sub-actions (`list`, `clear-cache`,
+    ...) is a minor.
+  - The `~/.kolt/tools/bundles/<alias>/<version>/` cache layout will
+    not move or rename across 1.x without a major. It is disjoint
+    from the kolt-internal flat `~/.kolt/tools/<filename>` layout
+    used for ktfmt / junit-console; the two are not interchangeable.
+  - `EXIT_TOOL_ERROR=7` (Main-Class missing / non-runnable jar /
+    JDK unavailable) will not change across 1.x without a major.
+    The other tool-related exit codes (`EXIT_CONFIG_ERROR=2`,
+    `EXIT_DEPENDENCY_ERROR=3`) follow the existing CLI-surface rule
+    above.
+  - `kolt update` re-resolves both `[dependencies]` and `[tools]` in
+    a single invocation. Shrinking that scope is a major; growing it
+    (e.g. adding a future `[plugins]` section) is a minor.
 - **Wire protocol.** The daemon protocol carries its own version
   (existing `protocolVersion` in the frame header, ADR 0016). A bump
   is allowed at a minor boundary if the native client negotiates down.

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -12,6 +12,7 @@ import kolt.concurrency.ProjectLock
 import kolt.config.*
 import kolt.infra.*
 import kolt.resolve.*
+import kolt.usertool.ToolEntry
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
 import platform.posix.getenv
@@ -216,7 +217,7 @@ private fun doUpdateInner(): Result<Unit, Int> {
   val bundleSeedsAll =
     config.classpaths.values.fold(emptyMap<String, String>()) { acc, m -> acc + m }
   val allSeeds = mainSeeds + testSeeds + bundleSeedsAll
-  if (allSeeds.isEmpty()) {
+  if (allSeeds.isEmpty() && config.tools.isEmpty()) {
     println("no dependencies to update")
     return Ok(Unit)
   }
@@ -227,41 +228,107 @@ private fun doUpdateInner(): Result<Unit, Int> {
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
-  println("updating dependencies...")
   val resolverDeps = createResolverDeps()
-  val resolveResult =
-    resolve(
-        config,
-        null,
-        paths.cacheBase,
-        resolverDeps,
-        mainSeeds = mainSeeds,
-        testSeeds = testSeeds,
-      )
-      .getOrElse { error ->
+  val depsCount: Int
+  val bundleEntryCount: Int
+  val mainAndBundleLockfile: Lockfile
+  if (allSeeds.isEmpty()) {
+    // Only [tools] declared: skip the [dependencies] / [classpaths] resolve to keep the user's
+    // dependencies-only update path regression-free, and start from an empty lockfile shape so
+    // the tools_bundles overlay below is the sole change.
+    depsCount = 0
+    bundleEntryCount = 0
+    mainAndBundleLockfile = buildLockfileFromResolved(config, deps = emptyList())
+  } else {
+    println("updating dependencies...")
+    val resolveResult =
+      resolve(
+          config,
+          null,
+          paths.cacheBase,
+          resolverDeps,
+          mainSeeds = mainSeeds,
+          testSeeds = testSeeds,
+        )
+        .getOrElse { error ->
+          eprintln(formatResolveError(error))
+          return Err(EXIT_DEPENDENCY_ERROR)
+        }
+
+    // Bundles re-resolve with `existingLock = null` so `[classpaths.<name>]`
+    // follow the same update policy as main / test.
+    val bundleResolutions =
+      resolveAllBundles(config, existingLock = null, paths.cacheBase, resolverDeps).getOrElse {
+        error ->
         eprintln(formatResolveError(error))
         return Err(EXIT_DEPENDENCY_ERROR)
       }
+    val bundleDeps = bundleResolutions.mapValues { it.value.deps }
+    depsCount = resolveResult.deps.size
+    bundleEntryCount = bundleDeps.values.sumOf { it.size }
+    mainAndBundleLockfile = buildLockfileFromResolved(config, resolveResult.deps, bundleDeps)
+  }
 
-  // Bundles re-resolve with `existingLock = null` so `[classpaths.<name>]`
-  // follow the same update policy as main / test.
-  val bundleResolutions =
-    resolveAllBundles(config, existingLock = null, paths.cacheBase, resolverDeps).getOrElse { error
-      ->
-      eprintln(formatResolveError(error))
-      return Err(EXIT_DEPENDENCY_ERROR)
+  // Re-resolve [tools] independently of [dependencies] / [classpaths] (R4.1) using the
+  // transitive-skip path; merge into the same atomic lockfile write so [dependencies] readers
+  // never observe a half-written file.
+  val toolsBundles =
+    if (config.tools.isEmpty()) emptyMap()
+    else {
+      println("updating tools...")
+      buildToolsBundleLockMap(config.tools) { coord, classifier, _ ->
+          resolveSingleArtifact(
+            coord = coord,
+            classifier = classifier,
+            repos = config.repositories.values.toList(),
+            cacheBase = paths.cacheBase,
+            deps = resolverDeps,
+          )
+        }
+        .getOrElse { error ->
+          eprintln(formatResolveError(error))
+          return Err(EXIT_DEPENDENCY_ERROR)
+        }
     }
-  val bundleDeps = bundleResolutions.mapValues { it.value.deps }
 
-  val lockfile = buildLockfileFromResolved(config, resolveResult.deps, bundleDeps)
+  val lockfile = mainAndBundleLockfile.copy(toolsBundles = toolsBundles)
   val lockJson = serializeLockfile(lockfile)
   writeFileAsString(LOCK_FILE, lockJson).getOrElse { error ->
     eprintln("error: could not write ${error.path}")
     return Err(EXIT_DEPENDENCY_ERROR)
   }
-  val bundleEntryCount = bundleDeps.values.sumOf { it.size }
-  println("updated ${resolveResult.deps.size + bundleEntryCount} dependencies")
+  val toolsCount = toolsBundles.values.sumOf { it.size }
+  println("updated ${depsCount + bundleEntryCount + toolsCount} dependencies")
   return Ok(Unit)
+}
+
+/**
+ * Map each `[tools.<alias>]` entry through [resolve] (typically
+ * `BundleResolver.resolveSingleArtifact`) and gather the per-alias lockfile shape. Pure
+ * orchestration so unit tests can drive it with a stubbed resolver — mirrors the design contract
+ * that `kolt update` is the sole `[tools]` write path.
+ *
+ * The lambda signature matches `resolveSingleArtifact` (coord, classifier, deps), but the third
+ * argument is unused inside the helper and exists only so the production wiring can pass through
+ * any state the caller wants without changing the helper shape later.
+ */
+internal fun buildToolsBundleLockMap(
+  tools: Map<String, ToolEntry>,
+  resolve: (Coordinate, String?, ResolverDeps?) -> Result<SingleArtifact, ResolveError>,
+): Result<Map<String, Map<String, LockEntry>>, ResolveError> {
+  if (tools.isEmpty()) return Ok(emptyMap())
+  val out = LinkedHashMap<String, Map<String, LockEntry>>(tools.size)
+  for ((alias, entry) in tools) {
+    val artifact =
+      resolve(entry.coords, entry.classifier, null).getOrElse {
+        return Err(it)
+      }
+    val ga = "${entry.coords.group}:${entry.coords.artifact}"
+    val innerKey = if (entry.classifier == null) ga else "$ga:${entry.classifier}"
+    out[alias] =
+      mapOf(innerKey to LockEntry(version = entry.coords.version, sha256 = artifact.sha256))
+  }
+  return Ok(out)
 }
 
 internal data class DepsTreeSeeds(

--- a/src/nativeMain/kotlin/kolt/cli/ExitCode.kt
+++ b/src/nativeMain/kotlin/kolt/cli/ExitCode.kt
@@ -7,4 +7,5 @@ const val EXIT_DEPENDENCY_ERROR = 3
 const val EXIT_TEST_ERROR = 4
 const val EXIT_FORMAT_ERROR = 5
 const val EXIT_LOCK_TIMEOUT = 6
+const val EXIT_TOOL_ERROR = 7
 const val EXIT_COMMAND_NOT_FOUND = 127

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -1,5 +1,6 @@
 package kolt.cli
 
+import com.github.michaelbull.result.fold
 import com.github.michaelbull.result.getOrElse
 import kolt.build.Profile
 import kolt.config.versionString
@@ -83,6 +84,13 @@ fun main(args: Array<String>) {
     "fetch" -> doFetch().getOrElse { exitProcess(it) }
     "update" -> doUpdate().getOrElse { exitProcess(it) }
     "tree" -> doTree().getOrElse { exitProcess(it) }
+    "tool" -> {
+      // The Ok value carries the tool's own exit code (verbatim propagation, R2.2);
+      // the Err value carries kolt's own ToolError-mapped exit code (R5.4). Both flow
+      // through exitProcess so the parent shell observes the right code.
+      val exit = doTool(filteredArgs.drop(1)).fold(success = { it }, failure = { it })
+      exitProcess(exit)
+    }
     "toolchain" -> doToolchain(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
     "daemon" -> doDaemon(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
     "cache" -> doCache(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
@@ -165,6 +173,7 @@ private fun printUsage() {
   eprintln("  fetch      Resolve dependencies and download JARs")
   eprintln("  update     Re-resolve dependencies and update kolt.lock")
   eprintln("  tree       Show dependency tree")
+  eprintln("  tool       Run a [tools] alias (kolt tool run <alias> [-- args...])")
   eprintln("  toolchain  Manage toolchains (install, list, remove)")
   eprintln("  daemon     Manage compiler daemons (stop)")
   eprintln("  cache      Manage the global dependency cache (clean)")

--- a/src/nativeMain/kotlin/kolt/cli/ToolCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/ToolCommands.kt
@@ -1,0 +1,282 @@
+package kolt.cli
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.config.KoltConfig
+import kolt.config.KoltPaths
+import kolt.config.resolveKoltPaths
+import kolt.infra.CopyFailed
+import kolt.infra.copyFile
+import kolt.infra.eprintln
+import kolt.infra.fileExists
+import kolt.infra.readFileAsString
+import kolt.infra.writeFileAsString
+import kolt.resolve.LOCKFILE_VERSION
+import kolt.resolve.Lockfile
+import kolt.resolve.LockfileLoadResult
+import kolt.resolve.ResolverDeps
+import kolt.resolve.classifyLockfileLoad
+import kolt.resolve.serializeLockfile
+import kolt.usertool.ToolEntry
+import kolt.usertool.ToolError
+import kolt.usertool.ToolFsDeps
+import kolt.usertool.ToolJarHandle
+import kolt.usertool.ensureTool
+import kolt.usertool.launch
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
+
+/**
+ * Parsed shape of `kolt tool ...` argv. The dispatcher only accepts `run` as the v1 sub-action
+ * (R7.3 — "do not generate one subcommand per alias"); future `list` / `clear-cache` would extend
+ * this sealed type rather than balloon `doTool`.
+ */
+internal sealed class ToolInvocation {
+  data class Run(val alias: String, val args: List<String>) : ToolInvocation()
+}
+
+internal sealed class ToolArgError {
+  data object MissingSubcommand : ToolArgError()
+
+  data class UnknownSubcommand(val subcommand: String) : ToolArgError()
+
+  data object MissingAlias : ToolArgError()
+}
+
+/**
+ * Pure parser for `kolt tool` argv. Caller has already stripped the leading `tool` token. The `--`
+ * separator after the alias is optional (`kolt tool run ktlint -F` and `kolt tool run ktlint -- -F`
+ * are equivalent), matching the precedent in `kolt run` / `kolt test`.
+ */
+internal fun parseToolArgs(args: List<String>): Result<ToolInvocation, ToolArgError> {
+  if (args.isEmpty()) return Err(ToolArgError.MissingSubcommand)
+  return when (args[0]) {
+    "run" -> {
+      if (args.size < 2) Err(ToolArgError.MissingAlias)
+      else {
+        val alias = args[1]
+        val rest = args.drop(2)
+        // Drop a single leading `--` so aliases with flag-prefixed args remain parseable.
+        // Subsequent `--` tokens are passed through verbatim — matches `doTest` / `doRun`.
+        val toolArgs = if (rest.firstOrNull() == "--") rest.drop(1) else rest
+        Ok(ToolInvocation.Run(alias = alias, args = toolArgs))
+      }
+    }
+    else -> Err(ToolArgError.UnknownSubcommand(args[0]))
+  }
+}
+
+/**
+ * Top-level dispatcher for `kolt tool ...`. Returns `Result<Int, Int>` where the Ok value is the
+ * tool's own exit code (R2.2) and the Err value is kolt's mapped exit code from `ToolError` (R5.4).
+ */
+internal fun doTool(args: List<String>): Result<Int, Int> {
+  val invocation =
+    parseToolArgs(args).getOrElse { err ->
+      printToolUsage()
+      return when (err) {
+        is ToolArgError.MissingSubcommand,
+        is ToolArgError.MissingAlias -> Err(EXIT_CONFIG_ERROR)
+        is ToolArgError.UnknownSubcommand -> {
+          eprintln("error: unknown 'kolt tool' subcommand '${err.subcommand}'")
+          Err(EXIT_CONFIG_ERROR)
+        }
+      }
+    }
+
+  return when (invocation) {
+    is ToolInvocation.Run -> doToolRun(invocation.alias, invocation.args)
+  }
+}
+
+private fun doToolRun(alias: String, toolArgs: List<String>): Result<Int, Int> {
+  val config =
+    loadProjectConfig().getOrElse {
+      return Err(it)
+    }
+  val paths =
+    resolveKoltPaths().getOrElse {
+      eprintln("error: $it")
+      return Err(EXIT_CONFIG_ERROR)
+    }
+  val entry =
+    lookupToolEntry(alias, config).getOrElse {
+      return Err(it)
+    }
+  return runToolWithDeps(
+    alias = alias,
+    entry = entry,
+    toolArgs = toolArgs,
+    config = config,
+    paths = paths,
+    deps = createToolDeps(),
+    env = currentEnvForTool(),
+  )
+}
+
+/**
+ * Resolve `alias` against `config.tools`. Missing alias surfaces a `ToolError.UnknownAlias` whose
+ * known-aliases hint is rendered to stderr by the caller (R2.3). Pure to keep the unknown-alias
+ * path covered by unit tests without spinning up project config / paths.
+ */
+internal fun lookupToolEntry(alias: String, config: KoltConfig): Result<ToolEntry, Int> {
+  val entry = config.tools[alias]
+  if (entry != null) return Ok(entry)
+  val toolError = ToolError.UnknownAlias(alias = alias, knownAliases = config.tools.keys.toList())
+  eprintln(toolError.formatStderr())
+  return Err(toolError.toExitCode())
+}
+
+/**
+ * Test-visible orchestration step. Caller injects `deps` and `env`, and the function performs the
+ * lockfile read, ensureTool / launch dance, and translates ToolError variants to exit codes /
+ * stderr. `lockfileChanged` write-through after first-fetch is currently routed through the
+ * standard `kolt update` path — see design.md §ToolResolution for the rationale on why `kolt tool
+ * run` itself does not rewrite kolt.lock.
+ */
+internal fun runToolWithDeps(
+  alias: String,
+  entry: ToolEntry,
+  toolArgs: List<String>,
+  config: KoltConfig,
+  paths: KoltPaths,
+  deps: ToolDeps,
+  env: Map<String, String>,
+): Result<Int, Int> {
+  val lockfile =
+    loadLockfileForTool(config).getOrElse {
+      return Err(it)
+    }
+  val handle =
+    ensureTool(
+        alias = alias,
+        entry = entry,
+        paths = paths,
+        lockfile = lockfile,
+        netDeps = deps,
+        repos = config.repositories.values.toList(),
+      )
+      .getOrElse { resolutionError ->
+        return surfaceToolError(ToolError.Resolve(resolutionError))
+      }
+
+  if (handle.lockfileChanged) {
+    writeFirstFetchLockEntry(lockfile, alias, handle).getOrElse {
+      return Err(it)
+    }
+  }
+
+  val exit =
+    launch(alias = alias, jarHandle = handle, args = toolArgs, paths = paths, env = env)
+      .getOrElse { launchError ->
+        return surfaceToolError(ToolError.Launch(launchError))
+      }
+  return Ok(exit)
+}
+
+private fun surfaceToolError(error: ToolError): Result<Int, Int> {
+  eprintln(error.formatStderr())
+  return Err(error.toExitCode())
+}
+
+private fun loadLockfileForTool(config: KoltConfig): Result<Lockfile, Int> {
+  val lockJson =
+    if (fileExists(LOCK_FILE)) {
+      readFileAsString(LOCK_FILE).getOrElse { error ->
+        eprintln("warning: could not read $LOCK_FILE: ${error.path}")
+        null
+      }
+    } else null
+  return when (val outcome = classifyLockfileLoad(lockJson, allowMigration = false)) {
+    is LockfileLoadResult.Loaded -> Ok(outcome.lockfile)
+    is LockfileLoadResult.Absent ->
+      Ok(
+        Lockfile(
+          version = LOCKFILE_VERSION,
+          kotlin = config.kotlin.version,
+          jvmTarget = config.build.jvmTarget,
+          dependencies = emptyMap(),
+        )
+      )
+    is LockfileLoadResult.Corrupt -> {
+      eprintln("warning: ${outcome.message}")
+      Ok(
+        Lockfile(
+          version = LOCKFILE_VERSION,
+          kotlin = config.kotlin.version,
+          jvmTarget = config.build.jvmTarget,
+          dependencies = emptyMap(),
+        )
+      )
+    }
+    is LockfileLoadResult.UnsupportedAndMigrationAllowed,
+    is LockfileLoadResult.UnsupportedAndMigrationDenied -> {
+      eprintln("error: $LOCK_FILE requires regeneration via 'kolt fetch'")
+      Err(EXIT_DEPENDENCY_ERROR)
+    }
+  }
+}
+
+// First-fetch write-through. See design.md §ToolResolution: lockfile pin absence is the only
+// case where `kolt tool run` writes the lockfile; coords mismatch routes through `kolt update`.
+private fun writeFirstFetchLockEntry(
+  lockfile: Lockfile,
+  alias: String,
+  handle: ToolJarHandle,
+): Result<Unit, Int> {
+  val innerKey =
+    if (handle.classifier == null)
+      "${handle.resolvedCoords.group}:${handle.resolvedCoords.artifact}"
+    else "${handle.resolvedCoords.group}:${handle.resolvedCoords.artifact}:${handle.classifier}"
+  val newEntry =
+    kolt.resolve.LockEntry(version = handle.resolvedCoords.version, sha256 = jarSha(handle.jarPath))
+  val updatedToolsBundles = lockfile.toolsBundles + (alias to mapOf(innerKey to newEntry))
+  val updated = lockfile.copy(toolsBundles = updatedToolsBundles)
+  val json = serializeLockfile(updated)
+  writeFileAsString(LOCK_FILE, json).getOrElse { error ->
+    eprintln("error: could not write ${error.path}")
+    return Err(EXIT_DEPENDENCY_ERROR)
+  }
+  return Ok(Unit)
+}
+
+private fun jarSha(jarPath: String): String =
+  // ensureTool already verified SHA-256 on the cache path. Re-deriving here keeps the lockfile
+  // write-through self-contained, matching what `kolt update` will write on a re-run.
+  kolt.infra.computeSha256(jarPath).getOrElse { "" }
+
+@OptIn(ExperimentalForeignApi::class)
+private fun currentEnvForTool(): Map<String, String> {
+  // Pass through the verbose flag only; tools inherit the broader process env via execvp. Adding
+  // entries here would *override* the inherited copy in the child (see Process.executeCommand).
+  return when (val v = getenv("KOLT_VERBOSE")?.toKString()) {
+    null -> emptyMap()
+    else -> mapOf("KOLT_VERBOSE" to v)
+  }
+}
+
+internal interface ToolDeps : ResolverDeps, ToolFsDeps
+
+private fun createToolDeps(): ToolDeps {
+  val resolver = createResolverDeps()
+  return object : ToolDeps {
+    override fun fileExists(path: String) = resolver.fileExists(path)
+
+    override fun ensureDirectoryRecursive(path: String) = resolver.ensureDirectoryRecursive(path)
+
+    override fun downloadFile(url: String, destPath: String) = resolver.downloadFile(url, destPath)
+
+    override fun computeSha256(filePath: String) = resolver.computeSha256(filePath)
+
+    override fun readFileContent(path: String) = resolver.readFileContent(path)
+
+    override fun copyFile(src: String, dest: String): Result<Unit, CopyFailed> = copyFile(src, dest)
+  }
+}
+
+private fun printToolUsage() {
+  eprintln("usage: kolt tool run <alias> [-- args...]")
+}

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -8,6 +8,7 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
 import kolt.resolve.compareVersions
+import kolt.usertool.RawToolEntry
 import kolt.usertool.ToolEntry
 import kolt.usertool.parseCoordsString
 import kotlinx.serialization.SerialName
@@ -118,19 +119,6 @@ data class KoltConfig(
   @Transient val tools: Map<String, ToolEntry> = emptyMap(),
   @SerialName("test") val testSection: TestSection = TestSection(),
   @SerialName("run") val runSection: RunSection = RunSection(),
-)
-
-// Raw shape for `[tools.<alias>]`. `coords` is the only allowlisted field;
-// `dependsOn` / `args` / `main` are declared nullable so ToolSectionParse can
-// reject orchestration fields explicitly (R7.1, R7.2). Other unknown keys are
-// silently dropped by ktoml's `ignoreUnknownNames=true` and may be tightened
-// later additively. See design.md §Components / ToolSectionParse.
-@Serializable
-internal data class RawToolEntry(
-  val coords: String? = null,
-  @SerialName("depends-on") val dependsOn: String? = null,
-  val args: List<String>? = null,
-  val main: String? = null,
 )
 
 private val toml = Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = true))

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -10,7 +10,8 @@ import com.github.michaelbull.result.getOrElse
 import kolt.resolve.compareVersions
 import kolt.usertool.RawToolEntry
 import kolt.usertool.ToolEntry
-import kolt.usertool.parseCoordsString
+import kolt.usertool.ToolSectionParseError
+import kolt.usertool.parseToolSection
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
@@ -365,6 +366,21 @@ private fun validateSysPropsProjectDirs(
   return Ok(Unit)
 }
 
+// Render a ToolSectionParseError for the existing ConfigError.ParseFailed
+// envelope. The detailed `ToolError` sealed (task 3.1) will replace this with
+// a structured `tool '<alias>': parse error: ...` prefix; for now we keep the
+// message inline so kolt.toml load failures stay loud and self-explanatory.
+private fun formatToolSectionParseError(err: ToolSectionParseError): String =
+  when (err) {
+    is ToolSectionParseError.ForbiddenField ->
+      "[tools.${err.alias}]: field '${err.field}' is not allowed in [tools] entries"
+    is ToolSectionParseError.InvalidAlias -> "[tools.${err.alias}]: ${err.reason}"
+    is ToolSectionParseError.MalformedCoords ->
+      "[tools.${err.alias}]: malformed coords '${err.coords}': ${err.reason}"
+    is ToolSectionParseError.DuplicateAlias -> "[tools.${err.alias}]: duplicate alias"
+    is ToolSectionParseError.MissingCoords -> "[tools.${err.alias}]: 'coords' is required"
+  }
+
 // ADR 0023 §3: scalar `[build] target = "X"` and `[build.targets.X]` are
 // mutually exclusive. Multi-target form is reserved — exactly one entry
 // is de-sugared into the scalar form, two or more are rejected.
@@ -469,23 +485,10 @@ fun parseConfig(tomlString: String): Result<KoltConfig, ConfigError> {
     validateSysPropsProjectDirs(testSysProps, runSysProps).getError()?.let {
       return Err(it)
     }
-    // Lift [tools.<alias>] entries from RawToolEntry to ToolEntry. Task 2.2
-    // wires the field plumbing and happy-path coords parse only; full
-    // validation (alias regex, forbidden-field reject, error envelope) is
-    // owned by ToolSectionParse and integrated into the validation chain in
-    // task 2.4.
-    val cleanedTools = LinkedHashMap<String, ToolEntry>()
-    raw.tools?.forEach { (rawAlias, rawEntry) ->
-      val alias = rawAlias.removeSurrounding("\"")
-      val coordsString =
-        rawEntry.coords
-          ?: return Err(ConfigError.ParseFailed("[tools.$alias]: 'coords' is required"))
-      val (coordinate, classifier) =
-        parseCoordsString(coordsString).getOrElse {
-          return Err(ConfigError.ParseFailed("[tools.$alias]: $it"))
-        }
-      cleanedTools[alias] = ToolEntry(coordinate, classifier)
-    }
+    val cleanedTools =
+      parseToolSection(raw.tools).getOrElse {
+        return Err(ConfigError.ParseFailed(formatToolSectionParseError(it)))
+      }
     Ok(
       KoltConfig(
         name = raw.name,

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -8,9 +8,12 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
 import kolt.resolve.compareVersions
+import kolt.usertool.ToolEntry
+import kolt.usertool.parseCoordsString
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Transient
 
 const val MAVEN_CENTRAL_BASE = "https://repo1.maven.org/maven2"
 
@@ -106,8 +109,28 @@ data class KoltConfig(
   // identical to [dependencies] (`"group:artifact" = "version"`), so the value
   // type stays a plain Map<String, String> rather than a wrapper data class.
   val classpaths: Map<String, Map<String, String>> = emptyMap(),
+  // [tools.<alias>] declares per-project runnable jar tools (ktlint / detekt / ...).
+  // Validated by ToolSectionParse, isolated from [dependencies] / [classpaths].
+  // ktoml never decodes into KoltConfig directly (RawKoltConfig owns the wire
+  // shape via RawToolEntry), so this field is @Transient to avoid forcing
+  // ToolEntry / Coordinate to be @Serializable across kolt.usertool / kolt.resolve.
+  // See design.md §Components / ToolSection.
+  @Transient val tools: Map<String, ToolEntry> = emptyMap(),
   @SerialName("test") val testSection: TestSection = TestSection(),
   @SerialName("run") val runSection: RunSection = RunSection(),
+)
+
+// Raw shape for `[tools.<alias>]`. `coords` is the only allowlisted field;
+// `dependsOn` / `args` / `main` are declared nullable so ToolSectionParse can
+// reject orchestration fields explicitly (R7.1, R7.2). Other unknown keys are
+// silently dropped by ktoml's `ignoreUnknownNames=true` and may be tightened
+// later additively. See design.md §Components / ToolSectionParse.
+@Serializable
+internal data class RawToolEntry(
+  val coords: String? = null,
+  @SerialName("depends-on") val dependsOn: String? = null,
+  val args: List<String>? = null,
+  val main: String? = null,
 )
 
 private val toml = Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = true))
@@ -153,6 +176,7 @@ private data class RawKoltConfig(
   val repositories: Map<String, String> = mapOf("central" to MAVEN_CENTRAL_BASE),
   val cinterop: List<CinteropConfig> = emptyList(),
   val classpaths: Map<String, Map<String, String>> = emptyMap(),
+  val tools: Map<String, RawToolEntry>? = null,
   val test: RawTestSection? = null,
   val run: RawRunSection? = null,
 )
@@ -457,6 +481,23 @@ fun parseConfig(tomlString: String): Result<KoltConfig, ConfigError> {
     validateSysPropsProjectDirs(testSysProps, runSysProps).getError()?.let {
       return Err(it)
     }
+    // Lift [tools.<alias>] entries from RawToolEntry to ToolEntry. Task 2.2
+    // wires the field plumbing and happy-path coords parse only; full
+    // validation (alias regex, forbidden-field reject, error envelope) is
+    // owned by ToolSectionParse and integrated into the validation chain in
+    // task 2.4.
+    val cleanedTools = LinkedHashMap<String, ToolEntry>()
+    raw.tools?.forEach { (rawAlias, rawEntry) ->
+      val alias = rawAlias.removeSurrounding("\"")
+      val coordsString =
+        rawEntry.coords
+          ?: return Err(ConfigError.ParseFailed("[tools.$alias]: 'coords' is required"))
+      val (coordinate, classifier) =
+        parseCoordsString(coordsString).getOrElse {
+          return Err(ConfigError.ParseFailed("[tools.$alias]: $it"))
+        }
+      cleanedTools[alias] = ToolEntry(coordinate, classifier)
+    }
     Ok(
       KoltConfig(
         name = raw.name,
@@ -480,6 +521,7 @@ fun parseConfig(tomlString: String): Result<KoltConfig, ConfigError> {
         repositories = cleanedRepos,
         cinterop = raw.cinterop,
         classpaths = cleanedClasspaths,
+        tools = cleanedTools,
         testSection = TestSection(testSysProps),
         runSection = RunSection(runSysProps),
       )

--- a/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
+++ b/src/nativeMain/kotlin/kolt/config/KoltPaths.kt
@@ -46,6 +46,13 @@ internal data class KoltPaths(val home: String) {
   fun konancBin(version: String): String = "${konancPath(version)}/bin/konanc"
 
   fun cinteropBin(version: String): String = "${konancPath(version)}/bin/cinterop"
+
+  // Per-alias bundle layout for `[tools]` runnable jars (separate from the flat
+  // `$toolsDir/<filename>` layout used by kolt-internal ktfmt / junit-console).
+  fun toolsBundleDir(alias: String, version: String): String = "$toolsDir/bundles/$alias/$version"
+
+  fun toolsBundleJarPath(alias: String, version: String, fileName: String): String =
+    "${toolsBundleDir(alias, version)}/$fileName"
 }
 
 internal fun resolveKoltPaths(): Result<KoltPaths, String> =

--- a/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
+++ b/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
@@ -381,7 +381,7 @@ private fun copyDirRecursive(src: String, dest: String): Result<Unit, CopyFailed
 }
 
 @OptIn(ExperimentalForeignApi::class)
-private fun copyFile(src: String, dest: String): Result<Unit, CopyFailed> {
+internal fun copyFile(src: String, dest: String): Result<Unit, CopyFailed> {
   val srcFp = fopen(src, "rb") ?: return Err(CopyFailed(src))
   try {
     val destFp = fopen(dest, "wb") ?: return Err(CopyFailed(dest))

--- a/src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt
@@ -89,6 +89,79 @@ internal fun resolveBundle(
 // policy. Re-verifying every warm bundle jar would defeat the reuse-path
 // performance win for no extra safety the main `kolt fetch` call doesn't
 // already provide on the next resolveTransitive pass.
+/**
+ * Single-artifact variant of `resolveBundle` that skips both POM-derived transitive enumeration and
+ * Gradle-module-metadata redirects.
+ *
+ * Intended for `[tools]` runnable jars (R2.4 + design.md §Resolver / ToolResolution): the caller
+ * supplies a Maven coordinate and an optional classifier and gets back the cache-resident jar's
+ * path + SHA-256, with no traversal of dependency graphs. The function is purely additive — the
+ * `[classpaths]` `resolveBundle` path is untouched.
+ *
+ * Returned `groupArtifact` and `version` mirror the input `coord`. `classifier` is echoed back so
+ * lockfile keying can include it.
+ */
+fun resolveSingleArtifact(
+  coord: Coordinate,
+  classifier: String?,
+  repos: List<String>,
+  cacheBase: String,
+  deps: ResolverDeps,
+): Result<SingleArtifact, ResolveError> {
+  val groupArtifact = "${coord.group}:${coord.artifact}"
+  val relativePath = buildRelativeJarPath(coord, classifier)
+  val cachePath = "$cacheBase/$relativePath"
+
+  if (!deps.fileExists(cachePath)) {
+    val parentDir = cachePath.substringBeforeLast('/')
+    deps.ensureDirectoryRecursive(parentDir).getOrElse {
+      return Err(ResolveError.DirectoryCreateFailed(parentDir))
+    }
+    downloadFromRepositories(
+        repos,
+        cachePath,
+        { repo -> "$repo/$relativePath" },
+        deps::downloadFile,
+      )
+      .getOrElse { failure ->
+        return Err(ResolveError.DownloadFailed(groupArtifact, failure))
+      }
+  }
+
+  val sha =
+    deps.computeSha256(cachePath).getOrElse { error ->
+      return Err(ResolveError.HashComputeFailed(groupArtifact, error))
+    }
+
+  return Ok(
+    SingleArtifact(
+      groupArtifact = groupArtifact,
+      version = coord.version,
+      classifier = classifier,
+      cachePath = cachePath,
+      sha256 = sha,
+    )
+  )
+}
+
+data class SingleArtifact(
+  val groupArtifact: String,
+  val version: String,
+  val classifier: String?,
+  val cachePath: String,
+  val sha256: String,
+)
+
+// Kept private to BundleResolver because the single-artifact path does not need to share Maven
+// path construction with the transitive resolver — `buildCachePath` there has no classifier
+// parameter, and exposing one there would invite accidental classifier-bearing transitive
+// resolves. See ADR 0028 §3 freeze on the `[classpaths]` resolution shape.
+private fun buildRelativeJarPath(coord: Coordinate, classifier: String?): String {
+  val groupPath = coord.group.replace('.', '/')
+  val suffix = if (classifier != null) "-$classifier" else ""
+  return "$groupPath/${coord.artifact}/${coord.version}/${coord.artifact}-${coord.version}$suffix.jar"
+}
+
 internal fun materialiseBundleJarsFromLock(
   resolution: BundleResolution,
   config: KoltConfig,

--- a/src/nativeMain/kotlin/kolt/resolve/Lockfile.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Lockfile.kt
@@ -38,6 +38,7 @@ data class Lockfile(
   val jvmTarget: String,
   val dependencies: Map<String, LockEntry>,
   val classpathBundles: Map<String, Map<String, LockEntry>> = emptyMap(),
+  val toolsBundles: Map<String, Map<String, LockEntry>> = emptyMap(),
 )
 
 // Result of loading kolt.lock at the start of a CLI command. Splits the
@@ -101,6 +102,8 @@ private data class LockfileJson(
   val dependencies: Map<String, LockEntryJson>,
   @SerialName("classpath_bundles")
   val classpathBundles: Map<String, Map<String, LockEntryJson>> = emptyMap(),
+  @SerialName("tools_bundles")
+  val toolsBundles: Map<String, Map<String, LockEntryJson>> = emptyMap(),
 )
 
 private val lockfileJson = Json {
@@ -135,6 +138,12 @@ fun parseLockfile(jsonString: String): Result<Lockfile, LockfileError> {
             LockEntry(v.version, v.sha256, v.transitive, v.test, v.redirectTarget)
           }
         },
+      toolsBundles =
+        parsed.toolsBundles.mapValues { (_, bundleEntries) ->
+          bundleEntries.mapValues { (_, v) ->
+            LockEntry(v.version, v.sha256, v.transitive, v.test, v.redirectTarget)
+          }
+        },
     )
   )
 }
@@ -157,6 +166,17 @@ fun serializeLockfile(lockfile: Lockfile): String {
               k to LockEntryJson(v.version, v.sha256, v.transitive, v.test, v.redirectTarget)
             }
       }
+  val sortedToolsBundles =
+    lockfile.toolsBundles.entries
+      .sortedBy { it.key }
+      .associate { (alias, entries) ->
+        alias to
+          entries.entries
+            .sortedBy { it.key }
+            .associate { (k, v) ->
+              k to LockEntryJson(v.version, v.sha256, v.transitive, v.test, v.redirectTarget)
+            }
+      }
   val json =
     LockfileJson(
       version = lockfile.version,
@@ -164,6 +184,7 @@ fun serializeLockfile(lockfile: Lockfile): String {
       jvmTarget = lockfile.jvmTarget,
       dependencies = sortedDeps,
       classpathBundles = sortedBundles,
+      toolsBundles = sortedToolsBundles,
     )
   return lockfileJson.encodeToString(LockfileJson.serializer(), json) + "\n"
 }

--- a/src/nativeMain/kotlin/kolt/usertool/ToolError.kt
+++ b/src/nativeMain/kotlin/kolt/usertool/ToolError.kt
@@ -1,0 +1,133 @@
+package kolt.usertool
+
+import kolt.cli.EXIT_CONFIG_ERROR
+import kolt.cli.EXIT_DEPENDENCY_ERROR
+import kolt.cli.EXIT_TOOL_ERROR
+import kolt.resolve.Coordinate
+
+/**
+ * Distinguishable failures surfaced by `ToolResolution.ensureTool`.
+ *
+ * `LockfileMismatch` carries both toml-side and lockfile-side coords + classifier so the formatted
+ * stderr message can render the design-mandated `'<pinned>' differs from '<toml>'` shape verbatim.
+ */
+sealed class ToolResolutionError {
+  data class ResolveFailed(val alias: String, val coords: Coordinate, val attempts: List<String>) :
+    ToolResolutionError()
+
+  data class IntegrityMismatch(
+    val alias: String,
+    val coords: Coordinate,
+    val expected: String,
+    val actual: String,
+  ) : ToolResolutionError()
+
+  data class LockfileMismatch(
+    val alias: String,
+    val tomlCoords: Coordinate,
+    val tomlClassifier: String?,
+    val lockedCoords: Coordinate,
+    val lockedClassifier: String?,
+  ) : ToolResolutionError()
+}
+
+/**
+ * Distinguishable failures surfaced by `ToolLauncher.launch`.
+ *
+ * The three Launch variants are the only failure shapes that route through `EXIT_TOOL_ERROR=7`
+ * (jar-launch failures); `JdkUnavailable` has no alias because it can also surface from the
+ * pre-launch bootstrap-jdk path, before any specific tool has been selected.
+ */
+sealed class ToolLaunchError {
+  data class NotRunnableJar(val alias: String, val jarPath: String, val reason: String) :
+    ToolLaunchError()
+
+  data class MainClassMissing(val alias: String, val jarPath: String) : ToolLaunchError()
+
+  data class JdkUnavailable(val cause: String) : ToolLaunchError()
+}
+
+/**
+ * Top-level error envelope for the `[tools]` pipeline. Variant choice maps cleanly to
+ * `kolt.cli.ExitCode`:
+ * - `Parse`, `UnknownAlias` → `EXIT_CONFIG_ERROR=2`
+ * - `Resolve.*` → `EXIT_DEPENDENCY_ERROR=3`
+ * - `Launch.*` → `EXIT_TOOL_ERROR=7` (the only three variants that do so — pinned by
+ *   `ToolErrorTest.exactlyThreeVariantsRouteThroughExitToolError`)
+ *
+ * `formatStderr()` emits the variant-specific prefix that R5.4 ("cause-distinguishable surface")
+ * relies on: the prefix identifies the cause, the exit code identifies kolt-level category.
+ */
+sealed class ToolError {
+  abstract fun toExitCode(): Int
+
+  abstract fun formatStderr(): String
+
+  data class Parse(val cause: ToolSectionParseError) : ToolError() {
+    override fun toExitCode(): Int = EXIT_CONFIG_ERROR
+
+    override fun formatStderr(): String {
+      val (alias, detail) =
+        when (val c = cause) {
+          is ToolSectionParseError.ForbiddenField ->
+            c.alias to "forbidden field '${c.field}' is not allowed in [tools.${c.alias}]"
+          is ToolSectionParseError.InvalidAlias -> c.alias to c.reason
+          is ToolSectionParseError.MalformedCoords ->
+            c.alias to "malformed coords '${c.coords}': ${c.reason}"
+          is ToolSectionParseError.MissingCoords -> c.alias to "missing required field 'coords'"
+          is ToolSectionParseError.DuplicateAlias -> c.alias to "duplicate alias"
+        }
+      return "tool '$alias': parse error: $detail"
+    }
+  }
+
+  data class Resolve(val cause: ToolResolutionError) : ToolError() {
+    override fun toExitCode(): Int = EXIT_DEPENDENCY_ERROR
+
+    override fun formatStderr(): String =
+      when (val c = cause) {
+        is ToolResolutionError.ResolveFailed -> {
+          val tail =
+            if (c.attempts.isEmpty()) "no repository attempts recorded"
+            else "tried ${c.attempts.joinToString(", ")}"
+          "tool '${c.alias}': resolve failed: $tail"
+        }
+        is ToolResolutionError.IntegrityMismatch ->
+          "tool '${c.alias}': integrity mismatch: expected ${c.expected} got ${c.actual}"
+        is ToolResolutionError.LockfileMismatch -> {
+          val pinned = formatCoordsWithClassifier(c.lockedCoords, c.lockedClassifier)
+          val toml = formatCoordsWithClassifier(c.tomlCoords, c.tomlClassifier)
+          "tool '${c.alias}': lockfile pin '$pinned' differs from kolt.toml '$toml'. " +
+            "Run `kolt update` to refresh tool pins."
+        }
+      }
+  }
+
+  data class Launch(val cause: ToolLaunchError) : ToolError() {
+    override fun toExitCode(): Int = EXIT_TOOL_ERROR
+
+    override fun formatStderr(): String =
+      when (val c = cause) {
+        is ToolLaunchError.NotRunnableJar ->
+          "tool '${c.alias}': not a runnable jar (${c.reason}) at ${c.jarPath}"
+        is ToolLaunchError.MainClassMissing ->
+          "tool '${c.alias}': Main-Class missing in MANIFEST.MF of ${c.jarPath}"
+        is ToolLaunchError.JdkUnavailable -> "tool: JDK unavailable: ${c.cause}"
+      }
+  }
+
+  data class UnknownAlias(val alias: String, val knownAliases: List<String>) : ToolError() {
+    override fun toExitCode(): Int = EXIT_CONFIG_ERROR
+
+    override fun formatStderr(): String {
+      val known =
+        if (knownAliases.isEmpty()) "(none declared)" else knownAliases.sorted().joinToString(", ")
+      return "tool '$alias': not declared in [tools]. Known aliases: $known"
+    }
+  }
+}
+
+private fun formatCoordsWithClassifier(coords: Coordinate, classifier: String?): String {
+  val base = "${coords.group}:${coords.artifact}:${coords.version}"
+  return if (classifier == null) base else "$base:$classifier"
+}

--- a/src/nativeMain/kotlin/kolt/usertool/ToolLauncher.kt
+++ b/src/nativeMain/kotlin/kolt/usertool/ToolLauncher.kt
@@ -3,6 +3,14 @@ package kolt.usertool
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import com.github.michaelbull.result.mapError
+import kolt.build.daemon.ensureBootstrapJavaBin
+import kolt.config.KoltPaths
+import kolt.infra.ProcessError
+import kolt.infra.eprintln
+import kolt.infra.executeCommand
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.CPointerVar
@@ -180,3 +188,71 @@ internal fun extractMainClass(manifest: String): String? {
 @OptIn(ExperimentalForeignApi::class)
 private fun errString(handle: CPointer<cnames.structs.archive>): String =
   archive_error_string(handle)?.toKString() ?: "unknown libarchive error"
+
+/**
+ * Launch the runnable jar represented by [jarHandle] under the bootstrap JDK.
+ *
+ * Failure modes mapped to [ToolLaunchError] (cause-distinguishable, R5.4):
+ * - MANIFEST.MF cannot be read or `Main-Class:` is absent → `MainClassMissing` / `NotRunnableJar`.
+ *   The alias placeholder set by [readMainClassFromJar] is overwritten with the real alias here.
+ * - Bootstrap JDK install / probe fails → `JdkUnavailable`. The cause string captures the install
+ *   target so users can re-run install or diagnose disk / network issues.
+ * - The child process exits or is signalled. Successful exits (including non-zero) propagate as
+ *   `Result.Ok(exitCode)` so kolt's wrapper transparently passes through the tool's value (R2.2).
+ *   `executeCommand` returns `Err(NonZeroExit(code))` on non-zero — that is unwrapped here into
+ *   `Ok(code)`. Fork / wait / signal failures are surfaced as `JdkUnavailable` with the underlying
+ *   `ProcessError` in the cause: the design's three EXIT_TOOL_ERROR variants are `NotRunnableJar` /
+ *   `MainClassMissing` / `JdkUnavailable`, and process-spawn failures fit the "broken host
+ *   environment" axis rather than a tool-jar defect — keeping the variant count at three in line
+ *   with `ToolErrorTest`.
+ *
+ * `KOLT_VERBOSE=1` (in the [env] map) emits a single stderr line `tool=<alias> jdk=<javaBin>
+ * jar=<jarPath>` immediately before launch (R6.3). It is the only kolt-side stderr written on the
+ * launch path; tool stderr is inherited from the child.
+ */
+internal fun launch(
+  alias: String,
+  jarHandle: ToolJarHandle,
+  args: List<String>,
+  paths: KoltPaths,
+  env: Map<String, String>,
+  resolveJavaBin: (KoltPaths) -> Result<String, String> = ::ensureBootstrapJavaBinDefault,
+  exec: (List<String>, Map<String, String>) -> Result<Int, ProcessError> = ::executeCommand,
+  log: (String) -> Unit = ::eprintln,
+): Result<Int, ToolLaunchError> {
+  readMainClassFromJar(jarHandle.jarPath).getOrElse { err ->
+    return Err(rebrandWithAlias(err, alias))
+  }
+
+  val javaBin =
+    resolveJavaBin(paths).getOrElse { cause ->
+      return Err(ToolLaunchError.JdkUnavailable(cause = cause))
+    }
+
+  if (env["KOLT_VERBOSE"] == "1") {
+    log("tool=$alias jdk=$javaBin jar=${jarHandle.jarPath}")
+  }
+
+  val command = listOf(javaBin, "-jar", jarHandle.jarPath) + args
+  val result = exec(command, env)
+  val err = result.getError() ?: return Ok(result.getOrElse { error("unreachable") })
+  return when (err) {
+    is ProcessError.NonZeroExit -> Ok(err.exitCode)
+    else ->
+      // Fork / wait / signal failures: render the underlying ProcessError into the JDK
+      // cause so the user sees a non-empty diagnostic. See KDoc above for rationale.
+      Err(ToolLaunchError.JdkUnavailable(cause = "process launch failed: $err"))
+  }
+}
+
+private fun rebrandWithAlias(err: ToolLaunchError, alias: String): ToolLaunchError =
+  when (err) {
+    is ToolLaunchError.NotRunnableJar -> err.copy(alias = alias)
+    is ToolLaunchError.MainClassMissing -> err.copy(alias = alias)
+    is ToolLaunchError.JdkUnavailable -> err
+  }
+
+internal fun ensureBootstrapJavaBinDefault(paths: KoltPaths): Result<String, String> =
+  ensureBootstrapJavaBin(paths).mapError {
+    "bootstrap JDK install failed at ${it.jdkInstallDir}: ${it.cause.message}"
+  }

--- a/src/nativeMain/kotlin/kolt/usertool/ToolLauncher.kt
+++ b/src/nativeMain/kotlin/kolt/usertool/ToolLauncher.kt
@@ -1,0 +1,182 @@
+package kolt.usertool
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.CPointerVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.readBytes
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.value
+import libarchive.ARCHIVE_EOF
+import libarchive.ARCHIVE_OK
+import libarchive.archive_entry_pathname
+import libarchive.archive_entry_size
+import libarchive.archive_error_string
+import libarchive.archive_read_close
+import libarchive.archive_read_data
+import libarchive.archive_read_free
+import libarchive.archive_read_new
+import libarchive.archive_read_next_header
+import libarchive.archive_read_open_filename
+import libarchive.archive_read_support_filter_all
+import libarchive.archive_read_support_format_all
+
+private const val MANIFEST_PATH = "META-INF/MANIFEST.MF"
+private const val MAIN_CLASS_KEY = "Main-Class"
+
+// libarchive read block size used elsewhere in kolt — see ArchiveExtraction.
+private const val READ_BLOCK_SIZE: ULong = 10240u
+
+/**
+ * Read the `Main-Class` attribute from a jar's `META-INF/MANIFEST.MF`.
+ *
+ * Returns:
+ * - [ToolLaunchError.NotRunnableJar] when libarchive cannot open the file as a zip (missing magic,
+ *   truncated, plain-text masquerading as `.jar`). The caller fills the alias.
+ * - [ToolLaunchError.MainClassMissing] when the archive opens but `META-INF/MANIFEST.MF` is absent
+ *   from the entries, or present but does not contain a `Main-Class:` line.
+ *
+ * MANIFEST.MF line-folding (RFC: a line beginning with SP or HT continues the previous logical
+ * line) is honoured for `Main-Class` only — the value is reassembled across continuations before
+ * the lookup. Other RFC 822 corner cases are intentionally out of scope for v1.
+ *
+ * The alias placeholder on returned errors is `""` because this internal helper has no alias
+ * context; [launch] lifts the error and substitutes the correct alias before surfacing to callers.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal fun readMainClassFromJar(jarPath: String): Result<String, ToolLaunchError> {
+  val reader =
+    archive_read_new()
+      ?: return Err(
+        ToolLaunchError.NotRunnableJar(
+          alias = "",
+          jarPath = jarPath,
+          reason = "archive_read_new returned null",
+        )
+      )
+  archive_read_support_format_all(reader)
+  archive_read_support_filter_all(reader)
+
+  try {
+    val openRc = archive_read_open_filename(reader, jarPath, READ_BLOCK_SIZE.convert())
+    if (openRc != ARCHIVE_OK) {
+      return Err(
+        ToolLaunchError.NotRunnableJar(
+          alias = "",
+          jarPath = jarPath,
+          reason = "archive_read_open_filename: ${errString(reader)}",
+        )
+      )
+    }
+    return findMainClass(reader, jarPath)
+  } finally {
+    archive_read_close(reader)
+    archive_read_free(reader)
+  }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun findMainClass(
+  reader: CPointer<cnames.structs.archive>,
+  jarPath: String,
+): Result<String, ToolLaunchError> = memScoped {
+  val entryHolder = alloc<CPointerVar<cnames.structs.archive_entry>>()
+  while (true) {
+    val rc = archive_read_next_header(reader, entryHolder.ptr)
+    if (rc == ARCHIVE_EOF) break
+    if (rc != ARCHIVE_OK) {
+      return@memScoped Err(
+        ToolLaunchError.NotRunnableJar(
+          alias = "",
+          jarPath = jarPath,
+          reason = "archive_read_next_header: ${errString(reader)}",
+        )
+      )
+    }
+    val entry =
+      entryHolder.value
+        ?: return@memScoped Err(
+          ToolLaunchError.NotRunnableJar(
+            alias = "",
+            jarPath = jarPath,
+            reason = "archive_read_next_header returned null entry",
+          )
+        )
+    val pathname = archive_entry_pathname(entry)?.toKString().orEmpty()
+    if (pathname != MANIFEST_PATH) continue
+
+    val size = archive_entry_size(entry)
+    val content = readEntryBytes(reader, size).decodeToString()
+    val mainClass = extractMainClass(content)
+    return@memScoped if (mainClass != null) {
+      Ok(mainClass)
+    } else {
+      Err(ToolLaunchError.MainClassMissing(alias = "", jarPath = jarPath))
+    }
+  }
+  Err(ToolLaunchError.MainClassMissing(alias = "", jarPath = jarPath))
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun readEntryBytes(reader: CPointer<cnames.structs.archive>, size: Long): ByteArray {
+  // For MANIFEST.MF (typically <4KiB), a single buffer keyed off the declared
+  // entry size is enough. We still loop archive_read_data because libarchive
+  // does not guarantee returning the whole entry in one call.
+  val capacity = if (size in 1..(64 * 1024)) size.toInt() else 64 * 1024
+  val out = ArrayList<Byte>(capacity)
+  memScoped {
+    val buf = allocArray<ByteVar>(capacity)
+    while (true) {
+      val n = archive_read_data(reader, buf, capacity.convert())
+      if (n <= 0) break
+      out.addAll(buf.readBytes(n.toInt()).asList())
+    }
+  }
+  return out.toByteArray()
+}
+
+/**
+ * Extract the `Main-Class` value from a MANIFEST.MF content string, honouring RFC continuation
+ * lines (next line starts with SP or HT — drop the leading whitespace and concatenate). Returns
+ * null when the attribute is absent. Manifest line endings are normalised to handle CRLF / LF
+ * before scanning.
+ */
+internal fun extractMainClass(manifest: String): String? {
+  val normalised = manifest.replace("\r\n", "\n").replace("\r", "\n")
+  val lines = normalised.split("\n")
+  var i = 0
+  while (i < lines.size) {
+    val line = lines[i]
+    val colon = line.indexOf(':')
+    if (colon > 0) {
+      val key = line.substring(0, colon)
+      if (key == MAIN_CLASS_KEY) {
+        // Value starts after `: ` (one optional space). Trim leading single space if present.
+        val rawValue = line.substring(colon + 1).let { if (it.startsWith(' ')) it.drop(1) else it }
+        val joined = StringBuilder(rawValue)
+        var j = i + 1
+        while (j < lines.size && (lines[j].startsWith(" ") || lines[j].startsWith("\t"))) {
+          // Spec: continuation drops exactly one leading whitespace.
+          joined.append(lines[j].substring(1))
+          j++
+        }
+        val value = joined.toString().trim()
+        return if (value.isEmpty()) null else value
+      }
+    }
+    i++
+  }
+  return null
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun errString(handle: CPointer<cnames.structs.archive>): String =
+  archive_error_string(handle)?.toKString() ?: "unknown libarchive error"

--- a/src/nativeMain/kotlin/kolt/usertool/ToolResolution.kt
+++ b/src/nativeMain/kotlin/kolt/usertool/ToolResolution.kt
@@ -63,10 +63,36 @@ internal fun <T> ensureTool(
   val fileName = jarFileName(coords, classifier)
   val toolsJarPath = paths.toolsBundleJarPath(alias, coords.version, fileName)
   val innerKey = innerLockfileKey(coords, classifier)
-  val pin = lockfile.toolsBundles[alias]?.get(innerKey)
+  val aliasPins = lockfile.toolsBundles[alias].orEmpty()
+
+  // Lockfile-mismatch reject (R4.3): if the alias has any pin at all, it must match the toml's
+  // (group, artifact, version, classifier) exactly. The transitive-skip resolver guarantees a
+  // single pin per alias, so we either find an exact match keyed by `innerKey` with the right
+  // version, or we surface a loud mismatch — even when the divergence is in the inner key (group
+  // / artifact / classifier), in which case the inner-key lookup misses entirely.
+  if (aliasPins.isNotEmpty()) {
+    val matchedPin = aliasPins[innerKey]
+    if (matchedPin == null || matchedPin.version != coords.version) {
+      val (lockedKey, lockedEntry) = aliasPins.entries.first().toPair()
+      val (lockedCoords, lockedClassifier) = decomposeInnerKey(lockedKey, lockedEntry.version)
+      return Err(
+        ToolResolutionError.LockfileMismatch(
+          alias = alias,
+          tomlCoords = coords,
+          tomlClassifier = classifier,
+          lockedCoords = lockedCoords,
+          lockedClassifier = lockedClassifier,
+        )
+      )
+    }
+  }
+
+  val pin = aliasPins[innerKey]
 
   // Cache hit path — verify SHA-256 against pin if a pin exists. The pin is required to declare
-  // the cache trustworthy; without one there is nothing to verify against.
+  // the cache trustworthy; without one there is nothing to verify against. SHA divergence on the
+  // cached jar is a loud `IntegrityMismatch` and must NOT trigger automatic refetch (R3.3): the
+  // user has to inspect / refresh manually.
   if (pin != null && netDeps.fileExists(toolsJarPath)) {
     val cachedSha =
       netDeps.computeSha256(toolsJarPath).getOrElse {
@@ -74,7 +100,7 @@ internal fun <T> ensureTool(
           ToolResolutionError.IntegrityMismatch(alias, coords, expected = pin.sha256, actual = "")
         )
       }
-    if (cachedSha == pin.sha256 && pin.version == coords.version) {
+    if (cachedSha == pin.sha256) {
       return Ok(
         ToolJarHandle(
           jarPath = toolsJarPath,
@@ -84,6 +110,14 @@ internal fun <T> ensureTool(
         )
       )
     }
+    return Err(
+      ToolResolutionError.IntegrityMismatch(
+        alias = alias,
+        coords = coords,
+        expected = pin.sha256,
+        actual = cachedSha,
+      )
+    )
   }
 
   // Cache miss — fetch into the Maven-layout cache and then copy to the per-alias path.
@@ -183,4 +217,17 @@ internal fun jarFileName(coords: Coordinate, classifier: String?): String {
 internal fun innerLockfileKey(coords: Coordinate, classifier: String?): String {
   val ga = "${coords.group}:${coords.artifact}"
   return if (classifier != null) "$ga:$classifier" else ga
+}
+
+// Inverse of `innerLockfileKey`. Used only on the loud-reject path to render the locked-side
+// coords inside the `LockfileMismatch` message; not in the validation hot loop. Splits on `:` and
+// expects exactly two or three parts. A malformed key falls back to a placeholder Coordinate so
+// the failure still surfaces with `alias` context (the actual loud reject already happened).
+internal fun decomposeInnerKey(innerKey: String, version: String): Pair<Coordinate, String?> {
+  val parts = innerKey.split(":")
+  return when (parts.size) {
+    2 -> Coordinate(parts[0], parts[1], version) to null
+    3 -> Coordinate(parts[0], parts[1], version) to parts[2]
+    else -> Coordinate(innerKey, "", version) to null
+  }
 }

--- a/src/nativeMain/kotlin/kolt/usertool/ToolResolution.kt
+++ b/src/nativeMain/kotlin/kolt/usertool/ToolResolution.kt
@@ -1,0 +1,186 @@
+package kolt.usertool
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.config.KoltPaths
+import kolt.infra.CopyFailed
+import kolt.resolve.Coordinate
+import kolt.resolve.Lockfile
+import kolt.resolve.RepositoryDownloadFailure
+import kolt.resolve.ResolveError
+import kolt.resolve.ResolverDeps
+import kolt.resolve.SingleArtifact
+import kolt.resolve.resolveSingleArtifact
+
+/**
+ * Filesystem capabilities used by [ensureTool] beyond what [ResolverDeps] supplies. Split from
+ * [ResolverDeps] so tests can record copies independently of resolver behaviour, and so the
+ * `[classpaths]` resolver — which has no copy step — does not grow an unused interface member.
+ */
+interface ToolFsDeps {
+  fun copyFile(src: String, dest: String): Result<Unit, CopyFailed>
+}
+
+/**
+ * Handle returned to [ensureTool] callers. `jarPath` is the per-alias bundle path that the launcher
+ * reads. `lockfileChanged=true` means the caller must persist the new pin via `serializeLockfile`
+ * (the typical first-fetch flow).
+ */
+data class ToolJarHandle(
+  val jarPath: String,
+  val resolvedCoords: Coordinate,
+  val classifier: String?,
+  val lockfileChanged: Boolean,
+)
+
+/**
+ * Resolve the runnable jar for a `[tools.<alias>]` entry, honouring the per-alias bundle cache and
+ * any existing lockfile pin.
+ *
+ * Three behaviours, all mutually exclusive:
+ * 1. **Cache hit** — `paths.toolsBundleJarPath` exists AND lockfile pin matches version + sha256.
+ *    Returns the existing path with `lockfileChanged=false`. No network, no copy.
+ * 2. **Cache miss + no pin** (first run) — fetch via [resolveSingleArtifact], copy into the
+ *    per-alias path, return with `lockfileChanged=true` so the caller writes the new pin.
+ * 3. **Cache miss + matching pin** — fetch into the Maven cache, copy into the per-alias path,
+ *    return with `lockfileChanged=false`.
+ *
+ * Failure paths (`LockfileMismatch`, `IntegrityMismatch`, `ResolveFailed`) are layered in by
+ * follow-up implementations; this happy-path entry point is enough to land sections 4.2.
+ */
+internal fun <T> ensureTool(
+  alias: String,
+  entry: ToolEntry,
+  paths: KoltPaths,
+  lockfile: Lockfile,
+  netDeps: T,
+  repos: List<String> = listOf("https://repo.maven.apache.org/maven2"),
+): Result<ToolJarHandle, ToolResolutionError> where T : ResolverDeps, T : ToolFsDeps {
+  val coords = entry.coords
+  val classifier = entry.classifier
+  val fileName = jarFileName(coords, classifier)
+  val toolsJarPath = paths.toolsBundleJarPath(alias, coords.version, fileName)
+  val innerKey = innerLockfileKey(coords, classifier)
+  val pin = lockfile.toolsBundles[alias]?.get(innerKey)
+
+  // Cache hit path — verify SHA-256 against pin if a pin exists. The pin is required to declare
+  // the cache trustworthy; without one there is nothing to verify against.
+  if (pin != null && netDeps.fileExists(toolsJarPath)) {
+    val cachedSha =
+      netDeps.computeSha256(toolsJarPath).getOrElse {
+        return Err(
+          ToolResolutionError.IntegrityMismatch(alias, coords, expected = pin.sha256, actual = "")
+        )
+      }
+    if (cachedSha == pin.sha256 && pin.version == coords.version) {
+      return Ok(
+        ToolJarHandle(
+          jarPath = toolsJarPath,
+          resolvedCoords = coords,
+          classifier = classifier,
+          lockfileChanged = false,
+        )
+      )
+    }
+  }
+
+  // Cache miss — fetch into the Maven-layout cache and then copy to the per-alias path.
+  val artifact =
+    resolveSingleArtifact(
+        coord = coords,
+        classifier = classifier,
+        repos = repos,
+        cacheBase = paths.cacheBase,
+        deps = netDeps,
+      )
+      .getOrElse { resolveError ->
+        return Err(translateResolveError(alias, coords, resolveError))
+      }
+
+  storeInPerAliasCache(artifact, toolsJarPath, netDeps).getOrElse { err ->
+    return Err(err)
+  }
+
+  val lockfileChanged = pin == null
+  return Ok(
+    ToolJarHandle(
+      jarPath = toolsJarPath,
+      resolvedCoords = coords,
+      classifier = classifier,
+      lockfileChanged = lockfileChanged,
+    )
+  )
+}
+
+private fun <T> storeInPerAliasCache(
+  artifact: SingleArtifact,
+  toolsJarPath: String,
+  netDeps: T,
+): Result<Unit, ToolResolutionError> where T : ResolverDeps, T : ToolFsDeps {
+  val parentDir = toolsJarPath.substringBeforeLast('/')
+  netDeps.ensureDirectoryRecursive(parentDir).getOrElse {
+    return Err(
+      ToolResolutionError.ResolveFailed(
+        alias = "",
+        coords = Coordinate("", "", artifact.version),
+        attempts = listOf("mkdir $parentDir"),
+      )
+    )
+  }
+  netDeps.copyFile(artifact.cachePath, toolsJarPath).getOrElse {
+    return Err(
+      ToolResolutionError.ResolveFailed(
+        alias = "",
+        coords = Coordinate("", "", artifact.version),
+        attempts = listOf("copy ${artifact.cachePath} → $toolsJarPath"),
+      )
+    )
+  }
+  return Ok(Unit)
+}
+
+private fun translateResolveError(
+  alias: String,
+  coords: Coordinate,
+  err: ResolveError,
+): ToolResolutionError =
+  when (err) {
+    is ResolveError.DownloadFailed -> {
+      val urls =
+        when (val f = err.failure) {
+          is RepositoryDownloadFailure.AllAttemptsFailed -> f.attempts.map { it.url }
+          RepositoryDownloadFailure.NoRepositoriesConfigured -> emptyList()
+        }
+      ToolResolutionError.ResolveFailed(alias = alias, coords = coords, attempts = urls)
+    }
+    is ResolveError.HashComputeFailed ->
+      ToolResolutionError.ResolveFailed(
+        alias = alias,
+        coords = coords,
+        attempts = listOf("hash compute failed"),
+      )
+    is ResolveError.DirectoryCreateFailed ->
+      ToolResolutionError.ResolveFailed(
+        alias = alias,
+        coords = coords,
+        attempts = listOf("mkdir ${err.path}"),
+      )
+    else ->
+      ToolResolutionError.ResolveFailed(
+        alias = alias,
+        coords = coords,
+        attempts = listOf(err.toString()),
+      )
+  }
+
+internal fun jarFileName(coords: Coordinate, classifier: String?): String {
+  val suffix = if (classifier != null) "-$classifier" else ""
+  return "${coords.artifact}-${coords.version}$suffix.jar"
+}
+
+internal fun innerLockfileKey(coords: Coordinate, classifier: String?): String {
+  val ga = "${coords.group}:${coords.artifact}"
+  return if (classifier != null) "$ga:$classifier" else ga
+}

--- a/src/nativeMain/kotlin/kolt/usertool/ToolSection.kt
+++ b/src/nativeMain/kotlin/kolt/usertool/ToolSection.kt
@@ -1,0 +1,12 @@
+package kolt.usertool
+
+import kolt.resolve.Coordinate
+
+/**
+ * Validated `[tools.<alias>]` entry, surfaced via `KoltConfig.tools`.
+ *
+ * `coords` is the parsed Maven coordinate; `classifier` holds the optional fourth segment of
+ * `group:artifact:version[:classifier]`. Construction is restricted to the parse pipeline in
+ * `ToolSectionParse`, so any `ToolEntry` reaching downstream code is already validated.
+ */
+data class ToolEntry(val coords: Coordinate, val classifier: String?)

--- a/src/nativeMain/kotlin/kolt/usertool/ToolSectionParse.kt
+++ b/src/nativeMain/kotlin/kolt/usertool/ToolSectionParse.kt
@@ -1,0 +1,50 @@
+package kolt.usertool
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import kolt.resolve.Coordinate
+
+// Charset shared by group / artifact / version / classifier per design.md
+// §Data Models. Maven coordinate grammar is otherwise opaque, so kolt only
+// rejects shapes that would break URL/path construction or our own colon
+// splitting; it does not enforce e.g. SemVer on the version segment.
+private val COORD_SEGMENT_REGEX = Regex("""^[A-Za-z0-9._-]+$""")
+
+/**
+ * Parse a `[tools]` `coords` value into `(Coordinate, classifier?)`.
+ *
+ * Accepts `group:artifact:version` and `group:artifact:version:classifier`. All four segments must
+ * be non-empty and match `[A-Za-z0-9._-]+`. Any other shape returns `Err(reason)`; the caller
+ * (`parseToolSection`) is expected to attach the offending alias to the message.
+ */
+fun parseCoordsString(s: String): Result<Pair<Coordinate, String?>, String> {
+  if (s.isEmpty()) {
+    return Err("coords must not be empty")
+  }
+  val parts = s.split(":")
+  if (parts.size !in 3..4) {
+    return Err(
+      "coords '$s' must be of the form group:artifact:version[:classifier] " +
+        "(found ${parts.size} colon-separated segments)"
+    )
+  }
+  val group = parts[0]
+  val artifact = parts[1]
+  val version = parts[2]
+  val classifier = if (parts.size == 4) parts[3] else null
+
+  if (!COORD_SEGMENT_REGEX.matches(group)) {
+    return Err("coords '$s': group '$group' must match [A-Za-z0-9._-]+ and be non-empty")
+  }
+  if (!COORD_SEGMENT_REGEX.matches(artifact)) {
+    return Err("coords '$s': artifact '$artifact' must match [A-Za-z0-9._-]+ and be non-empty")
+  }
+  if (!COORD_SEGMENT_REGEX.matches(version)) {
+    return Err("coords '$s': version '$version' must match [A-Za-z0-9._-]+ and be non-empty")
+  }
+  if (classifier != null && !COORD_SEGMENT_REGEX.matches(classifier)) {
+    return Err("coords '$s': classifier '$classifier' must match [A-Za-z0-9._-]+ and be non-empty")
+  }
+  return Ok(Coordinate(group, artifact, version) to classifier)
+}

--- a/src/nativeMain/kotlin/kolt/usertool/ToolSectionParse.kt
+++ b/src/nativeMain/kotlin/kolt/usertool/ToolSectionParse.kt
@@ -3,13 +3,97 @@ package kolt.usertool
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
 import kolt.resolve.Coordinate
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 // Charset shared by group / artifact / version / classifier per design.md
 // §Data Models. Maven coordinate grammar is otherwise opaque, so kolt only
 // rejects shapes that would break URL/path construction or our own colon
 // splitting; it does not enforce e.g. SemVer on the version segment.
 private val COORD_SEGMENT_REGEX = Regex("""^[A-Za-z0-9._-]+$""")
+
+// Alias grammar pinned in design.md §Data Models. Lowercase-letter prefix is
+// load-bearing for ADR 0028 §3 freeze: relaxing or narrowing later breaks
+// existing declarations, so the regex is captured at parse time and reused
+// across the validation pipeline.
+private val ALIAS_REGEX = Regex("""^[a-z][a-z0-9_-]{0,63}$""")
+
+/**
+ * Raw `[tools.<alias>]` entry as decoded by ktoml. `coords` is the only allowlisted field; the
+ * other three are declared explicitly nullable so [parseToolSection] can reject orchestration
+ * fields by name (R7.1, R7.2). Other unknown keys are silently dropped by ktoml's
+ * `ignoreUnknownNames=true` and may be tightened later additively.
+ */
+@Serializable
+data class RawToolEntry(
+  val coords: String? = null,
+  @SerialName("depends-on") val dependsOn: String? = null,
+  val args: List<String>? = null,
+  val main: String? = null,
+)
+
+/** Distinguishable failures surfaced by [parseToolSection]. */
+sealed class ToolSectionParseError {
+  data class ForbiddenField(val alias: String, val field: String) : ToolSectionParseError()
+
+  data class InvalidAlias(val alias: String, val reason: String) : ToolSectionParseError()
+
+  data class MalformedCoords(val alias: String, val coords: String, val reason: String) :
+    ToolSectionParseError()
+
+  data class DuplicateAlias(val alias: String) : ToolSectionParseError()
+
+  data class MissingCoords(val alias: String) : ToolSectionParseError()
+}
+
+/**
+ * Validate `[tools]` raw entries into a typed map. The validation order is:
+ * 1. alias regex `^[a-z][a-z0-9_-]{0,63}$` (R1.3)
+ * 2. orchestration field reject (`depends-on`, `args`, `main` — R7.1, R7.2)
+ * 3. `coords` presence (R1.1)
+ * 4. `coords` shape via [parseCoordsString] (R1.2, R1.4)
+ *
+ * `null` and empty input both yield an empty map; the `[tools]` section is fully optional.
+ *
+ * Duplicate aliases (R1.5) are reported by ktoml at TOML parse time before reaching this function,
+ * so [ToolSectionParseError.DuplicateAlias] is provided for completeness but not produced here.
+ */
+fun parseToolSection(
+  rawTools: Map<String, RawToolEntry>?
+): Result<Map<String, ToolEntry>, ToolSectionParseError> {
+  if (rawTools.isNullOrEmpty()) return Ok(emptyMap())
+  val out = LinkedHashMap<String, ToolEntry>(rawTools.size)
+  for ((rawAlias, rawEntry) in rawTools) {
+    val alias = rawAlias.removeSurrounding("\"")
+    if (!ALIAS_REGEX.matches(alias)) {
+      return Err(
+        ToolSectionParseError.InvalidAlias(
+          alias,
+          "alias must match ^[a-z][a-z0-9_-]{0,63}$ (lowercase letter prefix, " +
+            "[a-z0-9_-] thereafter, 64 chars max)",
+        )
+      )
+    }
+    rawEntry.dependsOn?.let {
+      return Err(ToolSectionParseError.ForbiddenField(alias, "depends-on"))
+    }
+    rawEntry.args?.let {
+      return Err(ToolSectionParseError.ForbiddenField(alias, "args"))
+    }
+    rawEntry.main?.let {
+      return Err(ToolSectionParseError.ForbiddenField(alias, "main"))
+    }
+    val coordsString = rawEntry.coords ?: return Err(ToolSectionParseError.MissingCoords(alias))
+    val (coordinate, classifier) =
+      parseCoordsString(coordsString).getOrElse {
+        return Err(ToolSectionParseError.MalformedCoords(alias, coordsString, it))
+      }
+    out[alias] = ToolEntry(coordinate, classifier)
+  }
+  return Ok(out)
+}
 
 /**
  * Parse a `[tools]` `coords` value into `(Coordinate, classifier?)`.

--- a/src/nativeTest/kotlin/kolt/build/UserToolBoundaryGuardTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/UserToolBoundaryGuardTest.kt
@@ -1,0 +1,89 @@
+package kolt.build
+
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.currentWorkingDirectory
+import kolt.infra.fileExists
+import kolt.infra.listKotlinFiles
+import kolt.infra.readFileAsString
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Structural assertion of R7.4: `[tools]` (the `kolt.usertool` package) is NOT coupled into the
+ * build / test lifecycle. The boundary commitment in design.md §Boundary Commitments declares that
+ * `kolt build` / `kolt test` paths must not invoke `[tools]` resolution or launch — this guard
+ * makes that promise structural rather than reviewer-only, by failing loudly the moment any source
+ * under `kolt.build` or the build/test CLI entry points imports or qualifies a `kolt.usertool`
+ * name.
+ *
+ * Scope:
+ * - `src/nativeMain/kotlin/kolt/build/` (recursive): the build pipeline
+ * - `src/nativeMain/kotlin/kolt/cli/BuildCommands.kt`: hosts both `doBuild` and `doTest`
+ *
+ * The check is a substring match on the literal `kolt.usertool` — sufficient for both `import
+ * kolt.usertool.*` and qualified references like `kolt.usertool.Foo`. False positives from comments
+ * are tolerated: a reviewer-facing comment that names the package would still be a yellow flag, so
+ * failing loudly is the correct response.
+ */
+class UserToolBoundaryGuardTest {
+
+  @Test
+  fun buildAndTestPathsDoNotReferenceUsertoolPackage() {
+    val root = projectRoot()
+    val targets = collectGuardedSources(root)
+    val violations = mutableListOf<String>()
+    for (path in targets) {
+      val text =
+        readFileAsString(path).getOrElse { fail("guard: could not read $path: ${it.path}") }
+      if (text.contains(FORBIDDEN_TOKEN)) {
+        violations.add(path)
+      }
+    }
+    if (violations.isNotEmpty()) {
+      val msg = buildString {
+        appendLine("R7.4 boundary violation: build / test source paths must not reference")
+        appendLine("`$FORBIDDEN_TOKEN`. Files containing the forbidden token:")
+        for (v in violations) appendLine("  - $v")
+        append(
+          "If you are intentionally lifting [tools] into the build lifecycle, this is " +
+            "an ADR-level change — see ADR 0028 §3 and update the design first."
+        )
+      }
+      fail(msg)
+    }
+  }
+
+  private fun collectGuardedSources(root: String): List<String> {
+    val buildDir = "$root/src/nativeMain/kotlin/kolt/build"
+    val files = mutableListOf<String>()
+    files.addAll(
+      listKotlinFiles(buildDir).getOrElse { fail("guard: could not list $buildDir: ${it.path}") }
+    )
+    val buildCommands = "$root/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt"
+    if (fileExists(buildCommands)) {
+      files.add(buildCommands)
+    } else {
+      fail("guard: expected $buildCommands to exist but it does not")
+    }
+    return files
+  }
+
+  // Walk up from cwd until we hit `.git` (project root). Mirrors `DriftGuardsTest.projectRoot`.
+  private fun projectRoot(): String {
+    var current = currentWorkingDirectory() ?: fail("could not get cwd for project-root lookup")
+    while (current.isNotEmpty() && current != "/") {
+      if (fileExists("$current/.git")) return current
+      val cut = current.lastIndexOf('/')
+      if (cut <= 0) break
+      current = current.substring(0, cut)
+    }
+    fail("could not locate project root (no .git ancestor) starting from cwd")
+  }
+
+  private companion object {
+    // The forbidden import token. Matches both `import kolt.usertool.*` and qualified references
+    // like `kolt.usertool.ToolEntry`. Splitting prevents this guard from flagging itself when the
+    // string appears verbatim in the source file.
+    val FORBIDDEN_TOKEN = "kolt." + "usertool"
+  }
+}

--- a/src/nativeTest/kotlin/kolt/cli/DependencyCommandsToolsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DependencyCommandsToolsTest.kt
@@ -1,0 +1,84 @@
+package kolt.cli
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.resolve.Coordinate
+import kolt.resolve.LockEntry
+import kolt.resolve.ResolveError
+import kolt.resolve.SingleArtifact
+import kolt.usertool.ToolEntry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DependencyCommandsToolsTest {
+
+  // ----- buildToolsBundleLockMap: pure orchestration over tool entries -----
+
+  @Test
+  fun emptyToolsMapProducesEmptyLockBundles() {
+    val result = buildToolsBundleLockMap(emptyMap()) { _, _, _ -> error("must not call resolver") }
+    assertEquals(emptyMap(), result.get())
+  }
+
+  @Test
+  fun singleToolEntryProducesAliasedLockBundle() {
+    val tools =
+      mapOf("ktlint" to ToolEntry(Coordinate("g", "ktlint-cli", "1.3.1"), classifier = "all"))
+    val result =
+      buildToolsBundleLockMap(tools) { coord, classifier, _ ->
+        Ok(
+          SingleArtifact(
+            groupArtifact = "${coord.group}:${coord.artifact}",
+            version = coord.version,
+            classifier = classifier,
+            cachePath = "/cache/${coord.artifact}-${coord.version}.jar",
+            sha256 = "fakesha-${coord.version}",
+          )
+        )
+      }
+    val toolsBundles = assertNotNull(result.get())
+    assertEquals(setOf("ktlint"), toolsBundles.keys)
+    val ktlintInner = toolsBundles.getValue("ktlint")
+    assertEquals(
+      mapOf("g:ktlint-cli:all" to LockEntry(version = "1.3.1", sha256 = "fakesha-1.3.1")),
+      ktlintInner,
+    )
+  }
+
+  @Test
+  fun multipleToolEntriesProduceAliasedLockBundles() {
+    val tools =
+      mapOf(
+        "ktlint" to ToolEntry(Coordinate("g", "ktlint-cli", "1.3.1"), classifier = null),
+        "detekt" to ToolEntry(Coordinate("io.detekt", "detekt-cli", "1.23.6"), classifier = null),
+      )
+    val result =
+      buildToolsBundleLockMap(tools) { coord, classifier, _ ->
+        Ok(
+          SingleArtifact(
+            groupArtifact = "${coord.group}:${coord.artifact}",
+            version = coord.version,
+            classifier = classifier,
+            cachePath = "/cache/${coord.artifact}-${coord.version}.jar",
+            sha256 = "sha-${coord.artifact}",
+          )
+        )
+      }
+    val toolsBundles = assertNotNull(result.get())
+    assertEquals(setOf("ktlint", "detekt"), toolsBundles.keys)
+    assertTrue(toolsBundles.getValue("ktlint").containsKey("g:ktlint-cli"))
+    assertTrue(toolsBundles.getValue("detekt").containsKey("io.detekt:detekt-cli"))
+  }
+
+  @Test
+  fun resolverFailureBubblesUp() {
+    val tools = mapOf("bad" to ToolEntry(Coordinate("g", "a", "1.0"), classifier = null))
+    val result =
+      buildToolsBundleLockMap(tools) { _, _, _ -> Err(ResolveError.DirectoryCreateFailed("/x")) }
+    assertNotNull(result.getError())
+  }
+}

--- a/src/nativeTest/kotlin/kolt/cli/ExitCodeTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ExitCodeTest.kt
@@ -12,6 +12,10 @@ class ExitCodeTest {
         EXIT_BUILD_ERROR,
         EXIT_CONFIG_ERROR,
         EXIT_DEPENDENCY_ERROR,
+        EXIT_TEST_ERROR,
+        EXIT_FORMAT_ERROR,
+        EXIT_LOCK_TIMEOUT,
+        EXIT_TOOL_ERROR,
         EXIT_COMMAND_NOT_FOUND,
       )
     assertEquals(codes.size, codes.toSet().size, "Exit codes must be unique")
@@ -27,6 +31,10 @@ class ExitCodeTest {
     assertEquals(1, EXIT_BUILD_ERROR)
     assertEquals(2, EXIT_CONFIG_ERROR)
     assertEquals(3, EXIT_DEPENDENCY_ERROR)
+    assertEquals(4, EXIT_TEST_ERROR)
+    assertEquals(5, EXIT_FORMAT_ERROR)
+    assertEquals(6, EXIT_LOCK_TIMEOUT)
+    assertEquals(7, EXIT_TOOL_ERROR)
     assertEquals(127, EXIT_COMMAND_NOT_FOUND)
   }
 }

--- a/src/nativeTest/kotlin/kolt/cli/ToolCommandsE2ETest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ToolCommandsE2ETest.kt
@@ -1,0 +1,288 @@
+package kolt.cli
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import kolt.config.KoltPaths
+import kolt.infra.CopyFailed
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.ProcessError
+import kolt.infra.Sha256Error
+import kolt.infra.computeSha256
+import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.removeDirectoryRecursive
+import kolt.resolve.Coordinate
+import kolt.resolve.LockEntry
+import kolt.resolve.Lockfile
+import kolt.resolve.ResolverDeps
+import kolt.usertool.ToolEntry
+import kolt.usertool.ToolFsDeps
+import kolt.usertool.ensureTool
+import kolt.usertool.launch
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import libarchive.ARCHIVE_OK
+import libarchive.archive_entry_free
+import libarchive.archive_entry_new
+import libarchive.archive_entry_set_filetype
+import libarchive.archive_entry_set_pathname
+import libarchive.archive_entry_set_size
+import libarchive.archive_write_close
+import libarchive.archive_write_data
+import libarchive.archive_write_free
+import libarchive.archive_write_header
+import libarchive.archive_write_new
+import libarchive.archive_write_open_filename
+import libarchive.archive_write_set_format_zip
+import platform.posix.S_IFREG
+import platform.posix.mkdtemp
+
+/**
+ * End-to-end test that wires `parseToolArgs` -> `lookupToolEntry` -> `ensureTool` -> `launch`
+ * together against a real fixture jar (built in-process via libarchive) and a stubbed
+ * `resolveJavaBin` / `exec` so the launch mechanics from `ToolLauncherTest` connect to the dispatch
+ * mechanics from `ToolCommandsTest`.
+ *
+ * Design choice (per task 7.1 implementation note): the launch step is stubbed via the existing
+ * [launch] injection points rather than spawning `kolt.kexe`. Spawning a subprocess from a unit
+ * test is heavyweight on WSL2 9p and the design intent ("argv passthrough + exit code propagation")
+ * is fully covered without real fork/exec. The fixture jar is a real libarchive-built zip, so the
+ * MANIFEST.MF read path inside `launch` is exercised exactly as in production.
+ */
+class ToolCommandsE2ETest {
+
+  @Test
+  fun toolRunDispatchPassesArgsVerbatimAndPropagatesExitCode() {
+    val tempDir = createTempDir("kolt_tool_e2e_")
+    try {
+      // Build a runnable-looking jar fixture: a zip with META-INF/MANIFEST.MF declaring a
+      // Main-Class.
+      // The jar is not actually executed (exec is stubbed) so the Main-Class string only needs to
+      // satisfy the launcher's MANIFEST validation.
+      val coords = Coordinate("com.example", "argv-echo", "1.0.0")
+      val paths = KoltPaths(home = tempDir)
+      val toolsJarPath = paths.toolsBundleJarPath("echo", "1.0.0", "argv-echo-1.0.0.jar")
+      ensureDirectoryRecursive(toolsJarPath.substringBeforeLast('/'))
+      writeRunnableJar(toolsJarPath, mainClass = "fixture.ArgvEcho")
+
+      // Parse the user-facing argv: `kolt tool run echo arg1 --foo bar`.
+      val invocation =
+        assertNotNull(parseToolArgs(listOf("run", "echo", "arg1", "--foo", "bar")).get())
+      assertEquals(
+        ToolInvocation.Run(alias = "echo", args = listOf("arg1", "--foo", "bar")),
+        invocation,
+      )
+      val run = invocation as ToolInvocation.Run
+
+      // Lockfile carries a matching pin so ensureTool short-circuits to the cache hit path (no
+      // resolver / network involvement). Computing the actual sha256 of the fixture means the cache
+      // hit branch validates against a real digest.
+      val sha = assertNotNull(computeSha256(toolsJarPath).get())
+      val lockfile =
+        Lockfile(
+          version = 4,
+          kotlin = "2.1.0",
+          jvmTarget = "17",
+          dependencies = emptyMap(),
+          classpathBundles = emptyMap(),
+          toolsBundles =
+            mapOf(
+              "echo" to mapOf("com.example:argv-echo" to LockEntry(version = "1.0.0", sha256 = sha))
+            ),
+        )
+
+      // Real cache-hit path through ensureTool. Exercises lockfile pin matching + sha verify on the
+      // cached jar; deps below provide just enough surface to satisfy ResolverDeps + ToolFsDeps.
+      val deps = E2EDeps(toolsJarPath, sha)
+      val handle =
+        assertNotNull(
+          ensureTool(
+              alias = "echo",
+              entry = ToolEntry(coords = coords, classifier = null),
+              paths = paths,
+              lockfile = lockfile,
+              netDeps = deps,
+              repos = listOf("https://central/"),
+            )
+            .get()
+        )
+      assertEquals(toolsJarPath, handle.jarPath)
+      assertEquals(false, handle.lockfileChanged, "warm cache must not require lockfile rewrite")
+      assertTrue(deps.downloads.isEmpty(), "cache hit must skip network: ${deps.downloads}")
+
+      // Launch with stubbed exec: capture the command line argv that would have been forked. The
+      // launcher injects `[javaBin, "-jar", jarPath, *args]`, which is exactly what proves verbatim
+      // argv passthrough end-to-end.
+      val capturedArgv = mutableListOf<List<String>>()
+      val toolExitCode = 42
+      val exit =
+        launch(
+            alias = run.alias,
+            jarHandle = handle,
+            args = run.args,
+            paths = paths,
+            env = emptyMap(),
+            resolveJavaBin = { Ok("/fake/jdk/bin/java") },
+            exec = { cmd, _ ->
+              capturedArgv.add(cmd)
+              // Simulate the tool exiting with a non-zero status so we can assert kolt
+              // propagates the value verbatim instead of overlaying.
+              Err(ProcessError.NonZeroExit(toolExitCode))
+            },
+          )
+          .get()
+
+      // 1) Argv reaching the tool is verbatim. The leading three tokens are the JDK trampoline; the
+      //    tail is the user-visible argv. R2.1.
+      assertEquals(
+        listOf(listOf("/fake/jdk/bin/java", "-jar", toolsJarPath, "arg1", "--foo", "bar")),
+        capturedArgv,
+      )
+      // 2) The tool's exit code propagates as Ok, not Err. R2.2.
+      assertEquals(toolExitCode, exit)
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun toolRunDispatchPropagatesZeroExitForSuccessfulTool() {
+    val tempDir = createTempDir("kolt_tool_e2e_zero_")
+    try {
+      val paths = KoltPaths(home = tempDir)
+      val toolsJarPath = paths.toolsBundleJarPath("ok", "0.1.0", "ok-0.1.0.jar")
+      ensureDirectoryRecursive(toolsJarPath.substringBeforeLast('/'))
+      writeRunnableJar(toolsJarPath, mainClass = "fixture.Ok")
+
+      val sha = assertNotNull(computeSha256(toolsJarPath).get())
+      val lockfile =
+        Lockfile(
+          version = 4,
+          kotlin = "2.1.0",
+          jvmTarget = "17",
+          dependencies = emptyMap(),
+          classpathBundles = emptyMap(),
+          toolsBundles =
+            mapOf("ok" to mapOf("com.example:ok" to LockEntry(version = "0.1.0", sha256 = sha))),
+        )
+      val deps = E2EDeps(toolsJarPath, sha)
+      val handle =
+        assertNotNull(
+          ensureTool(
+              alias = "ok",
+              entry = ToolEntry(Coordinate("com.example", "ok", "0.1.0"), classifier = null),
+              paths = paths,
+              lockfile = lockfile,
+              netDeps = deps,
+              repos = listOf("https://central/"),
+            )
+            .get()
+        )
+
+      val exit =
+        launch(
+            alias = "ok",
+            jarHandle = handle,
+            args = emptyList(),
+            paths = paths,
+            env = emptyMap(),
+            resolveJavaBin = { Ok("/fake/jdk/bin/java") },
+            exec = { _, _ -> Ok(0) },
+          )
+          .get()
+      assertEquals(0, exit)
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  // ----- Fixture / IO helpers (libarchive only) -----
+
+  @OptIn(ExperimentalForeignApi::class)
+  private fun writeRunnableJar(path: String, mainClass: String) {
+    val writer = archive_write_new() ?: error("archive_write_new returned null")
+    try {
+      check(archive_write_set_format_zip(writer) == ARCHIVE_OK) { "set_format_zip failed" }
+      check(archive_write_open_filename(writer, path) == ARCHIVE_OK) { "open_filename failed" }
+      val manifest = "Manifest-Version: 1.0\nMain-Class: $mainClass\n"
+      writeEntry(writer, "META-INF/MANIFEST.MF", manifest)
+      // A non-class payload distinguishes this from a manifest-only zip — the launcher does not
+      // care, but a real runnable jar would carry classes; we keep the fixture closer to reality.
+      writeEntry(writer, "fixture/ArgvEcho.class", "stub-classfile-bytes")
+    } finally {
+      archive_write_close(writer)
+      archive_write_free(writer)
+    }
+  }
+
+  @OptIn(ExperimentalForeignApi::class)
+  private fun writeEntry(writer: CPointer<cnames.structs.archive>, name: String, content: String) {
+    val entry = archive_entry_new() ?: error("archive_entry_new returned null")
+    try {
+      archive_entry_set_pathname(entry, name)
+      val bytes = content.encodeToByteArray()
+      archive_entry_set_size(entry, bytes.size.toLong())
+      archive_entry_set_filetype(entry, S_IFREG.convert())
+      check(archive_write_header(writer, entry) == ARCHIVE_OK) { "write_header failed" }
+      if (bytes.isNotEmpty()) {
+        bytes.usePinned { pinned ->
+          val n = archive_write_data(writer, pinned.addressOf(0), bytes.size.convert())
+          check(n == bytes.size.toLong()) { "short write: $n / ${bytes.size}" }
+        }
+      }
+    } finally {
+      archive_entry_free(entry)
+    }
+  }
+
+  @OptIn(ExperimentalForeignApi::class)
+  private fun createTempDir(prefix: String): String {
+    val template = "/tmp/${prefix}XXXXXX"
+    val buf = template.encodeToByteArray().copyOf(template.length + 1)
+    buf.usePinned { pinned ->
+      val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+      return result.toKString()
+    }
+  }
+
+  /**
+   * Minimal `ResolverDeps + ToolFsDeps` impl that promises a single cached file with a known
+   * sha256. The cache-hit path of `ensureTool` calls `fileExists` then `computeSha256` on the
+   * tools-bundle jar path, so this is the entire surface we need to mock.
+   */
+  private class E2EDeps(private val jarPath: String, private val sha: String) :
+    ResolverDeps, ToolFsDeps {
+
+    val downloads = mutableListOf<String>()
+
+    override fun fileExists(path: String): Boolean = path == jarPath
+
+    override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> =
+      kolt.infra.ensureDirectoryRecursive(path)
+
+    override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      downloads.add(url)
+      return Ok(Unit)
+    }
+
+    override fun computeSha256(filePath: String): Result<String, Sha256Error> =
+      if (filePath == jarPath) Ok(sha) else kolt.infra.computeSha256(filePath)
+
+    override fun readFileContent(path: String): Result<String, OpenFailed> =
+      kolt.infra.readFileAsString(path)
+
+    override fun copyFile(src: String, dest: String): Result<Unit, CopyFailed> =
+      kolt.infra.copyFile(src, dest)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/cli/ToolCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ToolCommandsTest.kt
@@ -1,0 +1,94 @@
+package kolt.cli
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.config.BuildSection
+import kolt.config.KoltConfig
+import kolt.config.KotlinSection
+import kolt.resolve.Coordinate
+import kolt.usertool.ToolEntry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+class ToolCommandsTest {
+
+  // ----- parseToolArgs: argv shape -----
+
+  @Test
+  fun parsesRunWithAliasOnly() {
+    val invocation = parseToolArgs(listOf("run", "ktlint")).get()
+    assertEquals(ToolInvocation.Run(alias = "ktlint", args = emptyList()), invocation)
+  }
+
+  @Test
+  fun parsesRunWithAliasAndPositionalArgs() {
+    val invocation = parseToolArgs(listOf("run", "ktlint", "--reporter", "plain")).get()
+    assertEquals(
+      ToolInvocation.Run(alias = "ktlint", args = listOf("--reporter", "plain")),
+      invocation,
+    )
+  }
+
+  @Test
+  fun stripsLeadingDoubleDashAfterAlias() {
+    // `kolt tool run ktlint -- -F` and `kolt tool run ktlint -F` are equivalent.
+    val a = parseToolArgs(listOf("run", "ktlint", "--", "-F")).get()
+    val b = parseToolArgs(listOf("run", "ktlint", "-F")).get()
+    assertEquals(b, a)
+  }
+
+  @Test
+  fun preservesNonLeadingDoubleDashTokens() {
+    val invocation = parseToolArgs(listOf("run", "ktlint", "-x", "--", "y")).get()
+    assertEquals(ToolInvocation.Run(alias = "ktlint", args = listOf("-x", "--", "y")), invocation)
+  }
+
+  @Test
+  fun returnsMissingSubcommandForEmptyArgs() {
+    val err = parseToolArgs(emptyList()).getError()
+    assertIs<ToolArgError.MissingSubcommand>(err)
+  }
+
+  @Test
+  fun returnsMissingAliasForRunWithoutAlias() {
+    val err = parseToolArgs(listOf("run")).getError()
+    assertIs<ToolArgError.MissingAlias>(err)
+  }
+
+  @Test
+  fun returnsUnknownSubcommandForNonRunFirstArg() {
+    val err = parseToolArgs(listOf("list")).getError()
+    val unknown = assertIs<ToolArgError.UnknownSubcommand>(err)
+    assertEquals("list", unknown.subcommand)
+  }
+
+  // ----- lookupToolEntry: alias dispatch -----
+
+  @Test
+  fun lookupReturnsEntryForKnownAlias() {
+    val entry = ToolEntry(Coordinate("g", "a", "1.0"), classifier = null)
+    val config = configWithTools(mapOf("ktlint" to entry))
+    assertEquals(entry, lookupToolEntry("ktlint", config).get())
+  }
+
+  @Test
+  fun lookupReturnsExitConfigErrorForUnknownAlias() {
+    val config = configWithTools(emptyMap())
+    val exit = lookupToolEntry("ktlint", config).getError()
+    assertNotNull(exit)
+    assertEquals(EXIT_CONFIG_ERROR, exit)
+  }
+
+  // ----- helpers -----
+
+  private fun configWithTools(tools: Map<String, ToolEntry>): KoltConfig =
+    KoltConfig(
+      name = "demo",
+      version = "0.0.1",
+      kotlin = KotlinSection(version = "2.1.0"),
+      build = BuildSection(target = "jvm", main = null, sources = listOf("src")),
+      tools = tools,
+    )
+}

--- a/src/nativeTest/kotlin/kolt/config/KoltPathsTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/KoltPathsTest.kt
@@ -190,4 +190,62 @@ class KoltPathsTest {
     val b = paths.daemonSocketPath("hash", "2.3.20")
     kotlin.test.assertNotEquals(a, b)
   }
+
+  @Test
+  fun toolsBundleDirSegmentedByAliasAndVersion() {
+    val paths = KoltPaths("/home/user")
+    assertEquals(
+      "/home/user/.kolt/tools/bundles/ktlint/1.3.1",
+      paths.toolsBundleDir("ktlint", "1.3.1"),
+    )
+  }
+
+  @Test
+  fun toolsBundleDirDifferentHome() {
+    val paths = KoltPaths("/root")
+    assertEquals(
+      "/root/.kolt/tools/bundles/detekt/1.23.6",
+      paths.toolsBundleDir("detekt", "1.23.6"),
+    )
+  }
+
+  @Test
+  fun toolsBundleDirDifferentVersionsProduceDifferentDirectories() {
+    val paths = KoltPaths("/home/user")
+    val a = paths.toolsBundleDir("ktlint", "1.3.0")
+    val b = paths.toolsBundleDir("ktlint", "1.3.1")
+    kotlin.test.assertNotEquals(a, b)
+  }
+
+  @Test
+  fun toolsBundleJarPathBuildsUnderToolsBundleDir() {
+    val paths = KoltPaths("/home/user")
+    assertEquals(
+      "/home/user/.kolt/tools/bundles/ktlint/1.3.1/ktlint-cli-1.3.1-all.jar",
+      paths.toolsBundleJarPath("ktlint", "1.3.1", "ktlint-cli-1.3.1-all.jar"),
+    )
+  }
+
+  @Test
+  fun toolsBundleJarPathSharesToolsBundleDir() {
+    val paths = KoltPaths("/home/user")
+    val dir = paths.toolsBundleDir("detekt", "1.23.6")
+    assertEquals(
+      "$dir/detekt-cli-1.23.6.jar",
+      paths.toolsBundleJarPath("detekt", "1.23.6", "detekt-cli-1.23.6.jar"),
+    )
+  }
+
+  @Test
+  fun toolsBundleDirDoesNotCollideWithFlatToolsLayout() {
+    // Existing kolt-internal flat layout: ~/.kolt/tools/<filename> (e.g.
+    // ktfmt-0.54-jar-with-dependencies.jar).
+    // tools_bundles/<alias>/<version>/ must live under a separate subdir so that a user-declared
+    // alias matching an internal tool name (e.g. "ktfmt") cannot collide with the flat artifact.
+    val paths = KoltPaths("/home/user")
+    val bundleDir = paths.toolsBundleDir("ktfmt", "0.54")
+    val flatArtifact = "${paths.toolsDir}/ktfmt-0.54-jar-with-dependencies.jar"
+    kotlin.test.assertNotEquals(bundleDir, flatArtifact)
+    kotlin.test.assertTrue(bundleDir.startsWith("${paths.toolsDir}/bundles/"))
+  }
 }

--- a/src/nativeTest/kotlin/kolt/config/ToolSectionConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ToolSectionConfigTest.kt
@@ -1,9 +1,12 @@
 package kolt.config
 
 import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
 import kolt.resolve.Coordinate
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -81,5 +84,97 @@ class ToolSectionConfigTest {
     assertEquals(Coordinate("a", "b", "1.0"), config.tools["foo"]?.coords)
     assertEquals(Coordinate("c", "d", "2.0"), config.tools["bar"]?.coords)
     assertEquals("cls", config.tools["bar"]?.classifier)
+  }
+
+  @Test
+  fun rejectsUppercaseAlias() {
+    val toml =
+      baseToml +
+        """
+
+        [tools.Foo]
+        coords = "a:b:1.0"
+      """
+          .trimIndent()
+    val err = assertIs<ConfigError.ParseFailed>(parseConfig(toml).getError())
+    assertContains(err.message, "Foo")
+    assertContains(err.message, "alias")
+  }
+
+  @Test
+  fun rejectsDependsOnField() {
+    val toml =
+      baseToml +
+        """
+
+        [tools.foo]
+        coords = "a:b:1.0"
+        depends-on = "bar"
+      """
+          .trimIndent()
+    val err = assertIs<ConfigError.ParseFailed>(parseConfig(toml).getError())
+    assertContains(err.message, "depends-on")
+    assertContains(err.message, "foo")
+  }
+
+  @Test
+  fun rejectsArgsField() {
+    val toml =
+      baseToml +
+        """
+
+        [tools.foo]
+        coords = "a:b:1.0"
+        args = []
+      """
+          .trimIndent()
+    val err = assertIs<ConfigError.ParseFailed>(parseConfig(toml).getError())
+    assertContains(err.message, "args")
+    assertContains(err.message, "foo")
+  }
+
+  @Test
+  fun rejectsMainField() {
+    val toml =
+      baseToml +
+        """
+
+        [tools.foo]
+        coords = "a:b:1.0"
+        main = "com.example.Main"
+      """
+          .trimIndent()
+    val err = assertIs<ConfigError.ParseFailed>(parseConfig(toml).getError())
+    assertContains(err.message, "main")
+    assertContains(err.message, "foo")
+  }
+
+  @Test
+  fun rejectsMissingCoords() {
+    val toml =
+      baseToml +
+        """
+
+        [tools.foo]
+      """
+          .trimIndent()
+    val err = assertIs<ConfigError.ParseFailed>(parseConfig(toml).getError())
+    assertContains(err.message, "coords")
+    assertContains(err.message, "foo")
+  }
+
+  @Test
+  fun rejectsMalformedCoords() {
+    val toml =
+      baseToml +
+        """
+
+        [tools.foo]
+        coords = "no-colons-here"
+      """
+          .trimIndent()
+    val err = assertIs<ConfigError.ParseFailed>(parseConfig(toml).getError())
+    assertContains(err.message, "foo")
+    assertContains(err.message, "no-colons-here")
   }
 }

--- a/src/nativeTest/kotlin/kolt/config/ToolSectionConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ToolSectionConfigTest.kt
@@ -1,0 +1,85 @@
+package kolt.config
+
+import com.github.michaelbull.result.get
+import kolt.resolve.Coordinate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ToolSectionConfigTest {
+
+  private val baseToml =
+    """
+        name = "x"
+        version = "0.1.0"
+
+        [kotlin]
+        version = "2.3.20"
+
+        [build]
+        target = "jvm"
+        main = "com.example.main"
+        sources = ["src"]
+    """
+      .trimIndent()
+
+  @Test
+  fun emptyToolsWhenSectionMissing() {
+    val config = assertNotNull(parseConfig(baseToml).get())
+    assertTrue(config.tools.isEmpty(), "tools should default to empty map")
+  }
+
+  @Test
+  fun parsesSingleToolEntryWithoutClassifier() {
+    val toml =
+      baseToml +
+        """
+
+        [tools.foo]
+        coords = "a:b:1.0"
+      """
+          .trimIndent()
+    val config = assertNotNull(parseConfig(toml).get())
+    val entry = assertNotNull(config.tools["foo"])
+    assertEquals(Coordinate("a", "b", "1.0"), entry.coords)
+    assertNull(entry.classifier)
+  }
+
+  @Test
+  fun parsesToolEntryWithClassifier() {
+    val toml =
+      baseToml +
+        """
+
+        [tools.ktlint]
+        coords = "com.pinterest.ktlint:ktlint-cli:1.3.1:all"
+      """
+          .trimIndent()
+    val config = assertNotNull(parseConfig(toml).get())
+    val entry = assertNotNull(config.tools["ktlint"])
+    assertEquals(Coordinate("com.pinterest.ktlint", "ktlint-cli", "1.3.1"), entry.coords)
+    assertEquals("all", entry.classifier)
+  }
+
+  @Test
+  fun parsesMultipleToolEntries() {
+    val toml =
+      baseToml +
+        """
+
+        [tools.foo]
+        coords = "a:b:1.0"
+
+        [tools.bar]
+        coords = "c:d:2.0:cls"
+      """
+          .trimIndent()
+    val config = assertNotNull(parseConfig(toml).get())
+    assertEquals(2, config.tools.size)
+    assertEquals(Coordinate("a", "b", "1.0"), config.tools["foo"]?.coords)
+    assertEquals(Coordinate("c", "d", "2.0"), config.tools["bar"]?.coords)
+    assertEquals("cls", config.tools["bar"]?.classifier)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/BundleResolverSingleArtifactTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/BundleResolverSingleArtifactTest.kt
@@ -1,0 +1,184 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BundleResolverSingleArtifactTest {
+
+  // Single Coordinate must produce exactly one resolved jar entry — no POM-derived
+  // transitive children should appear, even if the upstream POM declares them. The
+  // `[tools]` flow runs against fat / runnable jars, so transitive enumeration is
+  // out of scope (R2.4 + design.md §Resolver: transitive-skip path).
+  @Test
+  fun returnsSingleJarWithNoTransitives() {
+    val deps =
+      fakeDeps(sha256Results = mapOf("/cache/com/example/tool/1.0.0/tool-1.0.0.jar" to "abc123"))
+
+    val result =
+      resolveSingleArtifact(
+        coord = Coordinate("com.example", "tool", "1.0.0"),
+        classifier = null,
+        repos = listOf("https://repo1/"),
+        cacheBase = "/cache",
+        deps = deps,
+      )
+    val ok = assertNotNull(result.get())
+
+    assertEquals("/cache/com/example/tool/1.0.0/tool-1.0.0.jar", ok.cachePath)
+    assertEquals("abc123", ok.sha256)
+    assertEquals("com.example:tool", ok.groupArtifact)
+    assertEquals("1.0.0", ok.version)
+    assertNull(ok.classifier)
+  }
+
+  @Test
+  fun classifierIsAppendedToCachePath() {
+    val deps =
+      fakeDeps(
+        sha256Results = mapOf("/cache/com/example/tool/1.0.0/tool-1.0.0-all.jar" to "deadbeef")
+      )
+
+    val ok =
+      assertNotNull(
+        resolveSingleArtifact(
+            coord = Coordinate("com.example", "tool", "1.0.0"),
+            classifier = "all",
+            repos = listOf("https://repo1/"),
+            cacheBase = "/cache",
+            deps = deps,
+          )
+          .get()
+      )
+
+    assertEquals("/cache/com/example/tool/1.0.0/tool-1.0.0-all.jar", ok.cachePath)
+    assertEquals("all", ok.classifier)
+  }
+
+  @Test
+  fun cacheHitSkipsDownload() {
+    val downloads = mutableListOf<String>()
+    val deps =
+      fakeDeps(
+        cachedFiles = mutableSetOf("/cache/com/example/tool/1.0.0/tool-1.0.0.jar"),
+        sha256Results = mapOf("/cache/com/example/tool/1.0.0/tool-1.0.0.jar" to "abc"),
+        recordDownloads = downloads,
+      )
+
+    val ok =
+      assertNotNull(
+        resolveSingleArtifact(
+            coord = Coordinate("com.example", "tool", "1.0.0"),
+            classifier = null,
+            repos = listOf("https://repo1/"),
+            cacheBase = "/cache",
+            deps = deps,
+          )
+          .get()
+      )
+
+    assertEquals("abc", ok.sha256)
+    assertTrue(downloads.isEmpty(), "warm cache must not trigger network: got $downloads")
+  }
+
+  @Test
+  fun all404sSurfaceAsDownloadFailedWithAttempts() {
+    val deps =
+      fakeDeps(
+        downloadResult = { url, _ -> Err(DownloadError.HttpFailed(url, 404)) },
+        sha256Results = emptyMap(),
+      )
+
+    val err =
+      assertNotNull(
+        resolveSingleArtifact(
+            coord = Coordinate("com.example", "missing", "1.0.0"),
+            classifier = null,
+            repos = listOf("https://repo1/", "https://repo2/"),
+            cacheBase = "/cache",
+            deps = deps,
+          )
+          .getError()
+      )
+    val downloadFailed = assertIs<ResolveError.DownloadFailed>(err)
+    assertEquals("com.example:missing", downloadFailed.groupArtifact)
+    val attempts =
+      assertIs<RepositoryDownloadFailure.AllAttemptsFailed>(downloadFailed.failure).attempts
+    assertEquals(2, attempts.size)
+    assertEquals("https://repo1//com/example/missing/1.0.0/missing-1.0.0.jar", attempts[0].url)
+  }
+
+  // Ensure the existing [classpaths] resolveBundle path stays regression-free under
+  // a normal POM that declares no transitives. Cross-checks that adding the new entry
+  // point did not perturb the bundle pass.
+  @Test
+  fun classpathsBundlePathStillWorks() {
+    val libPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>lib</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+    val deps =
+      fakeDeps(
+        sha256Results = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.jar" to "h"),
+        pomContents = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.pom" to libPom),
+      )
+
+    val bundle =
+      assertNotNull(
+        resolveBundle(
+            config = kolt.testConfig(),
+            bundleName = "tools",
+            bundleSeeds = mapOf("com.example:lib" to "1.0.0"),
+            existingLock = null,
+            cacheBase = "/cache",
+            deps = deps,
+          )
+          .get()
+      )
+    assertEquals(1, bundle.jars.size)
+  }
+
+  private fun fakeDeps(
+    cachedFiles: MutableSet<String> = mutableSetOf(),
+    sha256Results: Map<String, String> = emptyMap(),
+    pomContents: Map<String, String> = emptyMap(),
+    downloadResult: ((String, String) -> Result<Unit, DownloadError>)? = null,
+    recordDownloads: MutableList<String>? = null,
+  ): ResolverDeps {
+    return object : ResolverDeps {
+      override fun fileExists(path: String): Boolean = path in cachedFiles
+
+      override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        recordDownloads?.add(url)
+        if (downloadResult != null) return downloadResult.invoke(url, destPath)
+        cachedFiles.add(destPath)
+        return Ok(Unit)
+      }
+
+      override fun computeSha256(filePath: String): Result<String, Sha256Error> {
+        val hash = sha256Results[filePath] ?: return Err(Sha256Error(filePath))
+        return Ok(hash)
+      }
+
+      override fun readFileContent(path: String): Result<String, OpenFailed> {
+        val content = pomContents[path] ?: return Err(OpenFailed(path))
+        return Ok(content)
+      }
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/LockfileTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/LockfileTest.kt
@@ -234,4 +234,76 @@ class LockfileTest {
     assertTrue(serialized.contains("\"version\": 4"), "must emit schema version 4")
     assertTrue(serialized.contains("\"test\": true"), "must emit per-entry test flag when true")
   }
+
+  @Test
+  fun serializeRoundTripPreservesToolsBundles() {
+    val lockfile =
+      Lockfile(
+        version = 4,
+        kotlin = "2.1.0",
+        jvmTarget = "17",
+        dependencies = emptyMap(),
+        toolsBundles =
+          mapOf(
+            "ktlint" to
+              mapOf("com.pinterest.ktlint:ktlint-cli:all" to LockEntry("1.3.1", "ktlinthash")),
+            "detekt" to
+              mapOf("io.gitlab.arturbosch.detekt:detekt-cli" to LockEntry("1.23.6", "detekthash")),
+          ),
+      )
+    val serialized = serializeLockfile(lockfile)
+    val reparsed = assertNotNull(parseLockfile(serialized).get())
+    assertEquals(lockfile, reparsed)
+    assertTrue(serialized.contains("\"tools_bundles\""), "must emit tools_bundles field")
+
+    val detektIndex = serialized.indexOf("\"detekt\"")
+    val ktlintIndex = serialized.indexOf("\"ktlint\"")
+    assertTrue(
+      detektIndex in 0..<ktlintIndex,
+      "tool aliases should be sorted alphabetically (detekt before ktlint)",
+    )
+  }
+
+  @Test
+  fun parseLockfileWithoutToolsBundlesYieldsEmptyMap() {
+    val json =
+      """
+            {
+                "version": 4,
+                "kotlin": "2.1.0",
+                "jvm_target": "17",
+                "dependencies": {}
+            }
+        """
+        .trimIndent()
+    val lockfile = assertNotNull(parseLockfile(json).get())
+    assertEquals(emptyMap(), lockfile.toolsBundles)
+  }
+
+  @Test
+  fun parseLockfileWithToolsBundles() {
+    val json =
+      """
+            {
+                "version": 4,
+                "kotlin": "2.1.0",
+                "jvm_target": "17",
+                "dependencies": {},
+                "tools_bundles": {
+                    "ktlint": {
+                        "com.pinterest.ktlint:ktlint-cli:all": {
+                            "version": "1.3.1",
+                            "sha256": "ktlinthash"
+                        }
+                    }
+                }
+            }
+        """
+        .trimIndent()
+    val lockfile = assertNotNull(parseLockfile(json).get())
+    val bundle = assertNotNull(lockfile.toolsBundles["ktlint"])
+    val entry = assertNotNull(bundle["com.pinterest.ktlint:ktlint-cli:all"])
+    assertEquals("1.3.1", entry.version)
+    assertEquals("ktlinthash", entry.sha256)
+  }
 }

--- a/src/nativeTest/kotlin/kolt/usertool/ToolErrorTest.kt
+++ b/src/nativeTest/kotlin/kolt/usertool/ToolErrorTest.kt
@@ -1,0 +1,214 @@
+package kolt.usertool
+
+import kolt.cli.EXIT_CONFIG_ERROR
+import kolt.cli.EXIT_DEPENDENCY_ERROR
+import kolt.cli.EXIT_TOOL_ERROR
+import kolt.resolve.Coordinate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ToolErrorTest {
+
+  // Parse variants — every ToolSectionParseError shape lifts through ToolError.Parse
+  // and surfaces with EXIT_CONFIG_ERROR (R5.4 cause-distinguishable surface — the prefix
+  // identifies the cause, the exit code identifies the kolt-level category).
+
+  @Test
+  fun parseInvalidAliasMapsToConfigExitCodeAndPrefix() {
+    val err =
+      ToolError.Parse(ToolSectionParseError.InvalidAlias(alias = "Foo", reason = "uppercase"))
+    assertEquals(EXIT_CONFIG_ERROR, err.toExitCode())
+    assertTrue(
+      err.formatStderr().startsWith("tool 'Foo': parse error:"),
+      "got: ${err.formatStderr()}",
+    )
+  }
+
+  @Test
+  fun parseForbiddenFieldMapsToConfigExitCodeAndPrefix() {
+    val err =
+      ToolError.Parse(ToolSectionParseError.ForbiddenField(alias = "ktlint", field = "depends-on"))
+    assertEquals(EXIT_CONFIG_ERROR, err.toExitCode())
+    assertTrue(err.formatStderr().startsWith("tool 'ktlint': parse error:"))
+    assertTrue(err.formatStderr().contains("depends-on"))
+  }
+
+  @Test
+  fun parseMalformedCoordsMapsToConfigExitCodeAndPrefix() {
+    val err =
+      ToolError.Parse(
+        ToolSectionParseError.MalformedCoords(alias = "ktlint", coords = "bogus", reason = "shape")
+      )
+    assertEquals(EXIT_CONFIG_ERROR, err.toExitCode())
+    assertTrue(err.formatStderr().startsWith("tool 'ktlint': parse error:"))
+  }
+
+  @Test
+  fun parseMissingCoordsMapsToConfigExitCodeAndPrefix() {
+    val err = ToolError.Parse(ToolSectionParseError.MissingCoords(alias = "ktlint"))
+    assertEquals(EXIT_CONFIG_ERROR, err.toExitCode())
+    assertTrue(err.formatStderr().startsWith("tool 'ktlint': parse error:"))
+  }
+
+  @Test
+  fun parseDuplicateAliasMapsToConfigExitCodeAndPrefix() {
+    val err = ToolError.Parse(ToolSectionParseError.DuplicateAlias(alias = "ktlint"))
+    assertEquals(EXIT_CONFIG_ERROR, err.toExitCode())
+    assertTrue(err.formatStderr().startsWith("tool 'ktlint': parse error:"))
+  }
+
+  // Resolve variants — surface as EXIT_DEPENDENCY_ERROR (network/integrity/lock semantics).
+
+  @Test
+  fun resolveResolveFailedMapsToDependencyExitCodeAndPrefix() {
+    val coords = Coordinate("g", "a", "1.0")
+    val err =
+      ToolError.Resolve(
+        ToolResolutionError.ResolveFailed(
+          alias = "ktlint",
+          coords = coords,
+          attempts = listOf("https://repo1/", "https://repo2/"),
+        )
+      )
+    assertEquals(EXIT_DEPENDENCY_ERROR, err.toExitCode())
+    assertTrue(err.formatStderr().startsWith("tool 'ktlint': resolve failed:"))
+  }
+
+  @Test
+  fun resolveIntegrityMismatchMapsToDependencyExitCodeAndPrefix() {
+    val err =
+      ToolError.Resolve(
+        ToolResolutionError.IntegrityMismatch(
+          alias = "ktlint",
+          coords = Coordinate("g", "a", "1.0"),
+          expected = "abc",
+          actual = "def",
+        )
+      )
+    assertEquals(EXIT_DEPENDENCY_ERROR, err.toExitCode())
+    assertTrue(err.formatStderr().startsWith("tool 'ktlint': integrity mismatch:"))
+    assertTrue(err.formatStderr().contains("abc"))
+    assertTrue(err.formatStderr().contains("def"))
+  }
+
+  // LockfileMismatch's stderr message is design-mandated verbatim — pin it.
+  @Test
+  fun resolveLockfileMismatchUsesDesignMandatedMessage() {
+    val err =
+      ToolError.Resolve(
+        ToolResolutionError.LockfileMismatch(
+          alias = "ktlint",
+          tomlCoords = Coordinate("g", "a", "1.1"),
+          tomlClassifier = null,
+          lockedCoords = Coordinate("g", "a", "1.0"),
+          lockedClassifier = null,
+        )
+      )
+    assertEquals(EXIT_DEPENDENCY_ERROR, err.toExitCode())
+    assertEquals(
+      "tool 'ktlint': lockfile pin 'g:a:1.0' differs from kolt.toml 'g:a:1.1'. " +
+        "Run `kolt update` to refresh tool pins.",
+      err.formatStderr(),
+    )
+  }
+
+  @Test
+  fun resolveLockfileMismatchWithClassifierIncludesClassifierInCoords() {
+    val err =
+      ToolError.Resolve(
+        ToolResolutionError.LockfileMismatch(
+          alias = "ktlint",
+          tomlCoords = Coordinate("g", "a", "1.1"),
+          tomlClassifier = "all",
+          lockedCoords = Coordinate("g", "a", "1.0"),
+          lockedClassifier = "all",
+        )
+      )
+    assertEquals(
+      "tool 'ktlint': lockfile pin 'g:a:1.0:all' differs from kolt.toml 'g:a:1.1:all'. " +
+        "Run `kolt update` to refresh tool pins.",
+      err.formatStderr(),
+    )
+  }
+
+  // Launch variants — the only three that route through EXIT_TOOL_ERROR=7.
+
+  @Test
+  fun launchNotRunnableJarMapsToToolExitCodeAndPrefix() {
+    val err =
+      ToolError.Launch(
+        ToolLaunchError.NotRunnableJar(
+          alias = "ktlint",
+          jarPath = "/x/y.jar",
+          reason = "zip magic mismatch",
+        )
+      )
+    assertEquals(EXIT_TOOL_ERROR, err.toExitCode())
+    assertTrue(err.formatStderr().startsWith("tool 'ktlint': not a runnable jar"))
+  }
+
+  @Test
+  fun launchMainClassMissingMapsToToolExitCodeAndPrefix() {
+    val err =
+      ToolError.Launch(ToolLaunchError.MainClassMissing(alias = "ktlint", jarPath = "/x/y.jar"))
+    assertEquals(EXIT_TOOL_ERROR, err.toExitCode())
+    assertTrue(err.formatStderr().startsWith("tool 'ktlint': Main-Class missing"))
+  }
+
+  @Test
+  fun launchJdkUnavailableMapsToToolExitCodeAndPrefix() {
+    val err = ToolError.Launch(ToolLaunchError.JdkUnavailable(cause = "install failed"))
+    assertEquals(EXIT_TOOL_ERROR, err.toExitCode())
+    assertTrue(err.formatStderr().startsWith("tool: JDK unavailable:"))
+  }
+
+  // UnknownAlias is config-shaped — exit 2 — and surfaces known aliases.
+  @Test
+  fun unknownAliasMapsToConfigExitCodeAndListsKnownAliases() {
+    val err = ToolError.UnknownAlias(alias = "ktl", knownAliases = listOf("ktlint", "detekt"))
+    assertEquals(EXIT_CONFIG_ERROR, err.toExitCode())
+    val msg = err.formatStderr()
+    assertTrue(msg.startsWith("tool 'ktl': not declared in [tools]."))
+    assertTrue(msg.contains("ktlint"))
+    assertTrue(msg.contains("detekt"))
+  }
+
+  // Pin: exactly three ToolError variants must route through EXIT_TOOL_ERROR=7.
+  // Adding a fourth would break ADR 0028 §3 freeze of jar-launch failure surface.
+  @Test
+  fun exactlyThreeVariantsRouteThroughExitToolError() {
+    val toolExitErrors: List<ToolError> =
+      listOf(
+        ToolError.Launch(ToolLaunchError.NotRunnableJar("a", "/j", "r")),
+        ToolError.Launch(ToolLaunchError.MainClassMissing("a", "/j")),
+        ToolError.Launch(ToolLaunchError.JdkUnavailable("c")),
+      )
+    assertEquals(3, toolExitErrors.count { it.toExitCode() == EXIT_TOOL_ERROR })
+    // Sanity: every other constructor we exercise lands elsewhere.
+    val nonToolExit: List<ToolError> =
+      listOf(
+        ToolError.Parse(ToolSectionParseError.MissingCoords("a")),
+        ToolError.Resolve(
+          ToolResolutionError.ResolveFailed("a", Coordinate("g", "a", "1.0"), emptyList())
+        ),
+        ToolError.Resolve(
+          ToolResolutionError.IntegrityMismatch("a", Coordinate("g", "a", "1.0"), "x", "y")
+        ),
+        ToolError.Resolve(
+          ToolResolutionError.LockfileMismatch(
+            "a",
+            Coordinate("g", "a", "1.1"),
+            null,
+            Coordinate("g", "a", "1.0"),
+            null,
+          )
+        ),
+        ToolError.UnknownAlias("a", emptyList()),
+      )
+    assertTrue(
+      nonToolExit.none { it.toExitCode() == EXIT_TOOL_ERROR },
+      "non-launch variants must not route through EXIT_TOOL_ERROR",
+    )
+  }
+}

--- a/src/nativeTest/kotlin/kolt/usertool/ToolLauncherTest.kt
+++ b/src/nativeTest/kotlin/kolt/usertool/ToolLauncherTest.kt
@@ -1,0 +1,196 @@
+package kolt.usertool
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import libarchive.ARCHIVE_OK
+import libarchive.archive_entry_free
+import libarchive.archive_entry_new
+import libarchive.archive_entry_set_filetype
+import libarchive.archive_entry_set_pathname
+import libarchive.archive_entry_set_size
+import libarchive.archive_write_close
+import libarchive.archive_write_data
+import libarchive.archive_write_free
+import libarchive.archive_write_header
+import libarchive.archive_write_new
+import libarchive.archive_write_open_filename
+import libarchive.archive_write_set_format_zip
+import platform.posix.S_IFREG
+import platform.posix.mkdtemp
+
+class ToolLauncherTest {
+
+  // ----- readMainClassFromJar -----
+
+  @Test
+  fun readsMainClassFromValidJar() {
+    val tempDir = createTempDir("kolt_jarread_ok_")
+    try {
+      val jarPath = "$tempDir/app.jar"
+      writeZip(jarPath, mapOf("META-INF/MANIFEST.MF" to "Main-Class: com.example.Main\n"))
+
+      val mainClass = readMainClassFromJar(jarPath).get()
+      assertEquals("com.example.Main", mainClass)
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun readsMainClassWithCrlfLineEndings() {
+    val tempDir = createTempDir("kolt_jarread_crlf_")
+    try {
+      val jarPath = "$tempDir/app.jar"
+      writeZip(
+        jarPath,
+        mapOf("META-INF/MANIFEST.MF" to "Manifest-Version: 1.0\r\nMain-Class: a.B\r\n"),
+      )
+      assertEquals("a.B", readMainClassFromJar(jarPath).get())
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun readsMainClassFromContinuationLines() {
+    val tempDir = createTempDir("kolt_jarread_fold_")
+    try {
+      val jarPath = "$tempDir/app.jar"
+      // RFC line-folding: a line starting with SP continues the previous line.
+      writeZip(jarPath, mapOf("META-INF/MANIFEST.MF" to "Main-Class: com.exa\n mple.Main\n"))
+
+      assertEquals("com.example.Main", readMainClassFromJar(jarPath).get())
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun returnsMainClassMissingWhenManifestAbsent() {
+    val tempDir = createTempDir("kolt_jarread_nomanifest_")
+    try {
+      val jarPath = "$tempDir/app.jar"
+      writeZip(jarPath, mapOf("payload.txt" to "no manifest here"))
+
+      val err = readMainClassFromJar(jarPath).getError()
+      val missing = assertIs<ToolLaunchError.MainClassMissing>(err)
+      assertEquals(jarPath, missing.jarPath)
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun returnsMainClassMissingWhenManifestPresentButHasNoMainClassLine() {
+    val tempDir = createTempDir("kolt_jarread_nomain_")
+    try {
+      val jarPath = "$tempDir/app.jar"
+      writeZip(jarPath, mapOf("META-INF/MANIFEST.MF" to "Manifest-Version: 1.0\n"))
+
+      val err = readMainClassFromJar(jarPath).getError()
+      assertIs<ToolLaunchError.MainClassMissing>(err)
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun returnsNotRunnableJarForPlainTextMasqueradingAsJar() {
+    val tempDir = createTempDir("kolt_jarread_text_")
+    try {
+      val jarPath = "$tempDir/fake.jar"
+      writeFileAsString(jarPath, "this is not a zip\n")
+
+      val err = readMainClassFromJar(jarPath).getError()
+      val notRunnable = assertIs<ToolLaunchError.NotRunnableJar>(err)
+      assertEquals(jarPath, notRunnable.jarPath)
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun returnsNotRunnableJarForNonexistentPath() {
+    val err = readMainClassFromJar("/nonexistent/path/does-not-exist.jar").getError()
+    assertIs<ToolLaunchError.NotRunnableJar>(err)
+  }
+
+  // ----- extractMainClass: pure helper, exercised independently of libarchive -----
+
+  @Test
+  fun extractMainClassReturnsNullWhenAbsent() {
+    assertNull(extractMainClass("Manifest-Version: 1.0\n"))
+  }
+
+  @Test
+  fun extractMainClassReturnsNullForEmptyValue() {
+    assertNull(extractMainClass("Main-Class: \n"))
+  }
+
+  @Test
+  fun extractMainClassHandlesTabContinuation() {
+    val joined = extractMainClass("Main-Class: com.exa\n\tmple.Main\n")
+    assertNotNull(joined)
+    assertEquals("com.example.Main", joined)
+  }
+
+  // ----- helpers -----
+
+  @OptIn(ExperimentalForeignApi::class)
+  private fun writeZip(path: String, entries: Map<String, String>) {
+    val writer = archive_write_new() ?: error("archive_write_new returned null")
+    try {
+      check(archive_write_set_format_zip(writer) == ARCHIVE_OK) {
+        "archive_write_set_format_zip failed"
+      }
+      check(archive_write_open_filename(writer, path) == ARCHIVE_OK) {
+        "archive_write_open_filename failed"
+      }
+      for ((name, content) in entries) {
+        val entry = archive_entry_new() ?: error("archive_entry_new returned null")
+        try {
+          archive_entry_set_pathname(entry, name)
+          val bytes = content.encodeToByteArray()
+          archive_entry_set_size(entry, bytes.size.toLong())
+          archive_entry_set_filetype(entry, S_IFREG.convert())
+          check(archive_write_header(writer, entry) == ARCHIVE_OK) { "archive_write_header failed" }
+          if (bytes.isNotEmpty()) {
+            bytes.usePinned { pinned ->
+              val written = archive_write_data(writer, pinned.addressOf(0), bytes.size.convert())
+              check(written == bytes.size.toLong()) {
+                "archive_write_data short write: $written / ${bytes.size}"
+              }
+            }
+          }
+        } finally {
+          archive_entry_free(entry)
+        }
+      }
+    } finally {
+      archive_write_close(writer)
+      archive_write_free(writer)
+    }
+  }
+
+  @OptIn(ExperimentalForeignApi::class)
+  private fun createTempDir(prefix: String): String {
+    val template = "/tmp/${prefix}XXXXXX"
+    val buf = template.encodeToByteArray().copyOf(template.length + 1)
+    buf.usePinned { pinned ->
+      val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+      return result.toKString()
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/usertool/ToolLauncherTest.kt
+++ b/src/nativeTest/kotlin/kolt/usertool/ToolLauncherTest.kt
@@ -1,14 +1,21 @@
 package kolt.usertool
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
+import kolt.config.KoltPaths
+import kolt.infra.ProcessError
 import kolt.infra.removeDirectoryRecursive
 import kolt.infra.writeFileAsString
+import kolt.resolve.Coordinate
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.convert
@@ -146,7 +153,217 @@ class ToolLauncherTest {
     assertEquals("com.example.Main", joined)
   }
 
+  // ----- launch -----
+
+  @Test
+  fun launchPropagatesZeroExitCode() {
+    val tempDir = createTempDir("kolt_launch_zero_")
+    try {
+      val jarPath = "$tempDir/app.jar"
+      writeZip(jarPath, mapOf("META-INF/MANIFEST.MF" to "Main-Class: a.B\n"))
+      val capturedCommands = mutableListOf<List<String>>()
+      val result =
+        launch(
+          alias = "stub",
+          jarHandle = handleFor(jarPath),
+          args = listOf("--foo", "bar"),
+          paths = KoltPaths(home = "/home/u"),
+          env = emptyMap(),
+          resolveJavaBin = { Ok("/fake/jdk/java") },
+          exec = { cmd, _ ->
+            capturedCommands.add(cmd)
+            Ok(0)
+          },
+        )
+      assertEquals(0, result.get())
+      assertEquals(
+        listOf(listOf("/fake/jdk/java", "-jar", jarPath, "--foo", "bar")),
+        capturedCommands,
+      )
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun launchPropagatesNonZeroExitCodeAsOk() {
+    val tempDir = createTempDir("kolt_launch_42_")
+    try {
+      val jarPath = "$tempDir/app.jar"
+      writeZip(jarPath, mapOf("META-INF/MANIFEST.MF" to "Main-Class: a.B\n"))
+      val result =
+        launch(
+          alias = "stub",
+          jarHandle = handleFor(jarPath),
+          args = emptyList(),
+          paths = KoltPaths(home = "/home/u"),
+          env = emptyMap(),
+          resolveJavaBin = { Ok("/fake/jdk/java") },
+          exec = { _, _ -> Err(ProcessError.NonZeroExit(42)) },
+        )
+      assertEquals(42, result.get())
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun launchEmitsVerboseLineWhenKoltVerboseSet() {
+    val tempDir = createTempDir("kolt_launch_verbose_")
+    try {
+      val jarPath = "$tempDir/app.jar"
+      writeZip(jarPath, mapOf("META-INF/MANIFEST.MF" to "Main-Class: a.B\n"))
+      val logged = mutableListOf<String>()
+      launch(
+        alias = "ktlint",
+        jarHandle = handleFor(jarPath),
+        args = emptyList(),
+        paths = KoltPaths(home = "/home/u"),
+        env = mapOf("KOLT_VERBOSE" to "1"),
+        resolveJavaBin = { Ok("/jdk25/bin/java") },
+        exec = { _, _ -> Ok(0) },
+        log = { logged.add(it) },
+      )
+      assertEquals(1, logged.size, "expected single verbose line, got $logged")
+      assertEquals("tool=ktlint jdk=/jdk25/bin/java jar=$jarPath", logged.single())
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun launchSuppressesVerboseLineWhenKoltVerboseUnset() {
+    val tempDir = createTempDir("kolt_launch_quiet_")
+    try {
+      val jarPath = "$tempDir/app.jar"
+      writeZip(jarPath, mapOf("META-INF/MANIFEST.MF" to "Main-Class: a.B\n"))
+      val logged = mutableListOf<String>()
+      launch(
+        alias = "x",
+        jarHandle = handleFor(jarPath),
+        args = emptyList(),
+        paths = KoltPaths(home = "/home/u"),
+        env = emptyMap(),
+        resolveJavaBin = { Ok("/jdk/java") },
+        exec = { _, _ -> Ok(0) },
+        log = { logged.add(it) },
+      )
+      assertTrue(logged.isEmpty(), "verbose log unexpectedly emitted: $logged")
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun launchReturnsJdkUnavailableWhenResolveFails() {
+    val tempDir = createTempDir("kolt_launch_nojdk_")
+    try {
+      val jarPath = "$tempDir/app.jar"
+      writeZip(jarPath, mapOf("META-INF/MANIFEST.MF" to "Main-Class: a.B\n"))
+      val result =
+        launch(
+          alias = "stub",
+          jarHandle = handleFor(jarPath),
+          args = emptyList(),
+          paths = KoltPaths(home = "/home/u"),
+          env = emptyMap(),
+          resolveJavaBin = { Err("install failed: disk full") },
+          exec = { _, _ -> error("exec must not be called when JDK is unavailable") },
+        )
+      val err = assertIs<ToolLaunchError.JdkUnavailable>(result.getError())
+      assertEquals("install failed: disk full", err.cause)
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun launchLiftsManifestMissingErrorWithAlias() {
+    val tempDir = createTempDir("kolt_launch_nomain_")
+    try {
+      val jarPath = "$tempDir/app.jar"
+      writeZip(jarPath, mapOf("META-INF/MANIFEST.MF" to "Manifest-Version: 1.0\n"))
+      var execCalled = false
+      val result =
+        launch(
+          alias = "ktlint",
+          jarHandle = handleFor(jarPath),
+          args = emptyList(),
+          paths = KoltPaths(home = "/home/u"),
+          env = emptyMap(),
+          resolveJavaBin = { Ok("/jdk/java") },
+          exec = { _, _ ->
+            execCalled = true
+            Ok(0)
+          },
+        )
+      val err = assertIs<ToolLaunchError.MainClassMissing>(result.getError())
+      assertEquals("ktlint", err.alias)
+      assertFalse(execCalled, "exec must not run when MANIFEST has no Main-Class")
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun launchLiftsNotRunnableJarErrorWithAlias() {
+    val tempDir = createTempDir("kolt_launch_text_")
+    try {
+      val jarPath = "$tempDir/fake.jar"
+      writeFileAsString(jarPath, "not a zip\n")
+      val result =
+        launch(
+          alias = "detekt",
+          jarHandle = handleFor(jarPath),
+          args = emptyList(),
+          paths = KoltPaths(home = "/home/u"),
+          env = emptyMap(),
+          resolveJavaBin = { Ok("/jdk/java") },
+          exec = { _, _ -> Ok(0) },
+        )
+      val err = assertIs<ToolLaunchError.NotRunnableJar>(result.getError())
+      assertEquals("detekt", err.alias)
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
+  @Test
+  fun launchPassesEnvVerbatimToExec() {
+    val tempDir = createTempDir("kolt_launch_env_")
+    try {
+      val jarPath = "$tempDir/app.jar"
+      writeZip(jarPath, mapOf("META-INF/MANIFEST.MF" to "Main-Class: a.B\n"))
+      val expectedEnv = mapOf("FOO" to "bar", "KOLT_VERBOSE" to "1")
+      val seenEnvs = mutableListOf<Map<String, String>>()
+      launch(
+        alias = "x",
+        jarHandle = handleFor(jarPath),
+        args = emptyList(),
+        paths = KoltPaths(home = "/home/u"),
+        env = expectedEnv,
+        resolveJavaBin = { Ok("/jdk/java") },
+        exec = { _, env ->
+          seenEnvs.add(env)
+          Ok(0)
+        },
+        log = { /* swallow verbose */ },
+      )
+      assertEquals(listOf(expectedEnv), seenEnvs)
+    } finally {
+      removeDirectoryRecursive(tempDir)
+    }
+  }
+
   // ----- helpers -----
+
+  private fun handleFor(jarPath: String): ToolJarHandle =
+    ToolJarHandle(
+      jarPath = jarPath,
+      resolvedCoords = Coordinate("g", "a", "1.0"),
+      classifier = null,
+      lockfileChanged = false,
+    )
 
   @OptIn(ExperimentalForeignApi::class)
   private fun writeZip(path: String, entries: Map<String, String>) {

--- a/src/nativeTest/kotlin/kolt/usertool/ToolResolutionTest.kt
+++ b/src/nativeTest/kotlin/kolt/usertool/ToolResolutionTest.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
 import kolt.config.KoltPaths
 import kolt.infra.CopyFailed
 import kolt.infra.DownloadError
@@ -17,6 +18,7 @@ import kolt.resolve.ResolverDeps
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -172,6 +174,176 @@ class ToolResolutionTest {
     assertFalse(handle.lockfileChanged, "matching pin must not flag lockfile as changed")
     assertEquals(1, deps.downloads.size, "must fetch into Maven cache")
     assertEquals(listOf(mavenJarPath to toolsJarPath), deps.copies)
+  }
+
+  // ----- Failure path: LockfileMismatch (version differs) -----
+  @Test
+  fun versionDivergenceBetweenTomlAndLockfileSurfacesAsLockfileMismatch() {
+    // toml says 1.1.0, lockfile pin says 1.0.0. Inner key (group:artifact[:classifier]) is the
+    // same, but version differs — must reject loudly without touching network or cache.
+    val tomlCoords = Coordinate("com.example", "tool", "1.1.0")
+    val deps = fakeDeps()
+
+    val lockfile =
+      lockfileWithToolPin(
+        alias = "mytool",
+        innerKey = "com.example:tool",
+        version = "1.0.0",
+        sha256 = "old",
+      )
+
+    val err =
+      assertNotNull(
+        ensureTool(
+            alias = "mytool",
+            entry = ToolEntry(tomlCoords, classifier = null),
+            paths = paths,
+            lockfile = lockfile,
+            netDeps = deps,
+          )
+          .getError()
+      )
+    val mismatch = assertIs<ToolResolutionError.LockfileMismatch>(err)
+    assertEquals("mytool", mismatch.alias)
+    assertEquals(tomlCoords, mismatch.tomlCoords)
+    assertEquals(Coordinate("com.example", "tool", "1.0.0"), mismatch.lockedCoords)
+    assertTrue(deps.downloads.isEmpty(), "mismatch must not trigger network")
+    assertTrue(deps.copies.isEmpty(), "mismatch must not trigger copy")
+  }
+
+  // ----- Failure path: LockfileMismatch (classifier differs) -----
+  @Test
+  fun classifierDivergenceBetweenTomlAndLockfileSurfacesAsLockfileMismatch() {
+    val tomlCoords = Coordinate("com.example", "tool", "1.0.0")
+    val deps = fakeDeps()
+
+    // Lockfile entry pins the same group:artifact:version but with a different classifier.
+    val lockfile =
+      lockfileWithToolPin(
+        alias = "mytool",
+        innerKey = "com.example:tool:sources",
+        version = "1.0.0",
+        sha256 = "old",
+      )
+
+    val err =
+      assertNotNull(
+        ensureTool(
+            alias = "mytool",
+            entry = ToolEntry(tomlCoords, classifier = "all"),
+            paths = paths,
+            lockfile = lockfile,
+            netDeps = deps,
+          )
+          .getError()
+      )
+    val mismatch = assertIs<ToolResolutionError.LockfileMismatch>(err)
+    assertEquals("all", mismatch.tomlClassifier)
+    assertEquals("sources", mismatch.lockedClassifier)
+  }
+
+  // ----- Failure path: LockfileMismatch (group differs) -----
+  @Test
+  fun groupArtifactDivergenceSurfacesAsLockfileMismatch() {
+    val tomlCoords = Coordinate("com.example", "tool", "1.0.0")
+    val deps = fakeDeps()
+    // Different group on the locked side — inner key won't match the toml entry, but the alias
+    // already has a pin so we must surface a mismatch rather than treat it as first run.
+    val lockfile =
+      lockfileWithToolPin(
+        alias = "mytool",
+        innerKey = "io.other:tool",
+        version = "1.0.0",
+        sha256 = "old",
+      )
+
+    val err =
+      assertNotNull(
+        ensureTool(
+            alias = "mytool",
+            entry = ToolEntry(tomlCoords, classifier = null),
+            paths = paths,
+            lockfile = lockfile,
+            netDeps = deps,
+          )
+          .getError()
+      )
+    assertIs<ToolResolutionError.LockfileMismatch>(err)
+  }
+
+  // ----- Failure path: cache jar SHA-256 mismatch with lockfile pin -----
+  @Test
+  fun cacheShaMismatchWithPinSurfacesAsIntegrityMismatchAndDoesNotRefetch() {
+    val coords = Coordinate("com.example", "tool", "1.0.0")
+    val toolsJarPath = paths.toolsBundleJarPath("mytool", "1.0.0", "tool-1.0.0.jar")
+    // The on-disk jar hashes to "tampered" but the lockfile pin says "expected" — integrity
+    // failure must not auto-refetch (R3.3 in design.md), it must surface to the user.
+    val deps =
+      fakeDeps(
+        cachedFiles = mutableSetOf(toolsJarPath),
+        sha256Results = mapOf(toolsJarPath to "tampered"),
+      )
+
+    val lockfile =
+      lockfileWithToolPin(
+        alias = "mytool",
+        innerKey = "com.example:tool",
+        version = "1.0.0",
+        sha256 = "expected",
+      )
+
+    val err =
+      assertNotNull(
+        ensureTool(
+            alias = "mytool",
+            entry = ToolEntry(coords, classifier = null),
+            paths = paths,
+            lockfile = lockfile,
+            netDeps = deps,
+          )
+          .getError()
+      )
+    val integrity = assertIs<ToolResolutionError.IntegrityMismatch>(err)
+    assertEquals("expected", integrity.expected)
+    assertEquals("tampered", integrity.actual)
+    assertTrue(
+      deps.downloads.isEmpty(),
+      "integrity mismatch must NOT trigger automatic refetch (got ${deps.downloads})",
+    )
+  }
+
+  // ----- Failure path: network fetch fails (all repos return 404) -----
+  @Test
+  fun allRepos404SurfaceAsResolveFailedWithAttemptedUrls() {
+    val coords = Coordinate("com.example", "tool", "1.0.0")
+    val tried = listOf("https://repo1/", "https://repo2/")
+    val deps = fakeDeps(downloadResult = { url, _ -> Err(DownloadError.HttpFailed(url, 404)) })
+    val lockfile = emptyLockfile()
+
+    val err =
+      assertNotNull(
+        ensureTool(
+            alias = "mytool",
+            entry = ToolEntry(coords, classifier = null),
+            paths = paths,
+            lockfile = lockfile,
+            netDeps = deps,
+            repos = tried,
+          )
+          .getError()
+      )
+    val resolveFailed = assertIs<ToolResolutionError.ResolveFailed>(err)
+    assertEquals("mytool", resolveFailed.alias)
+    assertEquals(coords, resolveFailed.coords)
+    assertEquals(
+      2,
+      resolveFailed.attempts.size,
+      "expected 2 repo URLs, got ${resolveFailed.attempts}",
+    )
+    assertTrue(
+      resolveFailed.attempts.all { it.contains("com/example/tool/1.0.0/tool-1.0.0.jar") },
+      "attempts must include the jar URL: ${resolveFailed.attempts}",
+    )
   }
 
   // ----- Helpers -----

--- a/src/nativeTest/kotlin/kolt/usertool/ToolResolutionTest.kt
+++ b/src/nativeTest/kotlin/kolt/usertool/ToolResolutionTest.kt
@@ -1,0 +1,250 @@
+package kolt.usertool
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import kolt.config.KoltPaths
+import kolt.infra.CopyFailed
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kolt.resolve.Coordinate
+import kolt.resolve.LockEntry
+import kolt.resolve.Lockfile
+import kolt.resolve.ResolverDeps
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ToolResolutionTest {
+
+  private val paths = KoltPaths(home = "/home/u")
+  private val repos = listOf("https://central/")
+
+  // The Maven-layout cacheBase that resolveSingleArtifact writes into.
+  private val cacheBase = "/home/u/.kolt/cache"
+
+  // ----- Cache hit: jar exists at toolsBundleJarPath AND lockfile pin matches -----
+  @Test
+  fun cacheHitReturnsHandleWithoutNetworkOrCopy() {
+    val toolsJarPath = paths.toolsBundleJarPath("ktlint", "1.3.1", "ktlint-cli-1.3.1-all.jar")
+    val deps =
+      fakeDeps(
+        cachedFiles = mutableSetOf(toolsJarPath),
+        sha256Results = mapOf(toolsJarPath to "abc123"),
+      )
+
+    val lockfile =
+      lockfileWithToolPin(
+        alias = "ktlint",
+        innerKey = "com.pinterest.ktlint:ktlint-cli:all",
+        version = "1.3.1",
+        sha256 = "abc123",
+      )
+
+    val handle =
+      assertNotNull(
+        ensureTool(
+            alias = "ktlint",
+            entry =
+              ToolEntry(
+                Coordinate("com.pinterest.ktlint", "ktlint-cli", "1.3.1"),
+                classifier = "all",
+              ),
+            paths = paths,
+            lockfile = lockfile,
+            netDeps = deps,
+          )
+          .get()
+      )
+
+    assertEquals(toolsJarPath, handle.jarPath)
+    assertEquals("all", handle.classifier)
+    assertFalse(handle.lockfileChanged, "warm cache must not require lockfile rewrite")
+    assertTrue(deps.downloads.isEmpty(), "warm cache must skip download: ${deps.downloads}")
+    assertTrue(deps.copies.isEmpty(), "warm cache must skip copy: ${deps.copies}")
+  }
+
+  @Test
+  fun cacheHitForCoordsWithoutClassifierUsesSimpleInnerKey() {
+    val toolsJarPath = paths.toolsBundleJarPath("detekt", "1.23.6", "detekt-cli-1.23.6.jar")
+    val deps =
+      fakeDeps(
+        cachedFiles = mutableSetOf(toolsJarPath),
+        sha256Results = mapOf(toolsJarPath to "xyz"),
+      )
+
+    val lockfile =
+      lockfileWithToolPin(
+        alias = "detekt",
+        innerKey = "io.gitlab.arturbosch.detekt:detekt-cli",
+        version = "1.23.6",
+        sha256 = "xyz",
+      )
+
+    val handle =
+      assertNotNull(
+        ensureTool(
+            alias = "detekt",
+            entry =
+              ToolEntry(
+                Coordinate("io.gitlab.arturbosch.detekt", "detekt-cli", "1.23.6"),
+                classifier = null,
+              ),
+            paths = paths,
+            lockfile = lockfile,
+            netDeps = deps,
+          )
+          .get()
+      )
+
+    assertEquals(toolsJarPath, handle.jarPath)
+    assertTrue(deps.downloads.isEmpty())
+  }
+
+  // ----- Cache miss + no lockfile pin (first run): fetch + copy + lockfileChanged -----
+  @Test
+  fun cacheMissNoPinFetchesCopiesAndMarksLockfileChanged() {
+    val coords = Coordinate("com.example", "tool", "1.0.0")
+    val mavenJarPath = "$cacheBase/com/example/tool/1.0.0/tool-1.0.0-all.jar"
+    val toolsJarPath = paths.toolsBundleJarPath("mytool", "1.0.0", "tool-1.0.0-all.jar")
+    val deps = fakeDeps(sha256Results = mapOf(mavenJarPath to "freshhash"))
+
+    val lockfile = emptyLockfile()
+
+    val handle =
+      assertNotNull(
+        ensureTool(
+            alias = "mytool",
+            entry = ToolEntry(coords, classifier = "all"),
+            paths = paths,
+            lockfile = lockfile,
+            netDeps = deps,
+          )
+          .get()
+      )
+
+    assertEquals(toolsJarPath, handle.jarPath)
+    assertEquals(coords, handle.resolvedCoords)
+    assertEquals("all", handle.classifier)
+    assertTrue(handle.lockfileChanged, "first-run cache miss must request lockfile write-through")
+    assertEquals(1, deps.downloads.size, "expected single fetch: got ${deps.downloads}")
+    assertEquals(
+      listOf(mavenJarPath to toolsJarPath),
+      deps.copies,
+      "must copy from Maven cache to per-alias path",
+    )
+  }
+
+  // ----- Cache miss + lockfile pin present: fetch per pin, lockfileChanged=false -----
+  @Test
+  fun cacheMissWithMatchingPinFetchesAndKeepsLockfileUnchanged() {
+    val coords = Coordinate("com.pinterest.ktlint", "ktlint-cli", "1.3.1")
+    val mavenJarPath = "$cacheBase/com/pinterest/ktlint/ktlint-cli/1.3.1/ktlint-cli-1.3.1-all.jar"
+    val toolsJarPath = paths.toolsBundleJarPath("ktlint", "1.3.1", "ktlint-cli-1.3.1-all.jar")
+    val deps = fakeDeps(sha256Results = mapOf(mavenJarPath to "pinnedhash"))
+
+    val lockfile =
+      lockfileWithToolPin(
+        alias = "ktlint",
+        innerKey = "com.pinterest.ktlint:ktlint-cli:all",
+        version = "1.3.1",
+        sha256 = "pinnedhash",
+      )
+
+    val handle =
+      assertNotNull(
+        ensureTool(
+            alias = "ktlint",
+            entry = ToolEntry(coords, classifier = "all"),
+            paths = paths,
+            lockfile = lockfile,
+            netDeps = deps,
+          )
+          .get()
+      )
+
+    assertEquals(toolsJarPath, handle.jarPath)
+    assertFalse(handle.lockfileChanged, "matching pin must not flag lockfile as changed")
+    assertEquals(1, deps.downloads.size, "must fetch into Maven cache")
+    assertEquals(listOf(mavenJarPath to toolsJarPath), deps.copies)
+  }
+
+  // ----- Helpers -----
+
+  private fun emptyLockfile(): Lockfile =
+    Lockfile(
+      version = 4,
+      kotlin = "2.1.0",
+      jvmTarget = "17",
+      dependencies = emptyMap(),
+      classpathBundles = emptyMap(),
+      toolsBundles = emptyMap(),
+    )
+
+  private fun lockfileWithToolPin(
+    alias: String,
+    innerKey: String,
+    version: String,
+    sha256: String,
+  ): Lockfile =
+    Lockfile(
+      version = 4,
+      kotlin = "2.1.0",
+      jvmTarget = "17",
+      dependencies = emptyMap(),
+      classpathBundles = emptyMap(),
+      toolsBundles =
+        mapOf(alias to mapOf(innerKey to LockEntry(version = version, sha256 = sha256))),
+    )
+
+  private class FakeNetDeps(
+    val cachedFiles: MutableSet<String>,
+    val sha256Results: Map<String, String>,
+    val pomContents: Map<String, String>,
+    val downloadResult: ((String, String) -> Result<Unit, DownloadError>)?,
+    val copyResult: ((String, String) -> Result<Unit, CopyFailed>)?,
+    val downloads: MutableList<String> = mutableListOf(),
+    val copies: MutableList<Pair<String, String>> = mutableListOf(),
+  ) : ResolverDeps, ToolFsDeps {
+    override fun fileExists(path: String): Boolean = path in cachedFiles
+
+    override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+    override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      downloads.add(url)
+      if (downloadResult != null) return downloadResult.invoke(url, destPath)
+      cachedFiles.add(destPath)
+      return Ok(Unit)
+    }
+
+    override fun computeSha256(filePath: String): Result<String, Sha256Error> {
+      val hash = sha256Results[filePath] ?: return Err(Sha256Error(filePath))
+      return Ok(hash)
+    }
+
+    override fun readFileContent(path: String): Result<String, OpenFailed> {
+      val content = pomContents[path] ?: return Err(OpenFailed(path))
+      return Ok(content)
+    }
+
+    override fun copyFile(src: String, dest: String): Result<Unit, CopyFailed> {
+      copies.add(src to dest)
+      if (copyResult != null) return copyResult.invoke(src, dest)
+      cachedFiles.add(dest)
+      return Ok(Unit)
+    }
+  }
+
+  private fun fakeDeps(
+    cachedFiles: MutableSet<String> = mutableSetOf(),
+    sha256Results: Map<String, String> = emptyMap(),
+    pomContents: Map<String, String> = emptyMap(),
+    downloadResult: ((String, String) -> Result<Unit, DownloadError>)? = null,
+    copyResult: ((String, String) -> Result<Unit, CopyFailed>)? = null,
+  ) = FakeNetDeps(cachedFiles, sha256Results, pomContents, downloadResult, copyResult)
+}

--- a/src/nativeTest/kotlin/kolt/usertool/ToolSectionParseTest.kt
+++ b/src/nativeTest/kotlin/kolt/usertool/ToolSectionParseTest.kt
@@ -1,0 +1,113 @@
+package kolt.usertool
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.resolve.Coordinate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ToolSectionParseTest {
+
+  @Test
+  fun parsesGroupArtifactVersion() {
+    val result = parseCoordsString("a.b:c:1.0")
+    val pair = assertNotNull(result.get())
+    assertEquals(Coordinate("a.b", "c", "1.0"), pair.first)
+    assertNull(pair.second)
+  }
+
+  @Test
+  fun parsesGroupArtifactVersionClassifier() {
+    val result = parseCoordsString("a.b:c:1.0:cls")
+    val pair = assertNotNull(result.get())
+    assertEquals(Coordinate("a.b", "c", "1.0"), pair.first)
+    assertEquals("cls", pair.second)
+  }
+
+  @Test
+  fun parsesRealisticKtlintCoords() {
+    val result = parseCoordsString("com.pinterest.ktlint:ktlint-cli:1.3.1:all")
+    val pair = assertNotNull(result.get())
+    assertEquals(Coordinate("com.pinterest.ktlint", "ktlint-cli", "1.3.1"), pair.first)
+    assertEquals("all", pair.second)
+  }
+
+  @Test
+  fun rejectsMissingVersion() {
+    val err = parseCoordsString("a.b:c").getError()
+    assertNotNull(err)
+  }
+
+  @Test
+  fun rejectsEmptyString() {
+    val err = parseCoordsString("").getError()
+    assertNotNull(err)
+  }
+
+  @Test
+  fun rejectsMissingGroup() {
+    val err = parseCoordsString(":c:1.0").getError()
+    assertNotNull(err)
+  }
+
+  @Test
+  fun rejectsMissingArtifact() {
+    val err = parseCoordsString("a.b::1.0").getError()
+    assertNotNull(err)
+  }
+
+  @Test
+  fun rejectsEmptyVersion() {
+    val err = parseCoordsString("a.b:c:").getError()
+    assertNotNull(err)
+  }
+
+  @Test
+  fun rejectsTooManyColons() {
+    val err = parseCoordsString("a:b:1.0:cls:extra").getError()
+    assertNotNull(err)
+  }
+
+  @Test
+  fun rejectsInvalidGroupCharset() {
+    val err = parseCoordsString("a/b:c:1.0").getError()
+    assertNotNull(err)
+  }
+
+  @Test
+  fun rejectsInvalidArtifactCharset() {
+    val err = parseCoordsString("a.b:c d:1.0").getError()
+    assertNotNull(err)
+  }
+
+  @Test
+  fun rejectsInvalidClassifierCharset() {
+    val err = parseCoordsString("a.b:c:1.0:cl s").getError()
+    assertNotNull(err)
+  }
+
+  @Test
+  fun acceptsAllowedCharsetsInGroupArtifactVersionClassifier() {
+    val result = parseCoordsString("g_1.A-x:art-2_b.x:1.0-RC_1:cl-s_2.x")
+    val pair = assertNotNull(result.get())
+    assertEquals(Coordinate("g_1.A-x", "art-2_b.x", "1.0-RC_1"), pair.first)
+    assertEquals("cl-s_2.x", pair.second)
+  }
+
+  @Test
+  fun rejectsEmptyClassifier() {
+    // Trailing colon without classifier means malformed (4 parts but classifier empty).
+    val err = parseCoordsString("a.b:c:1.0:").getError()
+    assertNotNull(err)
+  }
+
+  @Test
+  fun errorMessageMentionsInput() {
+    val err = parseCoordsString("not-coords").getError()
+    assertNotNull(err)
+    assertTrue(err.isNotEmpty(), "error message should be non-empty")
+  }
+}

--- a/src/nativeTest/kotlin/kolt/usertool/ToolSectionParseTest.kt
+++ b/src/nativeTest/kotlin/kolt/usertool/ToolSectionParseTest.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.getError
 import kolt.resolve.Coordinate
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -109,5 +110,122 @@ class ToolSectionParseTest {
     val err = parseCoordsString("not-coords").getError()
     assertNotNull(err)
     assertTrue(err.isNotEmpty(), "error message should be non-empty")
+  }
+
+  // parseToolSection coverage --------------------------------------------------
+
+  @Test
+  fun parseToolSectionAcceptsHappyPath() {
+    val raw = mapOf("ktlint" to RawToolEntry(coords = "com.pinterest.ktlint:ktlint-cli:1.3.1:all"))
+    val result = parseToolSection(raw).get()
+    val map = assertNotNull(result)
+    val entry = assertNotNull(map["ktlint"])
+    assertEquals(Coordinate("com.pinterest.ktlint", "ktlint-cli", "1.3.1"), entry.coords)
+    assertEquals("all", entry.classifier)
+  }
+
+  @Test
+  fun parseToolSectionReturnsEmptyForNullInput() {
+    val map = assertNotNull(parseToolSection(null).get())
+    assertTrue(map.isEmpty())
+  }
+
+  @Test
+  fun parseToolSectionReturnsEmptyForEmptyInput() {
+    val map = assertNotNull(parseToolSection(emptyMap()).get())
+    assertTrue(map.isEmpty())
+  }
+
+  @Test
+  fun parseToolSectionRejectsUppercaseAlias() {
+    val raw = mapOf("Foo" to RawToolEntry(coords = "a:b:1.0"))
+    val err = assertIs<ToolSectionParseError.InvalidAlias>(parseToolSection(raw).getError())
+    assertEquals("Foo", err.alias)
+  }
+
+  @Test
+  fun parseToolSectionRejectsAliasStartingWithDigit() {
+    val raw = mapOf("1foo" to RawToolEntry(coords = "a:b:1.0"))
+    val err = assertIs<ToolSectionParseError.InvalidAlias>(parseToolSection(raw).getError())
+    assertEquals("1foo", err.alias)
+  }
+
+  @Test
+  fun parseToolSectionRejects65CharAlias() {
+    val alias = "a" + "b".repeat(64) // 65 chars total
+    assertEquals(65, alias.length)
+    val raw = mapOf(alias to RawToolEntry(coords = "a:b:1.0"))
+    val err = assertIs<ToolSectionParseError.InvalidAlias>(parseToolSection(raw).getError())
+    assertEquals(alias, err.alias)
+  }
+
+  @Test
+  fun parseToolSectionAccepts64CharAlias() {
+    val alias = "a" + "b".repeat(63) // 64 chars total
+    assertEquals(64, alias.length)
+    val raw = mapOf(alias to RawToolEntry(coords = "a:b:1.0"))
+    val map = assertNotNull(parseToolSection(raw).get())
+    assertNotNull(map[alias])
+  }
+
+  @Test
+  fun parseToolSectionAcceptsAliasWithUnderscoreAndHyphen() {
+    val raw = mapOf("foo_bar-baz" to RawToolEntry(coords = "a:b:1.0"))
+    val map = assertNotNull(parseToolSection(raw).get())
+    assertNotNull(map["foo_bar-baz"])
+  }
+
+  @Test
+  fun parseToolSectionRejectsArgsField() {
+    val raw = mapOf("foo" to RawToolEntry(coords = "a:b:1.0", args = emptyList()))
+    val err = assertIs<ToolSectionParseError.ForbiddenField>(parseToolSection(raw).getError())
+    assertEquals("foo", err.alias)
+    assertEquals("args", err.field)
+  }
+
+  @Test
+  fun parseToolSectionRejectsDependsOnField() {
+    val raw = mapOf("foo" to RawToolEntry(coords = "a:b:1.0", dependsOn = "x"))
+    val err = assertIs<ToolSectionParseError.ForbiddenField>(parseToolSection(raw).getError())
+    assertEquals("foo", err.alias)
+    assertEquals("depends-on", err.field)
+  }
+
+  @Test
+  fun parseToolSectionRejectsMainField() {
+    val raw = mapOf("foo" to RawToolEntry(coords = "a:b:1.0", main = "com.example.Main"))
+    val err = assertIs<ToolSectionParseError.ForbiddenField>(parseToolSection(raw).getError())
+    assertEquals("foo", err.alias)
+    assertEquals("main", err.field)
+  }
+
+  @Test
+  fun parseToolSectionRejectsMissingCoords() {
+    val raw = mapOf("foo" to RawToolEntry(coords = null))
+    val err = assertIs<ToolSectionParseError.MissingCoords>(parseToolSection(raw).getError())
+    assertEquals("foo", err.alias)
+  }
+
+  @Test
+  fun parseToolSectionRejectsMalformedCoords() {
+    val raw = mapOf("foo" to RawToolEntry(coords = "no-colons-here"))
+    val err = assertIs<ToolSectionParseError.MalformedCoords>(parseToolSection(raw).getError())
+    assertEquals("foo", err.alias)
+    assertEquals("no-colons-here", err.coords)
+    assertTrue(err.reason.isNotEmpty())
+  }
+
+  @Test
+  fun parseToolSectionForbiddenFieldOverridesMissingCoords() {
+    // If both forbidden field and missing coords coexist, surface the forbidden
+    // field (more useful diagnostic — user removed coords by accident is rare).
+    // This is an implementation choice; only assert deterministic ordering.
+    val raw = mapOf("foo" to RawToolEntry(coords = null, args = emptyList()))
+    val err = parseToolSection(raw).getError()
+    assertNotNull(err)
+    // Either ForbiddenField or MissingCoords is acceptable as long as it's deterministic.
+    assertTrue(
+      err is ToolSectionParseError.ForbiddenField || err is ToolSectionParseError.MissingCoords
+    )
   }
 }


### PR DESCRIPTION
Closes #341.

Adds a `[tools]` section to kolt.toml. Each entry pins a runnable jar by Maven coordinates; `kolt tool run <alias> [args...]` resolves it into `~/.kolt/tools/bundles/<alias>/<version>/`, pins it in `kolt.lock`'s new `tools_bundles` field, and launches it under the bootstrap JDK. `kolt update` re-resolves both `[dependencies]` and `[tools]` in one atomic write.

Spec at `.kiro/specs/341-tools-section/`. ADR 0028 §3 grows one sub-section pinning six new freeze surfaces (toml schema, lockfile field, CLI surface, cache layout, `EXIT_TOOL_ERROR=7`, `kolt update` scope). After v1.0, narrowing any of them is a major.

## Where to focus the review

- New package `kolt.usertool` is deliberately beside (not inside) `kolt.tool` (toolchain provisioning) to keep the orchestration ban (R7) at a package boundary. CLI is a subcommand (`kolt tool run`), not a separate `kolt-x` binary — `research.md` captures the trade-off.
- Strict-key reject for forbidden orchestration fields uses explicit nullable `RawToolEntry` fields (`dependsOn` / `args` / `main`) rather than a ktoml AST scan. Simpler, but only catches named fields. ADR 0028 §3 additive-only is the long-term guard.
- `ToolError` exit-code mapping reuses kolt's existing semantic categories (`EXIT_CONFIG_ERROR=2`, `EXIT_DEPENDENCY_ERROR=3`, `EXIT_TOOL_ERROR=7`) instead of giving each variant its own slot. Cause-distinguishability moves to the stderr prefix; `ToolErrorTest.exactlyThreeVariantsRouteThroughExitToolError` pins the launch trio (`NotRunnableJar` / `MainClassMissing` / `JdkUnavailable`).
- R4.3 lockfile mismatch surfaces verbatim message wording from design.md and routes the user to `kolt update`. `doUpdateInner` is the single re-resolve path for both `[dependencies]` and `[tools]`.
- ADR 0028 §3 amendment: read `docs/adr/0028-v1-release-policy.md` carefully — six v1-stable surfaces ship together.

## Things to double-check

- `KOLT_VERBOSE=1` line format from `ToolLauncher.launch` (`tool=<alias> jdk=<javaBin> jar=<jarPath>` to stderr) — covered by unit tests but not yet validated against a real ktlint/detekt run.
- `BootstrapJdk` lives in `kolt.build.daemon`, not `kolt.tool` as design.md §Allowed Dependencies suggested. Harmless naming drift, recorded in tasks.md Implementation Notes.

## Test plan

- `kolt build` self-host: PASS (~19s)
- `kolt test`: 1708 PASS (+107 vs baseline)
- `kolt --help` lists the `tool` line; `kolt tool` exits 2 with usage
- `/kiro-validate-impl 341-tools-section`: GO (28/28 requirements, boundary audit clean, ADR amendment present)
- Real Maven Central fetch with ktlint or detekt as follow-up dogfood (`docs/dogfood.md`) recommended before merge.