### PR TITLE
Print download progress in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,9 +17,21 @@ KOLT_VERSION="${KOLT_VERSION:-}"
 KOLT_ALLOW_YANKED="${KOLT_ALLOW_YANKED:-0}"
 KOLT_TEST_BASE_URL="${KOLT_TEST_BASE_URL:-}"
 KOLT_TEST_YANKED_URL="${KOLT_TEST_YANKED_URL:-}"
+KOLT_TEST_RELEASES_URL="${KOLT_TEST_RELEASES_URL:-}"
 
 DEFAULT_YANKED_URL="https://raw.githubusercontent.com/snicmakino/kolt/main/YANKED"
 DEFAULT_RELEASES_API="https://api.github.com/repos/snicmakino/kolt/releases?per_page=100"
+
+# Progress output goes to stderr because fetch_yanked_and_validate /
+# select_version / download_and_verify return values via stdout ($()).
+progress_start() {
+    echo "fetching $1..." >&2
+}
+
+progress_done() {
+    ps_bytes=$(wc -c < "$1" | tr -d ' ')
+    echo "  done (${ps_bytes} bytes)" >&2
+}
 
 platform_detect() {
     os=$(uname -s)
@@ -47,11 +59,13 @@ fetch_yanked_and_validate() {
     url="${KOLT_TEST_YANKED_URL:-$DEFAULT_YANKED_URL}"
     tempfile=$(mktemp)
 
+    progress_start "YANKED manifest from $url"
     if ! curl -fsSL -o "$tempfile" "$url"; then
         rm -f "$tempfile"
         echo "fetch_yanked: failed to fetch $url" >&2
         exit 6
     fi
+    progress_done "$tempfile"
 
     if ! err=$(awk -F'\t' '
         {
@@ -91,12 +105,15 @@ select_version() {
         return
     fi
 
+    sv_url="${KOLT_TEST_RELEASES_URL:-$DEFAULT_RELEASES_API}"
     sv_response=$(mktemp)
-    if ! curl -fsSL -o "$sv_response" "$DEFAULT_RELEASES_API"; then
+    progress_start "release listing from $sv_url"
+    if ! curl -fsSL -o "$sv_response" "$sv_url"; then
         rm -f "$sv_response"
-        echo "select_version: failed to fetch $DEFAULT_RELEASES_API" >&2
+        echo "select_version: failed to fetch $sv_url" >&2
         exit 6
     fi
+    progress_done "$sv_response"
 
     sv_tags=$(grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]+"' "$sv_response" \
         | sed -E 's/^"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)"$/\1/')
@@ -156,18 +173,22 @@ download_and_verify() {
     dv_tarball_path="${dv_tempdir}/${dv_tarball_name}"
     dv_sha256_path="${dv_tarball_path}.sha256"
 
+    progress_start "kolt v${dv_version} (${dv_platform}) tarball from $dv_tarball_url"
     if ! curl -fsSL -o "$dv_tarball_path" "$dv_tarball_url"; then
         rm -rf "$dv_tempdir"
         echo "download_and_verify: failed to fetch $dv_tarball_url" >&2
         echo "(version $dv_version may predate the installer rollout — see #230)" >&2
         exit 4
     fi
+    progress_done "$dv_tarball_path"
 
+    progress_start "kolt v${dv_version} (${dv_platform}) checksum from $dv_sha256_url"
     if ! curl -fsSL -o "$dv_sha256_path" "$dv_sha256_url"; then
         rm -rf "$dv_tempdir"
         echo "download_and_verify: failed to fetch $dv_sha256_url" >&2
         exit 4
     fi
+    progress_done "$dv_sha256_path"
 
     if ! (cd "$dv_tempdir" && sha256sum -c "${dv_tarball_name}.sha256" >/dev/null 2>&1); then
         dv_expected=$(awk '{print $1}' "$dv_sha256_path")

--- a/test/install_progress_test.sh
+++ b/test/install_progress_test.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Verify install.sh announces every download step on stderr (#405).
+#
+# Runs the full installer end-to-end against file:// URLs so no network is
+# touched. Asserts a "fetching ..." line and a completion line for each of
+# the four fetches: release listing, YANKED manifest, tarball, sha256.
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+INSTALL_SH="${INSTALL_SH:-$SCRIPT_DIR/../install.sh}"
+
+TESTDIR=$(mktemp -d)
+trap 'rm -rf "$TESTDIR"' EXIT
+
+VERSION="0.18.1"
+PLATFORM="linux-x64"
+EXTRACTED_NAME="kolt-${VERSION}-${PLATFORM}"
+TARBALL_NAME="${EXTRACTED_NAME}.tar.gz"
+
+RELEASES_DIR="$TESTDIR/releases"
+mkdir -p "$RELEASES_DIR"
+
+WORK="$TESTDIR/work"
+mkdir -p "$WORK/$EXTRACTED_NAME/bin"
+mkdir -p "$WORK/$EXTRACTED_NAME/libexec/classpath"
+printf '#!/bin/sh\necho mock\n' > "$WORK/$EXTRACTED_NAME/bin/kolt"
+chmod +x "$WORK/$EXTRACTED_NAME/bin/kolt"
+(cd "$WORK" && tar czf "$RELEASES_DIR/$TARBALL_NAME" "$EXTRACTED_NAME")
+(cd "$RELEASES_DIR" && sha256sum "$TARBALL_NAME" > "$TARBALL_NAME.sha256")
+
+: > "$TESTDIR/YANKED"
+
+cat > "$TESTDIR/releases.json" <<EOF
+[{"tag_name":"v$VERSION"}]
+EOF
+
+TEST_HOME="$TESTDIR/home"
+mkdir -p "$TEST_HOME"
+
+STDERR_LOG="$TESTDIR/stderr.log"
+STDOUT_LOG="$TESTDIR/stdout.log"
+
+HOME="$TEST_HOME" \
+KOLT_TEST_BASE_URL="file://$RELEASES_DIR" \
+KOLT_TEST_YANKED_URL="file://$TESTDIR/YANKED" \
+KOLT_TEST_RELEASES_URL="file://$TESTDIR/releases.json" \
+sh "$INSTALL_SH" >"$STDOUT_LOG" 2>"$STDERR_LOG"
+
+fail() {
+    echo "FAIL: $1" >&2
+    echo "--- stderr was: ---" >&2
+    cat "$STDERR_LOG" >&2
+    echo "--- stdout was: ---" >&2
+    cat "$STDOUT_LOG" >&2
+    exit 1
+}
+
+grep -q "fetching .*release" "$STDERR_LOG" || fail "missing release-list announcement"
+grep -q "fetching .*YANKED" "$STDERR_LOG" || fail "missing YANKED announcement"
+grep -q "fetching .*tarball" "$STDERR_LOG" || fail "missing tarball announcement"
+grep -q "fetching .*checksum" "$STDERR_LOG" || fail "missing checksum announcement"
+
+completions=$(grep -c "^  done (" "$STDERR_LOG" || true)
+[ "$completions" -ge 4 ] || fail "expected >= 4 completion lines, got $completions"
+
+echo "PASS"


### PR DESCRIPTION
Closes #405.

Every install.sh curl now announces "fetching <name> from <url>..." on
stderr and prints "  done (N bytes)" on success. Failure paths are
unchanged (existing curl exit + URL still surface).

Stderr is forced — three of the touched functions return values via
$(func ...), so stdout is reserved.

KOLT_TEST_RELEASES_URL mirrors the existing KOLT_TEST_YANKED_URL /
KOLT_TEST_BASE_URL hooks so the new E2E test covers all four fetches
without hitting the live GitHub API.

## Where to look

- install.sh: progress_start / progress_done helpers and four insertion
  sites. The one comment justifies stderr.
- test/install_progress_test.sh: file:// fixtures, asserts >=4
  "  done (" lines.