### PR TITLE
Severity-tagged diagnostic writer + Did-you-mean + NO_COLOR honor (#2)

### DIFF
--- a/.kiro/specs/2-error-output-formatting/design.md
+++ b/.kiro/specs/2-error-output-formatting/design.md
@@ -1,0 +1,833 @@
+# Design Document — 2-error-output-formatting
+
+## Overview
+
+**Purpose**: kolt の全ユーザー向け診断出力 (error / warning / note) を、 単一の typed writer + ColorPolicy + 修復ヒント仕組みに集約し、 issue #2 (v1.0 Phase 5 DX) の要求 7 件を実現する。
+
+**Users**: kolt CLI の対話的ユーザー (TTY) と CI ユーザー (非 TTY / `NO_COLOR`) の双方が、 整形された severity 付き診断 (適切に着色 / 着色なし) を受け取る。
+
+**Impact**: 既存の散在した `eprintln("error: ...")` 30+ 箇所と既存の 2 つの ad-hoc renderer (`formatResolveError`, `ToolError.formatStderr`) を、 単一の `eprintError` / `eprintWarning` / `eprintNote` API 経由に統一する。 ANSI カラー / NO_COLOR / `--no-color` / TTY 判定 / Did-you-mean 提案 / kolt.toml 行番号抽出 / subprocess 色抑制をこの API の責務に集約する。
+
+### Goals
+- 全 kolt 生成診断が単一の writer 経由で出力されること (severity prefix + context インデント + hint ライン)
+- ANSI カラーが TTY + non-NO_COLOR + non-`--no-color` 条件下でのみ出ること、 stdout / stderr 個別判定であること
+- `kolt.toml` パース失敗時にファイル絶対パス + 行番号 (取得可能な範囲) + キーパスが診断に乗ること
+- 未知サブコマンド / 未知 global flag / 未知 kolt.toml キーに対して deterministic な Did-you-mean 候補が出ること
+- 既存の exit code 契約と stdout/stderr 分離が破壊的に変わらないこと
+- subprocess (kotlinc / konanc / daemon) の色情報が kolt の color policy と整合すること
+
+### Non-Goals
+- 機械可読出力 (JSON / SARIF) のフォーマット定義 (別 spec 行き)
+- `kotlinc` / `konanc` 自身の診断フォーマットの書き換え (kolt は pass-through のみ)
+- daemon socket protocol message の構造変更
+- `Result<V, E>` ADT (例: `ResolveError`) の data class 構造変更 (renderer 層の出力形だけを変える)
+- 進捗インジケータ / spinner / progress bar
+- `FORCE_COLOR` 環境変数サポート
+- `kolt run` 等で起動する target program の出力装飾
+
+## Boundary Commitments
+
+### This Spec Owns
+- 単一の typed diagnostic writer API (`eprintError` / `eprintWarning` / `eprintNote`) と、 その内部表現 `RenderedDiagnostic` (severity + headline + context lines + optional hint)
+- `ColorPolicy` 値と、 startup 時の resolver (TTY + `NO_COLOR` env + `--no-color` flag からの 1 回計算)
+- `--no-color` kolt-level CLI flag の parse とディスパッチへの伝搬 (`parseKoltArgs` 拡張)
+- ANSI escape code の出力ロジック (severity → 色マッピング)、 および subprocess 出力からの ANSI strip ロジック
+- `Levenshtein` ベースの fuzzy match utility (`kolt.cli.suggest` 新規モジュール) と、 未知サブコマンド / 未知 flag / 未知 kolt.toml キーへの Did-you-mean wiring
+- `kolt.toml` パース失敗時の行番号抽出ロジック (ktoml `Line N: ` プレフィックスからの regex 抽出) とそれを担う `ConfigError.ParseFailed` shape の field 拡張
+- subprocess (kotlinc / konanc / daemon) への `NO_COLOR=1` env 伝播ポリシー、 および daemon が string blob で返す stderr に対する ANSI strip
+- 既存 2 renderer (`formatResolveError` in `kolt.resolve`, `ToolError.formatStderr` in `kolt.usertool`) の signature 変更 — 文字列返却から `RenderedDiagnostic` 返却へ
+- 既存の `eprintln("error: ...")` / `eprintln("warning: ...")` 大量呼び出しの新 API への mass migration
+
+### Out of Boundary
+- `kotlinc` / `konanc` の診断フォーマット自体 (kolt は pass-through のみ)
+- daemon socket protocol message (`Message` / `CompileResult` 等) の wire 構造
+- `kolt info --format=json` 等の既存の構造化出力フォーマットの変更 (色を入れない契約のみ追加)
+- `Result<V, E>` ADT (`ResolveError`, `ConfigError`, `ToolError`, `CompileError`, `NativeCompileError`) の variant 集合・data class 構造の変更 (renderer 層の出力 shape のみ変える)
+- 既存の exit code 数値 (`ExitCodes.kt`) の変更
+- 進捗インジケータ / スピナー / progress bar (別 issue)
+- `FORCE_COLOR` 環境変数 (要件で out of scope 明示)
+- `--watch` ループの状態行内容 (本仕様の severity 慣習を採用するが、 行内容自体は別 issue)
+- `kolt run` の target program の stdout / stderr 装飾
+
+### Allowed Dependencies
+- `kolt.infra` (lowest layer, 全方向から import 可能) ← `eprintln` の隣に新 module を追加
+- `platform.posix` の `isatty`, `STDERR_FILENO`, `STDOUT_FILENO`, `getenv` (cinterop 既存)
+- ktoml-core 0.7.1 — message text の `Line N: ` regex 抽出のみ。 `internal` 型への cast はしない
+- 既存の `parseKoltArgs` / `KoltArgs` 構造を拡張 (`useColor: Boolean` field 追加)
+- 依存方向 (`cli → build → resolve / config / infra`) を厳守 — `kolt.resolve` / `kolt.usertool` から `kolt.cli.*` への upward import は禁止
+
+### Revalidation Triggers
+- ktoml major version bump → `Line N: ` 抽出 regex の検証要 (本仕様の `ConfigParseMessageFormatTest` で pin)
+- `Result<V, E>` ADT の variant 追加 (新しい error class 追加時) → 新 variant の renderer が `RenderedDiagnostic` 返却契約を守ること、 hint slot を埋めること
+- `parseKoltArgs` への kolt-level flag 追加 → 順序非依存性と filter ロジックへの干渉確認
+- daemon protocol で stderr 配送経路が変わったとき → ANSI strip / `NO_COLOR` 伝播の貼り直し
+- subprocess (kotlinc / konanc) major version bump で `NO_COLOR` semantics が変わったとき → fall back に post-strip 切り替え
+
+## Architecture
+
+### Existing Architecture Analysis
+
+kolt の現状 (research.md §1 詳述):
+
+- `kolt.infra.eprintln(msg: String)` は `STDERR_FILENO` 直書き、 buffer / formatter なし — 単一の chokepoint
+- `kolt.cli.Main.parseKoltArgs` が `--no-daemon` / `--watch` / `--release` / `-D<k>=<v>` を抽出する型付きパーサ — flag 追加の単一拡張点
+- `kolt.cli.ScaffoldIO` で `platform.posix.isatty` cinterop が既に import 済み — 新規 cinterop 不要
+- `kolt.resolve.Resolver.formatResolveError(error)` と `kolt.usertool.ToolError.formatStderr()` が既に headline-plus-context 風の string-builder renderer をローカル実装している — 集約のテンプレートとして再利用可能
+- ktoml 0.7.1 は `lineNo` を exception の `message` テキストに `"Line N: "` プレフィックスで埋め込む。 `internal` 型 (`ParseException`) なので外から pattern-match 不可、 `e.message` regex のみが安定経路
+- `BuildCommands.kt:526` パターン (`eprintln(body)` 後に `eprintln(formatCompileError(...))`) で subprocess 出力の verbatim forward が既に成立 — R6.1 / R6.4 はこの形を維持
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+    subgraph CLI [kolt.cli]
+        Main[Main / parseKoltArgs]
+        Suggest[kolt.cli.suggest<br/>Levenshtein + closestMatch]
+        BuildCmd[BuildCommands]
+        DepCmd[DependencyCommands]
+        ToolCmd[ToolCommands]
+    end
+
+    subgraph Domain [Domain renderers]
+        ResolveFmt[kolt.resolve<br/>formatResolveError]
+        ToolFmt[kolt.usertool<br/>ToolError.formatStderr]
+        ConfigErr[kolt.config<br/>ConfigError + lineNo extractor]
+    end
+
+    subgraph Infra [kolt.infra.output - new module]
+        Diag[RenderedDiagnostic<br/>+ Severity]
+        Policy[ColorPolicy<br/>fromEnv]
+        Writer[eprintError / eprintWarning / eprintNote<br/>+ ANSI strip helper]
+        EprintLn[eprintln existing]
+    end
+
+    Main --> Policy
+    Main --> Suggest
+    Main --> Writer
+    BuildCmd --> Writer
+    DepCmd --> Writer
+    ToolCmd --> Writer
+
+    BuildCmd --> ResolveFmt
+    DepCmd --> ResolveFmt
+    ToolCmd --> ToolFmt
+
+    ResolveFmt --> Diag
+    ToolFmt --> Diag
+    ConfigErr --> Diag
+
+    Writer --> EprintLn
+    Writer --> Policy
+```
+
+**選択 pattern**: Hybrid 集約 (research.md Option C) — 単一 writer + 単一 ColorPolicy への集約 + 既存 ADT 構造保存 + 新規モジュール 2 つ (`kolt.infra.output`, `kolt.cli.suggest`)
+
+**ドメイン境界**:
+- `kolt.infra.output` が出力ポリシー / 整形ロジック / ANSI 知識を独占。 cli / resolve / config / usertool は `RenderedDiagnostic` を生成して渡すだけ
+- `kolt.cli.suggest` は純粋ユーティリティ (Levenshtein + closestMatch)、 cli 内の dispatcher / config validator から呼ばれる
+- 既存 renderer (`formatResolveError`, `ToolError.formatStderr`) は signature が `String` から `RenderedDiagnostic` に変わるが、 ADT 構造と所属パッケージは不変
+
+**保持される既存 pattern**:
+- `Result<V, E>` 経由の error 返却 (ADR 0001)
+- `cli → build → resolve / config / infra` 依存方向
+- `eprintln` を最終出力 chokepoint として維持 (`kolt.infra.output.eprintError` 等は内部で `eprintln` を呼ぶ)
+- 既存の exit code 数値 / `ExitCodes.kt` 構造
+
+**新コンポーネント rationale**:
+- `kolt.infra.output` — ColorPolicy + Severity + Writer を 1 ヶ所に置くため。 `kolt.infra` (最下層) に置くことで全 caller (cli / resolve / config / usertool) から依存方向を犯さず import 可能
+- `kolt.cli.suggest` — Levenshtein は cli dispatcher (subcommand / flag) と config validator (kolt.toml key) の双方から呼ばれる。 cli 層に置けば config から `kolt.cli.suggest` を import できないが、 config は known-key list を渡すのではなく **新規 helper を別場所に置く** か、 `kolt.cli.suggest` 内容を **`kolt.infra.suggest` に移す** かのどちらか。 → 後者を選択 (依存方向順守、 純粋ロジックなので最下層が正しい)
+- 上記により、 最終的な module 配置: `kolt.infra.output` + `kolt.infra.suggest`
+
+**Steering compliance**:
+- ADR 0001 — 全エラーパスで `Result<V, E>`、 例外送出禁止 → writer / ColorPolicy / suggest は全て non-throwing
+- 言語ポリシー — コード / コメント / テスト名は英語
+- ktoml 2.x value class の `is Ok / is Err` 不可 → Result 経路は `getOrElse` / `getError` のみ
+- `kolt-result` 慣習 → ColorPolicy は `Result` を使わない (純粋計算、 失敗なし)
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| CLI runtime | Kotlin/Native (linuxX64), Kotlin 2.3.x | Writer + ColorPolicy + Suggest が動く環境 | 既存 |
+| TTY 検出 | `platform.posix.isatty` cinterop | `ColorPolicy.fromEnv` の TTY 判定 | 既存 cinterop (`kolt.cli.ScaffoldIO` で使用済み)、 新規 def 不要 |
+| 環境変数読み出し | `platform.posix.getenv` cinterop | `NO_COLOR` 検出 | 既存 cinterop |
+| TOML パース | `com.akuleshov7:ktoml-core` 0.7.1 | `Line N: ` プレフィックス付き message 提供 | 既存依存。 message format 変更検出のための regression test を pin |
+| Stdlib regex | `kotlin.text.Regex` | 行番号抽出 + ANSI strip | 既存。 新規依存なし |
+
+新規外部依存なし。 既存依存の使い方の拡張のみ。
+
+## File Structure Plan
+
+### Directory Structure
+
+```
+src/nativeMain/kotlin/kolt/
+├── infra/
+│   ├── FileSystem.kt                     # MOD: eprintln 既存維持、 新規ファイルから呼び出される
+│   ├── output/                           # NEW directory
+│   │   ├── ColorPolicy.kt                # NEW: sealed class ColorPolicy + fromEnv + install
+│   │   ├── Severity.kt                   # NEW: enum Severity (Error/Warning/Note)
+│   │   ├── RenderedDiagnostic.kt         # NEW: data class RenderedDiagnostic
+│   │   ├── DiagnosticWriter.kt           # NEW: eprintError / eprintWarning / eprintNote + AnsiStripper
+│   │   └── AnsiCodes.kt                  # NEW: ANSI escape constants (RED, YELLOW, CYAN, RESET)
+│   └── suggest/                          # NEW directory (sibling of output/)
+│       ├── Levenshtein.kt                # NEW: edit distance impl
+│       └── ClosestMatch.kt               # NEW: closestMatch(input, candidates, threshold)
+├── cli/
+│   ├── Main.kt                           # MOD: parseKoltArgs に --no-color、 dispatcher で
+│   │                                     #      ColorPolicy.install + 未知 subcommand に Did-you-mean
+│   ├── BuildCommands.kt                  # MOD: eprintln("error: ...") 全て eprintError(...) に置換
+│   ├── DependencyCommands.kt             # MOD: 同上
+│   ├── ToolCommands.kt                   # MOD: ToolError.formatStderr 経路を新 API に
+│   └── (other Commands)                  # MOD: 同パターン
+├── config/
+│   └── Config.kt                         # MOD: ktoml exception catch を拡張、
+│                                         #      ConfigError.ParseFailed に lineNo / keyPath / suggestion field 追加
+├── resolve/
+│   └── Resolver.kt                       # MOD: formatResolveError signature 変更
+│                                         #      String → RenderedDiagnostic
+└── usertool/
+    └── ToolError.kt                      # MOD: ToolError.formatStderr signature 変更
+                                          #      String → RenderedDiagnostic
+```
+
+### Modified Files (詳細)
+
+| Path | Change |
+|------|--------|
+| `kolt/infra/FileSystem.kt` | 既存 `eprintln(msg: String)` は無変更で維持 (新 API の internal target として) |
+| `kolt/cli/Main.kt:127-141` | `parseKoltArgs` に `--no-color` flag 追加、 `KoltArgs.useColor: Boolean` field 追加。 dispatcher 開始時に `ColorPolicy.install(...)`。 `else` 節 (line 102) で未知 subcommand の closestMatch 呼び出し |
+| `kolt/cli/Main.kt:159+` | `printUsage()` の eprintln 群はそのまま (情報表示、 severity 装飾不要) |
+| `kolt/cli/BuildCommands.kt` | `eprintln("error: X")` → `eprintError("X")`、 `eprintln("warning: X")` → `eprintWarning("X")` の機械置換。 multi-line context 含む箇所 (compile failure 等) は `eprintError(headline, context)` 形に整える |
+| `kolt/cli/DependencyCommands.kt` | 同上 |
+| `kolt/cli/ToolCommands.kt` | `error.formatStderr()` → `eprintError(rendered.headline, rendered.context, rendered.hint)` |
+| `kolt/config/Config.kt:520-524` | catch 節を `extractKtomlLineNo(e.message)` ヘルパー経由にし、 `ConfigError.ParseFailed(path, lineNo, keyPath, message, suggestion)` を返す。 unknown key の場合 `closestMatch` を試みて `suggestion` を埋める |
+| `kolt/resolve/Resolver.kt:65-101` | `formatResolveError(error: ResolveError): String` → `: RenderedDiagnostic`。 各 variant の string concat を `RenderedDiagnostic(severity = Error, headline = ..., context = listOf(...), hint = ...)` に転換。 `error: ` prefix を全て削除 |
+| `kolt/usertool/ToolError.kt` | `abstract fun formatStderr(): String` → `: RenderedDiagnostic`。 各 variant 同様の転換。 `LockfileMismatch` の inline `Run \`kolt update\`` ヒントは `hint` slot へ |
+| `kolt/build/CompilerBackend.kt` (および daemon backend) | subprocess 起動箇所で `if (!colorEnabled) env["NO_COLOR"] = "1"` を inject。 daemon-captured stderr blob は `eprintln(body)` 直前で `if (!colorEnabled) AnsiStripper.strip(body)` を通す |
+
+> 各ファイルは単一責務: writer は出力、 ColorPolicy は判定、 Suggest は距離計算、 既存 renderer は ADT → RenderedDiagnostic 変換のみ。 重複なし。
+
+## System Flows
+
+### Flow 1: Startup color policy resolution
+
+```mermaid
+flowchart TB
+    Start[main entry] --> ParseArgs[parseKoltArgs]
+    ParseArgs --> ExtractFlag{--no-color present?}
+    ExtractFlag -->|yes| Forced[ColorPolicy.Never]
+    ExtractFlag -->|no| ReadEnv{NO_COLOR env<br/>non-empty?}
+    ReadEnv -->|yes| Forced
+    ReadEnv -->|no| CheckTty[isatty STDERR + STDOUT]
+    CheckTty --> Auto[ColorPolicy.Auto<br/>per-stream tty]
+    Forced --> Install[ColorPolicy.install]
+    Auto --> Install
+    Install --> Dispatch[dispatch subcommand]
+```
+
+決定順: `--no-color` → `NO_COLOR` env → TTY 判定。 `Auto` 値は stderr / stdout 個別 TTY 状態を保持し、 writer 側で stream に応じて参照。
+
+### Flow 2: Diagnostic write path
+
+```mermaid
+flowchart TB
+    Caller[caller: eprintError headline, context, hint] --> Build[build RenderedDiagnostic]
+    Build --> CheckPolicy{ColorPolicy<br/>shouldColor stderr?}
+    CheckPolicy -->|yes| Colored[wrap headline with ANSI<br/>severity color + reset]
+    CheckPolicy -->|no| Plain[plain text]
+    Colored --> Render
+    Plain --> Render[render lines:<br/>1 severity:headline<br/>2 indent contextLines<br/>3 if hint: note: hint]
+    Render --> Write[eprintln per line]
+```
+
+context 行は 2 スペース indent (既存 `formatResolveError` と同じ)。 hint は別行で `note:` プレフィックス + 同じ ColorPolicy 判定。
+
+### Flow 3: Subprocess color forwarding (kotlinc / konanc / daemon)
+
+```mermaid
+flowchart TB
+    Spawn[spawn subprocess] --> Env{ColorPolicy<br/>shouldColor enabled?}
+    Env -->|yes| InheritEnv[inherit parent env<br/>subprocess emits color]
+    Env -->|no| InjectNoColor[env: NO_COLOR=1<br/>subprocess emits plain]
+    InheritEnv --> RunSub[subprocess runs]
+    InjectNoColor --> RunSub
+    RunSub --> Capture{capture mode?}
+    Capture -->|inherit fd<br/>direct subprocess| DirectOut[user sees subprocess stderr<br/>verbatim - no kolt prefix]
+    Capture -->|daemon string blob| Strip{ColorPolicy<br/>shouldColor?}
+    Strip -->|yes| Forward[eprintln blob verbatim]
+    Strip -->|no| StripAnsi[AnsiStripper.strip blob]
+    StripAnsi --> Forward
+```
+
+direct fd inherit (subprocess kotlinc / konanc) では `NO_COLOR=1` 注入のみで完結。 daemon 経路 (string blob 戻り) では ANSI strip を post-process で適用。 R6.1 / R6.2 / R6.3 を満たす。
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | `error:` prefix → stderr | DiagnosticWriter | `eprintError(headline, context, hint)` | Flow 2 |
+| 1.2 | `warning:` prefix → stderr | DiagnosticWriter | `eprintWarning(...)` | Flow 2 |
+| 1.3 | `note:` prefix → stderr | DiagnosticWriter | `eprintNote(...)` | Flow 2 |
+| 1.4 | context 行を 2 スペース indent | DiagnosticWriter | `RenderedDiagnostic.context: List<String>` | Flow 2 |
+| 1.5 | stdout は user-requested 出力専用 | (既存維持) | — | — |
+| 1.6 | exit code 不変 | (既存 `ExitCodes.kt` 維持) | — | — |
+| 2.1 | TTY + non-opt-out で red/yellow/cyan | ColorPolicy + AnsiCodes | `ColorPolicy.shouldColor(Stream): Boolean` | Flow 1, Flow 2 |
+| 2.2 | 非 TTY で ANSI 抑制 | ColorPolicy.Auto | 同上 | Flow 1 |
+| 2.3 | `NO_COLOR` env で抑制 | ColorPolicy.fromEnv | `ColorPolicy.fromEnv(noColorFlag): ColorPolicy` | Flow 1 |
+| 2.4 | `--no-color` flag で抑制 | parseKoltArgs + ColorPolicy.fromEnv | `KoltArgs.useColor` | Flow 1 |
+| 2.5 | stderr / stdout 個別 TTY 判定 | ColorPolicy.Auto | `Auto(isStderrTty, isStdoutTty)` | Flow 1 |
+| 2.6 | 色のみで情報を伝えない | DiagnosticWriter (severity prefix が常に text) | — | Flow 2 |
+| 3.1 | kolt.toml 絶対パス | ConfigErrorEnrichment | `ConfigError.ParseFailed.path` | — |
+| 3.2 | 行 / 列 (取得可能なとき) | ConfigErrorEnrichment + ktomlLineNoExtractor | `extractKtomlLineNo(message): Pair<Int?, String>` | — |
+| 3.3 | 違反 key path 表示 | ConfigErrorEnrichment | `ConfigError.ParseFailed.keyPath` | — |
+| 3.4 | unknown key の Did-you-mean | ConfigErrorEnrichment + ClosestMatch | `closestMatch(input, candidates, threshold): String?` | — |
+| 4.1 | Maven 座標フル表示 | (既存 `ResolveError` data class 維持 + `formatResolveError` headline) | — | — |
+| 4.2 | 親座標 / 宣言元 | (既存) + RenderedDiagnostic.context | — | — |
+| 4.3 | 試行リポジトリ列挙 | (既存 `RepositoryAttempt`) + RenderedDiagnostic.context | — | — |
+| 4.4 | sha256 mismatch の expected/observed | (既存 `Sha256Mismatch`) + RenderedDiagnostic.context | — | — |
+| 5.1 | recovery command の `note:` ライン | RenderedDiagnostic.hint | — | Flow 2 |
+| 5.2 | unknown subcommand の Did-you-mean | Main dispatcher + ClosestMatch | `closestMatch(input, knownSubcommands)` | — |
+| 5.3 | unknown global flag の Did-you-mean | parseKoltArgs + ClosestMatch | 同上 | — |
+| 5.4 | suggestion deterministic | ClosestMatch (stable iteration + 同点時 lex 順) | — | — |
+| 6.1 | subprocess 出力に kolt prefix 付けない | (既存パターン維持) BuildCommands.kt:526 | — | Flow 3 |
+| 6.2 | color enabled で ANSI pass-through | SubprocessColorForwarding | (env propagation) | Flow 3 |
+| 6.3 | color disabled で ANSI 漏らさない | SubprocessColorForwarding + AnsiStripper | `AnsiStripper.strip(s: String): String` | Flow 3 |
+| 6.4 | wrap 時 1 headline + verbatim body | (既存パターン維持) | — | Flow 3 |
+| 7.1 | `--format=json` 等に ANSI 混入禁止 | (既存 `println` 経路維持。 DiagnosticWriter は stderr 専用) | — | — |
+| 7.2 | stderr / stdout 分離維持 | (既存 `eprintln` / `println` 維持) | — | — |
+
+## Components and Interfaces
+
+| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies | Contracts |
+|-----------|--------------|--------|--------------|------------------|-----------|
+| `ColorPolicy` | infra/output | startup 1 回計算の色決定値 | 2.1, 2.2, 2.3, 2.4, 2.5 | `isatty`, `getenv` (P0) | Service, State |
+| `DiagnosticWriter` | infra/output | severity prefix + indent + hint の単一 writer | 1.1, 1.2, 1.3, 1.4, 1.6, 2.1, 2.6 | ColorPolicy (P0), `eprintln` (P0) | Service |
+| `RenderedDiagnostic` | infra/output | severity + headline + context + hint の値型 | 1.1-1.4, 4.x, 5.1 | — | State |
+| `AnsiStripper` | infra/output | subprocess blob から ANSI 削除 | 6.3 | — | Service |
+| `ClosestMatch` (Levenshtein) | infra/suggest | fuzzy match utility | 3.4, 5.2, 5.3, 5.4 | — | Service |
+| `ConfigErrorEnrichment` | config | ktoml message から lineNo / keyPath 抽出、 closestMatch 適用 | 3.1, 3.2, 3.3, 3.4 | ClosestMatch (P0) | Service |
+| `ResolveErrorRenderer` | resolve | `ResolveError` → `RenderedDiagnostic` 変換 (既存 `formatResolveError` 改修) | 4.1, 4.2, 4.3, 4.4 | RenderedDiagnostic (P0) | Service |
+| `ToolErrorRenderer` | usertool | `ToolError` → `RenderedDiagnostic` 変換 (既存 `ToolError.formatStderr` 改修) | 4.x, 5.1 | RenderedDiagnostic (P0) | Service |
+| `SubprocessColorForwarding` | build / build.daemon | subprocess 起動時の `NO_COLOR` 注入 + daemon blob の strip | 6.1, 6.2, 6.3, 6.4 | ColorPolicy (P0), AnsiStripper (P1) | Service |
+| `Main dispatcher` | cli | `--no-color` parse → ColorPolicy.install、 unknown subcommand への closestMatch 適用 | 2.4, 5.2, 5.3 | ColorPolicy (P0), ClosestMatch (P1) | Service |
+
+### infra/output
+
+#### ColorPolicy
+
+| Field | Detail |
+|-------|--------|
+| Intent | startup 時 1 回計算される色決定値、 stream 別 |
+| Requirements | 2.1, 2.2, 2.3, 2.4, 2.5 |
+
+**Responsibilities & Constraints**
+- 純粋値 — `fromEnv` 関数で構築、 install 後は不変
+- 失敗パスなし (`Result` は使わない)
+- stream-別 TTY 判定を内包 (stderr / stdout が独立にリダイレクトされうる)
+
+**Dependencies**
+- External: `platform.posix.isatty` (P0), `platform.posix.getenv` (P0)
+
+**Contracts**: Service, State
+
+##### Service Interface
+
+```kotlin
+package kolt.infra.output
+
+enum class Stream { Stderr, Stdout }
+
+sealed class ColorPolicy {
+  abstract fun shouldColor(stream: Stream): Boolean
+
+  data object Always : ColorPolicy() {
+    override fun shouldColor(stream: Stream): Boolean = true
+  }
+
+  data object Never : ColorPolicy() {
+    override fun shouldColor(stream: Stream): Boolean = false
+  }
+
+  data class Auto(val isStderrTty: Boolean, val isStdoutTty: Boolean) : ColorPolicy() {
+    override fun shouldColor(stream: Stream): Boolean =
+      when (stream) {
+        Stream.Stderr -> isStderrTty
+        Stream.Stdout -> isStdoutTty
+      }
+  }
+
+  companion object {
+    fun fromEnv(noColorFlag: Boolean): ColorPolicy
+    fun install(policy: ColorPolicy)
+    fun current(): ColorPolicy
+  }
+}
+```
+
+決定順 (`fromEnv`):
+1. `noColorFlag == true` → `Never`
+2. `getenv("NO_COLOR")` が non-null かつ非空文字列 → `Never`
+3. それ以外 → `Auto(isatty(STDERR_FILENO) != 0, isatty(STDOUT_FILENO) != 0)`
+
+`install` は module-level `var currentPolicy: ColorPolicy = ColorPolicy.Never` を更新。 startup 時 1 回呼ばれる。
+
+**State-discipline note** (validate-design Issue 2 の解決): `install` は startup 起動時の唯一の書き換え経路。 テスト / 単発呼び出しは `install` を経由せず、 writer 関数の `policy` default argument を明示渡しで override する経路を使う (下記 DiagnosticWriter の signature 参照)。 これにより global mutable は CLI startup 1 回計算という既存の不変式に閉じる。
+
+- Preconditions: 呼び出し前に `install` 必須 (default は `Never` なのでテストで未 install でも安全)
+- Postconditions: `current()` は最後に `install` された値を返す
+- Invariants: process 内で thread-safe (Kotlin/Native 単 thread CLI)、 startup 後 `install` を呼ばない契約
+
+#### Severity & RenderedDiagnostic
+
+```kotlin
+enum class Severity { Error, Warning, Note }
+
+data class RenderedDiagnostic(
+  val severity: Severity,
+  val headline: String,
+  val context: List<String> = emptyList(),
+  val hint: String? = null,
+)
+```
+
+- `headline`: 単一行、 改行禁止 (改行を含めたい場合は context に分ける)
+- `context`: 各要素 1 行、 各行は 2 スペース indent で出力される
+- `hint`: optional、 別 `note:` 行として出力される (色は note severity の cyan を流用)
+
+#### DiagnosticWriter
+
+| Field | Detail |
+|-------|--------|
+| Intent | 単一 writer API、 severity → ANSI / indent / hint レンダリングを所有 |
+| Requirements | 1.1-1.4, 1.6, 2.1, 2.6 |
+
+**Service Interface**
+
+```kotlin
+package kolt.infra.output
+
+fun eprintError(
+  headline: String,
+  context: List<String> = emptyList(),
+  hint: String? = null,
+  policy: ColorPolicy = ColorPolicy.current(),
+)
+
+fun eprintWarning(
+  headline: String,
+  context: List<String> = emptyList(),
+  hint: String? = null,
+  policy: ColorPolicy = ColorPolicy.current(),
+)
+
+fun eprintNote(
+  headline: String,
+  context: List<String> = emptyList(),
+  hint: String? = null,
+  policy: ColorPolicy = ColorPolicy.current(),
+)
+
+fun eprintDiagnostic(
+  diag: RenderedDiagnostic,
+  policy: ColorPolicy = ColorPolicy.current(),
+)
+```
+
+`eprintError` 等は `RenderedDiagnostic` を組み立てて `eprintDiagnostic` に委譲。 既存 renderer (`formatResolveError`, `ToolError.formatStderr`) は `eprintDiagnostic(diag)` を直接呼ぶ。
+
+**Policy resolution discipline** (validate-design Issue 2 の解決):
+- 通常呼び出しは `policy` を省略し、 default arg で `ColorPolicy.current()` を読む (startup `install` 後の global)
+- テストは `policy = ColorPolicy.Never` (or `Always`) を明示渡しで override する。 この経路では global state を一切触らない
+- これにより writer の動作はテストごとに deterministic、 並列実行や前 test の install 残留に起因する flaky は構造的に発生しない
+
+Rendering algorithm:
+1. severity ラベル決定 (`error:` / `warning:` / `note:`)
+2. `policy.shouldColor(Stream.Stderr)` で着色判定 (caller 渡し or default の current)
+3. Color enabled なら severity ラベルを ANSI で wrap (red / yellow / cyan + reset)
+4. headline 行 = `"{coloredOrPlainPrefix} {headline}"` を `eprintln`
+5. context の各行を `"  {line}"` で `eprintln`
+6. hint があれば `"{noteColoredPrefix} {hint}"` を `eprintln`
+
+#### AnsiStripper
+
+```kotlin
+object AnsiStripper {
+  // CSI sequences: ESC [ params <final-byte 0x40-0x7E>
+  private val CSI_REGEX = Regex("\\x1B\\[[0-?]*[ -/]*[@-~]")
+  fun strip(s: String): String = CSI_REGEX.replace(s, "")
+}
+```
+
+`CSI` (Control Sequence Introducer) のみ対象。 OSC / その他 ESC sequence は kotlinc / konanc / daemon が出さない前提 (Research Needed: 確認テストを後述)。
+
+### infra/suggest
+
+#### ClosestMatch
+
+| Field | Detail |
+|-------|--------|
+| Intent | Levenshtein 距離による fuzzy candidate 選択 |
+| Requirements | 3.4, 5.2, 5.3, 5.4 |
+
+**Service Interface**
+
+```kotlin
+package kolt.infra.suggest
+
+fun levenshtein(a: String, b: String): Int
+
+fun closestMatch(
+  input: String,
+  candidates: List<String>,
+  maxDistance: Int = adaptiveThreshold(input.length),
+): String?
+
+private fun adaptiveThreshold(inputLength: Int): Int =
+  if (inputLength <= 4) 1 else 2
+```
+
+Determinism (R5.4):
+- candidates 列を順に走査 (caller 側で sorted を渡す)
+- 最小距離が複数同点のとき、 最初に見つかった候補を返す (caller が辞書順 sorted リストを渡せば 同点時に lex 最小)
+- 距離 > `maxDistance` なら `null`
+
+### config
+
+#### ConfigErrorEnrichment
+
+| Field | Detail |
+|-------|--------|
+| Intent | ktoml exception → 行番号 / key path / Did-you-mean 付き `ConfigError` |
+| Requirements | 3.1, 3.2, 3.3, 3.4 |
+
+**Existing → New ConfigError shape**
+
+```kotlin
+sealed class ConfigError {
+  data class ParseFailed(
+    val path: String,
+    val lineNo: Int?,
+    val keyPath: String?,
+    val message: String,
+    val suggestion: String?,
+  ) : ConfigError()
+  // 既存の他 variant は変更なし
+}
+```
+
+**Internal helper**
+
+```kotlin
+package kolt.config
+
+internal val LINE_NO_REGEX = Regex("^Line (\\d+): ")
+
+internal fun extractKtomlLineNo(message: String?): Pair<Int?, String> {
+  if (message == null) return null to ""
+  val match = LINE_NO_REGEX.find(message) ?: return null to message
+  val n = match.groupValues[1].toIntOrNull()
+  val rest = message.substring(match.range.last + 1)
+  return n to rest
+}
+```
+
+`Config.kt:520-524` の catch 節を以下に変更:
+
+```kotlin
+} catch (e: SerializationException) {
+  val (lineNo, detail) = extractKtomlLineNo(e.message)
+  val (keyPath, suggestion) = parseUnknownKey(detail) // null pair if not unknown-key
+  return Err(ConfigError.ParseFailed(
+    path = absolutePathOfKoltToml,
+    lineNo = lineNo,
+    keyPath = keyPath,
+    message = detail,
+    suggestion = suggestion,
+  ))
+}
+```
+
+`parseUnknownKey` の scope は **top-level section 名のみ** に限定 (validate-design Issue 1 の解決、 R3.4 narrowed)。 ktoml の `UnknownNameException` text パターン (`"Unknown key received: <X> in scope <Y>"`) を regex 検出し、 `<Y>` が空 (=top-level) のときだけ `closestMatch(X, KNOWN_TOP_LEVEL_SECTIONS)` を呼ぶ。 ネスト内の unknown key には suggestion を出さない (ParseFailed.message に key path のみ載る)。
+
+```kotlin
+internal val KNOWN_TOP_LEVEL_SECTIONS = listOf(
+  "build", "cinterop", "classpaths", "dependencies",
+  "fmt", "kotlin", "repositories", "run", "test", "tools",
+).sorted()  // alphabetical for deterministic suggestion (R5.4)
+
+private val UNKNOWN_KEY_REGEX = Regex(
+  "^Unknown key received: <([^>]+)> in scope <([^>]*)>"
+)
+
+internal fun parseUnknownKey(detail: String): Pair<String?, String?> {
+  val m = UNKNOWN_KEY_REGEX.find(detail) ?: return null to null
+  val key = m.groupValues[1]
+  val scope = m.groupValues[2]
+  if (scope.isNotEmpty()) return key to null  // nested: keyPath only, no suggestion
+  return key to closestMatch(key, KNOWN_TOP_LEVEL_SECTIONS)
+}
+```
+
+list は ktoml format に依存しない hardcoded で、 kolt.toml schema 進化のときは catalog 1 ヶ所更新するだけ。 ネスト内 typo (例: `[kotlin] compilerr = "..."`) への suggestion は本仕様の out of scope (follow-up issue 候補)。
+
+Renderer (`Config.kt` 内 or `kolt/cli/BuildCommands.kt` 呼び出し側):
+
+```kotlin
+fun renderConfigError(e: ConfigError.ParseFailed): RenderedDiagnostic {
+  val location = if (e.lineNo != null) "${e.path}:${e.lineNo}" else e.path
+  val context = buildList {
+    add("at $location")
+    if (e.keyPath != null) add("key: ${e.keyPath}")
+  }
+  val hint = e.suggestion?.let { "Did you mean `$it`?" }
+  return RenderedDiagnostic(Severity.Error, e.message, context, hint)
+}
+```
+
+### resolve
+
+#### ResolveErrorRenderer (modify existing `formatResolveError`)
+
+Signature change:
+
+```kotlin
+// before:
+fun formatResolveError(error: ResolveError): String
+
+// after:
+fun formatResolveError(error: ResolveError): RenderedDiagnostic
+```
+
+各 variant の `error: ` prefix を全て削除し、 multi-line の `appendLine` パターンを `context: List<String>` に分解。 例:
+
+```kotlin
+is ResolveError.Sha256Mismatch ->
+  RenderedDiagnostic(
+    severity = Severity.Error,
+    headline = "sha256 mismatch for ${error.groupArtifact}",
+    context = listOf(
+      "expected: ${error.expected}",
+      "got:      ${error.actual}",
+    ),
+  )
+is ResolveError.DownloadFailed ->
+  RenderedDiagnostic(
+    severity = Severity.Error,
+    headline = "failed to download ${error.groupArtifact}",
+    context = formatRepositoryDownloadFailure(error.failure),
+  )
+```
+
+`formatRepositoryDownloadFailure` も `StringBuilder.appendLine` から `List<String>` 返却に変更。
+
+呼び出し側 (cli):
+
+```kotlin
+// before:
+eprintln(formatResolveError(error))
+// after:
+eprintDiagnostic(formatResolveError(error))
+```
+
+### usertool
+
+#### ToolErrorRenderer (modify existing `ToolError.formatStderr`)
+
+```kotlin
+sealed class ToolError {
+  abstract fun toExitCode(): Int
+  abstract fun render(): RenderedDiagnostic   // was: fun formatStderr(): String
+
+  data class Resolve(val cause: ToolResolutionError) : ToolError() {
+    override fun render(): RenderedDiagnostic =
+      when (val c = cause) {
+        is ToolResolutionError.LockfileMismatch -> RenderedDiagnostic(
+          severity = Severity.Error,
+          headline = "tool '${c.alias}': lockfile pin '$pinned' differs from kolt.toml '$toml'",
+          hint = "Run `kolt update` to refresh tool pins.",
+        )
+        // ...
+      }
+  }
+  // ...
+}
+```
+
+呼び出し側: `ToolCommands.kt` の `eprintln(error.formatStderr())` → `eprintDiagnostic(error.render())`。
+
+### build / build.daemon
+
+#### SubprocessColorForwarding
+
+| Field | Detail |
+|-------|--------|
+| Intent | subprocess (kotlinc / konanc / daemon) への `NO_COLOR` 伝播 + daemon blob ANSI strip |
+| Requirements | 6.1, 6.2, 6.3, 6.4 |
+
+**戦略 (3 経路)**:
+1. **kotlinc subprocess** (`SubprocessCompilerBackend.kt`): subprocess 起動 env に `if (!ColorPolicy.current().shouldColor(Stream.Stderr)) put("NO_COLOR", "1")` を追加。 fd inherit のため kolt 側の追加処理なし。 → R6.1 (verbatim) + R6.2 (color enabled で pass-through) + R6.3 (NO_COLOR で subprocess が plain 出力)
+2. **konanc subprocess** (`NativeSubprocessBackend.kt`): 同上。
+3. **JVM/Native daemon path** (`*DaemonBackend.kt`): daemon socket 接続前に subprocess 起動時の env に同じ注入。 daemon が return する `stderr: String` blob は cli 側の forward 直前 (`BuildCommands.kt:526` 近辺) で `if (!ColorPolicy.current().shouldColor(Stream.Stderr)) AnsiStripper.strip(body)` を適用してから `eprintln(body)`。
+
+**Implementation Notes**
+- Integration: env injection は既存の subprocess 起動 helper の内部で完結。 caller (`BuildCommands` 等) は ColorPolicy を意識しない。
+- Validation (validate-design Issue 3 の解決): Kotlin 2.3.x kotlinc / konanc の `NO_COLOR` honor を **integration test で実機 pin** する。 fixture に `NO_COLOR=1 kolt --no-daemon build <forced-fail>` を走らせ、 stderr に `\x1b[` が出ないことを assert。 Kotlin compiler bump 時に同 test の green を確認する契約。
+- Verified scope: Kotlin 2.3.x 系で確認した範囲では kotlinc / konanc とも `NO_COLOR` を honor することを前提とする (CI test で継続確認)。 万一将来 honor しなくなった version への bump があれば、 該当 test が RED になり、 そのとき初めて post-strip fallback を direct subprocess 経路に追加する判断を行う。
+- Risks: kotlinc / konanc が将来 `NO_COLOR` を尊重しない version に bump された場合、 上記 test が RED 化して検出される。 検出時は (a) version pin を留める、 (b) post-strip を direct subprocess 経路にも追加 (architectural change) の 2 択。
+
+### cli
+
+#### Main dispatcher (modify existing)
+
+**parseKoltArgs 拡張**:
+
+```kotlin
+internal const val NO_COLOR_FLAG = "--no-color"
+
+internal data class KoltArgs(
+  val useDaemon: Boolean,
+  val watch: Boolean,
+  val profile: Profile,
+  val cliSysProps: List<Pair<String, String>>,
+  val noColor: Boolean,                        // NEW
+  val filteredArgs: List<String>,
+)
+
+internal fun parseKoltArgs(argList: List<String>): KoltArgs {
+  // ... 既存 ...
+  val noColor = koltLevel.contains(NO_COLOR_FLAG)
+  val filteredArgs = koltLevel.filter {
+    it != NO_DAEMON_FLAG && it != WATCH_FLAG &&
+    it != RELEASE_FLAG && it != NO_COLOR_FLAG &&
+    parseDFlag(it) == null
+  } + passthrough
+  return KoltArgs(useDaemon, watch, profile, cliSysProps, noColor, filteredArgs)
+}
+```
+
+**main 起動時**:
+
+```kotlin
+fun main(args: Array<String>) {
+  val koltArgs = parseKoltArgs(args.toList())
+  ColorPolicy.install(ColorPolicy.fromEnv(noColorFlag = koltArgs.noColor))
+  // ... 既存 dispatch ...
+}
+```
+
+**Unknown subcommand → Did-you-mean** (`Main.kt:101-105`):
+
+```kotlin
+else -> {
+  val unknown = filteredArgs[0]
+  val candidate = closestMatch(unknown, KNOWN_SUBCOMMANDS_SORTED)
+  val hint = candidate?.let { "Did you mean `$it`?" }
+  eprintError("unknown command '$unknown'", hint = hint)
+  printUsage()
+  exitProcess(EXIT_COMMAND_NOT_FOUND)
+}
+```
+
+`KNOWN_SUBCOMMANDS_SORTED` は cli 側の hardcoded sorted list (alphabetical)、 `printUsage()` の表示順とは独立。
+
+**Unknown global flag → Did-you-mean** (`parseKoltArgs` 内):
+未知の `--xxx` flag (kolt-level prefix `--` で始まり、 既知 flag set にも `-D` にも passthrough にも該当しないもの) を検出した場合、 caller (main) に伝えて `eprintError` + closestMatch + `EXIT_USAGE_ERROR` 終了。 ただし subcommand 専用 flag を kolt-level で検出してはいけないため、 `parseKoltArgs` は **kolt-level 前置 flag block (subcommand 名より前) のみ** を対象にする (既存仕様と同じ)。
+
+## Error Handling
+
+### Error Strategy
+
+- 本仕様自体が「kolt のエラー出力規約」を定める仕様であり、 **本仕様内コンポーネントの失敗は基本的に存在しない**:
+  - `ColorPolicy.fromEnv` は失敗しない (POSIX read のみ)
+  - `levenshtein` / `closestMatch` は純粋計算
+  - `extractKtomlLineNo` は match しなければ `null` 返却 (失敗ではない)
+  - `AnsiStripper.strip` は always succeeds
+- `eprintError` 等の writer は出力に失敗しても (ENOSPC 等) silently 続行する (既存 `eprintln` 同様)。 `Result` 型を返さない設計を踏襲。
+
+### Error Categories and Responses
+
+- **diagnostic 出力経路の失敗** (例: stderr fd 閉鎖): 既存 `eprintln` の動作を継承 — `write()` の失敗は無視。 user-facing change なし。
+- **ktoml message format mismatch**: regex match 失敗時は `lineNo = null` で fallback。 表示は `path` のみ。 user は機能後退を被るが、 致命的失敗にはならない。
+- **subprocess `NO_COLOR` 不尊重**: kotlinc / konanc が `NO_COLOR` を honor しない version では subprocess 出力に ANSI が混入する可能性。 daemon 経路は post-strip で吸収、 direct subprocess 経路は user に漏れる。 → 現バージョンでは許容、 Open Question として monitor。
+
+### Monitoring
+
+- 通常運用での monitoring 対象なし (CLI ツール、 ステートレス)
+- self-host CI smoke (`self-host-post`) で `--no-color` / `NO_COLOR=1` 経路を 1 ケースずつ通すこと
+
+## Testing Strategy
+
+### Unit Tests (per component)
+
+- `ColorPolicy.fromEnv`:
+  - `--no-color` → Never
+  - `NO_COLOR=` (empty) → Auto
+  - `NO_COLOR=1` → Never
+  - `--no-color` + `NO_COLOR=1` → Never (順序非依存)
+  - flag/env なし、 isatty stub 経由で stderr-tty / stdout-non-tty → `Auto(true, false)`、 `shouldColor(Stream.Stdout) == false`
+
+- `DiagnosticWriter` (snapshot tests):
+  - `eprintError("foo")` → `error: foo\n`
+  - `eprintError("foo", listOf("at /a:1"))` → `error: foo\n  at /a:1\n`
+  - `eprintError("foo", hint = "try X")` → `error: foo\nnote: try X\n`
+  - color enabled (`ColorPolicy.Always`) で headline に red ANSI が wrap される
+  - color disabled で ANSI 含まない
+  - severity 3 種それぞれ確認
+
+- `AnsiStripper`:
+  - `\x1b[31mred\x1b[0m` → `red`
+  - 複数 sequence、 inline 混在
+  - non-ANSI 文字列 unchanged
+
+- `levenshtein` / `closestMatch`:
+  - distance 0 / 1 / 2
+  - threshold 超過は `null`
+  - 候補リスト lex sorted で同点時 first-match deterministic
+
+- `extractKtomlLineNo`:
+  - `"Line 5: foo"` → `(5, "foo")`
+  - `"foo"` (no prefix) → `(null, "foo")`
+  - `null` (`e.message` may be null) → `(null, "")`
+  - `"Line abc: foo"` → `(null, "Line abc: foo")` (toIntOrNull fail)
+
+- `ConfigErrorEnrichment`:
+  - synthetic broken `kolt.toml` (構文エラー) → `lineNo` 抽出される
+  - 未知 key (`[koltn]` typo) → `keyPath` + `suggestion = "kotlin"`
+  - missing required field → `keyPath` 抽出可、 `lineNo = null`
+
+- `formatResolveError` / `ToolError.render`:
+  - 既存 string-snapshot test を `RenderedDiagnostic` field-level assertion に書き換え (headline / context list / hint slot)
+
+### Integration Tests
+
+- `ConfigParseMessageFormatTest`: 故意に壊した `kolt.toml` に対して ktoml が `^Line N: ` プレフィックス付き message を返すことを pin。 ktoml minor bump 検出用。
+- self-host smoke: `kolt build` を `NO_COLOR=1` で叩いて出力に `\x1b[` が含まれないこと、 `--no-color` でも同じ、 通常 (CI 非 TTY) でも色が出ないこと。
+- subprocess color forwarding integration:
+  - mock kotlinc (色 emit する fixture) を使い、 `NO_COLOR=1 kolt build` が color-free 出力を生成すること
+  - daemon 経路で synthetic ANSI-included stderr blob を返す stub を入れ、 cli 出力で strip されていること
+- unknown subcommand: `kolt buidl` → `error: unknown command 'buidl'` + `note: Did you mean 'build'?` + exit code `EXIT_COMMAND_NOT_FOUND`
+
+### E2E (manual / smoke)
+
+- TTY 環境で `kolt build` 失敗時に red `error:` prefix が見えること
+- `kolt build > log.txt 2>&1` でログファイルに ANSI escape が含まれないこと (R2.2)
+- `kolt build` を `tee` 経由 (stderr が pipe) で stdout TTY のみ → stderr 着色なし、 stdout (もし出れば) 着色あり (R2.5)
+- `NO_COLOR=1 kolt build` で色なし
+- `kolt build --no-color` で色なし
+- `kolt info --format=json` 出力に ANSI 混入しない (R7.1)
+
+### Performance
+
+- 出力経路は既存 `eprintln` 比で 1 行あたり ANSI wrap (高々 ~10 byte 増) と stream check のみ。 perf-critical path ではないので測定対象外。
+
+## Open Questions / Risks
+
+| Item | Status | Mitigation |
+|------|--------|------------|
+| ktoml major bump で `Line N: ` / `Unknown key received` フォーマット変更 | Pinned by test | `ConfigParseMessageFormatTest` で fixture を pin、 bump 時に test green を確認 |
+| kotlinc / konanc subprocess の `NO_COLOR` 尊重保証 | Pinned by test (validate-design Issue 3 解決) | `SubprocessColorForwardingIntegrationTest` で `NO_COLOR=1 kolt --no-daemon build <fail>` の stderr に ANSI が含まれないことを実機 pin。 RED 化したら version 留めるか post-strip fallback 追加 |
+| daemon protocol の wire 変更で stderr blob path が変わる | Risk: Low | `SubprocessColorForwarding` の strip ポイントを protocol 側で再点検 |
+| `--no-color` 以外の global flag を kolt-level で誤抽出 | Risk: Low | parseKoltArgs は `--` までを kolt-level、 以降は passthrough — 既存契約 |
+| stderr / stdout 同時 redirect で TTY 判定が race | Risk: 無 | startup 1 回計算、 process 寿命中不変 |
+| ネスト内 unknown key の Did-you-mean 不在 (R3.4 narrowed) | Deferred (validate-design Issue 1 解決) | top-level section のみ suggestion、 ネスト内 typo は keyPath だけ表示。 follow-up issue 候補 |

--- a/.kiro/specs/2-error-output-formatting/requirements.md
+++ b/.kiro/specs/2-error-output-formatting/requirements.md
@@ -1,0 +1,106 @@
+# Requirements Document
+
+## Project Description (Input)
+GitHub issue #2 (labels: dx, enhancement, size: M, milestone: v1.0) の対応。 kolt の全コマンドに対し、 エラー / 警告 / 情報メッセージを読みやすく整形し、 ANSI カラーで提示し、 設定ファイル (kolt.toml) のエラーには行番号などのコンテキストを付け、 可能な箇所では actionable な提案 ("Did you mean...?", "Run `kolt update` to..." 等) を提示する。 `NO_COLOR` (https://no-color.org/) 環境変数に従う。 v1.0 に向けた Phase 5 (DX improvements) の一部。
+
+## Introduction
+
+kolt は現在、 ユーザー向けエラー / 警告 / 情報メッセージを `eprintln()` で平文 stderr に書き出している。 ANSI カラーは未使用、 ktoml が出すパース失敗の行 / 列情報は catch 時に捨てられ、 unknown command や typo に対する "Did you mean...?" の仕組みも存在しない。 この仕様では、 kolt 自身が生成するすべてのユーザー向けメッセージに対し、 一貫した severity ラベル / 整形 / カラー / コンテキスト / 修復ヒントを導入し、 v1.0 の DX bar (Cargo / Go の組み込みツール水準) を満たす。
+
+## Boundary Context
+
+### In scope
+- kolt 自身が生成するエラー / 警告 / 情報メッセージの整形と着色
+- `kolt.toml` パース / 検証エラーへのファイルパス + 行番号 (取得可能な場合) コンテキスト
+- 依存解決失敗時の座標 / 親座標 / 候補リポジトリの提示
+- 未知サブコマンド / 未知 global flag への "Did you mean...?" 提案と recovery command ヒント
+- `NO_COLOR` / `--no-color` / TTY による色出力ポリシー
+- Linux self-host (現在の唯一サポートプラットフォーム)、 将来 macOS が追加された場合も同じ規約で動作
+
+### Out of scope
+- 機械可読出力 (JSON / SARIF) — 別 spec で扱う
+- `kotlinc` / `konanc` 自身のコンパイラ診断フォーマットの書き換え (kolt は pass-through に徹する)
+- daemon socket protocol message の構造変更
+- `kolt run` 等で起動する target program の stdout / stderr の装飾
+- 進捗インジケータ / spinner / progress bar (本仕様の対象外、 別 issue で扱う)
+- `FORCE_COLOR` 環境変数サポート (v1.0 後に追加検討)
+- 既存の `Result<V, E>` ADT の構造変更 (renderer 層で対応するのが本仕様の前提)
+
+### Adjacent expectations
+- `--watch` ループの状態行は本仕様の severity / カラー規約を採用するが、 状態行の内容自体は本仕様外。
+- daemon log 行は本仕様の stderr / severity prefix 規約を共有するが、 daemon 実装側の責務として個別 PR で揃える。
+- `kolt fmt` / `kolt deps` 等の通常成功時のユーザー向け出力は stdout に書き続ける。 本仕様の severity prefix は stderr 専用。
+
+## Requirements
+
+### Requirement 1: Severity-tagged な統一エラー / 警告 / 情報出力
+
+**Objective:** kolt ユーザーとして、 すべての kolt 生成メッセージが同じ severity ラベル / 整形規約で出力されてほしい、 ターミナル上で error / warning / note を視覚的に瞬時に区別するため。
+
+#### Acceptance Criteria
+1. The kolt CLI shall prefix every fatal failure message with `error:` written to stderr.
+2. The kolt CLI shall prefix every non-fatal advisory message with `warning:` written to stderr.
+3. The kolt CLI shall prefix every supplemental note with `note:` written to stderr.
+4. When a kolt-originated message includes location or context lines (e.g., file path, coordinate, hint), the kolt CLI shall render each context line on its own line, indented beneath the severity-prefixed headline.
+5. The kolt CLI shall continue to write user-requested output (e.g., `kolt run` target program output, `kolt info` results, `kolt deps` listings) to stdout untouched, distinct from the severity-prefixed channel.
+6. While reformatting messages under this spec, the kolt CLI shall not change exit codes for any failure class — exit code contracts remain preserved.
+
+### Requirement 2: ANSI カラーポリシー
+
+**Objective:** kolt ユーザーとして、 端末では severity に応じた色を見たいが、 リダイレクト / `NO_COLOR` / 非 TTY 環境では色制御文字が混ざらないでほしい、 出力を grep / log capture / CI ログに通すため。
+
+#### Acceptance Criteria
+1. When the destination stream is a TTY and no opt-out is active, the kolt CLI shall emit red ANSI for the `error:` prefix, yellow ANSI for the `warning:` prefix, and a visually distinct third color for the `note:` prefix.
+2. When the destination stream is not a TTY (pipe, file redirect), the kolt CLI shall not emit any ANSI escape sequences.
+3. If the `NO_COLOR` environment variable is set to any non-empty value, the kolt CLI shall not emit any ANSI escape sequences regardless of TTY state.
+4. When the user passes `--no-color` on the kolt invocation, the kolt CLI shall not emit any ANSI escape sequences regardless of TTY state or `NO_COLOR` value.
+5. The kolt CLI shall evaluate TTY state independently for stdout and stderr — color is enabled only on streams whose own destination is a TTY.
+6. While color is disabled, the kolt CLI shall ensure no information is conveyed solely by color — every severity is identifiable from the leading text token (`error:` / `warning:` / `note:`).
+
+### Requirement 3: kolt.toml 設定エラーへのコンテキスト付与
+
+**Objective:** kolt ユーザーとして、 `kolt.toml` のシンタックス / 検証エラーがどの行で起きたか即座に分かってほしい、 大きな `kolt.toml` を上から目視で追わずに済ませるため。
+
+#### Acceptance Criteria
+1. When `kolt.toml` parsing or validation fails, the kolt CLI shall include the absolute path of the offending file in the error output.
+2. Where the underlying TOML decoder exposes a line and / or column for the parse failure, the kolt CLI shall include that location in the error output.
+3. When a known `kolt.toml` key is given an unsupported value (e.g., wrong type, malformed coordinate, out-of-range integer), the kolt CLI shall name the offending key path (e.g., `[kotlin] compiler`, `[dependencies] foo`) in the error output.
+4. Where `kolt.toml` decoding rejects an unknown top-level section name (e.g., `[koltn]` instead of `[kotlin]`), the kolt CLI shall include a "Did you mean...?" suggestion when a known top-level section is within a small edit distance of the unknown one. Did-you-mean for nested keys is out of scope for this spec.
+
+### Requirement 4: 依存解決エラーへのコンテキスト付与
+
+**Objective:** kolt ユーザーとして、 依存解決失敗時に「どの座標が」「どこから要求された」「どこを探した」かが分かってほしい、 transitive 解決のどこで詰まっているか特定するため。
+
+#### Acceptance Criteria
+1. When dependency resolution fails for a coordinate, the kolt CLI shall include the full Maven coordinate (group:artifact:version) in the error output.
+2. When the failing coordinate is a transitive dependency, the kolt CLI shall include the requesting parent coordinate (or the originating `kolt.toml` declaration when first-level) in the error output.
+3. If a requested coordinate cannot be found in any configured repository, the kolt CLI shall list the repositories that were probed.
+4. When a checksum or signature verification fails on a downloaded artifact, the kolt CLI shall name the artifact, the expected value, and the observed value in the error output.
+
+### Requirement 5: 修復行動を示す actionable ヒント
+
+**Objective:** kolt ユーザーとして、 エラーごとに次に打つべきコマンドが提示されてほしい、 自分でドキュメントを引かずに修復路に入るため。
+
+#### Acceptance Criteria
+1. When a build failure has a known recovery action (e.g., missing or stale lockfile, missing toolchain artifact), the kolt CLI shall append a `note:` line naming the recovery command (e.g., `kolt fetch`, `kolt update`, `kolt toolchain install`).
+2. If the user invokes an unknown subcommand, the kolt CLI shall list valid subcommands and, when a near-match exists, include a "Did you mean `<subcommand>`?" suggestion.
+3. If the user supplies an unknown global flag, the kolt CLI shall identify the offending flag and, when a near-match exists among supported flags, include a "Did you mean `<flag>`?" suggestion.
+4. The kolt CLI shall ensure suggestion strings are deterministic for a given input (no randomness in candidate selection or ordering).
+
+### Requirement 6: 外部プロセス / daemon 出力との整合
+
+**Objective:** kolt 開発者として、 `kotlinc` / `konanc` / daemon からの診断出力が二重装飾されたり色が消されたりしないでほしい、 kolt の整形と外部診断の境界が明確であるため。
+
+#### Acceptance Criteria
+1. While forwarding `kotlinc` / `konanc` / daemon stdout or stderr to the user, the kolt CLI shall not prepend its own `error:` / `warning:` / `note:` prefixes to forwarded lines.
+2. When the kolt CLI's color policy is enabled and a forwarded subprocess emits ANSI color codes, the kolt CLI shall pass those codes through unaltered.
+3. When the kolt CLI's color policy is disabled, the kolt CLI shall ensure forwarded subprocess output does not reach the user with ANSI color codes (either by signaling the subprocess via standard env vars or by stripping codes downstream).
+4. When the kolt CLI wraps a subprocess failure with its own headline (e.g., "compilation failed"), the kolt CLI shall emit one severity-prefixed kolt headline followed by the forwarded subprocess output without re-prefixing each forwarded line.
+
+### Requirement 7: 機械可読出力チャネルの保全
+
+**Objective:** kolt CI ユーザーとして、 `kolt info --format=json` 等の構造化出力が本仕様で破壊されないでほしい、 既存パイプラインを書き換えずに済ませるため。
+
+#### Acceptance Criteria
+1. While the user requests structured output (e.g., `kolt info --format=json`), the kolt CLI shall not inject ANSI color codes into that structured output stream regardless of TTY state.
+2. The kolt CLI shall continue to route structured output to stdout and severity-prefixed diagnostics to stderr — the two streams remain separately consumable by downstream tools.

--- a/.kiro/specs/2-error-output-formatting/research.md
+++ b/.kiro/specs/2-error-output-formatting/research.md
@@ -1,0 +1,127 @@
+# Gap Analysis — 2-error-output-formatting
+
+## 1. Current State Investigation
+
+### Output sink (single extension point)
+- `kolt/infra/FileSystem.kt:433` — `eprintln(msg: String)` writes to `STDERR_FILENO` directly via posix `write()`. **No buffering, no formatter layer.** This is the single chokepoint for stderr writes; `println` is used for stdout.
+
+### Existing partial renderer patterns (two of them already exist)
+- `kolt/usertool/ToolError.kt` — sealed `ToolError` with `abstract fun formatStderr(): String`. Per-variant rendering, multi-line via plain string concat. Comment in source even says: *"`formatStderr()` emits the variant-specific prefix that R5.4 ('cause-distinguishable surface') relies on"* — already in this style.
+- `kolt/resolve/Resolver.kt:65` — top-level `formatResolveError(error: ResolveError): String`, uses `buildString` + `appendLine` for multi-line context (e.g., `error: sha256 mismatch ... \n  expected: ... \n  got: ...`). Indentation is `"  "` ad hoc.
+
+→ **A pattern is emerging but is duplicated in string-builder form**: each renderer hardcodes its own `"error: "` prefix and its own indentation rule. The spec needs to centralize prefix + color + indent rule, not invent rendering from scratch.
+
+### Mass call sites with raw string `error:` / `warning:`
+- `kolt/cli/BuildCommands.kt` — 20+ inline `eprintln("error: ...")` and `eprintln("warning: ...")` sites (build, check, clean, watch).
+- `kolt/cli/DependencyCommands.kt` — similar pattern, 8+ sites.
+- `kolt/cli/Main.kt:102` — `eprintln("error: unknown command '${filteredArgs[0]}'")`. Extension point for Did-you-mean.
+- `kolt/cli/Main.kt:159+` — `printUsage()` writes via `eprintln(...)` for the help block.
+
+→ All these need to migrate to a typed helper that owns the `error:` prefix, the color decision, and the context-line indent.
+
+### TTY detection — already wired
+- `kolt/cli/ScaffoldIO.kt` imports and uses `platform.posix.isatty`. **No new cinterop needed.** Color policy can call `isatty(STDERR_FILENO)` / `isatty(STDOUT_FILENO)` immediately.
+
+### CLI flag plumbing — single extension point
+- `kolt/cli/Main.kt:127-141` — `parseKoltArgs(argList)` extracts kolt-level flags (`--no-daemon`, `--watch`, `--release`, `-D<k>=<v>`) into `KoltArgs`. **Adding `--no-color` is a 3-line change here** (constant + filter + field).
+
+### kolt.toml line numbers — recoverable but indirect
+- `kolt/config/Config.kt:520-524` catches `SerializationException` / `IllegalArgumentException` and renders `"failed to parse kolt.toml: ${e.message}"`.
+- ktoml-core 0.7.1 (`com/akuleshov7/ktoml/exceptions/TomlDecodingException.kt`) defines:
+  - `internal open class ParseException(message, lineNo) : TomlDecodingException("Line $lineNo: $message")`
+  - `internal class IllegalTypeException(message, lineNo) : TomlDecodingException("Line $lineNo: $message")`
+  - `internal class NullValueException(propertyName, lineNo) : ...("Line: <$lineNo>")` (different format)
+  - `internal class InvalidEnumValueException(value, descriptor, lineNo) : ...("Line $lineNo: ...")`
+  - **NO line number** on `MissingRequiredPropertyException`, `UnknownNameException`, `InternalDecodingException`.
+- The `internal` modifier means kolt cannot pattern-match the exception subclass from outside ktoml — only `e.message` text is stable.
+- ktoml's own `InvalidEnumValueException` already produces `"Did you mean <X>?"` for enum typos via `closestEnumName` (internal utility). Inspiration only — not reusable.
+
+### Existing fuzzy match — none
+- No Levenshtein, edit distance, or "Did you mean" anywhere in kolt source. ktoml's `closestEnumName` is `internal` so unusable from kolt. **New utility required** (~30 lines for normalized Levenshtein).
+
+### Subprocess output forwarding (kotlinc / konanc / daemon)
+- `kolt/build/CompilerBackend.kt` — `CompileError.CompilationFailed(exitCode, stdout, stderr)` carries forwarded subprocess output as separate fields.
+- `kolt/build/SubprocessCompilerBackend.kt:25` — `CompileOutcome(stdout = "", stderr = "")` — subprocess inherits parent stderr fd directly (no capture). Comment: *"konanc inherits the parent process's stderr fd"*.
+- `kolt/build/nativedaemon/NativeDaemonBackend.kt:269` — daemon path captures stderr to a string and surfaces it through `NativeCompileOutcome`.
+- BuildCommands.kt:526 — on failure, `eprintln(body)` then `eprintln(formatCompileError(...))`. So **the kolt headline is one line, then the multi-line forwarded output, then no trailing prefix**. Already roughly the shape R6.4 wants.
+
+### Existing exit codes
+- `kolt/cli/ExitCodes.kt` carries the constants `EXIT_CONFIG_ERROR=2`, `EXIT_DEPENDENCY_ERROR=3`, `EXIT_TOOL_ERROR=7`, `EXIT_COMMAND_NOT_FOUND`, etc. Test pin (`ToolErrorTest.exactlyThreeVariantsRouteThroughExitToolError`) already exists. **No changes needed** — R1.6 / R7.2 are pure preservation.
+
+## 2. Requirement-to-Asset Map
+
+| Req | Capability needed | Current asset | Gap |
+|----|-------------------|---------------|-----|
+| R1 (severity prefix + indent) | Single helper that owns `error:` / `warning:` / `note:` prefix + indented context lines | `eprintln`, two ad hoc renderers (`ToolError.formatStderr`, `formatResolveError`) | **Constraint**: helper must subsume both ad hoc renderers without losing exit-code typing. **Missing**: typed `eprintError(headline, context, hint)` API. |
+| R1.5 (stdout discipline) | Distinguish severity (stderr) from user-requested output (stdout) | Already correct — `println` for stdout, `eprintln` for stderr | None. Preservation only. |
+| R1.6 / R7.2 (exit code preservation) | No code path changes | Exit-code constants pinned by tests | None. |
+| R2 (TTY + NO_COLOR + --no-color) | Color policy module that consults TTY + env + flag, per-stream | `isatty` already imported; `parseKoltArgs` extensible | **Missing**: `ColorPolicy` decision module (new). `--no-color` flag entry in `parseKoltArgs`. |
+| R3.1 (file path) | Always include `kolt.toml` absolute path | `Config.kt:521` swallows path | **Missing**: pass path through `ConfigError.ParseFailed` so renderer can include it. |
+| R3.2 (line / column) | Surface ktoml's `Line N:` from exception message | ktoml encodes lineNo in `e.message` text only (`internal` types not pattern-matchable) | **Research Needed**: regex extraction of `^Line (\d+): ` from `e.message`; document message-format fragility (ktoml minor versions could reword). |
+| R3.3 (key path) | Identify the offending kolt.toml key path | Currently lost in catch | **Missing**: route ktoml `UnknownNameException` / `MissingRequiredPropertyException` content into a dedicated `ConfigError` variant that carries key path. |
+| R3.4 (Did-you-mean key) | Closest-match key suggestion | No prior art | **Missing**: Levenshtein utility + per-section known-key list. |
+| R4 (resolve context) | Coordinate / parent / repos / hashes | Already mostly present in `ResolveError` data classes + `formatResolveError` | **Constraint**: existing variants already carry coordinate; only need format normalization through new helper. R4.4 (checksum mismatch detail) — `Sha256Mismatch(groupArtifact, expected, actual)` already complete. |
+| R5.1 (recovery hint) | Per-error variant `hint: String?` | `LockfileMismatch` already says `"Run \`kolt update\` to refresh tool pins."` inline | **Constraint**: hints currently embedded in headline text; should split into separate `note:` continuation line per R1 indentation rule. |
+| R5.2-3 (subcommand / flag Did-you-mean) | Closest-match utility + known commands list | Known commands are hardcoded in `Main.kt` `when`; no fuzzy match | **Missing**: utility + known-name enumeration. |
+| R6.1 (no kolt prefix on subprocess) | Forward subprocess stderr verbatim | Already correct (BuildCommands.kt:526 pattern) | None. Preservation. |
+| R6.2 / R6.3 (color pass-through / strip) | Color-aware forwarding | Native subprocess inherits parent fd directly (no buffering); daemon path captures into string | **Research Needed**: how to honor `--no-color` for subprocess output. Two viable approaches — (a) env-propagate `NO_COLOR=1` to subprocess + daemon, (b) post-strip ANSI regex. (a) is cleaner but requires daemon protocol awareness. |
+| R7.1 (no ANSI in JSON) | Color policy aware of structured-output context | `kolt info --format=json` writes JSON to stdout via `println` | **Missing**: ensure stdout color policy is bypassed when `--format=json` is in effect (or simpler: structured output never reaches the color helper in the first place). Likely already correct since stdout `println` doesn't invoke severity helper. |
+
+## 3. Implementation Approach Options
+
+### Option A — Extend existing components only
+Centralize prefix + color into a typed `eprintError` / `eprintWarning` / `eprintNote` triplet wrapping `eprintln`. Existing two renderers (`ToolError.formatStderr`, `formatResolveError`) drop their `error:` prefix and return only headline + structured context. Mass-migrate raw `eprintln("error: ...")` call sites.
+
+- ✅ Minimal new files (one helper module + one ColorPolicy)
+- ✅ Reuses `eprintln` extension point and `parseKoltArgs` flag plumbing
+- ✅ Existing renderer ADTs (`ToolError`, `ResolveError`) keep their shapes
+- ❌ ~30+ call sites change mechanically — partial-migration risk
+- ❌ `formatResolveError` multi-line `buildString` needs careful split between headline / context
+- ❌ R3.2 line-number extraction via regex on ktoml's `e.message` is fragile (acknowledged Research Needed)
+
+### Option B — New `Diagnostic` ADT layer
+Define `data class Diagnostic(severity, headline, context: List<String>, hint: String?)` and a renderer module. All error paths produce `Diagnostic` values; CLI dispatcher renders. Existing `ToolError.formatStderr` / `formatResolveError` are replaced by `toDiagnostic()` returning the ADT.
+
+- ✅ Clean ADT-driven flow, easy unit testing of rendering
+- ✅ Severity / context / hint carried as data, not strings — easier to test "Did you mean" attachment
+- ✅ Future JSON output spec can serialize Diagnostic directly
+- ❌ Larger surface change — every error path call site changes, not just the eprintln callers
+- ❌ Existing two ad hoc renderers must be rewritten, not lightly tweaked
+- ❌ Risk of churning test fixtures pinned on current string formats
+
+### Option C — Hybrid: typed eprintln helpers + Diagnostic for new error contexts
+Phase 1 (this spec): introduce `eprintError(headline, context = emptyList(), hint = null)` / `eprintWarning(...)` / `eprintNote(...)` plus `ColorPolicy`. Refactor existing renderers to drop their hardcoded `error:` prefix and call the helper. Wire `--no-color` flag and `NO_COLOR` env. Add Levenshtein utility + Did-you-mean wiring at Main dispatcher and Config decoder.
+
+Phase 2 (out of scope, future): when JSON diagnostic output is added, introduce `Diagnostic` ADT around the same helper.
+
+- ✅ Smaller migration surface — `eprintln("error: X")` → `eprintError("X")` is mechanical and greppable
+- ✅ Existing `ToolError.formatStderr` style preserved (returns a tuple `(headline, context)`); only the prefix concatenation moves
+- ✅ Tests pin headline format separately from prefix, so refactor is bisectable
+- ❌ Two patterns coexist (positional helper call vs future Diagnostic ADT) until Phase 2 — minor cost
+
+## 4. Recommendation for design phase
+
+**Preferred approach: Option C (Hybrid)**. Phase 1 alone covers all 7 requirements without inventing a Diagnostic ADT this spec doesn't strictly need. The existing two renderers (`ToolError`, `ResolveError`) already prove the headline-plus-context shape works; centralizing prefix + color is sufficient.
+
+### Key design decisions for design.md
+1. **Color policy module shape**: `enum class ColorMode { Auto, Always, Never }` decided once at startup from `(--no-color flag, NO_COLOR env, isatty)`; cached per-stream (stderr vs stdout) since they have independent TTY state.
+2. **Renderer API surface**: `eprintError(headline: String, context: List<String> = emptyList(), hint: String? = null)` etc. Each context line is rendered indented (e.g., `"  ${line}"`) under the colored prefix; hint is a separate `note:`-prefixed continuation.
+3. **Where `--no-color` is parsed**: kolt-level flag in `parseKoltArgs`, threaded into the ColorPolicy initializer. Per-command parsing rejected — color decision must be uniform across the run.
+4. **kolt.toml line-number extraction**: regex `^Line (\d+): ` against `e.message`, applied in a new `ConfigError.ParseFailed(path, lineNo: Int?, detail: String)` shape. Add a lockstep test pinning ktoml version → message format. ktoml major-version bumps require revisiting.
+5. **Subprocess color stripping (R6.3)**: prefer env-propagation (`NO_COLOR=1` set in subprocess env when color is disabled) over post-strip. kotlinc + konanc both honor `NO_COLOR`. Daemon path is more involved — confirm in design that daemon subprocess wrapper passes the env through.
+6. **Did-you-mean utility**: new `kolt.cli.Suggestions` module with normalized Levenshtein, threshold ≤ 2 (or `min(2, |target| / 4)` adaptive). Candidate sets: known kolt subcommands (hardcoded list), known global flags (hardcoded list), known kolt.toml top-level keys (derived from `KoltConfigRaw` `@SerialName` annotations or hardcoded list).
+7. **`note:` color choice**: cyan or bright-black recommended (visually distinct from yellow/red, plays well on both light and dark backgrounds). Design phase should pin one for cross-platform consistency.
+
+### Research Needed (carry forward)
+- **R3.2 ktoml message-format stability**: Verify ktoml ≥ 0.7.1 always emits `^Line N: ` prefix on `ParseException` / `IllegalTypeException` / `InvalidEnumValueException`. Add a regression test against a synthetic broken `kolt.toml` to pin the format. ktoml minor-version bumps run this test.
+- **R6.3 daemon env propagation**: Walk the daemon spawn path (`kolt-jvm-compiler-daemon`, `kolt-native-compiler-daemon`) to confirm child process env inherits the parent's `NO_COLOR`. If not, decide between (a) protocol extension to ship the env, (b) post-strip on the captured stderr blob.
+- **R5.1 recovery hint catalog**: Enumerate the failure-class → recovery-command pairs that should fire `note:` lines. Initial candidates: stale-lockfile → `kolt update`; missing toolchain → `kolt toolchain install`; missing local jar → `kolt fetch`. Verify with current error variant coverage.
+- **R7.1 JSON path verification**: `kolt info --format=json` emits via `println` — confirm there is no path where severity helper writes to stdout in JSON mode.
+
+## 5. Effort & Risk
+
+- **Effort: M (3–7 days)**. Single-developer week. Bulk is mechanical refactor of ~30 raw `eprintln("error: ...")` sites + 2 renderer migrations + 1 ColorPolicy module + 1 Suggestions utility + 1 ktoml message regex extractor. Tests pin both pre- and post-format to catch partial migration.
+- **Risk: Low–Medium**.
+  - Low for color policy, severity helper, Did-you-mean wiring (extending established patterns).
+  - Medium for ktoml line-number extraction (string-format coupling) and subprocess color stripping (daemon protocol awareness).
+  - Cross-cutting test surface needs investment: one snapshot test per renderer covering color-on / color-off / NO_COLOR / non-TTY.

--- a/.kiro/specs/2-error-output-formatting/spec.json
+++ b/.kiro/specs/2-error-output-formatting/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "2-error-output-formatting",
+  "created_at": "2026-05-07T23:46:15Z",
+  "updated_at": "2026-05-08T00:50:00Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -12,7 +12,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 1.4_
   - _Boundary: kolt.infra.output value types_
 
-- [ ] 1.2 (P) `ColorPolicy` sealed class と `fromEnv` / `install` / `current` を実装
+- [x] 1.2 (P) `ColorPolicy` sealed class と `fromEnv` / `install` / `current` を実装
   - `ColorPolicy.Always / Never / Auto(isStderrTty, isStdoutTty)` sealed 階層
   - `fromEnv(noColorFlag)` の決定順: `noColorFlag → NO_COLOR env → isatty(STDERR/STDOUT_FILENO)` を実装
   - module-level `var currentPolicy` を `install` で更新、 `current()` で読む。 startup 1 回計算契約をコメントに残す

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -233,7 +233,7 @@
   - _Depends: 5.1, 6.1, 6.2, 6.3_
   - _Boundary: end-to-end (kotlinc / konanc subprocess + daemon)_
 
-- [ ] 8.4 (P) `kolt info --format=json` の no-ANSI 検証 (R7.1 pin)
+- [x] 8.4 (P) `kolt info --format=json` の no-ANSI 検証 (R7.1 pin)
   - `kolt info --format=json` を TTY 環境 (isatty stub or 実 TTY) で実行、 stdout 出力に ANSI escape が含まれないこと
   - `--no-color` / `NO_COLOR=1` / TTY-redirect の各組合せでも stdout JSON は変化しない (severity 系の writer が stdout に漏れない契約)
   - 観察可能な完了: integration test green、 JSON 出力が `JSON.parse` 可能で ANSI 0 件

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -194,7 +194,7 @@
   - _Depends: 1.3, 3.1, 4.4_
   - _Boundary: kolt.cli.DependencyCommands (raw eprintln sites)_
 
-- [ ] 7.3 (P) `ToolCommands.kt` および残り cli 系ファイル (InfoCommand / ScaffoldIO / DaemonCommand / CacheCommand 等) の raw eprintln 呼び出しを置換
+- [x] 7.3 (P) `ToolCommands.kt` および残り cli 系ファイル (InfoCommand / ScaffoldIO / DaemonCommand / CacheCommand 等) の raw eprintln 呼び出しを置換
   - 各 file 内の raw `eprintln("error:...` / `eprintln("warning:...` を typed writer に migrate
   - `printUsage()` の help 出力はそのまま (情報表示、 severity 装飾不要 — informational `eprintln` はそのまま許容)
   - 観察可能な完了: 全 cli/* ファイルで raw `eprintln("error:...` / `eprintln("warning:...` 0 件、 `kolt info` / `kolt daemon` / `kolt cache` の自動テスト green

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -22,7 +22,7 @@
   - _Requirements: 2.2, 2.3, 2.4, 2.5_
   - _Boundary: kolt.infra.output.ColorPolicy_
 
-- [ ] 1.3 `DiagnosticWriter` 関数群 (`eprintError` / `eprintWarning` / `eprintNote` / `eprintDiagnostic`) と `AnsiStripper` を実装
+- [x] 1.3 `DiagnosticWriter` 関数群 (`eprintError` / `eprintWarning` / `eprintNote` / `eprintDiagnostic`) と `AnsiStripper` を実装
   - 4 関数全てが `policy: ColorPolicy = ColorPolicy.current()` の default arg を持つ — caller 側 churn なしで testability を確保 (validate-design Issue 2 解決)
   - rendering algorithm: severity ラベル決定 → `policy.shouldColor(Stream.Stderr)` → ANSI wrap or plain → headline `eprintln` → context lines を 2 スペース indent で `eprintln` → hint があれば `note:` プレフィックス line で `eprintln`
   - `AnsiStripper.strip(s)` は CSI regex (`\\x1B\\[[0-?]*[ -/]*[@-~]`) で escape sequence を除去

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -105,7 +105,7 @@
   - _Depends: 1.3, 4.1, 4.2, 4.3_
   - _Boundary: kolt.config.Config (ktoml catch + renderConfigError) + cli consumers_
 
-- [ ] 4.5 ktoml message-format pin test (`ConfigParseMessageFormatTest`) を追加
+- [x] 4.5 ktoml message-format pin test (`ConfigParseMessageFormatTest`) を追加
   - `tmp/kolt.toml` に故意に壊した TOML (構文エラー / unknown top-level / unknown nested) を生成、 ktoml decode を呼んで実 exception の `message` 文字列を取得
   - regex `^Line \\d+: ` と `^Unknown key received: <[^>]+> in scope <[^>]*>` の 2 つが現行 ktoml 0.7.1 出力と一致することを assert
   - ktoml major bump 時にこのテストが RED 化することで形式変更を検知。 README にこの test の役割をコメントとして書く

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -203,7 +203,7 @@
   - _Boundary: kolt.cli (ToolCommands + InfoCommand + ScaffoldIO + DaemonCommand + CacheCommand) — ConfigError display sites は 4.4 所有のため再 migration しない_
 
 - [ ] 8. Validation: integration / E2E pin
-- [ ] 8.1 (P) `NO_COLOR` / `--no-color` / TTY-redirect の E2E smoke (cross-cutting)
+- [x] 8.1 (P) `NO_COLOR` / `--no-color` / TTY-redirect の E2E smoke (cross-cutting)
   - `kolt --no-color build <synthetic-fail-fixture>` の stderr に ANSI escape (`\\x1B[`) が一切含まれないこと (R2.4)
   - `NO_COLOR=1 kolt build <fail>` で同上 (R2.3)
   - `kolt build <fail> 2>log.txt` (stderr redirect) で log.txt に ANSI 含まれないこと (R2.2)

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -96,7 +96,7 @@
   - _Requirements: 3.1_
   - _Boundary: kolt.config (ConfigError data class shape)_
 
-- [ ] 4.4 ktoml 例外 catch 節を新 helper 経由にし、 `renderConfigError` を実装、 cli caller を更新
+- [x] 4.4 ktoml 例外 catch 節を新 helper 経由にし、 `renderConfigError` を実装、 cli caller を更新
   - `Config.kt:520-524` の catch 節を `extractKtomlLineNo` + `parseUnknownKey` 経由にし、 `ParseFailed(message, path = absKoltTomlPath, lineNo = ..., keyPath = ..., suggestion = ...)` を構築
   - `renderConfigError(e: ConfigError.ParseFailed): RenderedDiagnostic` を実装: headline = `e.message`、 context = `["at {path}:{lineNo}", "key: {keyPath}"]` (path / lineNo / keyPath が null なら該当行省略)、 hint = `suggestion?.let { "Did you mean \`$it\`?" }`
   - cli caller (`BuildCommands.kt:251`, `DependencyCommands.kt:42`) の `eprintln("error: ${error.message}")` を `eprintDiagnostic(renderConfigError(error))` に置換。 `WatchChangeDispatch.kt:76` / `InfoCommand.kt:380` は `.message` を文字列として再加工する経路なので renderer 経由に書き換え (情報が落ちないよう確認)

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -222,7 +222,7 @@
   - _Depends: 5.2, 5.3_
   - _Boundary: kolt.cli.Main (unknown subcommand / flag E2E)_
 
-- [ ] 8.3 (P) `SubprocessColorForwardingIntegrationTest` — kotlinc / konanc が `NO_COLOR=1` を honor することの実機 pin (validate-design Issue 3 解決)
+- [x] 8.3 (P) `SubprocessColorForwardingIntegrationTest` — kotlinc / konanc が `NO_COLOR=1` を honor することの実機 pin (validate-design Issue 3 解決)
   - fixture: 故意に compile error を起こす `*.kt` を配置した tmp project
   - シナリオ 1: `NO_COLOR=1 kolt --no-daemon build` (kotlinc direct subprocess 経路) — stderr に `\\x1B[` 含まれない
   - シナリオ 2: `kolt --no-color --no-daemon build` (同上、 flag 経由)

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -71,7 +71,7 @@
   - _Boundary: kolt.usertool.ToolError + その cli consumer_
 
 - [ ] 4. kolt.toml 設定エラー enrichment (path / lineNo / keyPath / suggestion)
-- [ ] 4.1 ktoml 例外 message から `Line N: ` プレフィックスを抽出する helper を実装
+- [x] 4.1 ktoml 例外 message から `Line N: ` プレフィックスを抽出する helper を実装
   - `extractKtomlLineNo(message: String?): Pair<Int?, String>` を `kolt.config` 内 internal で定義
   - regex `^Line (\\d+): ` で前置きにマッチ、 数値 + 残りメッセージを返す。 message null / マッチなし / `Line abc:` (toIntOrNull fail) の 3 fallback で `null` to original を返す
   - テスト: `"Line 5: foo" → (5, "foo")`、 `"foo" → (null, "foo")`、 `null → (null, "")`、 `"Line abc: foo" → (null, "Line abc: foo")` の 4 ケース
@@ -79,7 +79,7 @@
   - _Requirements: 3.2_
   - _Boundary: kolt.config (extractKtomlLineNo)_
 
-- [ ] 4.2 unknown key 検出 + top-level section の Did-you-mean を実装
+- [x] 4.2 unknown key 検出 + top-level section の Did-you-mean を実装
   - `KNOWN_TOP_LEVEL_SECTIONS` を `["build", "cinterop", "classpaths", "dependencies", "fmt", "kotlin", "repositories", "run", "test", "tools"]` の sorted hardcoded list として定義 (R3.4 narrow scope)
   - `parseUnknownKey(detail: String): Pair<String?, String?>` を実装、 ktoml の `"Unknown key received: <X> in scope <Y>"` regex 抽出。 `Y` が空 (top-level) のとき `closestMatch(X, KNOWN_TOP_LEVEL_SECTIONS)` を呼ぶ、 ネストでは suggestion なし (key path だけ返す)
   - テスト: top-level typo (`<koltn>` in scope `<>`) → key="koltn", suggestion="kotlin"、 nested unknown (`<compilerr>` in scope `<kotlin>`) → key="compilerr", suggestion=null、 regex 不一致 → both null

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -185,7 +185,7 @@
   - _Depends: 1.3, 3.1, 4.4, 6.3_
   - _Boundary: kolt.cli.BuildCommands (raw eprintln sites — daemon forward line は 6.3 所有、 ConfigError display は 4.4 所有のため対象外)_
 
-- [ ] 7.2 (P) `DependencyCommands.kt` の残り raw eprintln 呼び出しを置換
+- [x] 7.2 (P) `DependencyCommands.kt` の残り raw eprintln 呼び出しを置換
   - 対象: `kolt fetch` / `kolt update` / `kolt tree` / `kolt add` / `kolt remove` の error / warning 出力
   - 各置換で R6.4 (subprocess wrap pattern) を破壊しないよう注意 — daemon body forward + kolt headline の順序を 7.1 と同じ規則で維持
   - 既存 string-snapshot test の更新

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -1,0 +1,242 @@
+# Implementation Plan
+
+> Each executable sub-task is TDD-atomic (test + impl in the same task) per t_wada protocol — RED-only commit は reviewer に reject される (memory: feedback_tdd_red_green_atomic)。
+
+- [ ] 1. Foundation: infra/output 層 (severity / writer / color policy)
+- [x] 1.1 (P) `Severity` enum と `RenderedDiagnostic` data class、 ANSI escape constants を導入
+  - `Severity.Error / Warning / Note` の 3 値 enum を定義
+  - `RenderedDiagnostic(severity, headline, context, hint)` を pure data class として定義 (`headline` 単一行、 `context: List<String>`、 `hint: String?`)
+  - ANSI constants (`RED = "\\x1B[31m"`, `YELLOW`, `CYAN`, `RESET`) を定義
+  - 同パッケージで 3 種の data class equality / copy / toString が動くテストと、 ANSI 定数値が `\\x1B[31m` 等の正しいバイト列であるテストを追加
+  - 観察可能な完了: `kolt test --filter SeverityTest --filter RenderedDiagnosticTest --filter AnsiCodesTest` が green、 `kolt build` が green
+  - _Requirements: 1.1, 1.2, 1.3, 1.4_
+  - _Boundary: kolt.infra.output value types_
+
+- [ ] 1.2 (P) `ColorPolicy` sealed class と `fromEnv` / `install` / `current` を実装
+  - `ColorPolicy.Always / Never / Auto(isStderrTty, isStdoutTty)` sealed 階層
+  - `fromEnv(noColorFlag)` の決定順: `noColorFlag → NO_COLOR env → isatty(STDERR/STDOUT_FILENO)` を実装
+  - module-level `var currentPolicy` を `install` で更新、 `current()` で読む。 startup 1 回計算契約をコメントに残す
+  - 4 ケースのテスト: `noColorFlag=true → Never`、 `NO_COLOR=1 → Never`、 両者 set → `Never`、 環境クリーン → `Auto(true,true)` (isatty stub) と `Auto(true,false)` (stdout のみリダイレクト stub)
+  - `isatty` / `getenv` 呼び出しは callable parameter として注入できる internal seam を `fromEnv` に持たせ、 unit test は stub、 production は POSIX 実関数を渡す
+  - 観察可能な完了: `kolt test --filter ColorPolicyTest` で 4 ケース green、 stub 経由で全分岐がカバーされる
+  - _Requirements: 2.2, 2.3, 2.4, 2.5_
+  - _Boundary: kolt.infra.output.ColorPolicy_
+
+- [ ] 1.3 `DiagnosticWriter` 関数群 (`eprintError` / `eprintWarning` / `eprintNote` / `eprintDiagnostic`) と `AnsiStripper` を実装
+  - 4 関数全てが `policy: ColorPolicy = ColorPolicy.current()` の default arg を持つ — caller 側 churn なしで testability を確保 (validate-design Issue 2 解決)
+  - rendering algorithm: severity ラベル決定 → `policy.shouldColor(Stream.Stderr)` → ANSI wrap or plain → headline `eprintln` → context lines を 2 スペース indent で `eprintln` → hint があれば `note:` プレフィックス line で `eprintln`
+  - `AnsiStripper.strip(s)` は CSI regex (`\\x1B\\[[0-?]*[ -/]*[@-~]`) で escape sequence を除去
+  - snapshot test: 3 severity × `policy = Always / Never` × (headline-only / +context / +hint / +context+hint) の組合せで stderr 出力 byte-level pin。 `AnsiStripper.strip` は inline ANSI 混在 / 複数 sequence / non-ANSI unchanged の 3 ケース
+  - 観察可能な完了: `eprintError("foo", policy = ColorPolicy.Always)` が `\\x1B[31merror:\\x1B[0m foo\\n` を stderr に書く snapshot test green、 `eprintError("foo", listOf("at /a:1"), "try X", policy = ColorPolicy.Never)` が `error: foo\\n  at /a:1\\nnote: try X\\n` を書く snapshot test green
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.6, 6.3_
+  - _Depends: 1.1, 1.2_
+  - _Boundary: kolt.infra.output.DiagnosticWriter_
+
+- [ ] 2. Foundation: infra/suggest 層 (Levenshtein + closestMatch) — Major 1 と並行実行可、 sub-task が parallel-safe
+- [ ] 2.1 `levenshtein(a, b): Int` を実装
+  - 標準 dynamic-programming edit distance (insert / delete / substitute コスト各 1)
+  - テスト: distance 0 (`"foo" / "foo"`)、 1 (`"foo" / "fo"`)、 2 (`"foo" / "fox"`)、 完全相違 (`"" / "abc"` → 3) の 4 ケース
+  - 観察可能な完了: `kolt test --filter LevenshteinTest` 4 ケース green
+  - _Requirements: 5.4_
+  - _Boundary: kolt.infra.suggest.Levenshtein_
+
+- [ ] 2.2 `closestMatch(input, candidates, maxDistance)` を実装、 deterministic ordering を保証
+  - `adaptiveThreshold(inputLength) = if (inputLength <= 4) 1 else 2` の default
+  - candidates 走査は順序保存、 同点最小距離は最初に見つかったものを返す。 caller が sorted list を渡せば lex 順 deterministic
+  - テスト: 距離 1 で hit、 閾値超過で `null`、 同点候補 2 つで先頭が選ばれる、 空 candidates で `null` の 4 ケース
+  - 観察可能な完了: `closestMatch("buidl", listOf("build", "test"))` が `"build"` を返す test green、 `closestMatch("xyz", listOf("build"))` が `null` を返す test green
+  - _Requirements: 3.4, 5.2, 5.3, 5.4_
+  - _Depends: 2.1_
+  - _Boundary: kolt.infra.suggest.ClosestMatch_
+
+- [ ] 3. Renderer ADT migration (existing renderer の signature 変更 + 全 caller 同時更新)
+- [ ] 3.1 (P) `formatResolveError` を `String` 返却から `RenderedDiagnostic` 返却に migrate、 全 cli caller を同時更新
+  - 各 `ResolveError` variant の `error: ...` プレフィックスを削除し、 `headline` / `context: List<String>` / `hint` の 3 slot に分解
+  - 例: `Sha256Mismatch` は headline = `"sha256 mismatch for {ga}"`、 context = `["expected: ...", "got:      ..."]`、 hint = null
+  - 例: `DownloadFailed.AllAttemptsFailed` は context に各 attempt 行を `"  {url} -> {status}"` 形式で格納
+  - cli call site (`BuildCommands.kt`, `DependencyCommands.kt`) の `eprintln(formatResolveError(...))` を `eprintDiagnostic(formatResolveError(...))` に書き換え、 既存の string-snapshot test を `RenderedDiagnostic` field-level assertion に置換
+  - 観察可能な完了: `kolt test --filter ResolveErrorTest` 全 variant green、 `kolt build` で resolve error fixture が cli 経由で従来同等の出力 (color disabled で平文比較) を出す
+  - _Requirements: 4.1, 4.2, 4.3, 4.4, 5.1, 6.1_
+  - _Depends: 1.3_
+  - _Boundary: kolt.resolve.formatResolveError + その cli consumer_
+
+- [ ] 3.2 (P) `ToolError.formatStderr` を `ToolError.render(): RenderedDiagnostic` に migrate、 全 cli caller を同時更新
+  - sealed class `ToolError` の `abstract fun formatStderr(): String` を `abstract fun render(): RenderedDiagnostic` に置換、 全 variant を更新
+  - `LockfileMismatch` の inline `"Run \`kolt update\` to refresh tool pins."` を `hint` slot へ移動 (R5.1 の severity 分離)
+  - `ToolCommands.kt` の `eprintln(error.formatStderr())` を `eprintDiagnostic(error.render())` に書き換え
+  - 既存 `ToolErrorTest.exactlyThreeVariantsRouteThroughExitToolError` の exit code pin が green を維持していることを確認
+  - 観察可能な完了: `kolt test --filter ToolErrorTest` 全 variant green、 `EXIT_TOOL_ERROR=7` ルーティングが unchanged
+  - _Requirements: 4.1, 5.1, 6.1_
+  - _Depends: 1.3_
+  - _Boundary: kolt.usertool.ToolError + その cli consumer_
+
+- [ ] 4. kolt.toml 設定エラー enrichment (path / lineNo / keyPath / suggestion)
+- [ ] 4.1 ktoml 例外 message から `Line N: ` プレフィックスを抽出する helper を実装
+  - `extractKtomlLineNo(message: String?): Pair<Int?, String>` を `kolt.config` 内 internal で定義
+  - regex `^Line (\\d+): ` で前置きにマッチ、 数値 + 残りメッセージを返す。 message null / マッチなし / `Line abc:` (toIntOrNull fail) の 3 fallback で `null` to original を返す
+  - テスト: `"Line 5: foo" → (5, "foo")`、 `"foo" → (null, "foo")`、 `null → (null, "")`、 `"Line abc: foo" → (null, "Line abc: foo")` の 4 ケース
+  - 観察可能な完了: `kolt test --filter ExtractKtomlLineNoTest` 4 ケース green
+  - _Requirements: 3.2_
+  - _Boundary: kolt.config (extractKtomlLineNo)_
+
+- [ ] 4.2 unknown key 検出 + top-level section の Did-you-mean を実装
+  - `KNOWN_TOP_LEVEL_SECTIONS` を `["build", "cinterop", "classpaths", "dependencies", "fmt", "kotlin", "repositories", "run", "test", "tools"]` の sorted hardcoded list として定義 (R3.4 narrow scope)
+  - `parseUnknownKey(detail: String): Pair<String?, String?>` を実装、 ktoml の `"Unknown key received: <X> in scope <Y>"` regex 抽出。 `Y` が空 (top-level) のとき `closestMatch(X, KNOWN_TOP_LEVEL_SECTIONS)` を呼ぶ、 ネストでは suggestion なし (key path だけ返す)
+  - テスト: top-level typo (`<koltn>` in scope `<>`) → key="koltn", suggestion="kotlin"、 nested unknown (`<compilerr>` in scope `<kotlin>`) → key="compilerr", suggestion=null、 regex 不一致 → both null
+  - 観察可能な完了: `kolt test --filter ParseUnknownKeyTest` 3 ケース green、 hardcoded list が `KoltConfigRaw` の field 名と一致することを確認する drift guard test 1 件 green
+  - _Requirements: 3.3, 3.4_
+  - _Depends: 2.2_
+  - _Boundary: kolt.config (parseUnknownKey + KNOWN_TOP_LEVEL_SECTIONS)_
+
+- [ ] 4.3 `ConfigError.ParseFailed` shape を nullable default 付きで拡張 (compile-safe migration)
+  - field 追加: `path: String? = null`, `lineNo: Int? = null`, `keyPath: String? = null`, `suggestion: String? = null` を既存 `message: String` の後に **default 付き** で追加。 これにより `kolt.config.Config.kt` (~24 ヶ所)、 `kolt.config.Main.kt` (2 ヶ所)、 `kolt.cli.BuildCommands.kt:266` の既存全 ~28 構築箇所は no-op で再コンパイル成功する
+  - 既存パターン `is ConfigError.ParseFailed -> ... err.message` を読む箇所 (`WatchChangeDispatch.kt:76`, `InfoCommand.kt:380`, `DependencyCommands.kt:42`, `BuildCommands.kt:251`) は `message` field アクセスのみなので無変更で動作することを確認
+  - data class equality / copy / toString の test を更新、 nullable field を含む新 shape の round-trip pin
+  - 観察可能な完了: `kolt build` (kolt 自身) が green、 既存 `ConfigError.ParseFailed` の string-message-only 構築が全ファイル compile-success、 `ParseFailed("foo")` と `ParseFailed("foo", path = "/k.toml")` の両形式が共存する unit test green
+  - _Requirements: 3.1_
+  - _Boundary: kolt.config (ConfigError data class shape)_
+
+- [ ] 4.4 ktoml 例外 catch 節を新 helper 経由にし、 `renderConfigError` を実装、 cli caller を更新
+  - `Config.kt:520-524` の catch 節を `extractKtomlLineNo` + `parseUnknownKey` 経由にし、 `ParseFailed(message, path = absKoltTomlPath, lineNo = ..., keyPath = ..., suggestion = ...)` を構築
+  - `renderConfigError(e: ConfigError.ParseFailed): RenderedDiagnostic` を実装: headline = `e.message`、 context = `["at {path}:{lineNo}", "key: {keyPath}"]` (path / lineNo / keyPath が null なら該当行省略)、 hint = `suggestion?.let { "Did you mean \`$it\`?" }`
+  - cli caller (`BuildCommands.kt:251`, `DependencyCommands.kt:42`) の `eprintln("error: ${error.message}")` を `eprintDiagnostic(renderConfigError(error))` に置換。 `WatchChangeDispatch.kt:76` / `InfoCommand.kt:380` は `.message` を文字列として再加工する経路なので renderer 経由に書き換え (情報が落ちないよう確認)
+  - 観察可能な完了: synthetic broken `kolt.toml` (構文エラー / 未知 top-level key / 未知 nested key) 3 ケースの integration test で、 stderr 出力に絶対パス + 行番号 (該当時) + key path (該当時) + suggestion (top-level 未知時) が正しく出る
+  - _Requirements: 3.1, 3.2, 3.3, 3.4_
+  - _Depends: 1.3, 4.1, 4.2, 4.3_
+  - _Boundary: kolt.config.Config (ktoml catch + renderConfigError) + cli consumers_
+
+- [ ] 4.5 ktoml message-format pin test (`ConfigParseMessageFormatTest`) を追加
+  - `tmp/kolt.toml` に故意に壊した TOML (構文エラー / unknown top-level / unknown nested) を生成、 ktoml decode を呼んで実 exception の `message` 文字列を取得
+  - regex `^Line \\d+: ` と `^Unknown key received: <[^>]+> in scope <[^>]*>` の 2 つが現行 ktoml 0.7.1 出力と一致することを assert
+  - ktoml major bump 時にこのテストが RED 化することで形式変更を検知。 README にこの test の役割をコメントとして書く
+  - 観察可能な完了: `kolt test --filter ConfigParseMessageFormatTest` 3 ケース green、 ktoml 依存の正規表現 contract が test fixture で固定される
+  - _Requirements: 3.2, 3.3_
+  - _Depends: 4.1, 4.2_
+  - _Boundary: kolt.config (test fixture)_
+
+- [ ] 5. CLI startup + dispatcher integration
+- [ ] 5.1 `parseKoltArgs` に `--no-color` flag、 `KoltArgs.useColor` field、 `Main.kt` startup で `ColorPolicy.install` を実装
+  - `internal const val NO_COLOR_FLAG = "--no-color"` を追加、 `KoltArgs` に `noColor: Boolean` field を追加
+  - `parseKoltArgs` で `--no-color` を抽出、 `filteredArgs` から strip
+  - `main` 入口直後で `ColorPolicy.install(ColorPolicy.fromEnv(noColorFlag = koltArgs.noColor))` を呼ぶ。 既存 dispatch 順序は不変
+  - テスト: `parseKoltArgs(["--no-color", "build"])` → `noColor=true`, `filteredArgs=["build"]`、 `parseKoltArgs(["build"])` → `noColor=false`、 `parseKoltArgs(["--no-color", "--no-daemon", "build"])` → 両 flag 抽出されて filteredArgs から削除
+  - 観察可能な完了: `kolt --no-color build <synthetic-fail>` 実行で stderr 出力に ANSI escape (`\\x1B[`) が一切含まれない smoke test green、 `kolt build` (TTY redirect 想定の test 環境) でも非 TTY 経路により ANSI なし
+  - _Requirements: 2.4_
+  - _Depends: 1.2_
+  - _Boundary: kolt.cli.Main (parseKoltArgs + main startup)_
+
+- [ ] 5.2 未知サブコマンドへの Did-you-mean 提案を dispatcher に実装
+  - `Main.kt` の `else -> eprintln("error: unknown command ...")` 節を `eprintError(headline, hint = closestMatch(unknown, KNOWN_SUBCOMMANDS_SORTED)?.let { "Did you mean \`$it\`?" })` に置換
+  - `KNOWN_SUBCOMMANDS_SORTED` を dispatcher `when` の隣に sorted alphabetical list として hardcoded (drift guard コメントを残す)
+  - `printUsage()` の出力は維持。 exit code は `EXIT_COMMAND_NOT_FOUND` のまま
+  - テスト: `kolt buidl` → stderr に `error: unknown command 'buidl'` + `note: Did you mean \`build\`?` + exit code 確認
+  - 観察可能な完了: integration test で `kolt buidl` が `Did you mean \`build\`?` を出すこと、 `kolt xxx-totally-unrelated` (距離超過) では suggestion 行が出ないこと
+  - _Requirements: 5.2, 5.4_
+  - _Depends: 1.3, 2.2, 5.1_
+  - _Boundary: kolt.cli.Main (unknown subcommand path)_
+
+- [ ] 5.3 未知 global flag への Did-you-mean 提案を `parseKoltArgs` 経路に実装
+  - `KoltArgs` に `unknownFlags: List<String>` field を追加 (Result 返却ではなく値返却で統一、 既存 `parseKoltArgs` の signature と対称)
+  - `parseKoltArgs` で kolt-level block (subcommand 名より前) に既知 flag set / `-D` / passthrough のいずれにも該当しない `--xxx` を検出して `unknownFlags` に積む
+  - `KNOWN_KOLT_FLAGS = ["--no-color", "--no-daemon", "--release", "--watch"]` を sorted alphabetical list として hardcoded (drift guard コメント)
+  - dispatcher (`main`) で `unknownFlags` が非空なら最初の 1 つに対して `eprintError("unknown flag '$flag'", hint = closestMatch(flag, KNOWN_KOLT_FLAGS)?.let { "Did you mean \`$it\`?" })` を出力、 既存 `EXIT_COMMAND_NOT_FOUND` (=127) を流用して `exitProcess(EXIT_COMMAND_NOT_FOUND)` (新 exit code constant 追加は本仕様の対象外、 R1.6 の既存 exit code 不変方針に従う)
+  - テスト: `kolt --no-clor build` → `error: unknown flag '--no-clor'` + `note: Did you mean \`--no-color\`?` + exit code 127、 `kolt --xxx build` (距離超過) → suggestion なし、 `kolt --no-daemon build` (既知 flag) → 通常実行
+  - 観察可能な完了: integration test 上記 3 ケース green、 既存 `--no-daemon` / `--watch` / `--release` / `--no-color` parsing が regression なし
+  - _Requirements: 5.3, 5.4_
+  - _Depends: 1.3, 2.2, 5.1_
+  - _Boundary: kolt.cli.Main (parseKoltArgs unknown flag path)_
+
+- [ ] 6. Subprocess color forwarding (env injection + daemon blob strip)
+- [ ] 6.1 (P) kotlinc subprocess (direct + JVM daemon spawn) への `NO_COLOR` env injection
+  - `kolt.build.SubprocessCompilerBackend` の subprocess 起動 helper に `if (!ColorPolicy.current().shouldColor(Stream.Stderr)) put("NO_COLOR", "1")` を入れる。 caller (`BuildCommands` 等) は ColorPolicy を意識しない
+  - JVM daemon の spawn 経路 (`kolt.build.daemon.*`) でも同じ env injection を入れる、 daemon 自体が起動する kotlinc 子プロセスにも env が継承されるよう確認
+  - 既存 subprocess 起動経路の other env (`JAVA_HOME` 等) 設定を退化させないこと
+  - テスト: env capture mock subprocess に対して、 `ColorPolicy.Never` 時に env 内 `NO_COLOR=1` が含まれること、 `ColorPolicy.Always` 時に含まれないこと
+  - 観察可能な完了: unit test で env injection 動作確認、 self-host smoke で `kolt build --no-color` が JVM daemon path で動くこと
+  - _Requirements: 6.2, 6.3_
+  - _Depends: 1.2_
+  - _Boundary: kolt.build.SubprocessCompilerBackend + kolt.build.daemon spawn_
+
+- [ ] 6.2 (P) konanc subprocess (direct + Native daemon spawn) への `NO_COLOR` env injection
+  - `kolt.build.NativeSubprocessBackend` および `kolt.build.nativedaemon.*` の spawn 経路で同じ env injection
+  - kotlin-result `Result<V, E>` chain を破らないように env 構築 helper を共通化 (kotlinc 経路と一貫させる)
+  - テスト: env capture mock で `NO_COLOR=1` 注入確認 (kotlinc 経路と並列 fixture)
+  - 観察可能な完了: unit test green、 self-host smoke で `kolt build --no-color` が native daemon path でも動く
+  - _Requirements: 6.2, 6.3_
+  - _Depends: 1.2_
+  - _Boundary: kolt.build.NativeSubprocessBackend + kolt.build.nativedaemon spawn_
+
+- [ ] 6.3 daemon が string blob で返す stderr に対する ANSI strip wiring
+  - `BuildCommands.kt:526` 周辺の `eprintln(body)` を `eprintln(if (!ColorPolicy.current().shouldColor(Stream.Stderr)) AnsiStripper.strip(body) else body)` に書き換え (forwarded body は kolt prefix を付けない pass-through 維持、 R6.1)
+  - 同様の forward 経路が DependencyCommands / ToolCommands にあれば同 pattern を適用
+  - テスト: `body = "error: \\x1B[31mfoo\\x1B[0m\\n"` を mock daemon が返す状況で、 `ColorPolicy.Never` 時は `eprintln` 引数が `"error: foo\\n"` (ANSI 削除済み)、 `ColorPolicy.Always` 時は元 byte 列のまま
+  - 観察可能な完了: unit test green、 daemon 経路で kolt が wrap する headline は 1 つ + body は forwarded verbatim (R6.4) という ordering pattern を維持していることを assert
+  - _Requirements: 6.1, 6.2, 6.3, 6.4_
+  - _Depends: 1.3_
+  - _Boundary: cli forward point at BuildCommands daemon body forwarding_
+
+- [ ] 7. 残りの raw `eprintln("error/warning: ...")` 呼び出しの mass migration
+- [ ] 7.1 (P) `BuildCommands.kt` の resolve / tool / config 以外の raw eprintln 呼び出しを `eprintError` / `eprintWarning` に置換
+  - 対象: file IO error (`could not read`, `could not create directory`, `could not list Kotlin sources`, `could not copy resources` 等)、 generic `eprintln("error: ${it.message}")`、 `eprintln("warning: ...")` (clean / daemon IC state cleanup)
+  - 各置換で headline はコロン以降のテキスト、 file path / cause 等は context list に分解できる場合は分解。 既存 1 行記述は headline のみで OK
+  - 既存の build/check/run/test/clean 各経路で stderr 出力 byte が (色 off で) 旧文言と一致していることを既存 string-snapshot test で確認
+  - 観察可能な完了: BuildCommands.kt 内に raw `eprintln("error:...` / `eprintln("warning:...` が残らないこと (`grep` で 0 件)、 `kolt test` 全体 green
+  - _Requirements: 1.1, 1.2, 1.5, 1.6, 7.2_
+  - _Depends: 1.3, 3.1, 4.4, 6.3_
+  - _Boundary: kolt.cli.BuildCommands (raw eprintln sites — daemon forward line は 6.3 所有、 ConfigError display は 4.4 所有のため対象外)_
+
+- [ ] 7.2 (P) `DependencyCommands.kt` の残り raw eprintln 呼び出しを置換
+  - 対象: `kolt fetch` / `kolt update` / `kolt tree` / `kolt add` / `kolt remove` の error / warning 出力
+  - 各置換で R6.4 (subprocess wrap pattern) を破壊しないよう注意 — daemon body forward + kolt headline の順序を 7.1 と同じ規則で維持
+  - 既存 string-snapshot test の更新
+  - 観察可能な完了: DependencyCommands.kt 内 raw `eprintln("error:...` 0 件、 dep 系コマンドの自動テスト green
+  - _Requirements: 1.1, 1.2, 1.5, 1.6, 7.2_
+  - _Depends: 1.3, 3.1, 4.4_
+  - _Boundary: kolt.cli.DependencyCommands (raw eprintln sites)_
+
+- [ ] 7.3 (P) `ToolCommands.kt` および残り cli 系ファイル (InfoCommand / ScaffoldIO / DaemonCommand / CacheCommand 等) の raw eprintln 呼び出しを置換
+  - 各 file 内の raw `eprintln("error:...` / `eprintln("warning:...` を typed writer に migrate
+  - `printUsage()` の help 出力はそのまま (情報表示、 severity 装飾不要 — informational `eprintln` はそのまま許容)
+  - 観察可能な完了: 全 cli/* ファイルで raw `eprintln("error:...` / `eprintln("warning:...` 0 件、 `kolt info` / `kolt daemon` / `kolt cache` の自動テスト green
+  - _Requirements: 1.1, 1.2, 1.5, 1.6, 7.2_
+  - _Depends: 1.3, 3.2, 4.4_
+  - _Boundary: kolt.cli (ToolCommands + InfoCommand + ScaffoldIO + DaemonCommand + CacheCommand) — ConfigError display sites は 4.4 所有のため再 migration しない_
+
+- [ ] 8. Validation: integration / E2E pin
+- [ ] 8.1 (P) `NO_COLOR` / `--no-color` / TTY-redirect の E2E smoke (cross-cutting)
+  - `kolt --no-color build <synthetic-fail-fixture>` の stderr に ANSI escape (`\\x1B[`) が一切含まれないこと (R2.4)
+  - `NO_COLOR=1 kolt build <fail>` で同上 (R2.3)
+  - `kolt build <fail> 2>log.txt` (stderr redirect) で log.txt に ANSI 含まれないこと (R2.2)
+  - `NO_COLOR=` (空文字列) は無視されること、 `NO_COLOR=any-non-empty` で抑制発火 (no-color.org 仕様準拠)
+  - 観察可能な完了: 上記 4 ケースが integration test として CI で green、 self-host CI 経路 (`self-host-post`) でも 1 ケース通る
+  - _Requirements: 2.2, 2.3, 2.4, 2.6_
+  - _Depends: 5.1, 7.1_
+  - _Boundary: end-to-end_
+
+- [ ] 8.2 (P) 未知 subcommand / 未知 global flag の Did-you-mean E2E
+  - `kolt buidl` → exit code `EXIT_COMMAND_NOT_FOUND`、 stderr に `error: unknown command 'buidl'` と `note: Did you mean \`build\`?` (色 off で文字列比較)
+  - `kolt --no-clor build` → 未知 flag error + `Did you mean \`--no-color\`?`
+  - `kolt totally-unrelated-xxx` → suggestion なし (距離超過)
+  - 観察可能な完了: 3 ケース integration test green、 deterministic 出力 (R5.4) を assert
+  - _Requirements: 5.2, 5.3, 5.4_
+  - _Depends: 5.2, 5.3_
+  - _Boundary: kolt.cli.Main (unknown subcommand / flag E2E)_
+
+- [ ] 8.3 (P) `SubprocessColorForwardingIntegrationTest` — kotlinc / konanc が `NO_COLOR=1` を honor することの実機 pin (validate-design Issue 3 解決)
+  - fixture: 故意に compile error を起こす `*.kt` を配置した tmp project
+  - シナリオ 1: `NO_COLOR=1 kolt --no-daemon build` (kotlinc direct subprocess 経路) — stderr に `\\x1B[` 含まれない
+  - シナリオ 2: `kolt --no-color --no-daemon build` (同上、 flag 経由)
+  - シナリオ 3: `NO_COLOR=1 kolt build` (JVM daemon 経路) — stderr に ANSI 含まれない
+  - シナリオ 4: native target で `NO_COLOR=1 kolt build` (konanc / native daemon 経路) — 同上
+  - 観察可能な完了: 4 ケース integration test green、 Kotlin 2.3.x の `NO_COLOR` honor が pin される。 Kotlin / konanc bump 時にこのテストが RED 化したら post-strip fallback の検討 (Risks 表参照)
+  - _Requirements: 6.2, 6.3_
+  - _Depends: 5.1, 6.1, 6.2, 6.3_
+  - _Boundary: end-to-end (kotlinc / konanc subprocess + daemon)_
+
+- [ ] 8.4 (P) `kolt info --format=json` の no-ANSI 検証 (R7.1 pin)
+  - `kolt info --format=json` を TTY 環境 (isatty stub or 実 TTY) で実行、 stdout 出力に ANSI escape が含まれないこと
+  - `--no-color` / `NO_COLOR=1` / TTY-redirect の各組合せでも stdout JSON は変化しない (severity 系の writer が stdout に漏れない契約)
+  - 観察可能な完了: integration test green、 JSON 出力が `JSON.parse` 可能で ANSI 0 件
+  - _Requirements: 7.1, 7.2_
+  - _Depends: 7.3_
+  - _Boundary: kolt.cli.InfoCommand JSON output path_

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -147,7 +147,7 @@
   - _Boundary: kolt.cli.Main (parseKoltArgs unknown flag path)_
 
 - [ ] 6. Subprocess color forwarding (env injection + daemon blob strip)
-- [ ] 6.1 (P) kotlinc subprocess (direct + JVM daemon spawn) への `NO_COLOR` env injection
+- [x] 6.1 (P) kotlinc subprocess (direct + JVM daemon spawn) への `NO_COLOR` env injection
   - `kolt.build.SubprocessCompilerBackend` の subprocess 起動 helper に `if (!ColorPolicy.current().shouldColor(Stream.Stderr)) put("NO_COLOR", "1")` を入れる。 caller (`BuildCommands` 等) は ColorPolicy を意識しない
   - JVM daemon の spawn 経路 (`kolt.build.daemon.*`) でも同じ env injection を入れる、 daemon 自体が起動する kotlinc 子プロセスにも env が継承されるよう確認
   - 既存 subprocess 起動経路の other env (`JAVA_HOME` 等) 設定を退化させないこと

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -33,7 +33,7 @@
   - _Boundary: kolt.infra.output.DiagnosticWriter_
 
 - [ ] 2. Foundation: infra/suggest 層 (Levenshtein + closestMatch) — Major 1 と並行実行可、 sub-task が parallel-safe
-- [ ] 2.1 `levenshtein(a, b): Int` を実装
+- [x] 2.1 `levenshtein(a, b): Int` を実装
   - 標準 dynamic-programming edit distance (insert / delete / substitute コスト各 1)
   - テスト: distance 0 (`"foo" / "foo"`)、 1 (`"foo" / "fo"`)、 2 (`"foo" / "fox"`)、 完全相違 (`"" / "abc"` → 3) の 4 ケース
   - 観察可能な完了: `kolt test --filter LevenshteinTest` 4 ケース green

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -166,7 +166,7 @@
   - _Depends: 1.2_
   - _Boundary: kolt.build.NativeSubprocessBackend + kolt.build.nativedaemon spawn_
 
-- [ ] 6.3 daemon が string blob で返す stderr に対する ANSI strip wiring
+- [x] 6.3 daemon が string blob で返す stderr に対する ANSI strip wiring
   - `BuildCommands.kt:526` 周辺の `eprintln(body)` を `eprintln(if (!ColorPolicy.current().shouldColor(Stream.Stderr)) AnsiStripper.strip(body) else body)` に書き換え (forwarded body は kolt prefix を付けない pass-through 維持、 R6.1)
   - 同様の forward 経路が DependencyCommands / ToolCommands にあれば同 pattern を適用
   - テスト: `body = "error: \\x1B[31mfoo\\x1B[0m\\n"` を mock daemon が返す状況で、 `ColorPolicy.Never` 時は `eprintln` 引数が `"error: foo\\n"` (ANSI 削除済み)、 `ColorPolicy.Always` 時は元 byte 列のまま

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -50,7 +50,7 @@
   - _Boundary: kolt.infra.suggest.ClosestMatch_
 
 - [ ] 3. Renderer ADT migration (existing renderer の signature 変更 + 全 caller 同時更新)
-- [ ] 3.1 (P) `formatResolveError` を `String` 返却から `RenderedDiagnostic` 返却に migrate、 全 cli caller を同時更新
+- [x] 3.1 (P) `formatResolveError` を `String` 返却から `RenderedDiagnostic` 返却に migrate、 全 cli caller を同時更新
   - 各 `ResolveError` variant の `error: ...` プレフィックスを削除し、 `headline` / `context: List<String>` / `hint` の 3 slot に分解
   - 例: `Sha256Mismatch` は headline = `"sha256 mismatch for {ga}"`、 context = `["expected: ...", "got:      ..."]`、 hint = null
   - 例: `DownloadFailed.AllAttemptsFailed` は context に各 attempt 行を `"  {url} -> {status}"` 形式で格納

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -157,7 +157,7 @@
   - _Depends: 1.2_
   - _Boundary: kolt.build.SubprocessCompilerBackend + kolt.build.daemon spawn_
 
-- [ ] 6.2 (P) konanc subprocess (direct + Native daemon spawn) への `NO_COLOR` env injection
+- [x] 6.2 (P) konanc subprocess (direct + Native daemon spawn) への `NO_COLOR` env injection
   - `kolt.build.NativeSubprocessBackend` および `kolt.build.nativedaemon.*` の spawn 経路で同じ env injection
   - kotlin-result `Result<V, E>` chain を破らないように env 構築 helper を共通化 (kotlinc 経路と一貫させる)
   - テスト: env capture mock で `NO_COLOR=1` 注入確認 (kotlinc 経路と並列 fixture)

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -115,7 +115,7 @@
   - _Boundary: kolt.config (test fixture)_
 
 - [ ] 5. CLI startup + dispatcher integration
-- [ ] 5.1 `parseKoltArgs` に `--no-color` flag、 `KoltArgs.useColor` field、 `Main.kt` startup で `ColorPolicy.install` を実装
+- [x] 5.1 `parseKoltArgs` に `--no-color` flag、 `KoltArgs.useColor` field、 `Main.kt` startup で `ColorPolicy.install` を実装
   - `internal const val NO_COLOR_FLAG = "--no-color"` を追加、 `KoltArgs` に `noColor: Boolean` field を追加
   - `parseKoltArgs` で `--no-color` を抽出、 `filteredArgs` から strip
   - `main` 入口直後で `ColorPolicy.install(ColorPolicy.fromEnv(noColorFlag = koltArgs.noColor))` を呼ぶ。 既存 dispatch 順序は不変
@@ -125,7 +125,7 @@
   - _Depends: 1.2_
   - _Boundary: kolt.cli.Main (parseKoltArgs + main startup)_
 
-- [ ] 5.2 未知サブコマンドへの Did-you-mean 提案を dispatcher に実装
+- [x] 5.2 未知サブコマンドへの Did-you-mean 提案を dispatcher に実装
   - `Main.kt` の `else -> eprintln("error: unknown command ...")` 節を `eprintError(headline, hint = closestMatch(unknown, KNOWN_SUBCOMMANDS_SORTED)?.let { "Did you mean \`$it\`?" })` に置換
   - `KNOWN_SUBCOMMANDS_SORTED` を dispatcher `when` の隣に sorted alphabetical list として hardcoded (drift guard コメントを残す)
   - `printUsage()` の出力は維持。 exit code は `EXIT_COMMAND_NOT_FOUND` のまま
@@ -135,7 +135,7 @@
   - _Depends: 1.3, 2.2, 5.1_
   - _Boundary: kolt.cli.Main (unknown subcommand path)_
 
-- [ ] 5.3 未知 global flag への Did-you-mean 提案を `parseKoltArgs` 経路に実装
+- [x] 5.3 未知 global flag への Did-you-mean 提案を `parseKoltArgs` 経路に実装
   - `KoltArgs` に `unknownFlags: List<String>` field を追加 (Result 返却ではなく値返却で統一、 既存 `parseKoltArgs` の signature と対称)
   - `parseKoltArgs` で kolt-level block (subcommand 名より前) に既知 flag set / `-D` / passthrough のいずれにも該当しない `--xxx` を検出して `unknownFlags` に積む
   - `KNOWN_KOLT_FLAGS = ["--no-color", "--no-daemon", "--release", "--watch"]` を sorted alphabetical list として hardcoded (drift guard コメント)

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -176,7 +176,7 @@
   - _Boundary: cli forward point at BuildCommands daemon body forwarding_
 
 - [ ] 7. 残りの raw `eprintln("error/warning: ...")` 呼び出しの mass migration
-- [ ] 7.1 (P) `BuildCommands.kt` の resolve / tool / config 以外の raw eprintln 呼び出しを `eprintError` / `eprintWarning` に置換
+- [x] 7.1 (P) `BuildCommands.kt` の resolve / tool / config 以外の raw eprintln 呼び出しを `eprintError` / `eprintWarning` に置換
   - 対象: file IO error (`could not read`, `could not create directory`, `could not list Kotlin sources`, `could not copy resources` 等)、 generic `eprintln("error: ${it.message}")`、 `eprintln("warning: ...")` (clean / daemon IC state cleanup)
   - 各置換で headline はコロン以降のテキスト、 file path / cause 等は context list に分解できる場合は分解。 既存 1 行記述は headline のみで OK
   - 既存の build/check/run/test/clean 各経路で stderr 出力 byte が (色 off で) 旧文言と一致していることを既存 string-snapshot test で確認

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -60,7 +60,7 @@
   - _Depends: 1.3_
   - _Boundary: kolt.resolve.formatResolveError + その cli consumer_
 
-- [ ] 3.2 (P) `ToolError.formatStderr` を `ToolError.render(): RenderedDiagnostic` に migrate、 全 cli caller を同時更新
+- [x] 3.2 (P) `ToolError.formatStderr` を `ToolError.render(): RenderedDiagnostic` に migrate、 全 cli caller を同時更新
   - sealed class `ToolError` の `abstract fun formatStderr(): String` を `abstract fun render(): RenderedDiagnostic` に置換、 全 variant を更新
   - `LockfileMismatch` の inline `"Run \`kolt update\` to refresh tool pins."` を `hint` slot へ移動 (R5.1 の severity 分離)
   - `ToolCommands.kt` の `eprintln(error.formatStderr())` を `eprintDiagnostic(error.render())` に書き換え

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -88,7 +88,7 @@
   - _Depends: 2.2_
   - _Boundary: kolt.config (parseUnknownKey + KNOWN_TOP_LEVEL_SECTIONS)_
 
-- [ ] 4.3 `ConfigError.ParseFailed` shape を nullable default 付きで拡張 (compile-safe migration)
+- [x] 4.3 `ConfigError.ParseFailed` shape を nullable default 付きで拡張 (compile-safe migration)
   - field 追加: `path: String? = null`, `lineNo: Int? = null`, `keyPath: String? = null`, `suggestion: String? = null` を既存 `message: String` の後に **default 付き** で追加。 これにより `kolt.config.Config.kt` (~24 ヶ所)、 `kolt.config.Main.kt` (2 ヶ所)、 `kolt.cli.BuildCommands.kt:266` の既存全 ~28 構築箇所は no-op で再コンパイル成功する
   - 既存パターン `is ConfigError.ParseFailed -> ... err.message` を読む箇所 (`WatchChangeDispatch.kt:76`, `InfoCommand.kt:380`, `DependencyCommands.kt:42`, `BuildCommands.kt:251`) は `message` field アクセスのみなので無変更で動作することを確認
   - data class equality / copy / toString の test を更新、 nullable field を含む新 shape の round-trip pin

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -40,7 +40,7 @@
   - _Requirements: 5.4_
   - _Boundary: kolt.infra.suggest.Levenshtein_
 
-- [ ] 2.2 `closestMatch(input, candidates, maxDistance)` を実装、 deterministic ordering を保証
+- [x] 2.2 `closestMatch(input, candidates, maxDistance)` を実装、 deterministic ordering を保証
   - `adaptiveThreshold(inputLength) = if (inputLength <= 4) 1 else 2` の default
   - candidates 走査は順序保存、 同点最小距離は最初に見つかったものを返す。 caller が sorted list を渡せば lex 順 deterministic
   - テスト: 距離 1 で hit、 閾値超過で `null`、 同点候補 2 つで先頭が選ばれる、 空 candidates で `null` の 4 ケース

--- a/.kiro/specs/2-error-output-formatting/tasks.md
+++ b/.kiro/specs/2-error-output-formatting/tasks.md
@@ -213,7 +213,7 @@
   - _Depends: 5.1, 7.1_
   - _Boundary: end-to-end_
 
-- [ ] 8.2 (P) 未知 subcommand / 未知 global flag の Did-you-mean E2E
+- [x] 8.2 (P) 未知 subcommand / 未知 global flag の Did-you-mean E2E
   - `kolt buidl` → exit code `EXIT_COMMAND_NOT_FOUND`、 stderr に `error: unknown command 'buidl'` と `note: Did you mean \`build\`?` (色 off で文字列比較)
   - `kolt --no-clor build` → 未知 flag error + `Did you mean \`--no-color\`?`
   - `kolt totally-unrelated-xxx` → suggestion なし (距離超過)

--- a/src/nativeMain/kotlin/kolt/build/NativeSubprocessBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/NativeSubprocessBackend.kt
@@ -6,6 +6,8 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.infra.ProcessError
 import kolt.infra.executeCommand
+import kolt.infra.output.ColorPolicy
+import kolt.infra.output.Stream
 
 // Baseline native backend: invokes `konanc` as a subprocess. This is the
 // pre-ADR-0024 behaviour kept intact so FallbackNativeCompilerBackend can
@@ -17,15 +19,26 @@ import kolt.infra.executeCommand
 // first and falls back to PATH; without either it exits 127 on
 // `java: command not found`. `javaHome` injects the env var into the child
 // so the wrapper does not depend on the host's PATH (#285).
+//
+// `colorPolicy` is a seam so tests drive both branches without re-installing
+// the global ColorPolicy. Production callers leave it at the default and the
+// CLI's startup `ColorPolicy.install` governs behavior.
 class NativeSubprocessBackend(
   private val konancBin: String,
   private val javaHome: String? = null,
   private val jdkMajorVersion: Int? = null,
+  private val colorPolicy: () -> ColorPolicy = ColorPolicy::current,
 ) : NativeCompilerBackend {
 
   override fun compile(args: List<String>): Result<NativeCompileOutcome, NativeCompileError> {
     val argv = nativeSubprocessArgv(konancBin, args, jdkMajorVersion)
-    val env = if (javaHome != null) mapOf("JAVA_HOME" to javaHome) else emptyMap()
+    val env = buildMap {
+      if (javaHome != null) put("JAVA_HOME", javaHome)
+      // Signal konanc to emit plain (non-ANSI) diagnostics when kolt's color
+      // is off. Pass-through is the inherit-default — we set nothing when
+      // color is on so the child observes parent env verbatim.
+      if (!colorPolicy().shouldColor(Stream.Stderr)) put("NO_COLOR", "1")
+    }
     executeCommand(argv, env).getOrElse { err ->
       return Err(mapProcessErrorToNativeCompileError(err))
     }

--- a/src/nativeMain/kotlin/kolt/build/SubprocessCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/SubprocessCompilerBackend.kt
@@ -6,19 +6,32 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.infra.ProcessError
 import kolt.infra.executeCommand
+import kolt.infra.output.ColorPolicy
+import kolt.infra.output.Stream
 
 // kotlinc is a shell wrapper that resolves java through `$JAVA_HOME` first;
 // without it, the wrapper falls back to whatever `java` is on PATH and exits
 // 127 when that lookup also fails. `javaHome` injects the env var into the
 // child so the wrapper does not depend on the host's PATH.
+//
+// `colorPolicy` is a seam so tests drive both branches without re-installing
+// the global ColorPolicy. Production callers leave it at the default and the
+// CLI's startup `ColorPolicy.install` governs behavior.
 class SubprocessCompilerBackend(
   private val kotlincBin: String,
   private val javaHome: String? = null,
+  private val colorPolicy: () -> ColorPolicy = ColorPolicy::current,
 ) : CompilerBackend {
 
   override fun compile(request: CompileRequest): Result<CompileOutcome, CompileError> {
     val argv = subprocessArgv(kotlincBin, request)
-    val env = if (javaHome != null) mapOf("JAVA_HOME" to javaHome) else emptyMap()
+    val env = buildMap {
+      if (javaHome != null) put("JAVA_HOME", javaHome)
+      // Signal kotlinc to emit plain (non-ANSI) diagnostics when kolt's color
+      // is off. Pass-through is the inherit-default — we set nothing when
+      // color is on so the child observes parent env verbatim.
+      if (!colorPolicy().shouldColor(Stream.Stderr)) put("NO_COLOR", "1")
+    }
     executeCommand(argv, env).getOrElse { err ->
       return Err(mapProcessErrorToCompileError(err))
     }

--- a/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/DaemonCompilerBackend.kt
@@ -16,6 +16,8 @@ import kolt.infra.ProcessError
 import kolt.infra.eprintln
 import kolt.infra.net.UnixSocket
 import kolt.infra.net.UnixSocketError
+import kolt.infra.output.ColorPolicy
+import kolt.infra.output.Stream
 import kolt.infra.spawnDetached
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.alloc
@@ -49,6 +51,10 @@ internal constructor(
   private val sleeper: (Int) -> Unit = defaultSleeper,
   private val onSpawn: () -> Unit = {},
   private val warnSink: (String) -> Unit = ::eprintln,
+  // Seam: tests drive both color branches without mutating the global
+  // ColorPolicy. Production callers leave the default and the CLI's
+  // startup `ColorPolicy.install` governs behavior.
+  private val colorPolicy: () -> ColorPolicy = ColorPolicy::current,
 ) : CompilerBackend {
 
   constructor(
@@ -117,7 +123,13 @@ internal constructor(
     } ?: return Ok(first.get()!!)
 
     onSpawn()
-    val spawnErr = spawner(spawnArgv(), logPath).getError()
+    val spawnEnv = buildMap {
+      // Propagate to the JVM daemon and the kotlinc subprocesses it spawns
+      // (Java's ProcessBuilder default inherits env). With color enabled we
+      // inject nothing so the daemon inherits parent env verbatim.
+      if (!colorPolicy().shouldColor(Stream.Stderr)) put("NO_COLOR", "1")
+    }
+    val spawnErr = spawner(spawnArgv(), logPath, spawnEnv).getError()
     if (spawnErr != null) {
       return Err(CompileError.BackendUnavailable.Other("daemon spawn failed: $spawnErr"))
     }
@@ -197,7 +209,8 @@ internal class SocketDaemonConnection(private val socket: UnixSocket) : DaemonCo
 
 internal typealias DaemonConnector = (String) -> Result<DaemonConnection, UnixSocketError>
 
-internal typealias DaemonSpawner = (List<String>, String?) -> Result<Unit, ProcessError>
+internal typealias DaemonSpawner =
+  (List<String>, String?, Map<String, String>) -> Result<Unit, ProcessError>
 
 internal val defaultDaemonConnector: DaemonConnector = { path ->
   val socketResult = UnixSocket.connect(path)
@@ -205,7 +218,9 @@ internal val defaultDaemonConnector: DaemonConnector = { path ->
   if (err != null) Err(err) else Ok(SocketDaemonConnection(socketResult.get()!!))
 }
 
-internal val defaultDaemonSpawner: DaemonSpawner = { argv, logPath -> spawnDetached(argv, logPath) }
+internal val defaultDaemonSpawner: DaemonSpawner = { argv, logPath, extraEnv ->
+  spawnDetached(argv, logPath, extraEnv)
+}
 
 internal val defaultSleeper: (Int) -> Unit = { ms -> usleep((ms * 1000).toUInt()) }
 

--- a/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
+++ b/src/nativeMain/kotlin/kolt/build/nativedaemon/NativeDaemonBackend.kt
@@ -19,6 +19,8 @@ import kolt.infra.ProcessError
 import kolt.infra.eprintln
 import kolt.infra.net.UnixSocket
 import kolt.infra.net.UnixSocketError
+import kolt.infra.output.ColorPolicy
+import kolt.infra.output.Stream
 import kolt.infra.spawnDetached
 import kolt.nativedaemon.wire.FrameCodec
 import kolt.nativedaemon.wire.FrameError
@@ -53,6 +55,10 @@ internal constructor(
   private val sleeper: (Int) -> Unit = defaultNativeDaemonSleeper,
   private val onSpawn: () -> Unit = {},
   private val warnSink: (String) -> Unit = ::eprintln,
+  // Seam: tests drive both color branches without mutating the global
+  // ColorPolicy. Production callers leave the default and the CLI's
+  // startup `ColorPolicy.install` governs behavior.
+  private val colorPolicy: () -> ColorPolicy = ColorPolicy::current,
 ) : NativeCompilerBackend {
 
   constructor(
@@ -115,7 +121,13 @@ internal constructor(
     } ?: return Ok(first.get()!!)
 
     onSpawn()
-    val spawnErr = spawner(spawnArgv(), logPath).getError()
+    val spawnEnv = buildMap {
+      // Propagate to the JVM native daemon and the konanc subprocess it
+      // spawns reflectively. With color enabled we inject nothing so the
+      // daemon inherits parent env verbatim.
+      if (!colorPolicy().shouldColor(Stream.Stderr)) put("NO_COLOR", "1")
+    }
+    val spawnErr = spawner(spawnArgv(), logPath, spawnEnv).getError()
     if (spawnErr != null) {
       return Err(
         NativeCompileError.BackendUnavailable.Other("native daemon spawn failed: $spawnErr")
@@ -202,7 +214,8 @@ internal class SocketNativeDaemonConnection(private val socket: UnixSocket) :
 internal typealias NativeDaemonConnector =
   (String) -> Result<NativeDaemonConnection, UnixSocketError>
 
-internal typealias NativeDaemonSpawner = (List<String>, String?) -> Result<Unit, ProcessError>
+internal typealias NativeDaemonSpawner =
+  (List<String>, String?, Map<String, String>) -> Result<Unit, ProcessError>
 
 internal val defaultNativeDaemonConnector: NativeDaemonConnector = { path ->
   val socketResult = UnixSocket.connect(path)
@@ -210,8 +223,8 @@ internal val defaultNativeDaemonConnector: NativeDaemonConnector = { path ->
   if (err != null) Err(err) else Ok(SocketNativeDaemonConnection(socketResult.get()!!))
 }
 
-internal val defaultNativeDaemonSpawner: NativeDaemonSpawner = { argv, logPath ->
-  spawnDetached(argv, logPath)
+internal val defaultNativeDaemonSpawner: NativeDaemonSpawner = { argv, logPath, extraEnv ->
+  spawnDetached(argv, logPath, extraEnv)
 }
 
 internal val defaultNativeDaemonSleeper: (Int) -> Unit = { ms -> usleep((ms * 1000).toUInt()) }

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -25,6 +25,7 @@ import kolt.concurrency.LockHandle
 import kolt.concurrency.ProjectLock
 import kolt.config.*
 import kolt.infra.*
+import kolt.infra.output.eprintDiagnostic
 import kolt.resolve.buildClasspath
 import kolt.tool.*
 import kotlin.time.TimeSource
@@ -239,16 +240,22 @@ internal fun filterExistingDirs(
   return existing
 }
 
+// Resolve the absolute path the user reads as `kolt.toml`, used by parseConfig
+// to embed the file location in ParseFailed for richer renderer output.
+// Falls back to the bare filename when cwd is unknown.
+internal fun absoluteKoltTomlPath(): String =
+  currentWorkingDirectory()?.let { absolutise(KOLT_TOML, it) } ?: KOLT_TOML
+
 internal fun loadProjectConfig(): Result<KoltConfig, Int> {
   val tomlString =
     readFileAsString(KOLT_TOML).getOrElse { error ->
       eprintln("error: could not read ${error.path}")
       return Err(EXIT_CONFIG_ERROR)
     }
-  return parseConfig(tomlString)
+  return parseConfig(tomlString, path = absoluteKoltTomlPath())
     .getOrElse { error ->
       when (error) {
-        is ConfigError.ParseFailed -> eprintln("error: ${error.message}")
+        is ConfigError.ParseFailed -> eprintDiagnostic(renderConfigError(error))
       }
       return Err(EXIT_CONFIG_ERROR)
     }
@@ -265,7 +272,7 @@ internal fun parseProjectConfig(): Result<KoltConfig, ConfigError> {
     readFileAsString(KOLT_TOML).getOrElse { error ->
       return Err(ConfigError.ParseFailed("could not read ${error.path}"))
     }
-  return parseConfig(tomlString)
+  return parseConfig(tomlString, path = absoluteKoltTomlPath())
 }
 
 internal fun doCheck(

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -26,6 +26,7 @@ import kolt.concurrency.ProjectLock
 import kolt.config.*
 import kolt.infra.*
 import kolt.infra.output.eprintDiagnostic
+import kolt.infra.output.maybeStripAnsi
 import kolt.resolve.buildClasspath
 import kolt.tool.*
 import kotlin.time.TimeSource
@@ -530,7 +531,7 @@ private fun doBuildInner(
   backend.compile(request).getOrElse { error ->
     if (error is CompileError.CompilationFailed) {
       val body = renderCompilationFailure(error)
-      if (body.isNotEmpty()) eprintln(body)
+      if (body.isNotEmpty()) eprintln(maybeStripAnsi(body))
     }
     eprintln(formatCompileError(error, "compilation"))
     return Err(EXIT_BUILD_ERROR)
@@ -778,7 +779,7 @@ private fun doNativeBuildInner(
 // backend-supplied stderr; other variants don't have diagnostic content.
 private fun reportNativeCompileError(error: NativeCompileError, context: String) {
   if (error is NativeCompileError.CompilationFailed && error.stderr.isNotEmpty()) {
-    eprintln(error.stderr.trimEnd('\n'))
+    eprintln(maybeStripAnsi(error.stderr.trimEnd('\n')))
   }
   eprintln(formatNativeCompileError(error, context))
 }
@@ -1175,7 +1176,7 @@ private fun doTestInner(
   testBackend.compile(testRequest).getOrElse { error ->
     if (error is CompileError.CompilationFailed) {
       val body = renderCompilationFailure(error)
-      if (body.isNotEmpty()) eprintln(body)
+      if (body.isNotEmpty()) eprintln(maybeStripAnsi(body))
     }
     eprintln(formatCompileError(error, "test compilation"))
     return Err(EXIT_BUILD_ERROR)

--- a/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/BuildCommands.kt
@@ -26,6 +26,8 @@ import kolt.concurrency.ProjectLock
 import kolt.config.*
 import kolt.infra.*
 import kolt.infra.output.eprintDiagnostic
+import kolt.infra.output.eprintError
+import kolt.infra.output.eprintWarning
 import kolt.infra.output.maybeStripAnsi
 import kolt.resolve.buildClasspath
 import kolt.tool.*
@@ -250,7 +252,7 @@ internal fun absoluteKoltTomlPath(): String =
 internal fun loadProjectConfig(): Result<KoltConfig, Int> {
   val tomlString =
     readFileAsString(KOLT_TOML).getOrElse { error ->
-      eprintln("error: could not read ${error.path}")
+      eprintError("could not read ${error.path}")
       return Err(EXIT_CONFIG_ERROR)
     }
   return parseConfig(tomlString, path = absoluteKoltTomlPath())
@@ -297,12 +299,12 @@ private fun doCheckInner(useDaemon: Boolean, profile: Profile): Result<Unit, Int
   }
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_BUILD_ERROR)
     }
   val managedKotlincBin =
     ensureKotlincBin(config.kotlin.effectiveCompiler, paths).getOrElse {
-      eprintln("error: ${it.message}")
+      eprintError("${it.message}")
       return Err(EXIT_BUILD_ERROR)
     }
   val managedJdkBins =
@@ -318,14 +320,14 @@ private fun doCheckInner(useDaemon: Boolean, profile: Profile): Result<Unit, Int
       .mainClasspath
   val pArgs =
     resolvePluginArgs(config, paths, EXIT_BUILD_ERROR).getOrElse {
-      eprintln("error: ${it.message}")
+      eprintError("${it.message}")
       return Err(it.exitCode)
     }
   val cmd = checkCommand(config, classpath, pArgs, kotlincPath = managedKotlincBin)
 
   println("checking ${config.name}...")
   executeCommand(cmd, mapOf("JAVA_HOME" to managedJdkBins.home)).getOrElse { error ->
-    eprintln("error: " + formatProcessError(error, "check"))
+    eprintError(formatProcessError(error, "check"))
     return Err(EXIT_BUILD_ERROR)
   }
   val elapsed = startMark.elapsedNow()
@@ -337,7 +339,7 @@ internal fun doClean(): Result<Unit, Int> {
   val buildDirRemoved =
     if (fileExists(BUILD_DIR)) {
       removeDirectoryRecursive(BUILD_DIR).getOrElse { error ->
-        eprintln("error: could not remove ${error.path}")
+        eprintError("could not remove ${error.path}")
         return Err(EXIT_BUILD_ERROR)
       }
       println("removed $BUILD_DIR/")
@@ -352,7 +354,7 @@ internal fun doClean(): Result<Unit, Int> {
   val cwd = currentWorkingDirectory()
   if (paths != null && cwd != null) {
     cleanDaemonIcStateForProject(paths, cwd).getOrElse { error ->
-      eprintln("warning: could not remove daemon IC state at ${error.path}")
+      eprintWarning("could not remove daemon IC state at ${error.path}")
     }
   }
 
@@ -406,7 +408,7 @@ private fun doBuildInner(
 
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_BUILD_ERROR)
     }
   val managedJdkBins =
@@ -459,7 +461,7 @@ private fun doBuildInner(
   if (fileExists(BUILD_STATE_FILE)) deleteFile(BUILD_STATE_FILE)
   val managedKotlincBin =
     ensureKotlincBin(config.kotlin.effectiveCompiler, paths).getOrElse {
-      eprintln("error: ${it.message}")
+      eprintError("${it.message}")
       return Err(EXIT_BUILD_ERROR)
     }
   val resolutionOutcome =
@@ -471,20 +473,20 @@ private fun doBuildInner(
     buildClasspath(resolutionOutcome.allJars.map { it.cachePath }).ifEmpty { null }
   val pluginJarPathsByAlias =
     resolveEnabledPluginJarPaths(config, paths, EXIT_BUILD_ERROR).getOrElse {
-      eprintln("error: ${it.message}")
+      eprintError("${it.message}")
       return Err(it.exitCode)
     }
   val pArgs = pluginJarPathsByAlias.values.map { "-Xplugin=$it" }
   val pluginJarsForDaemon = pluginJarPathsByAlias.mapValues { (_, path) -> listOf(path) }
   ensureDirectoryRecursive(CLASSES_DIR).getOrElse { error ->
-    eprintln("error: could not create directory ${error.path}")
+    eprintError("could not create directory ${error.path}")
     return Err(EXIT_BUILD_ERROR)
   }
 
   val cwd =
     currentWorkingDirectory()
       ?: run {
-        eprintln("error: could not determine current working directory")
+        eprintError("could not determine current working directory")
         return Err(EXIT_BUILD_ERROR)
       }
 
@@ -514,7 +516,7 @@ private fun doBuildInner(
       // BTA requires individual .kt files, not directories (#117).
       sources =
         expandKotlinSources(config.build.sources.map { absolutise(it, cwd) }).getOrElse { err ->
-          eprintln("error: could not list Kotlin sources under ${err.path}")
+          eprintError("could not list Kotlin sources under ${err.path}")
           return Err(EXIT_BUILD_ERROR)
         },
       outputPath = absolutise(CLASSES_DIR, cwd),
@@ -540,18 +542,18 @@ private fun doBuildInner(
   val existingResourceDirs = filterExistingDirs(config.build.resources, "resource")
   for (resourceDir in existingResourceDirs) {
     copyDirectoryContents(resourceDir, CLASSES_DIR).getOrElse { error ->
-      eprintln("error: could not copy resources from ${error.path}")
+      eprintError("could not copy resources from ${error.path}")
       return Err(EXIT_BUILD_ERROR)
     }
   }
 
   val jarCmd = jarCommand(config, jarPath = managedJarBin, profile = profile)
   ensureDirectoryRecursive(jarCmd.outputPath.substringBeforeLast('/')).getOrElse { error ->
-    eprintln("error: could not create directory ${error.path}")
+    eprintError("could not create directory ${error.path}")
     return Err(EXIT_BUILD_ERROR)
   }
   executeCommand(jarCmd.args).getOrElse { error ->
-    eprintln("error: " + formatProcessError(error, "jar packaging"))
+    eprintError(formatProcessError(error, "jar packaging"))
     return Err(EXIT_BUILD_ERROR)
   }
 
@@ -563,9 +565,7 @@ private fun doBuildInner(
   // disk mirroring the existing jarCmd failure semantics).
   handleRuntimeClasspathManifest(config, resolutionOutcome.mainJars, profile).getOrElse { err ->
     val failure = err as ManifestWriteError.WriteFailed
-    eprintln(
-      "error: could not write runtime classpath manifest at ${failure.path}: ${failure.reason}"
-    )
+    eprintError("could not write runtime classpath manifest at ${failure.path}: ${failure.reason}")
     return Err(EXIT_BUILD_ERROR)
   }
 
@@ -577,7 +577,7 @@ private fun doBuildInner(
       testClasspath = testClasspath,
     )
   writeFileAsString(BUILD_STATE_FILE, serializeBuildState(newState)).getOrElse {
-    eprintln("warning: could not write build state file")
+    eprintWarning("could not write build state file")
   }
 
   val elapsed = startMark.elapsedNow()
@@ -603,12 +603,12 @@ private fun doNativeBuildInner(
 
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_BUILD_ERROR)
     }
   val managedKonancBin =
     ensureKonancBin(config.kotlin.effectiveCompiler, paths).getOrElse {
-      eprintln("error: ${it.message}")
+      eprintError("${it.message}")
       return Err(EXIT_BUILD_ERROR)
     }
 
@@ -663,12 +663,12 @@ private fun doNativeBuildInner(
 
   val nativePluginArgs =
     resolvePluginArgs(config, paths, EXIT_BUILD_ERROR).getOrElse {
-      eprintln("error: ${it.message}")
+      eprintError("${it.message}")
       return Err(it.exitCode)
     }
 
   ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
-    eprintln("error: could not create directory ${error.path}")
+    eprintError("could not create directory ${error.path}")
     return Err(EXIT_BUILD_ERROR)
   }
 
@@ -687,7 +687,7 @@ private fun doNativeBuildInner(
   val cwd =
     currentWorkingDirectory()
       ?: run {
-        eprintln("error: could not determine current working directory")
+        eprintError("could not determine current working directory")
         return Err(EXIT_BUILD_ERROR)
       }
   val subprocessBackend =
@@ -714,7 +714,7 @@ private fun doNativeBuildInner(
       profile = profile,
     )
   ensureDirectoryRecursive(libraryCmd.outputPath.substringBeforeLast('/')).getOrElse { error ->
-    eprintln("error: could not create directory ${error.path}")
+    eprintError("could not create directory ${error.path}")
     return Err(EXIT_BUILD_ERROR)
   }
   println("compiling ${config.name} (native)...")
@@ -731,7 +731,7 @@ private fun doNativeBuildInner(
   // kind; stage 1 already produced the `.klib` artifact.
   if (stagePlan.linkMain != null) {
     ensureDirectoryRecursive(nativeIcCacheDir(profile)).getOrElse { error ->
-      eprintln("error: could not create directory ${error.path}")
+      eprintError("could not create directory ${error.path}")
       return Err(EXIT_BUILD_ERROR)
     }
 
@@ -752,7 +752,7 @@ private fun doNativeBuildInner(
   }
 
   if (!fileExists(artifactPath)) {
-    eprintln("error: $artifactPath not produced by konanc")
+    eprintError("$artifactPath not produced by konanc")
     return Err(EXIT_BUILD_ERROR)
   }
 
@@ -766,7 +766,7 @@ private fun doNativeBuildInner(
 
   val newState = currentState.copy(classesDirMtime = fileMtime(artifactPath))
   writeFileAsString(BUILD_STATE_FILE, serializeBuildState(newState)).getOrElse {
-    eprintln("warning: could not write build state file")
+    eprintWarning("could not write build state file")
   }
 
   val elapsed = startMark.elapsedNow()
@@ -849,12 +849,12 @@ private fun runCinterop(
       )
     println("generating cinterop klib for ${entry.name}...")
     executeCommand(cmd.args, cinteropEnv).getOrElse { error ->
-      eprintln("error: " + formatProcessError(error, "cinterop (${entry.name})"))
+      eprintError(formatProcessError(error, "cinterop (${entry.name})"))
       return Err(EXIT_BUILD_ERROR)
     }
     if (currentStamp != null) {
       writeFileAsString(stampPath, currentStamp).getOrElse { error ->
-        eprintln("warning: failed to write cinterop stamp ${error.path}")
+        eprintWarning("failed to write cinterop stamp ${error.path}")
       }
     }
     klibs.add(klibPath)
@@ -944,7 +944,7 @@ private fun doRunInner(
   if (config.build.target in NATIVE_TARGETS) {
     val kexePath = outputKexePath(config, profile)
     if (!fileExists(kexePath)) {
-      eprintln("error: $kexePath not found. Run 'kolt build' first.")
+      eprintError("$kexePath not found. Run 'kolt build' first.")
       return Err(EXIT_BUILD_ERROR)
     }
     val cmd = nativeRunCommand(config, appArgs, profile)
@@ -959,7 +959,7 @@ private fun doRunInner(
     return Ok(Unit)
   }
   if (!fileExists(CLASSES_DIR)) {
-    eprintln("error: $CLASSES_DIR not found. Run 'kolt build' first.")
+    eprintError("$CLASSES_DIR not found. Run 'kolt build' first.")
     return Err(EXIT_BUILD_ERROR)
   }
 
@@ -969,7 +969,7 @@ private fun doRunInner(
   val projectRoot =
     currentWorkingDirectory()
       ?: run {
-        eprintln("error: could not determine current working directory")
+        eprintError("could not determine current working directory")
         return Err(EXIT_BUILD_ERROR)
       }
   val args =
@@ -1039,7 +1039,7 @@ private fun doTestInner(
 
   val existingTestSources = filterExistingDirs(config.build.testSources, "test source")
   if (existingTestSources.isEmpty()) {
-    eprintln("error: no test sources found in ${config.build.testSources}")
+    eprintError("no test sources found in ${config.build.testSources}")
     return Err(EXIT_TEST_ERROR)
   }
 
@@ -1082,23 +1082,23 @@ private fun doTestInner(
 
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_TEST_ERROR)
     }
   val consoleLauncherPath =
     ensureTool(paths, CONSOLE_LAUNCHER_SPEC).getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_TEST_ERROR)
     }
   val managedKotlincBin =
     ensureKotlincBin(config.kotlin.effectiveCompiler, paths).getOrElse {
-      eprintln("error: ${it.message}")
+      eprintError("${it.message}")
       return Err(EXIT_TEST_ERROR)
     }
 
   val pluginJarPathsByAlias =
     resolveEnabledPluginJarPaths(config, paths, EXIT_TEST_ERROR).getOrElse {
-      eprintln("error: ${it.message}")
+      eprintError("${it.message}")
       return Err(it.exitCode)
     }
   val pArgs = pluginJarPathsByAlias.values.map { "-Xplugin=$it" }
@@ -1120,7 +1120,7 @@ private fun doTestInner(
   val cwd =
     currentWorkingDirectory()
       ?: run {
-        eprintln("error: could not determine current working directory")
+        eprintError("could not determine current working directory")
         return Err(EXIT_TEST_ERROR)
       }
 
@@ -1144,7 +1144,7 @@ private fun doTestInner(
   val absMainClassesDir = absolutise(CLASSES_DIR, cwd)
   val testSources =
     expandKotlinSources(existingTestSources.map { absolutise(it, cwd) }).getOrElse { err ->
-      eprintln("error: could not list Kotlin sources under ${err.path}")
+      eprintError("could not list Kotlin sources under ${err.path}")
       return Err(EXIT_TEST_ERROR)
     }
   val testRequestClasspath = buildList {
@@ -1192,7 +1192,7 @@ private fun doTestInner(
         if (fileExists(TEST_CLASSES_DIR)) newestMtimeAll(TEST_CLASSES_DIR) else null
     )
   writeFileAsString(TEST_BUILD_STATE_FILE, serializeTestBuildState(newState)).getOrElse {
-    eprintln("warning: could not write test state file")
+    eprintWarning("could not write test state file")
   }
 
   val existingTestResourceDirs = filterExistingDirs(config.build.testResources, "test resource")
@@ -1222,7 +1222,7 @@ private fun doTestInner(
         val elapsed = testStartMark.elapsedNow()
         eprintln("tests failed in ${formatDuration(elapsed)}")
       }
-      else -> eprintln("error: failed to run tests")
+      else -> eprintError("failed to run tests")
     }
     return Err(EXIT_TEST_ERROR)
   }
@@ -1240,7 +1240,7 @@ private fun doNativeTest(
 ): Result<Unit, Int> {
   val existingTestSources = filterExistingDirs(config.build.testSources, "test source")
   if (existingTestSources.isEmpty()) {
-    eprintln("error: no test sources found in ${config.build.testSources}")
+    eprintError("no test sources found in ${config.build.testSources}")
     return Err(EXIT_TEST_ERROR)
   }
 
@@ -1278,12 +1278,12 @@ private fun doNativeTest(
 
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_TEST_ERROR)
     }
   val managedKonancBin =
     ensureKonancBin(config.kotlin.effectiveCompiler, paths).getOrElse {
-      eprintln("error: ${it.message}")
+      eprintError("${it.message}")
       return Err(EXIT_TEST_ERROR)
     }
   val managedJdkBins =
@@ -1292,7 +1292,7 @@ private fun doNativeTest(
     }
   val nativePluginArgs =
     resolvePluginArgs(config, paths, EXIT_TEST_ERROR).getOrElse {
-      eprintln("error: ${it.message}")
+      eprintError("${it.message}")
       return Err(it.exitCode)
     }
 
@@ -1302,7 +1302,7 @@ private fun doNativeTest(
     }
 
   ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
-    eprintln("error: could not create directory ${error.path}")
+    eprintError("could not create directory ${error.path}")
     return Err(EXIT_BUILD_ERROR)
   }
 
@@ -1315,7 +1315,7 @@ private fun doNativeTest(
   val cwd =
     currentWorkingDirectory()
       ?: run {
-        eprintln("error: could not determine current working directory")
+        eprintError("could not determine current working directory")
         return Err(EXIT_BUILD_ERROR)
       }
   val subprocessBackend =
@@ -1342,7 +1342,7 @@ private fun doNativeTest(
       profile = profile,
     )
   ensureDirectoryRecursive(libraryCmd.outputPath.substringBeforeLast('/')).getOrElse { error ->
-    eprintln("error: could not create directory ${error.path}")
+    eprintError("could not create directory ${error.path}")
     return Err(EXIT_BUILD_ERROR)
   }
   println("compiling tests (native)...")
@@ -1367,13 +1367,13 @@ private fun doNativeTest(
   }
 
   if (!fileExists(linkCmd.outputPath)) {
-    eprintln("error: ${linkCmd.outputPath} not produced by konanc")
+    eprintError("${linkCmd.outputPath} not produced by konanc")
     return Err(EXIT_BUILD_ERROR)
   }
 
   val newState = currentState.copy(testArtifactMtime = fileMtime(linkCmd.outputPath))
   writeFileAsString(TEST_BUILD_STATE_FILE, serializeTestBuildState(newState)).getOrElse {
-    eprintln("warning: could not write test state file")
+    eprintWarning("could not write test state file")
   }
 
   val runCmd = nativeTestRunCommand(testConfig, testArgs, profile)
@@ -1390,7 +1390,7 @@ private fun doNativeTest(
         val elapsed = testStartMark.elapsedNow()
         eprintln("tests failed in ${formatDuration(elapsed)}")
       }
-      else -> eprintln("error: failed to run tests")
+      else -> eprintError("failed to run tests")
     }
     return Err(EXIT_TEST_ERROR)
   }
@@ -1410,7 +1410,7 @@ internal fun ensureJdkBinsFromConfig(
   val version = config.build.jdk ?: BOOTSTRAP_JDK_VERSION
   return ensureJdkBins(version, paths)
     .getOrElse { err ->
-      eprintln("error: ${err.message}")
+      eprintError("${err.message}")
       return Err(EXIT_BUILD_ERROR)
     }
     .let { Ok(it) }
@@ -1614,7 +1614,7 @@ private inline fun <T> withProjectLock(
   crossinline body: (LockHandle) -> Result<T, Int>
 ): Result<T, Int> {
   ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
-    eprintln("error: could not create directory ${error.path}")
+    eprintError("could not create directory ${error.path}")
     return Err(EXIT_BUILD_ERROR)
   }
   val timeoutMs = parseLockTimeoutMs()
@@ -1629,16 +1629,14 @@ private fun mapLockErrorToExitCode(error: LockError, requestedTimeoutMs: Long): 
   when (error) {
     is LockError.TimedOut -> {
       val reportedMs = if (error.waitedMs > 0L) error.waitedMs else requestedTimeoutMs
-      eprintln(
-        "error: lock acquisition timed out after ${reportedMs}ms; " +
-          "another kolt build may be stuck"
+      eprintError(
+        "lock acquisition timed out after ${reportedMs}ms; another kolt build may be stuck"
       )
       EXIT_LOCK_TIMEOUT
     }
     is LockError.IoError -> {
-      eprintln(
-        "error: could not acquire build lock at $BUILD_DIR/.kolt-build.lock " +
-          "(errno=${error.errno}: ${error.message})"
+      eprintError(
+        "could not acquire build lock at $BUILD_DIR/.kolt-build.lock (errno=${error.errno}: ${error.message})"
       )
       EXIT_BUILD_ERROR
     }

--- a/src/nativeMain/kotlin/kolt/cli/CacheCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/CacheCommands.kt
@@ -12,6 +12,7 @@ import kolt.infra.directorySize
 import kolt.infra.eprintln
 import kolt.infra.fileExists
 import kolt.infra.formatBytes
+import kolt.infra.output.eprintError
 import kolt.infra.removeDirectoryRecursive
 
 internal data class CacheCleanArgs(val includeTools: Boolean)
@@ -83,7 +84,7 @@ private fun doCacheClean(args: List<String>): Result<Unit, Int> {
 
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_CONFIG_ERROR)
     }
 
@@ -91,7 +92,7 @@ private fun doCacheClean(args: List<String>): Result<Unit, Int> {
   for (path in result.removedPaths) println("removed $path")
 
   if (result.error != null) {
-    eprintln("error: could not remove ${result.error.path}")
+    eprintError("could not remove ${result.error.path}")
     if (result.freedBytes > 0) {
       println("partially freed ${formatBytes(result.freedBytes)} before failure")
     }

--- a/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DaemonCommands.kt
@@ -15,6 +15,7 @@ import kolt.infra.fileExists as infraFileExists
 import kolt.infra.listFiles as infraListFiles
 import kolt.infra.listSubdirectories as infraListSubdirectories
 import kolt.infra.net.UnixSocket
+import kolt.infra.output.eprintError
 import kolt.nativedaemon.wire.FrameCodec as NativeFrameCodec
 import kolt.nativedaemon.wire.Message as NativeMessage
 
@@ -32,7 +33,7 @@ internal fun doDaemon(args: List<String>): Result<Unit, Int> {
     "stop" -> doDaemonStop(args.drop(1))
     "reap" -> doDaemonReap()
     else -> {
-      eprintln("error: unknown daemon command '${args[0]}'")
+      eprintError("unknown daemon command '${args[0]}'")
       printDaemonUsage()
       Err(EXIT_CONFIG_ERROR)
     }
@@ -43,7 +44,7 @@ private fun doDaemonStop(args: List<String>): Result<Unit, Int> {
   val all = args.contains("--all")
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_CONFIG_ERROR)
     }
 
@@ -53,7 +54,7 @@ private fun doDaemonStop(args: List<String>): Result<Unit, Int> {
     val cwd =
       currentWorkingDirectory()
         ?: run {
-          eprintln("error: could not determine project directory")
+          eprintError("could not determine project directory")
           return Err(EXIT_CONFIG_ERROR)
         }
     val hash = projectHashOf(cwd)
@@ -163,7 +164,7 @@ private fun sendNativeShutdown(socketPath: String): Boolean {
 private fun doDaemonReap(): Result<Unit, Int> {
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_CONFIG_ERROR)
     }
   val result = reapStaleDaemons(paths.daemonBaseDir)

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -38,9 +38,9 @@ private fun doAddInner(args: List<String>): Result<Unit, Int> {
     }
 
   val config =
-    parseConfig(toml).getOrElse { error ->
+    parseConfig(toml, path = absoluteKoltTomlPath()).getOrElse { error ->
       when (error) {
-        is ConfigError.ParseFailed -> eprintln("error: ${error.message}")
+        is ConfigError.ParseFailed -> eprintDiagnostic(renderConfigError(error))
       }
       return Err(EXIT_CONFIG_ERROR)
     }

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -12,6 +12,8 @@ import kolt.concurrency.ProjectLock
 import kolt.config.*
 import kolt.infra.*
 import kolt.infra.output.eprintDiagnostic
+import kolt.infra.output.eprintError
+import kolt.infra.output.eprintWarning
 import kolt.resolve.*
 import kolt.usertool.ToolEntry
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -26,14 +28,14 @@ private fun doAddInner(args: List<String>): Result<Unit, Int> {
       when (error) {
         is AddArgsError.MissingCoordinate ->
           eprintln("usage: kolt add <group:artifact[:version]> [--test]")
-        is AddArgsError.InvalidFormat -> eprintln("error: invalid coordinate '${error.input}'")
+        is AddArgsError.InvalidFormat -> eprintError("invalid coordinate '${error.input}'")
       }
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
   val toml =
     readFileAsString(KOLT_TOML).getOrElse { error ->
-      eprintln("error: could not read ${error.path}")
+      eprintError("could not read ${error.path}")
       return Err(EXIT_CONFIG_ERROR)
     }
 
@@ -61,8 +63,8 @@ private fun doAddInner(args: List<String>): Result<Unit, Int> {
     addDependencyToToml(toml, groupArtifact, version, addArgs.isTest).getOrElse { error ->
       when (error) {
         is AlreadyExists ->
-          eprintln(
-            "error: '${error.groupArtifact}' already exists in ${if (addArgs.isTest) "[test-dependencies]" else "[dependencies]"}"
+          eprintError(
+            "'${error.groupArtifact}' already exists in ${if (addArgs.isTest) "[test-dependencies]" else "[dependencies]"}"
           )
       }
       return Err(EXIT_DEPENDENCY_ERROR)
@@ -85,7 +87,7 @@ private fun doAddInner(args: List<String>): Result<Unit, Int> {
   }
 
   writeFileAsString(KOLT_TOML, updatedToml).getOrElse { error ->
-    eprintln("error: could not write ${error.path}")
+    eprintError("could not write ${error.path}")
     return Err(EXIT_CONFIG_ERROR)
   }
 
@@ -104,14 +106,14 @@ private fun doRemoveInner(args: List<String>): Result<Unit, Int> {
     parseRemoveArgs(args).getOrElse { error ->
       when (error) {
         is RemoveArgsError.MissingCoordinate -> eprintln("usage: kolt remove <group:artifact>")
-        is RemoveArgsError.InvalidFormat -> eprintln("error: invalid coordinate '${error.input}'")
+        is RemoveArgsError.InvalidFormat -> eprintError("invalid coordinate '${error.input}'")
       }
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
   val toml =
     readFileAsString(KOLT_TOML).getOrElse { error ->
-      eprintln("error: could not read ${error.path}")
+      eprintError("could not read ${error.path}")
       return Err(EXIT_CONFIG_ERROR)
     }
 
@@ -122,7 +124,7 @@ private fun doRemoveInner(args: List<String>): Result<Unit, Int> {
   }
 
   writeFileAsString(KOLT_TOML, result.newToml).getOrElse { error ->
-    eprintln("error: could not write ${error.path}")
+    eprintError("could not write ${error.path}")
     return Err(EXIT_CONFIG_ERROR)
   }
 
@@ -144,14 +146,14 @@ private fun fetchLatestVersion(
 ): Result<String, Int> {
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_DEPENDENCY_ERROR)
     }
   val groupPath = group.replace('.', '/')
   val metadataPath = "${paths.cacheBase}/$groupPath/$artifact/maven-metadata.xml"
 
   ensureDirectoryRecursive("${paths.cacheBase}/$groupPath/$artifact").getOrElse { error ->
-    eprintln("error: could not create directory ${error.path}")
+    eprintError("could not create directory ${error.path}")
     return Err(EXIT_DEPENDENCY_ERROR)
   }
 
@@ -172,17 +174,17 @@ private fun fetchLatestVersion(
 
   val xml =
     readFileAsString(metadataPath).getOrElse { error ->
-      eprintln("error: could not read ${error.path}")
+      eprintError("could not read ${error.path}")
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
   val resolution =
     parseMetadataXml(xml).getOrElse { error ->
-      eprintln("error: ${error.message}")
+      eprintError("${error.message}")
       return Err(EXIT_DEPENDENCY_ERROR)
     }
   if (resolution.fallbackToPrerelease) {
-    eprintln("warning: no stable release found for $group:$artifact; using ${resolution.version}")
+    eprintWarning("no stable release found for $group:$artifact; using ${resolution.version}")
   }
   return Ok(resolution.version)
 }
@@ -227,7 +229,7 @@ private fun doUpdateInner(): Result<Unit, Int> {
 
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
@@ -297,7 +299,7 @@ private fun doUpdateInner(): Result<Unit, Int> {
   val lockfile = mainAndBundleLockfile.copy(toolsBundles = toolsBundles)
   val lockJson = serializeLockfile(lockfile)
   writeFileAsString(LOCK_FILE, lockJson).getOrElse { error ->
-    eprintln("error: could not write ${error.path}")
+    eprintError("could not write ${error.path}")
     return Err(EXIT_DEPENDENCY_ERROR)
   }
   val toolsCount = toolsBundles.values.sumOf { it.size }
@@ -368,7 +370,7 @@ internal fun doTree(): Result<Unit, Int> {
 
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
@@ -457,7 +459,7 @@ internal fun parseDependencyLockTimeoutMs(): Long {
 // EXIT_DEPENDENCY_ERROR (the deps tree of CLI exit codes — task 3.2).
 internal inline fun <T> withDependencyLock(crossinline body: () -> Result<T, Int>): Result<T, Int> {
   ensureDirectoryRecursive(BUILD_DIR).getOrElse { error ->
-    eprintln("error: could not create directory ${error.path}")
+    eprintError("could not create directory ${error.path}")
     return Err(EXIT_DEPENDENCY_ERROR)
   }
   val timeoutMs = parseDependencyLockTimeoutMs()
@@ -472,15 +474,14 @@ private fun mapDependencyLockErrorToExitCode(error: LockError, requestedTimeoutM
   when (error) {
     is LockError.TimedOut -> {
       val reportedMs = if (error.waitedMs > 0L) error.waitedMs else requestedTimeoutMs
-      eprintln(
-        "error: lock acquisition timed out after ${reportedMs}ms; " +
-          "another kolt build may be stuck"
+      eprintError(
+        "lock acquisition timed out after ${reportedMs}ms; " + "another kolt build may be stuck"
       )
       EXIT_LOCK_TIMEOUT
     }
     is LockError.IoError -> {
-      eprintln(
-        "error: could not acquire build lock at $BUILD_DIR/.kolt-build.lock " +
+      eprintError(
+        "could not acquire build lock at $BUILD_DIR/.kolt-build.lock " +
           "(errno=${error.errno}: ${error.message})"
       )
       EXIT_DEPENDENCY_ERROR

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -11,6 +11,7 @@ import kolt.concurrency.LockHandle
 import kolt.concurrency.ProjectLock
 import kolt.config.*
 import kolt.infra.*
+import kolt.infra.output.eprintDiagnostic
 import kolt.resolve.*
 import kolt.usertool.ToolEntry
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -163,7 +164,9 @@ private fun fetchLatestVersion(
       )
       .getError()
   if (failure != null) {
-    eprintln(formatResolveError(ResolveError.MetadataDownloadFailed("$group:$artifact", failure)))
+    eprintDiagnostic(
+      formatResolveError(ResolveError.MetadataDownloadFailed("$group:$artifact", failure))
+    )
     return Err(EXIT_DEPENDENCY_ERROR)
   }
 
@@ -251,7 +254,7 @@ private fun doUpdateInner(): Result<Unit, Int> {
           testSeeds = testSeeds,
         )
         .getOrElse { error ->
-          eprintln(formatResolveError(error))
+          eprintDiagnostic(formatResolveError(error))
           return Err(EXIT_DEPENDENCY_ERROR)
         }
 
@@ -260,7 +263,7 @@ private fun doUpdateInner(): Result<Unit, Int> {
     val bundleResolutions =
       resolveAllBundles(config, existingLock = null, paths.cacheBase, resolverDeps).getOrElse {
         error ->
-        eprintln(formatResolveError(error))
+        eprintDiagnostic(formatResolveError(error))
         return Err(EXIT_DEPENDENCY_ERROR)
       }
     val bundleDeps = bundleResolutions.mapValues { it.value.deps }
@@ -286,7 +289,7 @@ private fun doUpdateInner(): Result<Unit, Int> {
           )
         }
         .getOrElse { error ->
-          eprintln(formatResolveError(error))
+          eprintDiagnostic(formatResolveError(error))
           return Err(EXIT_DEPENDENCY_ERROR)
         }
     }

--- a/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
@@ -17,6 +17,8 @@ import kolt.build.resolveUserJdkHome
 import kolt.config.*
 import kolt.infra.*
 import kolt.infra.output.eprintDiagnostic
+import kolt.infra.output.eprintError
+import kolt.infra.output.eprintWarning
 import kolt.resolve.*
 
 internal const val LOCK_FILE = "kolt.lock"
@@ -65,8 +67,8 @@ internal fun resolveDependencies(
   allowLockfileMigration: Boolean = false,
 ): Result<JvmResolutionOutcome, Int> {
   for (dep in findOverlappingDependencies(config.dependencies, config.testDependencies)) {
-    eprintln(
-      "warning: '${dep.groupArtifact}' is in both [dependencies] (${dep.mainVersion}) and [test-dependencies] (${dep.testVersion}); using ${dep.mainVersion}"
+    eprintWarning(
+      "'${dep.groupArtifact}' is in both [dependencies] (${dep.mainVersion}) and [test-dependencies] (${dep.testVersion}); using ${dep.mainVersion}"
     )
   }
 
@@ -83,14 +85,14 @@ internal fun resolveDependencies(
 
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
   val lockJsonOnDisk =
     if (fileExists(LOCK_FILE)) {
       readFileAsString(LOCK_FILE).getOrElse { error ->
-        eprintln("warning: could not read $LOCK_FILE: ${error.path}")
+        eprintWarning("could not read $LOCK_FILE: ${error.path}")
         null
       }
     } else null
@@ -102,18 +104,18 @@ internal fun resolveDependencies(
       is LockfileLoadResult.Loaded -> outcome.lockfile
       is LockfileLoadResult.Absent -> null
       is LockfileLoadResult.Corrupt -> {
-        eprintln("warning: ${outcome.message}")
+        eprintWarning("${outcome.message}")
         null
       }
       is LockfileLoadResult.UnsupportedAndMigrationAllowed -> {
-        eprintln(
-          "warning: kolt.lock v${outcome.version} detected, regenerating as v$LOCKFILE_VERSION (one-time migration for v0.X)"
+        eprintWarning(
+          "kolt.lock v${outcome.version} detected, regenerating as v$LOCKFILE_VERSION (one-time migration for v0.X)"
         )
         null
       }
       is LockfileLoadResult.UnsupportedAndMigrationDenied -> {
-        eprintln(
-          "error: kolt.lock v${outcome.version} is no longer supported, run 'kolt fetch' to regenerate"
+        eprintError(
+          "kolt.lock v${outcome.version} is no longer supported, run 'kolt fetch' to regenerate"
         )
         return Err(EXIT_DEPENDENCY_ERROR)
       }
@@ -155,7 +157,7 @@ internal fun resolveDependencies(
     val lockfile = buildLockfileFromResolved(config, resolveResult.deps, bundleDeps)
     val lockJson = serializeLockfile(lockfile)
     writeFileAsString(LOCK_FILE, lockJson).getOrElse { error ->
-      eprintln("error: could not write ${error.path}")
+      eprintError("could not write ${error.path}")
       return Err(EXIT_DEPENDENCY_ERROR)
     }
   }
@@ -364,7 +366,7 @@ private fun writeWorkspaceFiles(config: KoltConfig, paths: KoltPaths, deps: List
   val sdkHomePath = resolveWorkspaceSdkHomePath(config, paths)
   val workspaceJson = generateWorkspaceJson(config, mainDeps, testDeps, sdkHomePath = sdkHomePath)
   writeFileAsString(WORKSPACE_JSON, workspaceJson).getOrElse { error ->
-    eprintln("warning: could not write $WORKSPACE_JSON: ${error.path}")
+    eprintWarning("could not write $WORKSPACE_JSON: ${error.path}")
     return
   }
 }

--- a/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
@@ -16,6 +16,7 @@ import kolt.build.generateWorkspaceJson
 import kolt.build.resolveUserJdkHome
 import kolt.config.*
 import kolt.infra.*
+import kolt.infra.output.eprintDiagnostic
 import kolt.resolve.*
 
 internal const val LOCK_FILE = "kolt.lock"
@@ -130,7 +131,7 @@ internal fun resolveDependencies(
         testSeeds = testSeeds,
       )
       .getOrElse { error ->
-        eprintln(formatResolveError(error))
+        eprintDiagnostic(formatResolveError(error))
         if (error is ResolveError.Sha256Mismatch) {
           eprintln("delete the cached jar and rebuild to re-download")
         }
@@ -139,7 +140,7 @@ internal fun resolveDependencies(
 
   val bundleResolutions =
     resolveAllBundles(config, existingLock, paths.cacheBase, resolverDeps).getOrElse { error ->
-      eprintln(formatResolveError(error))
+      eprintDiagnostic(formatResolveError(error))
       if (error is ResolveError.Sha256Mismatch) {
         eprintln("delete the cached jar and rebuild to re-download")
       }
@@ -352,7 +353,7 @@ internal fun resolveNativeDependencies(
   println("resolving native dependencies...")
   val result =
     resolve(config, existingLock = null, paths.cacheBase, createResolverDeps()).getOrElse { error ->
-      eprintln(formatResolveError(error))
+      eprintDiagnostic(formatResolveError(error))
       return Err(EXIT_DEPENDENCY_ERROR)
     }
   return Ok(result.deps.map { it.cachePath })

--- a/src/nativeMain/kotlin/kolt/cli/FormatCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/FormatCommands.kt
@@ -7,6 +7,7 @@ import com.github.michaelbull.result.getOrElse
 import kolt.build.formatCommand
 import kolt.config.*
 import kolt.infra.*
+import kolt.infra.output.eprintError
 import kolt.tool.*
 
 internal fun doFmt(args: List<String>): Result<Unit, Int> {
@@ -19,12 +20,12 @@ internal fun doFmt(args: List<String>): Result<Unit, Int> {
 
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_FORMAT_ERROR)
     }
   val ktfmtPath =
     ensureTool(paths, KTFMT_SPEC).getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_FORMAT_ERROR)
     }
   val managedJdkBins =
@@ -37,7 +38,7 @@ internal fun doFmt(args: List<String>): Result<Unit, Int> {
     if (isDirectory(dir)) {
       files.addAll(
         listKotlinFiles(dir).getOrElse { error ->
-          eprintln("error: could not read directory ${error.path}")
+          eprintError("could not read directory ${error.path}")
           return Err(EXIT_FORMAT_ERROR)
         }
       )
@@ -47,7 +48,7 @@ internal fun doFmt(args: List<String>): Result<Unit, Int> {
     if (isDirectory(dir)) {
       files.addAll(
         listKotlinFiles(dir).getOrElse { error ->
-          eprintln("error: could not read directory ${error.path}")
+          eprintError("could not read directory ${error.path}")
           return Err(EXIT_FORMAT_ERROR)
         }
       )
@@ -78,8 +79,8 @@ internal fun doFmt(args: List<String>): Result<Unit, Int> {
   executeCommand(cmd.args).getOrElse { error ->
     when (error) {
       is ProcessError.NonZeroExit ->
-        eprintln(if (checkOnly) "error: format check failed" else "error: formatting failed")
-      else -> eprintln("error: failed to run ktfmt")
+        eprintError(if (checkOnly) "format check failed" else "formatting failed")
+      else -> eprintError("failed to run ktfmt")
     }
     return Err(EXIT_FORMAT_ERROR)
   }

--- a/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
@@ -374,7 +374,7 @@ internal fun loadProjectForInfo(): ProjectLoad {
       return ProjectLoad.ParseFailed("could not read ${err.path}")
     }
   val config =
-    parseConfig(toml).getOrElse { err ->
+    parseConfig(toml, path = absoluteKoltTomlPath()).getOrElse { err ->
       val message =
         when (err) {
           is ConfigError.ParseFailed -> err.message

--- a/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
@@ -18,6 +18,7 @@ import kolt.infra.eprintln
 import kolt.infra.fileExists
 import kolt.infra.formatBytes
 import kolt.infra.homeDirectory
+import kolt.infra.output.eprintError
 import kolt.infra.readFileAsString
 import kolt.infra.readSelfExe
 import kolt.resolve.compareVersions
@@ -249,7 +250,7 @@ internal fun doInfo(args: List<String>): Result<Unit, Int> {
   // `--verbose --format=json` is equivalent to `--format=json` — json always
   // carries the full field set.
   val snap = gatherInfo(verbose = opts.verbose || opts.json)
-  snap.parseError?.let { eprintln("error: $it") }
+  snap.parseError?.let { eprintError("$it") }
   if (opts.json) {
     println(formatInfoJson(snap))
   } else {

--- a/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/InfoCommand.kt
@@ -10,6 +10,7 @@ import kolt.config.KOLT_VERSION
 import kolt.config.KoltConfig
 import kolt.config.KoltPaths
 import kolt.config.parseConfig
+import kolt.config.renderConfigErrorAsLine
 import kolt.config.resolveKoltPaths
 import kolt.infra.absolutise
 import kolt.infra.currentWorkingDirectory
@@ -378,7 +379,7 @@ internal fun loadProjectForInfo(): ProjectLoad {
     parseConfig(toml, path = absoluteKoltTomlPath()).getOrElse { err ->
       val message =
         when (err) {
-          is ConfigError.ParseFailed -> err.message
+          is ConfigError.ParseFailed -> renderConfigErrorAsLine(err)
         }
       return ProjectLoad.ParseFailed(message)
     }

--- a/src/nativeMain/kotlin/kolt/cli/InitCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/InitCommand.kt
@@ -4,8 +4,8 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.config.inferProjectName
-import kolt.infra.eprintln
 import kolt.infra.fileExists
+import kolt.infra.output.eprintError
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.allocArray
@@ -18,7 +18,7 @@ import platform.posix.getcwd
 internal fun doInit(args: List<String>, io: ScaffoldIO = SystemScaffoldIO): Result<Unit, Int> {
   val parsed =
     parseInitArgs(args).getOrElse { msg ->
-      eprintln("error: $msg")
+      eprintError(msg)
       return Err(EXIT_CONFIG_ERROR)
     }
 
@@ -30,25 +30,25 @@ internal fun doInit(args: List<String>, io: ScaffoldIO = SystemScaffoldIO): Resu
           getcwd(buf, PATH_MAX.toULong())?.toKString()
         }
         if (cwd == null) {
-          eprintln("error: could not determine current directory")
+          eprintError("could not determine current directory")
           return Err(EXIT_CONFIG_ERROR)
         }
         inferProjectName(cwd)
       }
 
   validateProjectName(projectName).getOrElse { msg ->
-    eprintln("error: $msg")
+    eprintError(msg)
     return Err(EXIT_CONFIG_ERROR)
   }
 
   if (fileExists(KOLT_TOML)) {
-    eprintln("error: $KOLT_TOML already exists")
+    eprintError("$KOLT_TOML already exists")
     return Err(EXIT_CONFIG_ERROR)
   }
 
   val resolved =
     resolveInteractive(parsed, io).getOrElse { msg ->
-      eprintln("error: $msg")
+      eprintError(msg)
       return Err(EXIT_CONFIG_ERROR)
     }
 

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -5,6 +5,9 @@ import com.github.michaelbull.result.getOrElse
 import kolt.build.Profile
 import kolt.config.versionString
 import kolt.infra.eprintln
+import kolt.infra.output.ColorPolicy
+import kolt.infra.output.eprintError
+import kolt.infra.suggest.closestMatch
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
@@ -14,6 +17,15 @@ fun main(args: Array<String>) {
   }
 
   val parsed = parseKoltArgs(args.toList())
+  // Resolve color policy once at startup from the kolt-level `--no-color`
+  // flag plus the NO_COLOR env var and per-stream isatty state.
+  ColorPolicy.install(ColorPolicy.fromEnv(noColorFlag = parsed.noColor))
+  if (parsed.unknownFlags.isNotEmpty()) {
+    val unknown = parsed.unknownFlags.first()
+    val hint = closestMatch(unknown, KNOWN_KOLT_FLAGS)?.let { "Did you mean `$it`?" }
+    eprintError("unknown flag '$unknown'", hint = hint)
+    exitProcess(EXIT_COMMAND_NOT_FOUND)
+  }
   val useDaemon = parsed.useDaemon
   val watch = parsed.watch
   val profile = parsed.profile
@@ -99,31 +111,77 @@ fun main(args: Array<String>) {
     "--version",
     "version" -> println(versionString())
     else -> {
-      eprintln("error: unknown command '${filteredArgs[0]}'")
+      val unknown = filteredArgs[0]
+      val hint = closestMatch(unknown, KNOWN_SUBCOMMANDS_SORTED)?.let { "Did you mean `$it`?" }
+      eprintError("unknown command '$unknown'", hint = hint)
       printUsage()
       exitProcess(EXIT_COMMAND_NOT_FOUND)
     }
   }
 }
 
+// Sorted alphabetically for deterministic Did-you-mean ordering.
+// Source of truth is the dispatcher `when` above; keep this list in sync
+// when subcommands are added or removed.
+internal val KNOWN_SUBCOMMANDS_SORTED: List<String> =
+  listOf(
+      "add",
+      "build",
+      "cache",
+      "check",
+      "clean",
+      "daemon",
+      "fetch",
+      "fmt",
+      "info",
+      "init",
+      "new",
+      "outdated",
+      "remove",
+      "run",
+      "test",
+      "tool",
+      "toolchain",
+      "tree",
+      "update",
+      "version",
+    )
+    .sorted()
+
 internal const val NO_DAEMON_FLAG = "--no-daemon"
 internal const val WATCH_FLAG = "--watch"
 internal const val RELEASE_FLAG = "--release"
+internal const val NO_COLOR_FLAG = "--no-color"
 internal const val SYS_PROP_PREFIX = "-D"
+
+// Sorted alphabetically for deterministic Did-you-mean. Adding a new
+// kolt-level flag requires updating both this list and parseKoltArgs.
+internal val KNOWN_KOLT_FLAGS: List<String> =
+  listOf(NO_COLOR_FLAG, NO_DAEMON_FLAG, RELEASE_FLAG, WATCH_FLAG).sorted()
+
+// `--version` is `--`-prefixed but semantically a subcommand alias (the
+// dispatcher routes it through the version branch). Treating it as a
+// kolt-level flag would either require special-casing in `unknownFlags`
+// detection or break `kolt --version`; carving it out here keeps both
+// the boundary computation and the catalog clean.
+private val KOLT_SUBCOMMAND_ALIASES: Set<String> = setOf("--version")
 
 internal data class KoltArgs(
   val useDaemon: Boolean,
   val watch: Boolean,
   val profile: Profile,
+  val noColor: Boolean,
   val cliSysProps: List<Pair<String, String>>,
   val filteredArgs: List<String>,
+  val unknownFlags: List<String>,
 )
 
 // Splits the kolt-level flags from the subcommand and from any `--`
 // passthrough segment. The kolt-level flags (--no-daemon, --watch,
-// --release, -D<k>=<v>) are extracted into typed fields and stripped from
-// `filteredArgs`; the passthrough block (after `--`) is appended verbatim
-// so `kolt run -- --foo` still passes `-- --foo` to the subcommand parser.
+// --release, --no-color, -D<k>=<v>) are extracted into typed fields and
+// stripped from `filteredArgs`; the passthrough block (after `--`) is
+// appended verbatim so `kolt run -- --foo` still passes `-- --foo` to the
+// subcommand parser.
 internal fun parseKoltArgs(argList: List<String>): KoltArgs {
   val passthroughStart = argList.indexOf("--")
   val koltLevel = if (passthroughStart >= 0) argList.subList(0, passthroughStart) else argList
@@ -132,12 +190,29 @@ internal fun parseKoltArgs(argList: List<String>): KoltArgs {
   val useDaemon = !koltLevel.contains(NO_DAEMON_FLAG)
   val watch = koltLevel.contains(WATCH_FLAG)
   val profile = if (koltLevel.contains(RELEASE_FLAG)) Profile.Release else Profile.Debug
+  val noColor = koltLevel.contains(NO_COLOR_FLAG)
   val cliSysProps = koltLevel.mapNotNull(::parseDFlag)
+  // The kolt-level flag block ends at the first non-`--` non-`-D` token,
+  // which is the subcommand name (e.g. `build`, `test`); a `--version`
+  // alias also closes the block. Tokens after this boundary belong to
+  // the subcommand and must not be misclassified as unknown kolt-level
+  // flags. Within the kolt-level block, any `--xxx` not in the known set
+  // is an unknown flag.
+  val subcommandIndex =
+    koltLevel.indexOfFirst { token ->
+      (!token.startsWith("--") && parseDFlag(token) == null) || token in KOLT_SUBCOMMAND_ALIASES
+    }
+  val koltLevelOnly = if (subcommandIndex >= 0) koltLevel.subList(0, subcommandIndex) else koltLevel
+  val unknownFlags = koltLevelOnly.filter { it.startsWith("--") && it !in KNOWN_KOLT_FLAGS }
   val filteredArgs =
     koltLevel.filter {
-      it != NO_DAEMON_FLAG && it != WATCH_FLAG && it != RELEASE_FLAG && parseDFlag(it) == null
+      it != NO_DAEMON_FLAG &&
+        it != WATCH_FLAG &&
+        it != RELEASE_FLAG &&
+        it != NO_COLOR_FLAG &&
+        parseDFlag(it) == null
     } + passthrough
-  return KoltArgs(useDaemon, watch, profile, cliSysProps, filteredArgs)
+  return KoltArgs(useDaemon, watch, profile, noColor, cliSysProps, filteredArgs, unknownFlags)
 }
 
 // Returns null when `arg` is not a valid `-D<key>=<value>` form. Bare `-D`,

--- a/src/nativeMain/kotlin/kolt/cli/NewCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/NewCommand.kt
@@ -6,41 +6,42 @@ import com.github.michaelbull.result.getOrElse
 import kolt.infra.ensureDirectory
 import kolt.infra.eprintln
 import kolt.infra.fileExists
+import kolt.infra.output.eprintError
 
 internal fun doNew(args: List<String>, io: ScaffoldIO = SystemScaffoldIO): Result<Unit, Int> {
   val parsed =
     parseInitArgs(args).getOrElse { msg ->
-      eprintln("error: $msg")
+      eprintError(msg)
       return Err(EXIT_CONFIG_ERROR)
     }
 
   val projectName =
     parsed.projectName
       ?: run {
-        eprintln("error: kolt new requires a project name")
+        eprintError("kolt new requires a project name")
         eprintln("usage: kolt new <name> [--lib|--app] [--target <target>] [--group <group>]")
         return Err(EXIT_CONFIG_ERROR)
       }
 
   validateProjectName(projectName).getOrElse { msg ->
-    eprintln("error: $msg")
+    eprintError(msg)
     return Err(EXIT_CONFIG_ERROR)
   }
 
   if (fileExists(projectName)) {
-    eprintln("error: directory '$projectName' already exists")
+    eprintError("directory '$projectName' already exists")
     eprintln("  use `kolt init` to scaffold inside an existing directory")
     return Err(EXIT_CONFIG_ERROR)
   }
 
   val resolved =
     resolveInteractive(parsed, io).getOrElse { msg ->
-      eprintln("error: $msg")
+      eprintError(msg)
       return Err(EXIT_CONFIG_ERROR)
     }
 
   ensureDirectory(projectName).getOrElse { error ->
-    eprintln("error: could not create directory ${error.path}")
+    eprintError("could not create directory ${error.path}")
     return Err(EXIT_BUILD_ERROR)
   }
 

--- a/src/nativeMain/kotlin/kolt/cli/OutdatedCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/OutdatedCommand.kt
@@ -9,6 +9,7 @@ import kolt.config.resolveKoltPaths
 import kolt.infra.downloadFile
 import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.eprintln
+import kolt.infra.output.eprintError
 import kolt.infra.readFileAsString
 import kolt.resolve.RepositoryDownloadFailure
 import kolt.resolve.buildMetadataDownloadUrl
@@ -34,7 +35,7 @@ private fun doOutdatedInner(opts: OutdatedOptions): Result<Unit, Int> {
 
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
@@ -124,11 +125,11 @@ private fun shortMetadataFailure(failure: RepositoryDownloadFailure): String =
 
 private fun reportArgsError(error: OutdatedArgsError) {
   when (error) {
-    is OutdatedArgsError.UnknownFlag -> eprintln("error: unknown flag '${error.flag}'")
+    is OutdatedArgsError.UnknownFlag -> eprintError("unknown flag '${error.flag}'")
     is OutdatedArgsError.MissingFilterValue ->
-      eprintln("error: --filter requires a value (e.g. --filter major,minor)")
+      eprintError("--filter requires a value (e.g. --filter major,minor)")
     is OutdatedArgsError.InvalidFilter ->
-      eprintln("error: invalid filter token '${error.token}' (expected major|minor|patch)")
+      eprintError("invalid filter token '${error.token}' (expected major|minor|patch)")
   }
   eprintln("usage: kolt outdated [--filter <major,minor,patch>] [--json]")
 }

--- a/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
+++ b/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
@@ -12,7 +12,7 @@ import kolt.infra.MkdirFailed
 import kolt.infra.OpenFailed
 import kolt.infra.Sha256Error
 import kolt.infra.WriteFailed
-import kolt.infra.eprintln
+import kolt.infra.output.eprintWarning
 import kolt.resolve.PluginFetchError
 import kolt.resolve.PluginFetcherDeps
 import kolt.resolve.fetchEnabledPluginJars
@@ -36,7 +36,7 @@ private fun defaultPluginFetcherDeps(): PluginFetcherDeps =
     override fun writeFileAsString(path: String, content: String): Result<Unit, WriteFailed> =
       kolt.infra.writeFileAsString(path, content)
 
-    override fun warn(message: String) = eprintln("warning: $message")
+    override fun warn(message: String) = eprintWarning(message)
   }
 
 internal fun resolveEnabledPluginJarPaths(

--- a/src/nativeMain/kotlin/kolt/cli/Scaffold.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Scaffold.kt
@@ -18,11 +18,12 @@ import kolt.config.isValidGroup
 import kolt.config.isValidProjectName
 import kolt.config.projectNameToPackageSegment
 import kolt.infra.ensureDirectoryRecursive
-import kolt.infra.eprintln
 import kolt.infra.executeCommand
 import kolt.infra.executeCommandQuiet
 import kolt.infra.fileExists
 import kolt.infra.formatProcessError
+import kolt.infra.output.eprintError
+import kolt.infra.output.eprintWarning
 import kolt.infra.writeFileAsString
 
 internal data class ScaffoldOptions(
@@ -157,7 +158,7 @@ internal fun scaffoldProject(targetDir: String, options: ScaffoldOptions): Resul
   // doNew creates `<name>/` itself before delegating, because the precondition
   // "<name>/ must not exist" cannot be enforced from inside ensureDirectory.
   if (!targetDir.isCurrent() && !fileExists(targetDir)) {
-    eprintln("error: target directory '$targetDir' does not exist")
+    eprintError("target directory '$targetDir' does not exist")
     return Err(EXIT_CONFIG_ERROR)
   }
 
@@ -167,7 +168,7 @@ internal fun scaffoldProject(targetDir: String, options: ScaffoldOptions): Resul
       generateKoltToml(options.projectName, options.kind, options.target, options.group),
     )
     .getOrElse { error ->
-      eprintln("error: could not write ${error.path}")
+      eprintError("could not write ${error.path}")
       return Err(EXIT_BUILD_ERROR)
     }
   println("created $tomlPath")
@@ -188,7 +189,7 @@ internal fun scaffoldProject(targetDir: String, options: ScaffoldOptions): Resul
   val gitignorePath = resolveInTarget(targetDir, GITIGNORE)
   if (!fileExists(gitignorePath)) {
     writeFileAsString(gitignorePath, generateGitignore()).getOrElse { error ->
-      eprintln("error: could not write ${error.path}")
+      eprintError("could not write ${error.path}")
       return Err(EXIT_BUILD_ERROR)
     }
     println("created $gitignorePath")
@@ -203,7 +204,7 @@ internal fun scaffoldProject(targetDir: String, options: ScaffoldOptions): Resul
     if (err == null) {
       println("initialized git repository")
     } else {
-      eprintln("warning: could not run git init (${formatProcessError(err, "git init")})")
+      eprintWarning("could not run git init (${formatProcessError(err, "git init")})")
     }
   }
 
@@ -238,13 +239,13 @@ private fun writeKindFile(
 ): Result<Unit, Int> {
   val dir = nestedDir(baseDir, packageRelPath)
   ensureDirectoryRecursive(dir).getOrElse { error ->
-    eprintln("error: could not create directory ${error.path}")
+    eprintError("could not create directory ${error.path}")
     return Err(EXIT_BUILD_ERROR)
   }
   val path = "$dir/${template.name}"
   if (fileExists(path)) return Ok(Unit)
   writeFileAsString(path, template.content).getOrElse { error ->
-    eprintln("error: could not write ${error.path}")
+    eprintError("could not write ${error.path}")
     return Err(EXIT_BUILD_ERROR)
   }
   println("created $path")

--- a/src/nativeMain/kotlin/kolt/cli/ToolCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/ToolCommands.kt
@@ -12,6 +12,8 @@ import kolt.infra.copyFile
 import kolt.infra.eprintln
 import kolt.infra.fileExists
 import kolt.infra.output.eprintDiagnostic
+import kolt.infra.output.eprintError
+import kolt.infra.output.eprintWarning
 import kolt.infra.readFileAsString
 import kolt.infra.writeFileAsString
 import kolt.resolve.LOCKFILE_VERSION
@@ -82,7 +84,7 @@ internal fun doTool(args: List<String>): Result<Int, Int> {
         is ToolArgError.MissingSubcommand,
         is ToolArgError.MissingAlias -> Err(EXIT_CONFIG_ERROR)
         is ToolArgError.UnknownSubcommand -> {
-          eprintln("error: unknown 'kolt tool' subcommand '${err.subcommand}'")
+          eprintError("unknown 'kolt tool' subcommand '${err.subcommand}'")
           Err(EXIT_CONFIG_ERROR)
         }
       }
@@ -100,7 +102,7 @@ private fun doToolRun(alias: String, toolArgs: List<String>): Result<Int, Int> {
     }
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_CONFIG_ERROR)
     }
   val entry =
@@ -187,7 +189,7 @@ private fun loadLockfileForTool(config: KoltConfig): Result<Lockfile, Int> {
   val lockJson =
     if (fileExists(LOCK_FILE)) {
       readFileAsString(LOCK_FILE).getOrElse { error ->
-        eprintln("warning: could not read $LOCK_FILE: ${error.path}")
+        eprintWarning("could not read $LOCK_FILE: ${error.path}")
         null
       }
     } else null
@@ -203,7 +205,7 @@ private fun loadLockfileForTool(config: KoltConfig): Result<Lockfile, Int> {
         )
       )
     is LockfileLoadResult.Corrupt -> {
-      eprintln("warning: ${outcome.message}")
+      eprintWarning("${outcome.message}")
       Ok(
         Lockfile(
           version = LOCKFILE_VERSION,
@@ -215,7 +217,7 @@ private fun loadLockfileForTool(config: KoltConfig): Result<Lockfile, Int> {
     }
     is LockfileLoadResult.UnsupportedAndMigrationAllowed,
     is LockfileLoadResult.UnsupportedAndMigrationDenied -> {
-      eprintln("error: $LOCK_FILE requires regeneration via 'kolt fetch'")
+      eprintError("$LOCK_FILE requires regeneration via 'kolt fetch'")
       Err(EXIT_DEPENDENCY_ERROR)
     }
   }
@@ -238,7 +240,7 @@ private fun writeFirstFetchLockEntry(
   val updated = lockfile.copy(toolsBundles = updatedToolsBundles)
   val json = serializeLockfile(updated)
   writeFileAsString(LOCK_FILE, json).getOrElse { error ->
-    eprintln("error: could not write ${error.path}")
+    eprintError("could not write ${error.path}")
     return Err(EXIT_DEPENDENCY_ERROR)
   }
   return Ok(Unit)

--- a/src/nativeMain/kotlin/kolt/cli/ToolCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/ToolCommands.kt
@@ -11,6 +11,7 @@ import kolt.infra.CopyFailed
 import kolt.infra.copyFile
 import kolt.infra.eprintln
 import kolt.infra.fileExists
+import kolt.infra.output.eprintDiagnostic
 import kolt.infra.readFileAsString
 import kolt.infra.writeFileAsString
 import kolt.resolve.LOCKFILE_VERSION
@@ -126,7 +127,7 @@ internal fun lookupToolEntry(alias: String, config: KoltConfig): Result<ToolEntr
   val entry = config.tools[alias]
   if (entry != null) return Ok(entry)
   val toolError = ToolError.UnknownAlias(alias = alias, knownAliases = config.tools.keys.toList())
-  eprintln(toolError.formatStderr())
+  eprintDiagnostic(toolError.render())
   return Err(toolError.toExitCode())
 }
 
@@ -178,7 +179,7 @@ internal fun runToolWithDeps(
 }
 
 private fun surfaceToolError(error: ToolError): Result<Int, Int> {
-  eprintln(error.formatStderr())
+  eprintDiagnostic(error.render())
   return Err(error.toExitCode())
 }
 

--- a/src/nativeMain/kotlin/kolt/cli/ToolchainCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/ToolchainCommands.kt
@@ -6,6 +6,7 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.config.*
 import kolt.infra.*
+import kolt.infra.output.eprintError
 import kolt.tool.installJdkToolchain
 import kolt.tool.installKonancToolchain
 import kolt.tool.installKotlincToolchain
@@ -44,22 +45,22 @@ private fun doToolchainInstall(): Result<Unit, Int> {
     }
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_CONFIG_ERROR)
     }
   installKotlincToolchain(config.kotlin.effectiveCompiler, paths).getOrElse {
-    eprintln("error: ${it.message}")
+    eprintError("${it.message}")
     return Err(EXIT_BUILD_ERROR)
   }
   if (config.build.jdk != null) {
     installJdkToolchain(config.build.jdk, paths).getOrElse {
-      eprintln("error: ${it.message}")
+      eprintError("${it.message}")
       return Err(EXIT_BUILD_ERROR)
     }
   }
   if (config.build.target in NATIVE_TARGETS) {
     installKonancToolchain(config.kotlin.effectiveCompiler, paths).getOrElse {
-      eprintln("error: ${it.message}")
+      eprintError("${it.message}")
       return Err(EXIT_BUILD_ERROR)
     }
   }
@@ -69,7 +70,7 @@ private fun doToolchainInstall(): Result<Unit, Int> {
 private fun doToolchainList(): Result<Unit, Int> {
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_CONFIG_ERROR)
     }
   val kotlincVersions = listInstalledVersions("${paths.toolchainsDir}/kotlinc")
@@ -146,17 +147,17 @@ private fun doToolchainRemove(args: List<String>): Result<Unit, Int> {
 
   val paths =
     resolveKoltPaths().getOrElse {
-      eprintln("error: $it")
+      eprintError("$it")
       return Err(EXIT_CONFIG_ERROR)
     }
   val toolchainPath = resolveToolchainPathForRemove(parsed.name, parsed.version, paths)
   if (toolchainPath == null) {
-    eprintln("error: ${parsed.name} ${parsed.version} is not installed")
+    eprintError("${parsed.name} ${parsed.version} is not installed")
     return Err(EXIT_BUILD_ERROR)
   }
 
   removeDirectoryRecursive(toolchainPath).getOrElse { err ->
-    eprintln("error: could not remove ${parsed.name} ${parsed.version}: ${err.path}")
+    eprintError("could not remove ${parsed.name} ${parsed.version}: ${err.path}")
     return Err(EXIT_BUILD_ERROR)
   }
   println("removed ${parsed.name} ${parsed.version}")

--- a/src/nativeMain/kotlin/kolt/cli/WatchChangeDispatch.kt
+++ b/src/nativeMain/kotlin/kolt/cli/WatchChangeDispatch.kt
@@ -7,6 +7,7 @@ import kolt.config.KoltConfig
 import kolt.config.SectionChange
 import kolt.config.classifyChange
 import kolt.config.planDispatch
+import kolt.config.renderConfigErrorAsLine
 
 /**
  * Outcome of classifying a kolt.toml change against the matrix. Watch loops translate this into
@@ -73,5 +74,5 @@ internal fun dispatchKoltTomlChange(
 
 private fun formatParseError(err: ConfigError): String =
   when (err) {
-    is ConfigError.ParseFailed -> err.message
+    is ConfigError.ParseFailed -> renderConfigErrorAsLine(err)
   }

--- a/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
+++ b/src/nativeMain/kotlin/kolt/cli/WatchLoop.kt
@@ -9,6 +9,8 @@ import kolt.config.KoltConfig
 import kolt.config.NATIVE_TARGETS
 import kolt.config.NOTIFICATION_MARKER
 import kolt.infra.*
+import kolt.infra.output.eprintError
+import kolt.infra.output.eprintWarning
 import kotlin.concurrent.AtomicInt
 import kotlinx.cinterop.*
 import platform.linux.IN_CREATE
@@ -69,7 +71,7 @@ private data class KoltTomlEffect(
 private fun setupWatches(watchDirs: List<String>, config: KoltConfig): WatchSetup? {
   val watcher =
     InotifyWatcher.create().getOrElse { err ->
-      eprintln("error: failed to initialize inotify: $err")
+      eprintError("failed to initialize inotify: $err")
       return null
     }
   val wdKinds = mutableMapOf<Int, WatchKind>()
@@ -105,11 +107,11 @@ private fun setupWatches(watchDirs: List<String>, config: KoltConfig): WatchSetu
 private fun reportWatchError(err: InotifyError) {
   when (err) {
     is InotifyError.WatchLimitExceeded ->
-      eprintln(
-        "error: inotify watch limit exceeded on ${err.path}\n" +
+      eprintError(
+        "inotify watch limit exceeded on ${err.path}\n" +
           "hint: increase with: sudo sysctl -w fs.inotify.max_user_watches=65536"
       )
-    else -> eprintln("error: inotify watch failed: $err")
+    else -> eprintError("inotify watch failed: $err")
   }
 }
 
@@ -190,7 +192,7 @@ internal fun watchCommandLoop(
 ) {
   var currentConfig =
     loadProjectConfig().getOrElse {
-      eprintln("error: cannot start watch mode with invalid config")
+      eprintError("cannot start watch mode with invalid config")
       return
     }
   val initialSetup =
@@ -227,7 +229,7 @@ internal fun watchCommandLoop(
           val rebuilt =
             setupWatches(collectWatchPaths(currentConfig, command), currentConfig)
               ?: run {
-                eprintln("error: failed to rebuild watcher after kolt.toml change; exiting watch")
+                eprintError("failed to rebuild watcher after kolt.toml change; exiting watch")
                 return false
               }
           watcher = rebuilt.watcher
@@ -247,7 +249,7 @@ internal fun watchCommandLoop(
   while (!shouldExit()) {
     val events =
       watcher.pollEvents(timeoutMs = 500).getOrElse {
-        if (!shouldExit()) eprintln("warning: inotify read failed")
+        if (!shouldExit()) eprintWarning("inotify read failed")
         break
       }
     if (shouldExit()) break
@@ -409,7 +411,7 @@ internal fun watchRunLoop(
           val rebuilt =
             setupWatches(collectWatchPaths(currentConfig, "run"), currentConfig)
               ?: run {
-                eprintln("error: failed to rebuild watcher after kolt.toml change; exiting watch")
+                eprintError("failed to rebuild watcher after kolt.toml change; exiting watch")
                 return KoltTomlEffect(
                   breakInnerLoop = true,
                   shouldRebuild = false,
@@ -460,7 +462,7 @@ internal fun watchRunLoop(
     val projectRoot =
       currentWorkingDirectory()
         ?: run {
-          eprintln("error: could not determine current working directory")
+          eprintError("could not determine current working directory")
           break
         }
     val runCmd =
@@ -471,7 +473,7 @@ internal fun watchRunLoop(
       }
     val childPid = spawnInProcessGroup(runCmd.args)
     if (childPid < 0) {
-      eprintln("error: failed to spawn application")
+      eprintError("failed to spawn application")
       break
     }
 

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -7,6 +7,8 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
+import kolt.infra.output.RenderedDiagnostic
+import kolt.infra.output.Severity
 import kolt.resolve.compareVersions
 import kolt.usertool.RawToolEntry
 import kolt.usertool.ToolEntry
@@ -132,7 +134,11 @@ data class KoltConfig(
   @SerialName("run") val runSection: RunSection = RunSection(),
 )
 
-private val toml = Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = true))
+// Strict-unknown-keys lets a typo in a top-level section (`[koltn]` for
+// `[kotlin]`) surface as a `ParseFailed` instead of silently being dropped;
+// the catch path below uses parseUnknownKey to attach a Did-you-mean hint
+// for top-level typos.
+private val toml = Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = false))
 
 // Two-tier parse: ktoml deserializes into the Raw* classes (target/main/sources
 // optional, plus `targets` map for `[build.targets.X]`). parseConfig then
@@ -423,7 +429,10 @@ private fun resolveEffectiveTarget(raw: RawBuildSection): Result<String, ConfigE
   return Ok(scalar)
 }
 
-fun parseConfig(tomlString: String): Result<KoltConfig, ConfigError> {
+// `path` is the kolt.toml location the caller read `tomlString` from,
+// surfaced verbatim in the rendered diagnostic when populated. Internal
+// validation paths and tests omit it (defaults to null).
+fun parseConfig(tomlString: String, path: String? = null): Result<KoltConfig, ConfigError> {
   return try {
     val raw = toml.decodeFromString(RawKoltConfig.serializer(), tomlString)
     // Validation order is load-bearing: tests match on canonical error
@@ -528,10 +537,42 @@ fun parseConfig(tomlString: String): Result<KoltConfig, ConfigError> {
       )
     )
   } catch (e: SerializationException) {
-    Err(ConfigError.ParseFailed("failed to parse kolt.toml: ${e.message}"))
+    Err(buildKtomlParseError(e.message, path))
   } catch (e: IllegalArgumentException) {
-    Err(ConfigError.ParseFailed("failed to parse kolt.toml: ${e.message}"))
+    Err(buildKtomlParseError(e.message, path))
   }
+}
+
+private fun buildKtomlParseError(rawMessage: String?, path: String?): ConfigError.ParseFailed {
+  val (lineNo, detail) = extractKtomlLineNo(rawMessage)
+  val (keyPath, suggestion) = parseUnknownKey(detail)
+  val headline = "failed to parse kolt.toml: $detail"
+  return ConfigError.ParseFailed(
+    message = headline,
+    path = path,
+    lineNo = lineNo,
+    keyPath = keyPath,
+    suggestion = suggestion,
+  )
+}
+
+// Renders a ParseFailed into the writer-ready diagnostic shape. The headline
+// already begins with `failed to parse kolt.toml: ...` for ktoml-origin
+// errors; legacy validation errors carry a domain-specific message and just
+// pass through. Location and key-path lines are only added when populated.
+fun renderConfigError(e: ConfigError.ParseFailed): RenderedDiagnostic {
+  val context = buildList {
+    val location =
+      when {
+        e.path != null && e.lineNo != null -> "${e.path}:${e.lineNo}"
+        e.path != null -> e.path
+        else -> null
+      }
+    if (location != null) add("at $location")
+    if (e.keyPath != null) add("key: ${e.keyPath}")
+  }
+  val hint = e.suggestion?.let { "Did you mean `$it`?" }
+  return RenderedDiagnostic(Severity.Error, e.message, context, hint)
 }
 
 internal fun KoltConfig.isLibrary(): Boolean = kind == "lib"

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -575,4 +575,22 @@ fun renderConfigError(e: ConfigError.ParseFailed): RenderedDiagnostic {
   return RenderedDiagnostic(Severity.Error, e.message, context, hint)
 }
 
+// Single-line composite for callers that emit a one-line notification
+// (watch-mode marker line) or carry the message through a String-typed
+// channel (kolt info JSON `parseError`). Equivalent semantically to
+// renderConfigError but flattened — preserves path/lineNo/keyPath/suggestion
+// rather than dropping them.
+fun renderConfigErrorAsLine(e: ConfigError.ParseFailed): String = buildString {
+  append(e.message)
+  val location =
+    when {
+      e.path != null && e.lineNo != null -> "${e.path}:${e.lineNo}"
+      e.path != null -> e.path
+      else -> null
+    }
+  if (location != null) append(" at ").append(location)
+  if (e.keyPath != null) append(" (key: ").append(e.keyPath).append(")")
+  if (e.suggestion != null) append(" -- Did you mean `").append(e.suggestion).append("`?")
+}
+
 internal fun KoltConfig.isLibrary(): Boolean = kind == "lib"

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -43,7 +43,17 @@ fun konanTargetGradleName(target: String): String =
   target.replace(Regex("([a-z])([A-Z])"), "$1_$2").lowercase()
 
 sealed class ConfigError {
-  data class ParseFailed(val message: String) : ConfigError()
+  // Optional fields default to null so single-argument construction
+  // (`ParseFailed("...")`) stays valid; the ktoml-origin parse path that
+  // knows the file path and line number fills them so error rendering can
+  // include line / key / Did-you-mean context.
+  data class ParseFailed(
+    val message: String,
+    val path: String? = null,
+    val lineNo: Int? = null,
+    val keyPath: String? = null,
+    val suggestion: String? = null,
+  ) : ConfigError()
 }
 
 @Serializable

--- a/src/nativeMain/kotlin/kolt/config/KtomlMessageParse.kt
+++ b/src/nativeMain/kotlin/kolt/config/KtomlMessageParse.kt
@@ -1,0 +1,64 @@
+package kolt.config
+
+import kolt.infra.suggest.closestMatch
+
+// ktoml encodes parse-position into the exception message text rather than
+// exposing it via a public field — the relevant `ParseException`,
+// `IllegalTypeException`, etc. are `internal` to the ktoml-core module.
+// The pre-version-bump format is `"Line N: <detail>"` (note the trailing
+// space). Bumping ktoml major can change this format; the
+// `ConfigParseMessageFormatTest` fixture pins the regex against a synthetic
+// broken kolt.toml so a format drift surfaces as a RED test.
+internal val LINE_NO_REGEX = Regex("^Line (\\d+): ")
+
+// Returns (lineNumber, restOfMessage). Falls back to (null, original) when
+// the prefix is missing or malformed; (null, "") when the input itself is null.
+internal fun extractKtomlLineNo(message: String?): Pair<Int?, String> {
+  if (message == null) return null to ""
+  val match = LINE_NO_REGEX.find(message) ?: return null to message
+  val n = match.groupValues[1].toIntOrNull()
+  val rest = message.substring(match.range.last + 1)
+  return n to rest
+}
+
+// Top-level kolt.toml sections recognised today. R3.4 (narrowed) only
+// suggests when the typo'd key is at top level — nested unknowns surface
+// the key path without a suggestion. Updating this list when a new
+// top-level section is added keeps the suggestion accurate; the drift
+// guard test pins the contents against the RawKoltConfig field set.
+internal val KNOWN_TOP_LEVEL_SECTIONS: List<String> =
+  listOf(
+      "build",
+      "cinterop",
+      "classpaths",
+      "dependencies",
+      "fmt",
+      "kotlin",
+      "repositories",
+      "run",
+      "test",
+      "test-dependencies",
+      "tools",
+    )
+    .sorted()
+
+private val UNKNOWN_KEY_REGEX = Regex("^Unknown key received: <([^>]+)> in scope <([^>]*)>")
+
+// ktoml-core 0.7.1 names the implicit root TOML node "rootNode" (see
+// `com.akuleshov7.ktoml.tree.nodes.TomlFile.name`). UnknownNameException
+// surfaces top-level typos with `scope <rootNode>`; nested scopes carry
+// the parent section name (e.g. `<kotlin>`). The constant lives here so a
+// future ktoml bump that renames the root surfaces as a single-edit fix
+// and the empirical-pin test in ConfigParseMessageFormatTest catches it.
+private const val KTOML_ROOT_SCOPE = "rootNode"
+
+// Returns (offendingKey, suggestion). When the message does not match
+// ktoml's UnknownNameException format, both are null. Nested-scope unknowns
+// return the key but null suggestion (R3.4 narrowed scope).
+internal fun parseUnknownKey(detail: String): Pair<String?, String?> {
+  val match = UNKNOWN_KEY_REGEX.find(detail) ?: return null to null
+  val key = match.groupValues[1]
+  val scope = match.groupValues[2]
+  if (scope != KTOML_ROOT_SCOPE) return key to null
+  return key to closestMatch(key, KNOWN_TOP_LEVEL_SECTIONS)
+}

--- a/src/nativeMain/kotlin/kolt/infra/Process.kt
+++ b/src/nativeMain/kotlin/kolt/infra/Process.kt
@@ -75,7 +75,11 @@ fun executeCommand(
 // Double-fork detach. Ok(Unit) means the fork chain completed, not
 // that execvp succeeded — callers must poll the socket to confirm.
 @OptIn(ExperimentalForeignApi::class)
-fun spawnDetached(args: List<String>, logPath: String? = null): Result<Unit, ProcessError> {
+fun spawnDetached(
+  args: List<String>,
+  logPath: String? = null,
+  extraEnv: Map<String, String> = emptyMap(),
+): Result<Unit, ProcessError> {
   if (args.isEmpty()) return Err(ProcessError.EmptyArgs)
 
   val pid1 = fork()
@@ -88,6 +92,12 @@ fun spawnDetached(args: List<String>, logPath: String? = null): Result<Unit, Pro
     val pid2 = fork()
     if (pid2 < 0) _exit(127)
     if (pid2 > 0) _exit(0)
+
+    // After the second fork the grandchild owns its process image, so setenv
+    // here cannot leak back to the kolt CLI parent or sibling subprocesses.
+    for ((key, value) in extraEnv) {
+      setenv(key, value, 1)
+    }
 
     val devNull = open("/dev/null", O_RDWR)
     val logFd =

--- a/src/nativeMain/kotlin/kolt/infra/output/AnsiCodes.kt
+++ b/src/nativeMain/kotlin/kolt/infra/output/AnsiCodes.kt
@@ -1,5 +1,8 @@
 package kolt.infra.output
 
+// ANSI CSI escape sequences for terminal coloring. Encoded with explicit
+// `` so the source remains correct regardless of editor / tooling
+// handling of the raw ESC byte.
 object AnsiCodes {
   const val RED: String = "[31m"
   const val YELLOW: String = "[33m"

--- a/src/nativeMain/kotlin/kolt/infra/output/AnsiCodes.kt
+++ b/src/nativeMain/kotlin/kolt/infra/output/AnsiCodes.kt
@@ -1,0 +1,8 @@
+package kolt.infra.output
+
+object AnsiCodes {
+  const val RED: String = "[31m"
+  const val YELLOW: String = "[33m"
+  const val CYAN: String = "[36m"
+  const val RESET: String = "[0m"
+}

--- a/src/nativeMain/kotlin/kolt/infra/output/ColorPolicy.kt
+++ b/src/nativeMain/kotlin/kolt/infra/output/ColorPolicy.kt
@@ -1,0 +1,70 @@
+package kolt.infra.output
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import platform.posix.STDERR_FILENO
+import platform.posix.STDOUT_FILENO
+import platform.posix.getenv
+import platform.posix.isatty
+
+enum class Stream {
+  Stderr,
+  Stdout,
+}
+
+sealed class ColorPolicy {
+  abstract fun shouldColor(stream: Stream): Boolean
+
+  data object Always : ColorPolicy() {
+    override fun shouldColor(stream: Stream): Boolean = true
+  }
+
+  data object Never : ColorPolicy() {
+    override fun shouldColor(stream: Stream): Boolean = false
+  }
+
+  data class Auto(val isStderrTty: Boolean, val isStdoutTty: Boolean) : ColorPolicy() {
+    override fun shouldColor(stream: Stream): Boolean =
+      when (stream) {
+        Stream.Stderr -> isStderrTty
+        Stream.Stdout -> isStdoutTty
+      }
+  }
+
+  companion object {
+    // Mutated exactly once, at CLI startup, via `install`. Tests override the
+    // active policy by passing an explicit `policy` argument to writer
+    // functions (see DiagnosticWriter), not by re-installing — this keeps the
+    // global state contract single-write-at-startup and prevents test leakage
+    // across the unit suite.
+    private var currentPolicy: ColorPolicy = Never
+
+    fun fromEnv(noColorFlag: Boolean): ColorPolicy =
+      resolveColorPolicy(noColorFlag = noColorFlag, getEnv = ::posixGetEnv, isTty = ::posixIsTty)
+
+    fun install(policy: ColorPolicy) {
+      currentPolicy = policy
+    }
+
+    fun current(): ColorPolicy = currentPolicy
+  }
+}
+
+// `getEnv` / `isTty` are seam parameters so unit tests can drive every branch
+// without touching the real process environment or controlling terminals.
+internal fun resolveColorPolicy(
+  noColorFlag: Boolean,
+  getEnv: (String) -> String?,
+  isTty: (Int) -> Boolean,
+): ColorPolicy {
+  if (noColorFlag) return ColorPolicy.Never
+  // no-color.org: any non-empty value disables color. Empty string does not.
+  val noColor = getEnv("NO_COLOR")
+  if (!noColor.isNullOrEmpty()) return ColorPolicy.Never
+  return ColorPolicy.Auto(isStderrTty = isTty(STDERR_FILENO), isStdoutTty = isTty(STDOUT_FILENO))
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun posixGetEnv(name: String): String? = getenv(name)?.toKString()
+
+@OptIn(ExperimentalForeignApi::class) private fun posixIsTty(fd: Int): Boolean = isatty(fd) != 0

--- a/src/nativeMain/kotlin/kolt/infra/output/DiagnosticWriter.kt
+++ b/src/nativeMain/kotlin/kolt/infra/output/DiagnosticWriter.kt
@@ -1,0 +1,88 @@
+package kolt.infra.output
+
+import kolt.infra.eprintln
+
+// Severity → ANSI color: error red, warning yellow, note (and hint) cyan.
+private fun colorFor(severity: Severity): String =
+  when (severity) {
+    Severity.Error -> AnsiCodes.RED
+    Severity.Warning -> AnsiCodes.YELLOW
+    Severity.Note -> AnsiCodes.CYAN
+  }
+
+private fun labelFor(severity: Severity): String =
+  when (severity) {
+    Severity.Error -> "error:"
+    Severity.Warning -> "warning:"
+    Severity.Note -> "note:"
+  }
+
+private fun coloredLabel(severity: Severity, color: Boolean): String {
+  val label = labelFor(severity)
+  return if (color) "${colorFor(severity)}$label${AnsiCodes.RESET}" else label
+}
+
+// Pure renderer: severity prefix + headline on line 1, context lines indented
+// by two spaces, optional hint as a separate `note:` line that uses the cyan
+// note color regardless of the parent severity. Always evaluated against the
+// stderr stream because the typed writer is stderr-only by contract.
+internal fun renderDiagnostic(diag: RenderedDiagnostic, policy: ColorPolicy): List<String> {
+  val color = policy.shouldColor(Stream.Stderr)
+  val out = mutableListOf<String>()
+  out.add("${coloredLabel(diag.severity, color)} ${diag.headline}")
+  for (line in diag.context) {
+    out.add("  $line")
+  }
+  if (diag.hint != null) {
+    out.add("${coloredLabel(Severity.Note, color)} ${diag.hint}")
+  }
+  return out
+}
+
+fun eprintDiagnostic(
+  diag: RenderedDiagnostic,
+  policy: ColorPolicy = ColorPolicy.current(),
+  sink: (String) -> Unit = ::eprintln,
+) {
+  for (line in renderDiagnostic(diag, policy)) {
+    sink(line)
+  }
+}
+
+fun eprintError(
+  headline: String,
+  context: List<String> = emptyList(),
+  hint: String? = null,
+  policy: ColorPolicy = ColorPolicy.current(),
+  sink: (String) -> Unit = ::eprintln,
+) {
+  eprintDiagnostic(RenderedDiagnostic(Severity.Error, headline, context, hint), policy, sink)
+}
+
+fun eprintWarning(
+  headline: String,
+  context: List<String> = emptyList(),
+  hint: String? = null,
+  policy: ColorPolicy = ColorPolicy.current(),
+  sink: (String) -> Unit = ::eprintln,
+) {
+  eprintDiagnostic(RenderedDiagnostic(Severity.Warning, headline, context, hint), policy, sink)
+}
+
+fun eprintNote(
+  headline: String,
+  context: List<String> = emptyList(),
+  hint: String? = null,
+  policy: ColorPolicy = ColorPolicy.current(),
+  sink: (String) -> Unit = ::eprintln,
+) {
+  eprintDiagnostic(RenderedDiagnostic(Severity.Note, headline, context, hint), policy, sink)
+}
+
+object AnsiStripper {
+  // CSI sequence: ESC `[` parameters intermediate-bytes final-byte (0x40-0x7E).
+  // Matches all ANSI color codes (final `m`) plus most other CSI controls.
+  private val CSI_REGEX = Regex("\\x1B\\[[0-?]*[ -/]*[@-~]")
+
+  fun strip(s: String): String = CSI_REGEX.replace(s, "")
+}

--- a/src/nativeMain/kotlin/kolt/infra/output/DiagnosticWriter.kt
+++ b/src/nativeMain/kotlin/kolt/infra/output/DiagnosticWriter.kt
@@ -86,3 +86,10 @@ object AnsiStripper {
 
   fun strip(s: String): String = CSI_REGEX.replace(s, "")
 }
+
+// Caller-side gate for forwarded subprocess stderr blobs (daemon / fallback
+// backends emit pre-rendered byte streams that may carry ANSI). Kept as a
+// pure helper so unit tests can drive both branches via an injected policy
+// without touching the global `ColorPolicy.current()`.
+fun maybeStripAnsi(body: String, policy: ColorPolicy = ColorPolicy.current()): String =
+  if (policy.shouldColor(Stream.Stderr)) body else AnsiStripper.strip(body)

--- a/src/nativeMain/kotlin/kolt/infra/output/RenderedDiagnostic.kt
+++ b/src/nativeMain/kotlin/kolt/infra/output/RenderedDiagnostic.kt
@@ -1,0 +1,8 @@
+package kolt.infra.output
+
+data class RenderedDiagnostic(
+  val severity: Severity,
+  val headline: String,
+  val context: List<String> = emptyList(),
+  val hint: String? = null,
+)

--- a/src/nativeMain/kotlin/kolt/infra/output/Severity.kt
+++ b/src/nativeMain/kotlin/kolt/infra/output/Severity.kt
@@ -1,0 +1,7 @@
+package kolt.infra.output
+
+enum class Severity {
+  Error,
+  Warning,
+  Note,
+}

--- a/src/nativeMain/kotlin/kolt/infra/suggest/ClosestMatch.kt
+++ b/src/nativeMain/kotlin/kolt/infra/suggest/ClosestMatch.kt
@@ -1,0 +1,28 @@
+package kolt.infra.suggest
+
+// Tighter threshold for very short inputs to avoid suggesting unrelated
+// candidates: a 1-char input within distance 2 of every candidate
+// would yield false positives. The cutoff at length 4 lets short
+// CLI flags (`--no-color`, `--watch`) still get useful suggestions.
+internal fun adaptiveThreshold(inputLength: Int): Int = if (inputLength <= 4) 1 else 2
+
+// Returns the candidate with smallest edit distance from `input` if and only
+// if that distance is within `maxDistance`; otherwise `null`. Determinism
+// (R5.4): scan order is the caller-supplied list, ties resolve to the first
+// encountered. Callers that need lex-ordered tie-break should pre-sort.
+fun closestMatch(
+  input: String,
+  candidates: List<String>,
+  maxDistance: Int = adaptiveThreshold(input.length),
+): String? {
+  var best: String? = null
+  var bestDistance = Int.MAX_VALUE
+  for (candidate in candidates) {
+    val d = levenshtein(input, candidate)
+    if (d < bestDistance) {
+      bestDistance = d
+      best = candidate
+    }
+  }
+  return if (best != null && bestDistance <= maxDistance) best else null
+}

--- a/src/nativeMain/kotlin/kolt/infra/suggest/Levenshtein.kt
+++ b/src/nativeMain/kotlin/kolt/infra/suggest/Levenshtein.kt
@@ -1,0 +1,26 @@
+package kolt.infra.suggest
+
+import kotlin.math.min
+
+// Standard Wagner-Fischer dynamic-programming edit distance.
+// Cost 1 for insertion, deletion, and substitution.
+fun levenshtein(a: String, b: String): Int {
+  if (a == b) return 0
+  if (a.isEmpty()) return b.length
+  if (b.isEmpty()) return a.length
+
+  // Two-row optimisation: only the previous row is needed at any time.
+  var prev = IntArray(b.length + 1) { it }
+  var curr = IntArray(b.length + 1)
+  for (i in 1..a.length) {
+    curr[0] = i
+    for (j in 1..b.length) {
+      val substCost = if (a[i - 1] == b[j - 1]) 0 else 1
+      curr[j] = min(min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + substCost)
+    }
+    val tmp = prev
+    prev = curr
+    curr = tmp
+  }
+  return prev[b.length]
+}

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -7,6 +7,8 @@ import kolt.infra.DownloadError
 import kolt.infra.MkdirFailed
 import kolt.infra.OpenFailed
 import kolt.infra.Sha256Error
+import kolt.infra.output.RenderedDiagnostic
+import kolt.infra.output.Severity
 
 // Per-repository attempt captured by `downloadFromRepositories`. The
 // resolver keeps the URL it tried alongside the underlying error so
@@ -62,42 +64,64 @@ sealed class ResolveError {
   ) : ResolveError()
 }
 
-fun formatResolveError(error: ResolveError): String =
+fun formatResolveError(error: ResolveError): RenderedDiagnostic =
   when (error) {
-    is ResolveError.InvalidDependency -> "error: invalid dependency '${error.input}'"
+    is ResolveError.InvalidDependency ->
+      RenderedDiagnostic(Severity.Error, "invalid dependency '${error.input}'")
     is ResolveError.Sha256Mismatch ->
-      buildString {
-        appendLine("error: sha256 mismatch for ${error.groupArtifact}")
-        appendLine("  expected: ${error.expected}")
-        append("  got:      ${error.actual}")
-      }
+      RenderedDiagnostic(
+        severity = Severity.Error,
+        headline = "sha256 mismatch for ${error.groupArtifact}",
+        context = listOf("expected: ${error.expected}", "got:      ${error.actual}"),
+      )
     is ResolveError.DownloadFailed ->
-      buildString {
-        append("error: failed to download ${error.groupArtifact}")
-        appendRepositoryDownloadFailure(error.failure)
-      }
+      RenderedDiagnostic(
+        severity = Severity.Error,
+        headline = "failed to download ${error.groupArtifact}",
+        context = repositoryDownloadFailureContext(error.failure),
+      )
     is ResolveError.MetadataDownloadFailed ->
-      buildString {
-        append("error: could not fetch metadata for ${error.groupArtifact}")
-        appendRepositoryDownloadFailure(error.failure)
-      }
-    is ResolveError.HashComputeFailed -> "error: failed to compute hash for ${error.groupArtifact}"
-    is ResolveError.DirectoryCreateFailed -> "error: could not create directory ${error.path}"
+      RenderedDiagnostic(
+        severity = Severity.Error,
+        headline = "could not fetch metadata for ${error.groupArtifact}",
+        context = repositoryDownloadFailureContext(error.failure),
+      )
+    is ResolveError.HashComputeFailed ->
+      RenderedDiagnostic(Severity.Error, "failed to compute hash for ${error.groupArtifact}")
+    is ResolveError.DirectoryCreateFailed ->
+      RenderedDiagnostic(Severity.Error, "could not create directory ${error.path}")
     is ResolveError.NoNativeVariant ->
-      "error: ${error.groupArtifact} has no Kotlin/Native variant for target '${error.nativeTarget}'"
+      RenderedDiagnostic(
+        Severity.Error,
+        "${error.groupArtifact} has no Kotlin/Native variant for target " +
+          "'${error.nativeTarget}'",
+      )
     is ResolveError.MetadataParseFailed ->
-      "error: failed to parse Gradle module metadata for ${error.groupArtifact}"
+      RenderedDiagnostic(
+        Severity.Error,
+        "failed to parse Gradle module metadata for ${error.groupArtifact}",
+      )
     is ResolveError.MetadataFetchFailed ->
-      "error: failed to read Gradle module metadata for ${error.groupArtifact}"
+      RenderedDiagnostic(
+        Severity.Error,
+        "failed to read Gradle module metadata for ${error.groupArtifact}",
+      )
     is ResolveError.StrictVersionConflict ->
-      if (error.otherIsStrict)
-        "error: conflicting strict versions on ${error.groupArtifact}: " +
-          "${error.strictVersion} and ${error.otherVersion}"
-      else
-        "error: strict version conflict on ${error.groupArtifact}: " +
-          "${error.strictVersion} required strictly, but ${error.otherVersion} also requested"
+      RenderedDiagnostic(
+        Severity.Error,
+        if (error.otherIsStrict)
+          "conflicting strict versions on ${error.groupArtifact}: " +
+            "${error.strictVersion} and ${error.otherVersion}"
+        else
+          "strict version conflict on ${error.groupArtifact}: " +
+            "${error.strictVersion} required strictly, but ${error.otherVersion} also requested",
+      )
     is ResolveError.RejectedVersionResolved ->
-      "error: resolved ${error.groupArtifact}:${error.version} is rejected by constraint '${error.rejectPattern}'"
+      RenderedDiagnostic(
+        Severity.Error,
+        "resolved ${error.groupArtifact}:${error.version} is rejected by " +
+          "constraint '${error.rejectPattern}'",
+      )
   }
 
 internal fun formatAttemptStatus(error: DownloadError): String =
@@ -111,16 +135,13 @@ internal fun formatAttemptStatus(error: DownloadError): String =
     is DownloadError.WriteFailed -> "local write failed (${error.path})"
   }
 
-private fun StringBuilder.appendRepositoryDownloadFailure(failure: RepositoryDownloadFailure) {
+private fun repositoryDownloadFailureContext(failure: RepositoryDownloadFailure): List<String> =
   when (failure) {
     is RepositoryDownloadFailure.NoRepositoriesConfigured ->
-      append("\n  no repositories configured (add a `[repositories]` entry to kolt.toml)")
+      listOf("no repositories configured (add a `[repositories]` entry to kolt.toml)")
     is RepositoryDownloadFailure.AllAttemptsFailed ->
-      for (attempt in failure.attempts) {
-        append("\n  ${attempt.url} -> ${formatAttemptStatus(attempt.error)}")
-      }
+      failure.attempts.map { "${it.url} -> ${formatAttemptStatus(it.error)}" }
   }
-}
 
 enum class Origin {
   MAIN,

--- a/src/nativeMain/kotlin/kolt/usertool/ToolError.kt
+++ b/src/nativeMain/kotlin/kolt/usertool/ToolError.kt
@@ -3,6 +3,8 @@ package kolt.usertool
 import kolt.cli.EXIT_CONFIG_ERROR
 import kolt.cli.EXIT_DEPENDENCY_ERROR
 import kolt.cli.EXIT_TOOL_ERROR
+import kolt.infra.output.RenderedDiagnostic
+import kolt.infra.output.Severity
 import kolt.resolve.Coordinate
 
 /**
@@ -55,18 +57,18 @@ sealed class ToolLaunchError {
  * - `Launch.*` → `EXIT_TOOL_ERROR=7` (the only three variants that do so — pinned by
  *   `ToolErrorTest.exactlyThreeVariantsRouteThroughExitToolError`)
  *
- * `formatStderr()` emits the variant-specific prefix that R5.4 ("cause-distinguishable surface")
- * relies on: the prefix identifies the cause, the exit code identifies kolt-level category.
+ * `render()` emits the variant-specific headline that R5.4 ("cause-distinguishable surface") relies
+ * on: the headline identifies the cause, the exit code identifies kolt-level category.
  */
 sealed class ToolError {
   abstract fun toExitCode(): Int
 
-  abstract fun formatStderr(): String
+  abstract fun render(): RenderedDiagnostic
 
   data class Parse(val cause: ToolSectionParseError) : ToolError() {
     override fun toExitCode(): Int = EXIT_CONFIG_ERROR
 
-    override fun formatStderr(): String {
+    override fun render(): RenderedDiagnostic {
       val (alias, detail) =
         when (val c = cause) {
           is ToolSectionParseError.ForbiddenField ->
@@ -77,28 +79,34 @@ sealed class ToolError {
           is ToolSectionParseError.MissingCoords -> c.alias to "missing required field 'coords'"
           is ToolSectionParseError.DuplicateAlias -> c.alias to "duplicate alias"
         }
-      return "tool '$alias': parse error: $detail"
+      return RenderedDiagnostic(Severity.Error, "tool '$alias': parse error: $detail")
     }
   }
 
   data class Resolve(val cause: ToolResolutionError) : ToolError() {
     override fun toExitCode(): Int = EXIT_DEPENDENCY_ERROR
 
-    override fun formatStderr(): String =
+    override fun render(): RenderedDiagnostic =
       when (val c = cause) {
         is ToolResolutionError.ResolveFailed -> {
           val tail =
             if (c.attempts.isEmpty()) "no repository attempts recorded"
             else "tried ${c.attempts.joinToString(", ")}"
-          "tool '${c.alias}': resolve failed: $tail"
+          RenderedDiagnostic(Severity.Error, "tool '${c.alias}': resolve failed: $tail")
         }
         is ToolResolutionError.IntegrityMismatch ->
-          "tool '${c.alias}': integrity mismatch: expected ${c.expected} got ${c.actual}"
+          RenderedDiagnostic(
+            Severity.Error,
+            "tool '${c.alias}': integrity mismatch: expected ${c.expected} got ${c.actual}",
+          )
         is ToolResolutionError.LockfileMismatch -> {
           val pinned = formatCoordsWithClassifier(c.lockedCoords, c.lockedClassifier)
           val toml = formatCoordsWithClassifier(c.tomlCoords, c.tomlClassifier)
-          "tool '${c.alias}': lockfile pin '$pinned' differs from kolt.toml '$toml'. " +
-            "Run `kolt update` to refresh tool pins."
+          RenderedDiagnostic(
+            severity = Severity.Error,
+            headline = "tool '${c.alias}': lockfile pin '$pinned' differs from kolt.toml '$toml'",
+            hint = "Run `kolt update` to refresh tool pins.",
+          )
         }
       }
   }
@@ -106,23 +114,33 @@ sealed class ToolError {
   data class Launch(val cause: ToolLaunchError) : ToolError() {
     override fun toExitCode(): Int = EXIT_TOOL_ERROR
 
-    override fun formatStderr(): String =
+    override fun render(): RenderedDiagnostic =
       when (val c = cause) {
         is ToolLaunchError.NotRunnableJar ->
-          "tool '${c.alias}': not a runnable jar (${c.reason}) at ${c.jarPath}"
+          RenderedDiagnostic(
+            Severity.Error,
+            "tool '${c.alias}': not a runnable jar (${c.reason}) at ${c.jarPath}",
+          )
         is ToolLaunchError.MainClassMissing ->
-          "tool '${c.alias}': Main-Class missing in MANIFEST.MF of ${c.jarPath}"
-        is ToolLaunchError.JdkUnavailable -> "tool: JDK unavailable: ${c.cause}"
+          RenderedDiagnostic(
+            Severity.Error,
+            "tool '${c.alias}': Main-Class missing in MANIFEST.MF of ${c.jarPath}",
+          )
+        is ToolLaunchError.JdkUnavailable ->
+          RenderedDiagnostic(Severity.Error, "tool: JDK unavailable: ${c.cause}")
       }
   }
 
   data class UnknownAlias(val alias: String, val knownAliases: List<String>) : ToolError() {
     override fun toExitCode(): Int = EXIT_CONFIG_ERROR
 
-    override fun formatStderr(): String {
+    override fun render(): RenderedDiagnostic {
       val known =
         if (knownAliases.isEmpty()) "(none declared)" else knownAliases.sorted().joinToString(", ")
-      return "tool '$alias': not declared in [tools]. Known aliases: $known"
+      return RenderedDiagnostic(
+        Severity.Error,
+        "tool '$alias': not declared in [tools]. Known aliases: $known",
+      )
     }
   }
 }

--- a/src/nativeTest/kotlin/kolt/build/NativeSubprocessBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/NativeSubprocessBackendTest.kt
@@ -2,6 +2,7 @@ package kolt.build
 
 import com.github.michaelbull.result.getError
 import kolt.infra.ProcessError
+import kolt.infra.output.ColorPolicy
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -182,6 +183,58 @@ class NativeSubprocessBackendTest {
     } finally {
       if (previous != null) platform.posix.setenv("JAVA_HOME", previous, 1)
       else platform.posix.unsetenv("JAVA_HOME")
+    }
+  }
+
+  // When ColorPolicy disables stderr color, the child konanc must see
+  // NO_COLOR=1 in its env so the underlying compiler emits plain
+  // (non-ANSI) diagnostics. Mirrors the kotlinc-side contract.
+  @Test
+  fun compileInjectsNoColorEnvWhenColorPolicyDisablesStderr() {
+    val backend = NativeSubprocessBackend(konancBin = "sh", colorPolicy = { ColorPolicy.Never })
+    val error = backend.compile(listOf("-c", "[ \"\$NO_COLOR\" = \"1\" ]")).getError()
+    if (error != null) {
+      kotlin.test.fail("expected sh to see NO_COLOR=1, got error: $error")
+    }
+  }
+
+  // When ColorPolicy enables color, kolt must NOT inject NO_COLOR — the child
+  // should inherit parent env verbatim so konanc keeps emitting ANSI codes
+  // for fd-inherit pass-through.
+  @OptIn(ExperimentalForeignApi::class)
+  @Test
+  fun compileDoesNotInjectNoColorEnvWhenColorPolicyAllowsStderr() {
+    val previous = platform.posix.getenv("NO_COLOR")?.toKString()
+    platform.posix.unsetenv("NO_COLOR")
+    try {
+      val backend = NativeSubprocessBackend(konancBin = "sh", colorPolicy = { ColorPolicy.Always })
+      val error = backend.compile(listOf("-c", "[ -z \"\$NO_COLOR\" ]")).getError()
+      if (error != null) {
+        kotlin.test.fail("expected sh to see NO_COLOR unset, got error: $error")
+      }
+    } finally {
+      if (previous != null) platform.posix.setenv("NO_COLOR", previous, 1)
+    }
+  }
+
+  // JAVA_HOME injection must still work when NO_COLOR is also injected — both
+  // env entries land in the child without one displacing the other.
+  @Test
+  fun compileSetsBothJavaHomeAndNoColorWhenColorDisabledAndJavaHomeSupplied() {
+    val backend =
+      NativeSubprocessBackend(
+        konancBin = "sh",
+        javaHome = "/managed/jdk/home",
+        colorPolicy = { ColorPolicy.Never },
+      )
+    val error =
+      backend
+        .compile(
+          listOf("-c", "[ \"\$JAVA_HOME\" = \"/managed/jdk/home\" ] && [ \"\$NO_COLOR\" = \"1\" ]")
+        )
+        .getError()
+    if (error != null) {
+      kotlin.test.fail("expected sh to see both JAVA_HOME and NO_COLOR, got error: $error")
     }
   }
 }

--- a/src/nativeTest/kotlin/kolt/build/SubprocessCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/SubprocessCompilerBackendTest.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import kolt.infra.ProcessError
 import kolt.infra.fileExists
+import kolt.infra.output.ColorPolicy
 import kolt.infra.removeDirectoryRecursive
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -269,6 +270,81 @@ class SubprocessCompilerBackendIntegrationTest {
     val error = backend.compile(request).getError()
     if (error != null) {
       kotlin.test.fail("expected sh to see JAVA_HOME, got error: $error")
+    }
+  }
+
+  // When ColorPolicy disables stderr color, the child kotlinc must see
+  // NO_COLOR=1 in its env so the compiler emits plain (non-ANSI) diagnostics.
+  @Test
+  fun compileInjectsNoColorEnvWhenColorPolicyDisablesStderr() {
+    val backend = SubprocessCompilerBackend(kotlincBin = "sh", colorPolicy = { ColorPolicy.Never })
+    val request =
+      CompileRequest(
+        workingDir = "",
+        classpath = emptyList(),
+        sources = listOf("-c", "[ \"\$NO_COLOR\" = \"1\" ]"),
+        outputPath = "/dev/null",
+        moduleName = "probe",
+        extraArgs = emptyList(),
+      )
+    val error = backend.compile(request).getError()
+    if (error != null) {
+      kotlin.test.fail("expected sh to see NO_COLOR=1, got error: $error")
+    }
+  }
+
+  // When ColorPolicy enables color, kolt must NOT inject NO_COLOR — the child
+  // should inherit parent env verbatim so kotlinc keeps emitting ANSI codes
+  // for fd-inherit pass-through.
+  @OptIn(ExperimentalForeignApi::class)
+  @Test
+  fun compileDoesNotInjectNoColorEnvWhenColorPolicyAllowsStderr() {
+    val previous = platform.posix.getenv("NO_COLOR")?.toKString()
+    platform.posix.unsetenv("NO_COLOR")
+    try {
+      val backend =
+        SubprocessCompilerBackend(kotlincBin = "sh", colorPolicy = { ColorPolicy.Always })
+      val request =
+        CompileRequest(
+          workingDir = "",
+          classpath = emptyList(),
+          sources = listOf("-c", "[ -z \"\$NO_COLOR\" ]"),
+          outputPath = "/dev/null",
+          moduleName = "probe",
+          extraArgs = emptyList(),
+        )
+      val error = backend.compile(request).getError()
+      if (error != null) {
+        kotlin.test.fail("expected sh to see NO_COLOR unset, got error: $error")
+      }
+    } finally {
+      if (previous != null) platform.posix.setenv("NO_COLOR", previous, 1)
+    }
+  }
+
+  // JAVA_HOME injection must still work when NO_COLOR is also injected — both
+  // env entries land in the child without one displacing the other.
+  @Test
+  fun compileSetsBothJavaHomeAndNoColorWhenColorDisabledAndJavaHomeSupplied() {
+    val backend =
+      SubprocessCompilerBackend(
+        kotlincBin = "sh",
+        javaHome = "/managed/jdk/home",
+        colorPolicy = { ColorPolicy.Never },
+      )
+    val request =
+      CompileRequest(
+        workingDir = "",
+        classpath = emptyList(),
+        sources =
+          listOf("-c", "[ \"\$JAVA_HOME\" = \"/managed/jdk/home\" ] && [ \"\$NO_COLOR\" = \"1\" ]"),
+        outputPath = "/dev/null",
+        moduleName = "probe",
+        extraArgs = emptyList(),
+      )
+    val error = backend.compile(request).getError()
+    if (error != null) {
+      kotlin.test.fail("expected sh to see both JAVA_HOME and NO_COLOR, got error: $error")
     }
   }
 

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonCompilerBackendTest.kt
@@ -13,6 +13,7 @@ import kolt.daemon.wire.Message
 import kolt.daemon.wire.Severity
 import kolt.infra.ProcessError
 import kolt.infra.net.UnixSocketError
+import kolt.infra.output.ColorPolicy
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -65,12 +66,13 @@ private fun sampleRequest() =
 
 private fun newBackend(
   connector: DaemonConnector,
-  spawner: DaemonSpawner = { _, _ -> Ok(Unit) },
+  spawner: DaemonSpawner = { _, _, _ -> Ok(Unit) },
   clock: FakeClock = FakeClock(),
   pluginJars: Map<String, List<String>> = emptyMap(),
   kotlinLanguageVersion: String? = null,
   kotlinCompilerVersion: String? = null,
   warnSink: (String) -> Unit = {},
+  colorPolicy: () -> ColorPolicy = { ColorPolicy.Never },
 ): DaemonCompilerBackend =
   DaemonCompilerBackend(
     javaBin = "/opt/jdk/bin/java",
@@ -87,6 +89,7 @@ private fun newBackend(
     clockMs = clock.clock,
     sleeper = clock.sleeper,
     warnSink = warnSink,
+    colorPolicy = colorPolicy,
   )
 
 class DaemonCompilerBackendHappyPathTest {
@@ -250,7 +253,7 @@ class DaemonCompilerBackendConnectAndSpawnTest {
     val backend =
       newBackend(
         connector = { Ok(FakeConnection()) },
-        spawner = { _, _ ->
+        spawner = { _, _, _ ->
           spawnCalls++
           Ok(Unit)
         },
@@ -276,7 +279,7 @@ class DaemonCompilerBackendConnectAndSpawnTest {
     val backend =
       newBackend(
         connector = connector,
-        spawner = { argv, _ ->
+        spawner = { argv, _, _ ->
           captured = argv
           Ok(Unit)
         },
@@ -309,7 +312,7 @@ class DaemonCompilerBackendConnectAndSpawnTest {
     val backend =
       newBackend(
         connector = connector,
-        spawner = { argv, _ ->
+        spawner = { argv, _, _ ->
           captured = argv
           Ok(Unit)
         },
@@ -341,7 +344,7 @@ class DaemonCompilerBackendConnectAndSpawnTest {
     val backend =
       newBackend(
         connector = connector,
-        spawner = { argv, _ ->
+        spawner = { argv, _, _ ->
           captured = argv
           Ok(Unit)
         },
@@ -373,7 +376,7 @@ class DaemonCompilerBackendConnectAndSpawnTest {
     val backend =
       newBackend(
         connector = connector,
-        spawner = { argv, _ ->
+        spawner = { argv, _, _ ->
           captured = argv
           Ok(Unit)
         },
@@ -404,7 +407,7 @@ class DaemonCompilerBackendConnectAndSpawnTest {
     val backend =
       newBackend(
         connector = connector,
-        spawner = { argv, _ ->
+        spawner = { argv, _, _ ->
           captured = argv
           Ok(Unit)
         },
@@ -434,7 +437,7 @@ class DaemonCompilerBackendConnectAndSpawnTest {
     val backend =
       newBackend(
         connector = connector,
-        spawner = { argv, _ ->
+        spawner = { argv, _, _ ->
           captured = argv
           Ok(Unit)
         },
@@ -469,7 +472,7 @@ class DaemonCompilerBackendConnectAndSpawnTest {
     val backend =
       newBackend(
         connector = connector,
-        spawner = { _, _ ->
+        spawner = { _, _, _ ->
           spawnCalls++
           Ok(Unit)
         },
@@ -506,7 +509,7 @@ class DaemonCompilerBackendConnectAndSpawnTest {
     val backend =
       newBackend(
         connector = connector,
-        spawner = { _, _ ->
+        spawner = { _, _, _ ->
           spawnCalls++
           Ok(Unit)
         },
@@ -533,7 +536,7 @@ class DaemonCompilerBackendConnectAndSpawnTest {
       Err(UnixSocketError.ConnectFailed(it, platform.posix.ENOENT, "No such file"))
     }
     val backend =
-      newBackend(connector = connector, spawner = { _, _ -> Err(ProcessError.ForkFailed) })
+      newBackend(connector = connector, spawner = { _, _, _ -> Err(ProcessError.ForkFailed) })
     val err = assertNotNull(backend.compile(sampleRequest()).getError())
     val unavailable = assertIs<CompileError.BackendUnavailable.Other>(err)
     assertTrue(unavailable.detail.contains("spawn"))
@@ -547,7 +550,8 @@ class DaemonCompilerBackendConnectAndSpawnTest {
       attempts++
       Err(UnixSocketError.ConnectFailed(it, platform.posix.ENOENT, "No such file"))
     }
-    val backend = newBackend(connector = connector, spawner = { _, _ -> Ok(Unit) }, clock = clock)
+    val backend =
+      newBackend(connector = connector, spawner = { _, _, _ -> Ok(Unit) }, clock = clock)
     val err = assertNotNull(backend.compile(sampleRequest()).getError())
     val unavailable = assertIs<CompileError.BackendUnavailable.Other>(err)
     assertTrue(unavailable.detail.contains("within 10000ms"))
@@ -712,5 +716,68 @@ class IsRetryableConnectErrorTest {
   @Test
   fun invalidArgumentIsNotRetryable() {
     assertFalse(isRetryableConnectError(UnixSocketError.InvalidArgument("too long")))
+  }
+}
+
+class DaemonCompilerBackendNoColorEnvTest {
+
+  // When ColorPolicy disables stderr color, the daemon spawn must carry
+  // NO_COLOR=1 so the JVM daemon (and the kotlinc subprocess it spawns) emits
+  // plain diagnostics.
+  @Test
+  fun spawnEnvIncludesNoColorWhenColorPolicyDisablesStderr() {
+    var capturedEnv: Map<String, String>? = null
+    var attempt = 0
+    val connector: DaemonConnector = { path ->
+      attempt++
+      if (attempt == 1) {
+        Err(UnixSocketError.ConnectFailed(path, platform.posix.ENOENT, "No such file"))
+      } else {
+        Ok(FakeConnection())
+      }
+    }
+    val backend =
+      newBackend(
+        connector = connector,
+        spawner = { _, _, env ->
+          capturedEnv = env
+          Ok(Unit)
+        },
+        colorPolicy = { ColorPolicy.Never },
+      )
+    backend.compile(sampleRequest())
+    val env = assertNotNull(capturedEnv, "spawner must have been invoked after ENOENT")
+    assertEquals("1", env["NO_COLOR"], "expected NO_COLOR=1 in spawn env, got: $env")
+  }
+
+  // When color is enabled, kolt must not inject NO_COLOR — the daemon (and
+  // its kotlinc subprocess) inherits parent env verbatim.
+  @Test
+  fun spawnEnvOmitsNoColorWhenColorPolicyAllowsStderr() {
+    var capturedEnv: Map<String, String>? = null
+    var attempt = 0
+    val connector: DaemonConnector = { path ->
+      attempt++
+      if (attempt == 1) {
+        Err(UnixSocketError.ConnectFailed(path, platform.posix.ENOENT, "No such file"))
+      } else {
+        Ok(FakeConnection())
+      }
+    }
+    val backend =
+      newBackend(
+        connector = connector,
+        spawner = { _, _, env ->
+          capturedEnv = env
+          Ok(Unit)
+        },
+        colorPolicy = { ColorPolicy.Always },
+      )
+    backend.compile(sampleRequest())
+    val env = assertNotNull(capturedEnv, "spawner must have been invoked after ENOENT")
+    assertFalse(
+      env.containsKey("NO_COLOR"),
+      "expected spawn env to omit NO_COLOR when color enabled, got: $env",
+    )
   }
 }

--- a/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/nativedaemon/NativeDaemonBackendTest.kt
@@ -9,10 +9,12 @@ import kolt.build.NativeCompileError
 import kolt.build.daemon.BOOTSTRAP_JDK_VERSION
 import kolt.infra.ProcessError
 import kolt.infra.net.UnixSocketError
+import kolt.infra.output.ColorPolicy
 import kolt.nativedaemon.wire.FrameError
 import kolt.nativedaemon.wire.Message
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -52,10 +54,11 @@ private class FakeClock(var nowMs: Long = 0) {
 
 private fun newBackend(
   connector: NativeDaemonConnector,
-  spawner: NativeDaemonSpawner = { _, _ -> Ok(Unit) },
+  spawner: NativeDaemonSpawner = { _, _, _ -> Ok(Unit) },
   clock: FakeClock = FakeClock(),
   onSpawn: () -> Unit = {},
   warnSink: (String) -> Unit = {},
+  colorPolicy: () -> ColorPolicy = { ColorPolicy.Never },
 ): NativeDaemonBackend =
   NativeDaemonBackend(
     javaBin = "/opt/jdk/bin/java",
@@ -71,6 +74,7 @@ private fun newBackend(
     sleeper = clock.sleeper,
     onSpawn = onSpawn,
     warnSink = warnSink,
+    colorPolicy = colorPolicy,
   )
 
 private val sampleArgs =
@@ -332,7 +336,7 @@ class NativeDaemonBackendConnectAndSpawnTest {
     val backend =
       newBackend(
         connector = { Ok(fake) },
-        spawner = { _, _ ->
+        spawner = { _, _, _ ->
           spawnCount++
           Ok(Unit)
         },
@@ -396,7 +400,7 @@ class NativeDaemonBackendConnectAndSpawnTest {
         connector = { _ ->
           Err(UnixSocketError.ConnectFailed(path = "/tmp/s", errno = 13, message = "EACCES"))
         },
-        spawner = { _, _ ->
+        spawner = { _, _, _ ->
           spawnCount++
           Ok(Unit)
         },
@@ -430,7 +434,7 @@ class NativeDaemonBackendConnectAndSpawnTest {
         connector = { _ ->
           Err(UnixSocketError.ConnectFailed(path = "/tmp/s", errno = 2, message = "ENOENT"))
         },
-        spawner = { _, _ -> Err(ProcessError.ForkFailed) },
+        spawner = { _, _, _ -> Err(ProcessError.ForkFailed) },
       )
 
     val err = backend.compile(sampleArgs).getError()
@@ -470,7 +474,7 @@ class NativeDaemonBackendConnectAndSpawnTest {
         connector = { _ ->
           Err(UnixSocketError.ConnectFailed(path = "/tmp/s", errno = 2, message = "ENOENT"))
         },
-        spawner = { argv, _ ->
+        spawner = { argv, _, _ ->
           capturedArgv = argv
           Err(ProcessError.ForkFailed)
         },
@@ -502,7 +506,7 @@ class NativeDaemonBackendConnectAndSpawnTest {
         connector = { _ ->
           Err(UnixSocketError.ConnectFailed(path = "/tmp/s", errno = 2, message = "ENOENT"))
         },
-        spawner = { argv, _ ->
+        spawner = { argv, _, _ ->
           capturedArgv = argv
           Err(ProcessError.ForkFailed)
         },
@@ -585,7 +589,7 @@ class NativeDaemonBackendConnectAndSpawnTest {
         connector = { _ ->
           Err(UnixSocketError.ConnectFailed(path = "/tmp/s", errno = 2, message = "ENOENT"))
         },
-        spawner = { _, _ -> Ok(Unit) },
+        spawner = { _, _, _ -> Ok(Unit) },
         clockMs = clock.clock,
         sleeper = budgetOverflowSleeper,
       )
@@ -611,5 +615,68 @@ class NativeDaemonBackendConnectAndSpawnTest {
     backend.compile(sampleArgs)
 
     assertTrue(fake.closed, "connection must close on send error")
+  }
+}
+
+class NativeDaemonBackendNoColorEnvTest {
+
+  // When ColorPolicy disables stderr color, the native daemon spawn must
+  // carry NO_COLOR=1 so the JVM daemon (and the konanc subprocess it spawns)
+  // emits plain diagnostics. Mirrors DaemonCompilerBackendNoColorEnvTest.
+  @Test
+  fun spawnEnvIncludesNoColorWhenColorPolicyDisablesStderr() {
+    var capturedEnv: Map<String, String>? = null
+    var attempt = 0
+    val connector: NativeDaemonConnector = { path ->
+      attempt++
+      if (attempt == 1) {
+        Err(UnixSocketError.ConnectFailed(path, platform.posix.ENOENT, "No such file"))
+      } else {
+        Ok(FakeConnection())
+      }
+    }
+    val backend =
+      newBackend(
+        connector = connector,
+        spawner = { _, _, env ->
+          capturedEnv = env
+          Ok(Unit)
+        },
+        colorPolicy = { ColorPolicy.Never },
+      )
+    backend.compile(sampleArgs)
+    val env = assertNotNull(capturedEnv, "spawner must have been invoked after ENOENT")
+    assertEquals("1", env["NO_COLOR"], "expected NO_COLOR=1 in spawn env, got: $env")
+  }
+
+  // When color is enabled, kolt must not inject NO_COLOR — the daemon (and
+  // its konanc subprocess) inherits parent env verbatim.
+  @Test
+  fun spawnEnvOmitsNoColorWhenColorPolicyAllowsStderr() {
+    var capturedEnv: Map<String, String>? = null
+    var attempt = 0
+    val connector: NativeDaemonConnector = { path ->
+      attempt++
+      if (attempt == 1) {
+        Err(UnixSocketError.ConnectFailed(path, platform.posix.ENOENT, "No such file"))
+      } else {
+        Ok(FakeConnection())
+      }
+    }
+    val backend =
+      newBackend(
+        connector = connector,
+        spawner = { _, _, env ->
+          capturedEnv = env
+          Ok(Unit)
+        },
+        colorPolicy = { ColorPolicy.Always },
+      )
+    backend.compile(sampleArgs)
+    val env = assertNotNull(capturedEnv, "spawner must have been invoked after ENOENT")
+    assertFalse(
+      env.containsKey("NO_COLOR"),
+      "expected spawn env to omit NO_COLOR when color enabled, got: $env",
+    )
   }
 }

--- a/src/nativeTest/kotlin/kolt/cli/DidYouMeanE2EIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DidYouMeanE2EIT.kt
@@ -1,0 +1,211 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package kolt.cli
+
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.eprintln
+import kolt.infra.executeCommand
+import kolt.infra.fileExists
+import kolt.infra.readFileAsString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.getcwd
+import platform.posix.getenv
+import platform.posix.mkdtemp
+
+/**
+ * E2E for Did-you-mean output on unknown subcommand and unknown global flag (tasks.md 8.2,
+ * requirements 5.2, 5.3, 5.4).
+ *
+ * Spawns the built kolt.kexe with intentional typos and asserts on the rendered stderr:
+ * - `kolt --no-color buidl` → exit 127, `error: unknown command 'buidl'` plus `note: Did you mean
+ *   `build`?`.
+ * - `kolt --no-color --no-clor build` → exit 127, `error: unknown flag '--no-clor'` plus `note: Did
+ *   you mean `--no-color`?`.
+ * - `kolt --no-color xyzzy-totally-unrelated-blob` → exit 127, error line present, no `Did you
+ *   mean` and no `note:` line because the typo is beyond the adaptive threshold.
+ *
+ * Each invocation passes `--no-color` so stderr is byte-deterministic for substring comparison
+ * (R5.4); the unknown-flag case still resolves the leading `--no-color` before the unknown-flag
+ * branch fires, so color is suppressed in the diagnostic.
+ *
+ * Gated behind `KOLT_DIDYOUMEAN_E2E=1` because the cases require a built `build/debug/kolt.kexe`
+ * (or `build/release/kolt.kexe`); without the env var the methods return immediately so `kolt test`
+ * stays fast.
+ *
+ * Shell harness scripts use a Kotlin-side D = "$" token for shell variable references so the
+ * raw-string templates do not collide with Kotlin's own `$variable` interpolation.
+ */
+class DidYouMeanE2EIT {
+
+  // R5.2: unknown subcommand within edit-distance threshold gets a `Did you mean` hint.
+  @Test
+  fun unknownSubcommandWithNearMatchSuggestsBuild() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val workdir = createTempDir("kolt-it-dym-cmd-")
+    val script =
+      """
+            set -u
+            cd "$workdir"
+            "$kolt" --no-color buidl > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(workdir, "out.exit")
+    val stderr = readOptional(workdir, "out.stderr") ?: ""
+    assertEquals(EXIT_COMMAND_NOT_FOUND, exit, "unknown command must exit 127; stderr=$stderr")
+    assertTrue(
+      stderr.contains("error: unknown command 'buidl'"),
+      "stderr must contain unknown-command error; got:\n$stderr",
+    )
+    assertTrue(
+      stderr.contains("note: Did you mean `build`?"),
+      "stderr must contain Did-you-mean note for build; got:\n$stderr",
+    )
+  }
+
+  // R5.3: unknown global flag within edit-distance threshold gets a `Did you mean` hint.
+  // The leading `--no-color` is the *known* flag so color is off; the trailing `--no-clor`
+  // is the typo under test, exercising parseKoltArgs's unknown-flag boundary.
+  @Test
+  fun unknownGlobalFlagWithNearMatchSuggestsNoColor() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val workdir = createTempDir("kolt-it-dym-flag-")
+    val script =
+      """
+            set -u
+            cd "$workdir"
+            "$kolt" --no-color --no-clor build > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(workdir, "out.exit")
+    val stderr = readOptional(workdir, "out.stderr") ?: ""
+    assertEquals(EXIT_COMMAND_NOT_FOUND, exit, "unknown flag must exit 127; stderr=$stderr")
+    assertTrue(
+      stderr.contains("error: unknown flag '--no-clor'"),
+      "stderr must contain unknown-flag error; got:\n$stderr",
+    )
+    assertTrue(
+      stderr.contains("note: Did you mean `--no-color`?"),
+      "stderr must contain Did-you-mean note for --no-color; got:\n$stderr",
+    )
+  }
+
+  // R5.2 negative arm + R5.4: a far-off typo must not produce a hint, and the absence
+  // must be deterministic (no `note:` line, no `Did you mean` substring anywhere in
+  // stderr).
+  @Test
+  fun unknownSubcommandBeyondThresholdHasNoSuggestion() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val workdir = createTempDir("kolt-it-dym-far-")
+    val script =
+      """
+            set -u
+            cd "$workdir"
+            "$kolt" --no-color xyzzy-totally-unrelated-blob > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(workdir, "out.exit")
+    val stderr = readOptional(workdir, "out.stderr") ?: ""
+    assertNotEquals(0, exit, "unknown command must fail; stderr=$stderr")
+    assertTrue(
+      stderr.contains("error: unknown command 'xyzzy-totally-unrelated-blob'"),
+      "stderr must contain unknown-command error; got:\n$stderr",
+    )
+    assertFalse(
+      stderr.contains("Did you mean"),
+      "stderr must not contain Did-you-mean for far-off typo; got:\n$stderr",
+    )
+    assertFalse(
+      stderr.contains("note:"),
+      "stderr must not contain note: line when there is no suggestion; got:\n$stderr",
+    )
+  }
+
+  // The IT cases need a kolt-built kolt.kexe. `kolt test` does not produce
+  // the executable on its own; if the user opted into the gate the binary
+  // must already be present.
+  private fun locateKoltKexe(): String? {
+    val cwd = currentWorkingDir() ?: return null
+    val candidates = listOf("$cwd/build/debug/kolt.kexe", "$cwd/build/release/kolt.kexe")
+    val found = candidates.firstOrNull { fileExists(it) }
+    if (found == null) {
+      error(
+        "KOLT_DIDYOUMEAN_E2E=1 but kolt.kexe is not built. Run " +
+          "`kolt build` first. Looked under: $candidates"
+      )
+    }
+    return found
+  }
+
+  private fun createTempDir(prefix: String): String {
+    val template = "/tmp/${prefix}XXXXXX"
+    val buf = template.encodeToByteArray().copyOf(template.length + 1)
+    buf.usePinned { pinned ->
+      val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+      return result.toKString()
+    }
+  }
+
+  private fun currentWorkingDir(): String? = memScoped {
+    val buf = allocArray<ByteVar>(PATH_MAX)
+    getcwd(buf, PATH_MAX.toULong())?.toKString()
+  }
+
+  private fun runHarness(script: String) {
+    executeCommand(listOf("bash", "-c", script)).getOrElse { err ->
+      error("harness bash failed: $err — script was:\n$script")
+    }
+  }
+
+  private fun readExit(dir: String, name: String): Int {
+    val raw =
+      readFileAsString("$dir/$name").getOrElse {
+        error("missing $dir/$name — harness did not record an exit code")
+      }
+    return raw.trim().toIntOrNull() ?: error("could not parse exit code from $dir/$name: '$raw'")
+  }
+
+  private fun readOptional(dir: String, name: String): String? {
+    val path = "$dir/$name"
+    if (!fileExists(path)) return null
+    return readFileAsString(path).getOrElse {
+      return null
+    }
+  }
+
+  private fun enabled(): Boolean {
+    val on = getenv("KOLT_DIDYOUMEAN_E2E")?.toKString() == "1"
+    if (!on && !skipNoticePrinted) {
+      skipNoticePrinted = true
+      eprintln(
+        "DidYouMeanE2EIT: skipped (set KOLT_DIDYOUMEAN_E2E=1 and run `kolt build` to enable)"
+      )
+    }
+    return on
+  }
+
+  companion object {
+    private const val D = "$"
+
+    private var skipNoticePrinted = false
+  }
+}

--- a/src/nativeTest/kotlin/kolt/cli/InfoJsonAnsiE2EIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/InfoJsonAnsiE2EIT.kt
@@ -1,0 +1,278 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package kolt.cli
+
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.eprintln
+import kolt.infra.executeCommand
+import kolt.infra.fileExists
+import kolt.infra.readFileAsString
+import kolt.infra.removeDirectoryRecursive
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.getcwd
+import platform.posix.getenv
+import platform.posix.mkdtemp
+
+/**
+ * E2E pin for `kolt info --format=json` (tasks.md 8.4, requirements 7.1, 7.2).
+ *
+ * The structured output channel must remain ANSI-free regardless of color policy. The
+ * DiagnosticWriter is stderr-only by contract, so the stdout JSON path should never carry CSI
+ * introducer bytes; this IT pins that contract end-to-end against the built kolt.kexe.
+ *
+ * Scenarios:
+ * 1. Default invocation (`kolt info --format=json`) with NO_COLOR cleared — stdout is JSON-shaped,
+ *    no ANSI, exit 0.
+ * 2. `--no-color` flag — same assertion; the flag must not perturb the JSON channel.
+ * 3. `NO_COLOR=1` env var — same assertion.
+ * 4. Byte-equivalence: scenarios 1 / 2 / 3 produce byte-identical stdout, pinning the contract that
+ *    the JSON channel is invariant under color policy.
+ *
+ * Gated behind `KOLT_INFO_JSON_E2E=1` because the cases require a built `build/debug/kolt.kexe` (or
+ * `build/release/kolt.kexe`); without the env var the methods return immediately so `kolt test`
+ * stays fast.
+ *
+ * Shell harness scripts use a Kotlin-side `D = "$"` token for shell variable references so the
+ * raw-string templates do not collide with Kotlin's own `$variable` interpolation.
+ */
+class InfoJsonAnsiE2EIT {
+
+  private val createdDirs = mutableListOf<String>()
+
+  @AfterTest
+  fun cleanup() {
+    for (dir in createdDirs) {
+      if (fileExists(dir)) {
+        removeDirectoryRecursive(dir)
+      }
+    }
+    createdDirs.clear()
+  }
+
+  // R7.1: default invocation must not inject ANSI into the JSON channel. NO_COLOR is explicitly
+  // cleared so this case isolates the stdout-channel contract from the env-var branch — even with
+  // no opt-out signal, the JSON path is stderr-detached and color-free.
+  @Test
+  fun defaultInvocationProducesAnsiFreeJson() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val workdir = createTempDir("kolt-it-info-json-default-")
+    val script =
+      """
+            set -u
+            unset NO_COLOR
+            cd "$workdir"
+            "$kolt" info --format=json > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(workdir, "out.exit")
+    val stdout = readOptional(workdir, "out.stdout") ?: ""
+    val stderr = readOptional(workdir, "out.stderr") ?: ""
+    assertEquals(0, exit, "info --format=json must exit 0; stderr=$stderr")
+    assertTrue(stdout.isNotEmpty(), "stdout must contain JSON; got empty")
+    assertJsonShaped(stdout, "default invocation")
+    assertNoAnsi(stdout, "default invocation stdout")
+  }
+
+  // R7.1 + R2.4: --no-color flag must not perturb stdout JSON. The flag flips kolt's ColorPolicy
+  // to Never; the JSON channel must remain byte-identical to the default case.
+  @Test
+  fun noColorFlagDoesNotPerturbJson() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val workdir = createTempDir("kolt-it-info-json-flag-")
+    val script =
+      """
+            set -u
+            unset NO_COLOR
+            cd "$workdir"
+            "$kolt" --no-color info --format=json > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(workdir, "out.exit")
+    val stdout = readOptional(workdir, "out.stdout") ?: ""
+    val stderr = readOptional(workdir, "out.stderr") ?: ""
+    assertEquals(0, exit, "info --format=json with --no-color must exit 0; stderr=$stderr")
+    assertTrue(stdout.isNotEmpty(), "stdout must contain JSON; got empty")
+    assertJsonShaped(stdout, "--no-color flag")
+    assertNoAnsi(stdout, "--no-color flag stdout")
+  }
+
+  // R7.1 + R2.3: NO_COLOR=1 env var must not perturb stdout JSON. Same channel-isolation contract
+  // as the flag case but via the env-var branch.
+  @Test
+  fun noColorEnvDoesNotPerturbJson() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val workdir = createTempDir("kolt-it-info-json-env-")
+    val script =
+      """
+            set -u
+            cd "$workdir"
+            NO_COLOR=1 "$kolt" info --format=json > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(workdir, "out.exit")
+    val stdout = readOptional(workdir, "out.stdout") ?: ""
+    val stderr = readOptional(workdir, "out.stderr") ?: ""
+    assertEquals(0, exit, "info --format=json with NO_COLOR=1 must exit 0; stderr=$stderr")
+    assertTrue(stdout.isNotEmpty(), "stdout must contain JSON; got empty")
+    assertJsonShaped(stdout, "NO_COLOR=1 env")
+    assertNoAnsi(stdout, "NO_COLOR=1 env stdout")
+  }
+
+  // R7.1 invariance pin: the stdout JSON channel is byte-identical across the three color-policy
+  // shapes (default / --no-color flag / NO_COLOR=1 env). If any future change leaks color decisions
+  // into the JSON channel, this assertion fires before downstream tools see the divergence.
+  @Test
+  fun jsonOutputIsByteIdenticalAcrossColorPolicies() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val workdir = createTempDir("kolt-it-info-json-invariance-")
+    val script =
+      """
+            set -u
+            cd "$workdir"
+            unset NO_COLOR
+            "$kolt" info --format=json > default.stdout 2> default.stderr
+            echo $D? > default.exit
+            "$kolt" --no-color info --format=json > flag.stdout 2> flag.stderr
+            echo $D? > flag.exit
+            NO_COLOR=1 "$kolt" info --format=json > env.stdout 2> env.stderr
+            echo $D? > env.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    assertEquals(0, readExit(workdir, "default.exit"), "default invocation must exit 0")
+    assertEquals(0, readExit(workdir, "flag.exit"), "--no-color invocation must exit 0")
+    assertEquals(0, readExit(workdir, "env.exit"), "NO_COLOR=1 invocation must exit 0")
+    val default = readOptional(workdir, "default.stdout") ?: ""
+    val flag = readOptional(workdir, "flag.stdout") ?: ""
+    val env = readOptional(workdir, "env.stdout") ?: ""
+    assertEquals(
+      default,
+      flag,
+      "stdout JSON must be byte-identical between default and --no-color invocations",
+    )
+    assertEquals(
+      default,
+      env,
+      "stdout JSON must be byte-identical between default and NO_COLOR=1 invocations",
+    )
+  }
+
+  // CSI sequences begin with ESC followed by an open bracket (0x1B 0x5B). Asserting on the two-byte
+  // introducer catches every ANSI color escape because every ANSI color code is a CSI sequence;
+  // checking the introducer is sufficient and avoids false positives from substrings like a literal
+  // "[" inside a JSON array — though `kolt info --format=json` does not currently emit one, the
+  // schema permits arrays (e.g., `enabledPlugins`) so the assertion targets the ESC byte
+  // explicitly.
+  private fun assertNoAnsi(body: String, label: String) {
+    assertTrue(
+      !body.contains(ESC_BRACKET),
+      "$label: stdout must not contain ANSI escape sequence; got:\n$body",
+    )
+  }
+
+  // Pragmatic JSON-shape check. Kotlin/Native's test harness has no JSON parser bundled; verifying
+  // the payload starts with "{" and trim-ends with "}" is sufficient to assert the writer emitted
+  // a JSON object (not an empty payload, not stderr noise leaked to stdout).
+  private fun assertJsonShaped(body: String, label: String) {
+    val trimmed = body.trimEnd()
+    assertTrue(
+      trimmed.startsWith("{") && trimmed.endsWith("}"),
+      "$label: stdout must be a JSON object; got:\n$body",
+    )
+  }
+
+  // The IT cases need a kolt-built kolt.kexe. `kolt test` does not produce the executable on its
+  // own; if the user opted into the gate the binary must already be present.
+  private fun locateKoltKexe(): String? {
+    val cwd = currentWorkingDir() ?: return null
+    val candidates = listOf("$cwd/build/debug/kolt.kexe", "$cwd/build/release/kolt.kexe")
+    val found = candidates.firstOrNull { fileExists(it) }
+    if (found == null) {
+      error(
+        "KOLT_INFO_JSON_E2E=1 but kolt.kexe is not built. Run " +
+          "`kolt build` first. Looked under: $candidates"
+      )
+    }
+    return found
+  }
+
+  private fun createTempDir(prefix: String): String {
+    val template = "/tmp/${prefix}XXXXXX"
+    val buf = template.encodeToByteArray().copyOf(template.length + 1)
+    buf.usePinned { pinned ->
+      val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+      val path = result.toKString()
+      createdDirs.add(path)
+      return path
+    }
+  }
+
+  private fun currentWorkingDir(): String? = memScoped {
+    val buf = allocArray<ByteVar>(PATH_MAX)
+    getcwd(buf, PATH_MAX.toULong())?.toKString()
+  }
+
+  private fun runHarness(script: String) {
+    executeCommand(listOf("bash", "-c", script)).getOrElse { err ->
+      error("harness bash failed: $err — script was:\n$script")
+    }
+  }
+
+  private fun readExit(dir: String, name: String): Int {
+    val raw =
+      readFileAsString("$dir/$name").getOrElse {
+        error("missing $dir/$name — harness did not record an exit code")
+      }
+    return raw.trim().toIntOrNull() ?: error("could not parse exit code from $dir/$name: '$raw'")
+  }
+
+  private fun readOptional(dir: String, name: String): String? {
+    val path = "$dir/$name"
+    if (!fileExists(path)) return null
+    return readFileAsString(path).getOrElse {
+      return null
+    }
+  }
+
+  private fun enabled(): Boolean {
+    val on = getenv("KOLT_INFO_JSON_E2E")?.toKString() == "1"
+    if (!on && !skipNoticePrinted) {
+      skipNoticePrinted = true
+      eprintln(
+        "InfoJsonAnsiE2EIT: skipped (set KOLT_INFO_JSON_E2E=1 and run `kolt build` to enable)"
+      )
+    }
+    return on
+  }
+
+  companion object {
+    private const val D = "$"
+
+    private var skipNoticePrinted = false
+
+    // Two-byte CSI introducer: ESC (0x1B) followed by open bracket. Built via the Unicode escape
+    // so the source file contains no literal ESC byte (which would otherwise mangle terminal
+    // output if anyone cats the file or grep -r over the test tree).
+    private const val ESC_BRACKET = "\u001B["
+  }
+}

--- a/src/nativeTest/kotlin/kolt/cli/NoColorE2EIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/NoColorE2EIT.kt
@@ -1,0 +1,280 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package kolt.cli
+
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.eprintln
+import kolt.infra.executeCommand
+import kolt.infra.fileExists
+import kolt.infra.readFileAsString
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.getcwd
+import platform.posix.getenv
+import platform.posix.mkdtemp
+
+/**
+ * E2E smoke for NO_COLOR / --no-color / stderr-redirect ANSI suppression (tasks.md 8.1,
+ * requirements 2.2, 2.3, 2.4, 2.6).
+ *
+ * Spawns the built kolt.kexe against a tmp project whose kolt.toml is intentionally malformed so
+ * the parse path emits a real error diagnostic to stderr. The four cases each redirect stderr to a
+ * file and assert the file contains no CSI introducer (ESC + open bracket) byte sequence.
+ *
+ * Gated behind KOLT_NOCOLOR_E2E=1 because the realistic scenarios depend on `kolt build` having
+ * produced build/debug/kolt.kexe. Without the env variable each case returns immediately so `kolt
+ * test` stays fast and offline-safe; with the env variable the test exercises real fork+execvp of
+ * the binary and asserts on its stderr file contents.
+ *
+ * A malformed kolt.toml (rather than a broken *.kt) is used as the synthetic fail fixture: parse
+ * failure happens before toolchain resolution or dependency download, so the test is instant and
+ * network-free, and the stderr it produces is rendered by kolt's own eprintDiagnostic — which is
+ * the exact channel that --no-color / NO_COLOR are supposed to suppress.
+ *
+ * Shell harness scripts use a Kotlin-side D = "$" token for shell variable references so the
+ * raw-string templates do not collide with Kotlin's own `$variable` interpolation.
+ */
+class NoColorE2EIT {
+
+  private val createdDirs = mutableListOf<String>()
+
+  @AfterTest
+  fun cleanup() {
+    for (dir in createdDirs) {
+      if (fileExists(dir)) {
+        removeDirectoryRecursive(dir)
+      }
+    }
+    createdDirs.clear()
+  }
+
+  // R2.4: explicit --no-color flag suppresses ANSI in stderr regardless of
+  // TTY state. The harness pipes stderr to a file so the destination is also
+  // non-TTY, which would already disable color via Auto; the assertion still
+  // holds for the contract under test.
+  @Test
+  fun noColorFlagSuppressesAnsiInStderr() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val fixture = createFailingFixture("kolt-it-nocolor-flag-")
+    val script =
+      """
+            set -u
+            cd "$fixture"
+            "$kolt" --no-color build > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(fixture, "out.exit")
+    val stderr = readOptional(fixture, "out.stderr") ?: ""
+    assertNotEquals(0, exit, "build must fail on malformed kolt.toml; stderr=$stderr")
+    assertTrue(stderr.isNotEmpty(), "stderr must contain the error diagnostic; got empty")
+    assertNoAnsi(stderr, "--no-color flag")
+  }
+
+  // R2.3: NO_COLOR=1 env var suppresses ANSI in stderr. no-color.org spec —
+  // any non-empty value disables color.
+  @Test
+  fun noColorEnvVarSuppressesAnsiInStderr() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val fixture = createFailingFixture("kolt-it-nocolor-env-")
+    val script =
+      """
+            set -u
+            cd "$fixture"
+            NO_COLOR=1 "$kolt" build > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(fixture, "out.exit")
+    val stderr = readOptional(fixture, "out.stderr") ?: ""
+    assertNotEquals(0, exit, "build must fail on malformed kolt.toml; stderr=$stderr")
+    assertTrue(stderr.isNotEmpty(), "stderr must contain the error diagnostic; got empty")
+    assertNoAnsi(stderr, "NO_COLOR=1 env")
+  }
+
+  // R2.2: when stderr is redirected to a file the destination is non-TTY, so
+  // the ColorPolicy.Auto branch must report isStderrTty = false and emit no
+  // ANSI even without any explicit opt-out flag or env var.
+  @Test
+  fun stderrRedirectSuppressesAnsi() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val fixture = createFailingFixture("kolt-it-nocolor-redir-")
+    // Explicitly unset NO_COLOR so this case isolates the TTY-detection
+    // branch (R2.2) from the env-var branch (R2.3). --no-color is also not
+    // passed.
+    val script =
+      """
+            set -u
+            unset NO_COLOR
+            cd "$fixture"
+            "$kolt" build > out.stdout 2> log.txt
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(fixture, "out.exit")
+    val log = readOptional(fixture, "log.txt") ?: ""
+    assertNotEquals(0, exit, "build must fail on malformed kolt.toml; log=$log")
+    assertTrue(log.isNotEmpty(), "log.txt must contain the error diagnostic; got empty")
+    assertNoAnsi(log, "stderr redirect to log.txt")
+  }
+
+  // R2.6 (no-color.org spec): NO_COLOR with a non-empty value triggers
+  // suppression. Asserting the empty-value branch ("ANSI MAY appear") is
+  // unstable in a non-TTY harness, so we assert only the binding contract:
+  // any non-empty NO_COLOR value disables color.
+  @Test
+  fun noColorEnvVarWithArbitraryNonEmptyValueSuppressesAnsi() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val fixture = createFailingFixture("kolt-it-nocolor-foobar-")
+    val script =
+      """
+            set -u
+            cd "$fixture"
+            NO_COLOR=foobar "$kolt" build > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(fixture, "out.exit")
+    val stderr = readOptional(fixture, "out.stderr") ?: ""
+    assertNotEquals(0, exit, "build must fail on malformed kolt.toml; stderr=$stderr")
+    assertTrue(stderr.isNotEmpty(), "stderr must contain the error diagnostic; got empty")
+    assertNoAnsi(stderr, "NO_COLOR=foobar env")
+  }
+
+  // CSI sequences begin with ESC followed by an open bracket (0x1B 0x5B).
+  // Asserting on the two-byte introducer catches every ANSI color escape
+  // because every ANSI color code is a CSI sequence; checking the
+  // introducer is sufficient and avoids false positives from substrings
+  // like a literal "[INFO]" tag.
+  private fun assertNoAnsi(body: String, label: String) {
+    assertTrue(
+      !body.contains(ESC_BRACKET),
+      "$label: stderr must not contain ANSI escape sequence; got:\n$body",
+    )
+  }
+
+  // The IT cases need a kolt-built kolt.kexe. `kolt test` does not produce
+  // the executable on its own, so we cannot assume the binary is present.
+  // When it is missing we surface a clear error rather than silently passing
+  // — the env-gate already guarded the "do not run" path; if the user opted
+  // in, the binary really should be there.
+  private fun locateKoltKexe(): String? {
+    val cwd = currentWorkingDir() ?: return null
+    val candidates = listOf("$cwd/build/debug/kolt.kexe", "$cwd/build/release/kolt.kexe")
+    val found = candidates.firstOrNull { fileExists(it) }
+    if (found == null) {
+      error(
+        "KOLT_NOCOLOR_E2E=1 but kolt.kexe is not built. Run " +
+          "`kolt build` first. Looked under: $candidates"
+      )
+    }
+    return found
+  }
+
+  // Synthetic fail fixture: the kolt.toml is intentionally malformed so the
+  // ktoml decoder rejects it on the very first pass — before toolchain
+  // resolution or dependency download. This keeps the test offline and
+  // instant while still exercising kolt's own error diagnostic path,
+  // which is the channel the color policy is supposed to suppress.
+  private fun createFailingFixture(prefix: String): String {
+    val dir = createTempDir(prefix)
+    writeFileAsString("$dir/kolt.toml", FAIL_FIXTURE_TOML).getOrElse {
+      error("write kolt.toml: $it")
+    }
+    return dir
+  }
+
+  private fun createTempDir(prefix: String): String {
+    val template = "/tmp/${prefix}XXXXXX"
+    val buf = template.encodeToByteArray().copyOf(template.length + 1)
+    buf.usePinned { pinned ->
+      val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+      val path = result.toKString()
+      createdDirs.add(path)
+      return path
+    }
+  }
+
+  private fun currentWorkingDir(): String? = memScoped {
+    val buf = allocArray<ByteVar>(PATH_MAX)
+    getcwd(buf, PATH_MAX.toULong())?.toKString()
+  }
+
+  private fun runHarness(script: String) {
+    executeCommand(listOf("bash", "-c", script)).getOrElse { err ->
+      error("harness bash failed: $err — script was:\n$script")
+    }
+  }
+
+  private fun readExit(dir: String, name: String): Int {
+    val raw =
+      readFileAsString("$dir/$name").getOrElse {
+        error("missing $dir/$name — harness did not record an exit code")
+      }
+    return raw.trim().toIntOrNull() ?: error("could not parse exit code from $dir/$name: '$raw'")
+  }
+
+  private fun readOptional(dir: String, name: String): String? {
+    val path = "$dir/$name"
+    if (!fileExists(path)) return null
+    return readFileAsString(path).getOrElse {
+      return null
+    }
+  }
+
+  private fun enabled(): Boolean {
+    val on = getenv("KOLT_NOCOLOR_E2E")?.toKString() == "1"
+    if (!on && !skipNoticePrinted) {
+      skipNoticePrinted = true
+      eprintln("NoColorE2EIT: skipped (set KOLT_NOCOLOR_E2E=1 and run `kolt build` to enable)")
+    }
+    return on
+  }
+
+  companion object {
+    private const val D = "$"
+
+    private var skipNoticePrinted = false
+
+    // Two-byte CSI introducer: ESC (0x1B) followed by open bracket. Built
+    // via the Unicode escape so the source file contains no literal ESC
+    // byte (which would otherwise mangle terminal output if anyone cats
+    // the file or grep -r over the test tree).
+    private const val ESC_BRACKET = "\u001B["
+
+    // Malformed: dangling "[" opens a table header that is never closed by
+    // a "]", which the ktoml lexer rejects deterministically with a parse
+    // error. No [dependencies] section means no network is touched even
+    // if the parser were lenient. No source files exist either, so the
+    // build would fail at config-load anyway.
+    private val FAIL_FIXTURE_TOML =
+      """
+            name = "nocolor-it"
+            version = "0.0.1"
+            kind = "app"
+
+            [kotlin
+            version = "2.3.20"
+            """
+        .trimIndent()
+  }
+}

--- a/src/nativeTest/kotlin/kolt/cli/ParseKoltArgsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ParseKoltArgsTest.kt
@@ -153,4 +153,109 @@ class ParseKoltArgsTest {
     assertEquals(listOf("foo" to "bar", "baz" to "qux"), parsed.cliSysProps)
     assertEquals(listOf("test"), parsed.filteredArgs)
   }
+
+  @Test
+  fun absentNoColorFlagDefaultsToFalse() {
+    val parsed = parseKoltArgs(listOf("build"))
+    assertFalse(parsed.noColor)
+  }
+
+  @Test
+  fun presentNoColorFlagYieldsTrue() {
+    val parsed = parseKoltArgs(listOf("--no-color", "build"))
+    assertTrue(parsed.noColor)
+  }
+
+  @Test
+  fun noColorFlagIsStrippedFromFilteredArgs() {
+    val parsed = parseKoltArgs(listOf("--no-color", "build"))
+    assertEquals(listOf("build"), parsed.filteredArgs)
+  }
+
+  @Test
+  fun noColorCombinesWithOtherKoltLevelFlags() {
+    val parsed = parseKoltArgs(listOf("--no-daemon", "--no-color", "--release", "--watch", "test"))
+    assertTrue(parsed.noColor)
+    assertFalse(parsed.useDaemon)
+    assertTrue(parsed.watch)
+    assertEquals(Profile.Release, parsed.profile)
+    assertEquals(listOf("test"), parsed.filteredArgs)
+  }
+
+  @Test
+  fun noColorAfterDoubleDashIsTreatedAsPassthrough() {
+    val parsed = parseKoltArgs(listOf("run", "--", "--no-color"))
+    assertFalse(parsed.noColor)
+    assertEquals(listOf("run", "--", "--no-color"), parsed.filteredArgs)
+  }
+
+  @Test
+  fun noColorFlagPositionDoesNotMatter() {
+    val before = parseKoltArgs(listOf("--no-color", "build"))
+    val after = parseKoltArgs(listOf("build", "--no-color"))
+    assertEquals(before.noColor, after.noColor)
+    assertEquals(before.filteredArgs, after.filteredArgs)
+  }
+
+  @Test
+  fun knownKoltFlagsListIsAlphabetical() {
+    assertEquals(KNOWN_KOLT_FLAGS.sorted(), KNOWN_KOLT_FLAGS)
+  }
+
+  @Test
+  fun unknownGlobalFlagSurfacesInUnknownFlagsList() {
+    val parsed = parseKoltArgs(listOf("--no-clor", "build"))
+    assertEquals(listOf("--no-clor"), parsed.unknownFlags)
+  }
+
+  @Test
+  fun knownFlagsDoNotPopulateUnknownFlags() {
+    val parsed = parseKoltArgs(listOf("--no-daemon", "--no-color", "build"))
+    assertEquals(emptyList(), parsed.unknownFlags)
+  }
+
+  @Test
+  fun unknownFlagAfterDoubleDashIsNotSurfaced() {
+    val parsed = parseKoltArgs(listOf("run", "--", "--unknown-app-flag"))
+    assertEquals(emptyList(), parsed.unknownFlags)
+  }
+
+  @Test
+  fun subcommandLevelFlagAfterSubcommandIsNotSurfaced() {
+    // `init --lib`, `daemon stop --all`, `cache clean --tools` etc. —
+    // subcommand-level flags belong to the subcommand parser and must
+    // not be misclassified as unknown kolt-level flags.
+    val initLib = parseKoltArgs(listOf("init", "--lib"))
+    assertEquals(emptyList(), initLib.unknownFlags)
+    val daemonStop = parseKoltArgs(listOf("daemon", "stop", "--all"))
+    assertEquals(emptyList(), daemonStop.unknownFlags)
+    val cacheClean = parseKoltArgs(listOf("cache", "clean", "--tools"))
+    assertEquals(emptyList(), cacheClean.unknownFlags)
+    val outdatedFilter = parseKoltArgs(listOf("outdated", "--json", "--filter=major"))
+    assertEquals(emptyList(), outdatedFilter.unknownFlags)
+    val infoVerbose = parseKoltArgs(listOf("info", "--verbose", "--format=json"))
+    assertEquals(emptyList(), infoVerbose.unknownFlags)
+  }
+
+  @Test
+  fun versionAliasIsNotSurfacedAsUnknownFlag() {
+    // `--version` is a subcommand alias, dispatched as if it were
+    // `version`. parseKoltArgs must not treat it as an unknown flag.
+    val parsed = parseKoltArgs(listOf("--version"))
+    assertEquals(emptyList(), parsed.unknownFlags)
+  }
+
+  @Test
+  fun unknownKoltLevelFlagBeforeSubcommandIsSurfaced() {
+    val parsed = parseKoltArgs(listOf("--no-clor", "build"))
+    assertEquals(listOf("--no-clor"), parsed.unknownFlags)
+  }
+
+  @Test
+  fun unknownKoltLevelFlagBeforeSubcommandLevelFlagIsSurfacedAlone() {
+    // Genuine kolt-level typo before the subcommand AND a valid
+    // subcommand-level flag after it — only the kolt-level typo surfaces.
+    val parsed = parseKoltArgs(listOf("--xxx", "init", "--lib"))
+    assertEquals(listOf("--xxx"), parsed.unknownFlags)
+  }
 }

--- a/src/nativeTest/kotlin/kolt/cli/SubprocessColorForwardingE2EIT.kt
+++ b/src/nativeTest/kotlin/kolt/cli/SubprocessColorForwardingE2EIT.kt
@@ -1,0 +1,369 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package kolt.cli
+
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.eprintln
+import kolt.infra.executeCommand
+import kolt.infra.fileExists
+import kolt.infra.readFileAsString
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.PATH_MAX
+import platform.posix.getcwd
+import platform.posix.getenv
+import platform.posix.mkdtemp
+
+/**
+ * E2E pin for `kotlinc` / `konanc` honoring `NO_COLOR=1` (tasks.md 8.3, requirements 6.2, 6.3).
+ *
+ * Where 8.1 (`NoColorE2EIT`) exercises kolt's own diagnostic channel via a malformed `kolt.toml`,
+ * this IT exercises the forwarded subprocess stderr channel: the fixture is a syntactically broken
+ * `*.kt` that reaches `kotlinc` (and on scenario 4, `konanc`). The contract under test is that when
+ * `colorPolicy` is disabled, kolt sets `NO_COLOR=1` in the subprocess env (R6.3) and that the
+ * upstream Kotlin compilers honor that env — i.e. emit no `\x1B[` CSI introducer to their stderr.
+ * Validate-design Issue 3's mitigation is to lock that honor as a test contract; if a future Kotlin
+ * / konanc bump regresses, this IT goes RED, prompting either a version pin or a post-strip
+ * fallback (Risks table).
+ *
+ * Gated behind `KOLT_SUBPROC_COLOR_E2E=1`. The env gate is the user's signal that the host can
+ * actually compile via kolt — including, for scenario 4, having konanc downloaded (kolt fetches it
+ * on first native build under `~/.kolt/`). Without the env variable each case returns immediately
+ * so `kolt test` stays fast and offline-safe.
+ *
+ * Scenarios:
+ * 1. `NO_COLOR=1 kolt --no-daemon build` against a JVM fixture — kotlinc direct subprocess.
+ * 2. `kolt --no-color --no-daemon build` against a JVM fixture — same path, flag mechanism.
+ * 3. `NO_COLOR=1 kolt build` against a JVM fixture — JVM daemon path (default).
+ * 4. `NO_COLOR=1 kolt build` against a native (linuxX64) fixture — konanc / native daemon.
+ *
+ * Each scenario asserts the build fails (compile error), produces non-empty stderr, and that the
+ * stderr contains no `\x1B[` byte sequence.
+ *
+ * Shell harness scripts use a Kotlin-side `D = "$"` token for shell variable references so the
+ * raw-string templates do not collide with Kotlin's own `$variable` interpolation.
+ */
+class SubprocessColorForwardingE2EIT {
+
+  private val createdDirs = mutableListOf<String>()
+
+  @AfterTest
+  fun cleanup() {
+    for (dir in createdDirs) {
+      if (fileExists(dir)) {
+        removeDirectoryRecursive(dir)
+      }
+    }
+    createdDirs.clear()
+  }
+
+  // Scenario 1 (R6.3 direct subprocess path). NO_COLOR env var threads through
+  // SubprocessCompilerBackend's env injection into the kotlinc child process.
+  @Test
+  fun kotlincDirectSubprocessHonorsNoColorEnv() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val fixture = createJvmCompileErrorFixture("kolt-it-subproc-direct-env-")
+    val script =
+      """
+            set -u
+            cd "$fixture"
+            NO_COLOR=1 "$kolt" --no-daemon build > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(fixture, "out.exit")
+    val stderr = readOptional(fixture, "out.stderr") ?: ""
+    assertNotEquals(0, exit, "build must fail on broken kotlin source; stderr=$stderr")
+    assertTrue(stderr.isNotEmpty(), "stderr must contain the kotlinc diagnostic; got empty")
+    assertTrue(
+      stderr.contains("Main.kt"),
+      "scenario 1: stderr must come from kotlinc (source-file-level diagnostic), " +
+        "not kolt's validator; got:\n$stderr",
+    )
+    assertNoAnsi(stderr, "scenario 1: NO_COLOR=1 kolt --no-daemon build (kotlinc direct)")
+  }
+
+  // Scenario 2 (R6.3 direct subprocess path, flag mechanism). The --no-color
+  // flag flips the kolt-level ColorPolicy to Never, which the
+  // SubprocessCompilerBackend reads and translates into NO_COLOR=1 for the
+  // child env. Independent of NO_COLOR being set in the parent shell.
+  @Test
+  fun kotlincDirectSubprocessHonorsNoColorFlag() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val fixture = createJvmCompileErrorFixture("kolt-it-subproc-direct-flag-")
+    // Explicitly unset NO_COLOR so this case isolates the --no-color flag
+    // mechanism from the env-var mechanism (scenario 1).
+    val script =
+      """
+            set -u
+            unset NO_COLOR
+            cd "$fixture"
+            "$kolt" --no-color --no-daemon build > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(fixture, "out.exit")
+    val stderr = readOptional(fixture, "out.stderr") ?: ""
+    assertNotEquals(0, exit, "build must fail on broken kotlin source; stderr=$stderr")
+    assertTrue(stderr.isNotEmpty(), "stderr must contain the kotlinc diagnostic; got empty")
+    assertTrue(
+      stderr.contains("Main.kt"),
+      "scenario 2: stderr must come from kotlinc (source-file-level diagnostic), " +
+        "not kolt's validator; got:\n$stderr",
+    )
+    assertNoAnsi(stderr, "scenario 2: kolt --no-color --no-daemon build (kotlinc direct, flag)")
+  }
+
+  // Scenario 3 (R6.3 daemon path). Default invocation routes through the JVM
+  // compiler daemon; DaemonCompilerBackend injects NO_COLOR=1 into the daemon
+  // launch env when ColorPolicy is disabled. Asserting on the same broken-kt
+  // fixture confirms the daemon-launched kotlinc honors NO_COLOR equivalently
+  // to the direct subprocess case.
+  @Test
+  fun kotlincJvmDaemonHonorsNoColorEnv() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val fixture = createJvmCompileErrorFixture("kolt-it-subproc-daemon-env-")
+    val script =
+      """
+            set -u
+            cd "$fixture"
+            NO_COLOR=1 "$kolt" build > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(fixture, "out.exit")
+    val stderr = readOptional(fixture, "out.stderr") ?: ""
+    assertNotEquals(0, exit, "build must fail on broken kotlin source; stderr=$stderr")
+    assertTrue(stderr.isNotEmpty(), "stderr must contain the kotlinc diagnostic; got empty")
+    assertTrue(
+      stderr.contains("Main.kt"),
+      "scenario 3: stderr must come from kotlinc (source-file-level diagnostic), " +
+        "not kolt's validator; got:\n$stderr",
+    )
+    assertNoAnsi(stderr, "scenario 3: NO_COLOR=1 kolt build (JVM daemon)")
+  }
+
+  // Scenario 4 (R6.3 native daemon path / konanc). The native target routes
+  // through NativeDaemonBackend / NativeSubprocessBackend; the konanc child
+  // process must honor NO_COLOR=1 with the same contract as kotlinc. The env
+  // gate KOLT_SUBPROC_COLOR_E2E=1 implies the user has a working build
+  // environment; the first native invocation will download konanc on demand.
+  @Test
+  fun konancNativeDaemonHonorsNoColorEnv() {
+    if (!enabled()) return
+    val kolt = locateKoltKexe() ?: return
+    val fixture = createNativeCompileErrorFixture("kolt-it-subproc-native-env-")
+    val script =
+      """
+            set -u
+            cd "$fixture"
+            NO_COLOR=1 "$kolt" build > out.stdout 2> out.stderr
+            echo $D? > out.exit
+            """
+        .trimIndent()
+    runHarness(script)
+    val exit = readExit(fixture, "out.exit")
+    val stderr = readOptional(fixture, "out.stderr") ?: ""
+    assertNotEquals(0, exit, "native build must fail on broken kotlin source; stderr=$stderr")
+    assertTrue(stderr.isNotEmpty(), "stderr must contain the konanc diagnostic; got empty")
+    assertTrue(
+      stderr.contains("Main.kt"),
+      "scenario 4: stderr must come from konanc (source-file-level diagnostic), " +
+        "not kolt's validator; got:\n$stderr",
+    )
+    assertNoAnsi(stderr, "scenario 4: NO_COLOR=1 kolt build (konanc / native daemon)")
+  }
+
+  // CSI sequences begin with ESC followed by an open bracket (0x1B 0x5B).
+  // Asserting on the two-byte introducer catches every ANSI color escape
+  // because every ANSI color code is a CSI sequence; checking the
+  // introducer is sufficient and avoids false positives from substrings
+  // like a literal "[INFO]" tag.
+  private fun assertNoAnsi(body: String, label: String) {
+    assertTrue(
+      !body.contains(ESC_BRACKET),
+      "$label: stderr must not contain ANSI escape sequence; got:\n$body",
+    )
+  }
+
+  // The IT cases need a kolt-built kolt.kexe. `kolt test` does not produce
+  // the executable on its own, so we cannot assume the binary is present.
+  // When it is missing we surface a clear error rather than silently passing
+  // — the env-gate already guarded the "do not run" path; if the user opted
+  // in, the binary really should be there.
+  private fun locateKoltKexe(): String? {
+    val cwd = currentWorkingDir() ?: return null
+    val candidates = listOf("$cwd/build/debug/kolt.kexe", "$cwd/build/release/kolt.kexe")
+    val found = candidates.firstOrNull { fileExists(it) }
+    if (found == null) {
+      error(
+        "KOLT_SUBPROC_COLOR_E2E=1 but kolt.kexe is not built. Run " +
+          "`kolt build` first. Looked under: $candidates"
+      )
+    }
+    return found
+  }
+
+  // JVM-target fixture: kolt.toml is well-formed, but src/Main.kt contains
+  // intentionally broken Kotlin syntax (`let` is not a Kotlin keyword) so
+  // kotlinc reaches its parser and emits a real compile-error diagnostic to
+  // stderr. That stderr is the channel under test — the one to which the
+  // SubprocessCompilerBackend / DaemonCompilerBackend forwards. No
+  // [dependencies] section means the compile path runs without network
+  // (only the bundled kotlinc + kolt's own toolchain bootstrap).
+  private fun createJvmCompileErrorFixture(prefix: String): String {
+    val dir = createTempDir(prefix)
+    writeFileAsString("$dir/kolt.toml", JVM_FIXTURE_TOML).getOrElse {
+      error("write kolt.toml: $it")
+    }
+    val srcDir = "$dir/src"
+    executeCommand(listOf("mkdir", "-p", srcDir)).getOrElse { error("mkdir src: $it") }
+    writeFileAsString("$srcDir/Main.kt", BROKEN_MAIN).getOrElse { error("write Main.kt: $it") }
+    return dir
+  }
+
+  // Native-target fixture: same broken-kt content but with target = "linuxX64"
+  // so the build routes through konanc (NativeDaemonBackend or its subprocess
+  // fallback) instead of kotlinc-jvm. Using the linuxX64 target string to
+  // match the kolt repo's own kolt.toml; kolt downloads konanc on demand.
+  private fun createNativeCompileErrorFixture(prefix: String): String {
+    val dir = createTempDir(prefix)
+    writeFileAsString("$dir/kolt.toml", NATIVE_FIXTURE_TOML).getOrElse {
+      error("write kolt.toml: $it")
+    }
+    val srcDir = "$dir/src"
+    executeCommand(listOf("mkdir", "-p", srcDir)).getOrElse { error("mkdir src: $it") }
+    writeFileAsString("$srcDir/Main.kt", BROKEN_MAIN).getOrElse { error("write Main.kt: $it") }
+    return dir
+  }
+
+  private fun createTempDir(prefix: String): String {
+    val template = "/tmp/${prefix}XXXXXX"
+    val buf = template.encodeToByteArray().copyOf(template.length + 1)
+    buf.usePinned { pinned ->
+      val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+      val path = result.toKString()
+      createdDirs.add(path)
+      return path
+    }
+  }
+
+  private fun currentWorkingDir(): String? = memScoped {
+    val buf = allocArray<ByteVar>(PATH_MAX)
+    getcwd(buf, PATH_MAX.toULong())?.toKString()
+  }
+
+  private fun runHarness(script: String) {
+    executeCommand(listOf("bash", "-c", script)).getOrElse { err ->
+      error("harness bash failed: $err — script was:\n$script")
+    }
+  }
+
+  private fun readExit(dir: String, name: String): Int {
+    val raw =
+      readFileAsString("$dir/$name").getOrElse {
+        error("missing $dir/$name — harness did not record an exit code")
+      }
+    return raw.trim().toIntOrNull() ?: error("could not parse exit code from $dir/$name: '$raw'")
+  }
+
+  private fun readOptional(dir: String, name: String): String? {
+    val path = "$dir/$name"
+    if (!fileExists(path)) return null
+    return readFileAsString(path).getOrElse {
+      return null
+    }
+  }
+
+  private fun enabled(): Boolean {
+    val on = getenv("KOLT_SUBPROC_COLOR_E2E")?.toKString() == "1"
+    if (!on && !skipNoticePrinted) {
+      skipNoticePrinted = true
+      eprintln(
+        "SubprocessColorForwardingE2EIT: skipped " +
+          "(set KOLT_SUBPROC_COLOR_E2E=1 and run `kolt build` to enable)"
+      )
+    }
+    return on
+  }
+
+  companion object {
+    private const val D = "$"
+
+    private var skipNoticePrinted = false
+
+    // Two-byte CSI introducer: ESC (0x1B) followed by open bracket. Built
+    // via the Unicode escape so the source file contains no literal ESC
+    // byte (which would otherwise mangle terminal output if anyone cats
+    // the file or grep -r over the test tree).
+    private const val ESC_BRACKET = "\u001B["
+
+    private const val JVM_FIXTURE_NAME = "subproc-color-jvm"
+    private const val NATIVE_FIXTURE_NAME = "subproc-color-native"
+
+    // `let` is not a Kotlin keyword for declaring locals; it is a stdlib
+    // scope function. Used as a statement-leading identifier this is a
+    // syntax error the kotlinc parser rejects deterministically with a
+    // diagnostic on stderr — which is exactly the forwarded channel that
+    // the color-policy contract is supposed to govern.
+    private val BROKEN_MAIN =
+      """
+            fun main() {
+                let x = 1
+                println(x)
+            }
+            """
+        .trimIndent()
+
+    private val JVM_FIXTURE_TOML =
+      """
+            name = "$JVM_FIXTURE_NAME"
+            version = "0.0.1"
+            kind = "app"
+
+            [kotlin]
+            version = "2.3.20"
+
+            [build]
+            target = "jvm"
+            jvm_target = "21"
+            main = "main"
+            sources = ["src"]
+            test_sources = []
+            """
+        .trimIndent()
+
+    private val NATIVE_FIXTURE_TOML =
+      """
+            name = "$NATIVE_FIXTURE_NAME"
+            version = "0.0.1"
+            kind = "app"
+
+            [kotlin]
+            version = "2.3.20"
+
+            [build]
+            target = "linuxX64"
+            main = "main"
+            sources = ["src"]
+            test_sources = []
+            """
+        .trimIndent()
+  }
+}

--- a/src/nativeTest/kotlin/kolt/cli/UnknownCommandSuggestionTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/UnknownCommandSuggestionTest.kt
@@ -1,0 +1,66 @@
+package kolt.cli
+
+import kolt.infra.suggest.closestMatch
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UnknownCommandSuggestionTest {
+
+  @Test
+  fun knownSubcommandsListIsAlphabetical() {
+    assertEquals(KNOWN_SUBCOMMANDS_SORTED.sorted(), KNOWN_SUBCOMMANDS_SORTED)
+  }
+
+  @Test
+  fun knownSubcommandsCatalogMatchesDispatcher() {
+    // Drift guard: every `when` branch in `Main.main` must have a matching
+    // entry here, and vice versa. Update this set when the dispatcher gains
+    // or loses a subcommand.
+    val expected =
+      setOf(
+        "add",
+        "build",
+        "cache",
+        "check",
+        "clean",
+        "daemon",
+        "fetch",
+        "fmt",
+        "info",
+        "init",
+        "new",
+        "outdated",
+        "remove",
+        "run",
+        "test",
+        "tool",
+        "toolchain",
+        "tree",
+        "update",
+        "version",
+      )
+    assertEquals(expected, KNOWN_SUBCOMMANDS_SORTED.toSet())
+  }
+
+  @Test
+  fun closestMatchSuggestsBuildForBuidl() {
+    assertEquals("build", closestMatch("buidl", KNOWN_SUBCOMMANDS_SORTED))
+  }
+
+  @Test
+  fun closestMatchSuggestsCheckForChck() {
+    // length 4 → adaptive threshold 1; "chck" → "check" (insert 'e') is distance 1.
+    assertEquals("check", closestMatch("chck", KNOWN_SUBCOMMANDS_SORTED))
+  }
+
+  @Test
+  fun closestMatchReturnsNullForFarOffTypo() {
+    assertNull(closestMatch("totally-unrelated-xxx", KNOWN_SUBCOMMANDS_SORTED))
+  }
+
+  @Test
+  fun closestMatchOnExactKnownNameReturnsItself() {
+    assertEquals("build", closestMatch("build", KNOWN_SUBCOMMANDS_SORTED))
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/ConfigErrorTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigErrorTest.kt
@@ -1,0 +1,56 @@
+package kolt.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+class ConfigErrorTest {
+  @Test
+  fun messageOnlyConstructionLeavesEnrichmentFieldsNull() {
+    // Pin: legacy call sites (`ParseFailed("foo")`) still compile and the
+    // optional fields default to null.
+    val err = ConfigError.ParseFailed("project_dir must not be empty")
+    assertEquals("project_dir must not be empty", err.message)
+    assertNull(err.path)
+    assertNull(err.lineNo)
+    assertNull(err.keyPath)
+    assertNull(err.suggestion)
+  }
+
+  @Test
+  fun fullEnrichmentRoundTrip() {
+    val err =
+      ConfigError.ParseFailed(
+        message = "unknown key 'koltn'",
+        path = "/tmp/kolt.toml",
+        lineNo = 7,
+        keyPath = "koltn",
+        suggestion = "kotlin",
+      )
+    assertEquals("/tmp/kolt.toml", err.path)
+    assertEquals(7, err.lineNo)
+    assertEquals("koltn", err.keyPath)
+    assertEquals("kotlin", err.suggestion)
+  }
+
+  @Test
+  fun equalityIsValueBased() {
+    val a = ConfigError.ParseFailed("m", path = "/p", lineNo = 1)
+    val b = ConfigError.ParseFailed("m", path = "/p", lineNo = 1)
+    val c = ConfigError.ParseFailed("m", path = "/p", lineNo = 2)
+    assertEquals(a, b)
+    assertNotEquals(a, c)
+  }
+
+  @Test
+  fun copyOnlyOverridesNamedFields() {
+    val original = ConfigError.ParseFailed(message = "m", path = "/p", lineNo = 1, keyPath = "k")
+    val updated = original.copy(suggestion = "kotlin")
+    assertEquals("m", updated.message)
+    assertEquals("/p", updated.path)
+    assertEquals(1, updated.lineNo)
+    assertEquals("k", updated.keyPath)
+    assertEquals("kotlin", updated.suggestion)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/ConfigParseMessageFormatTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigParseMessageFormatTest.kt
@@ -1,0 +1,80 @@
+package kolt.config
+
+import com.akuleshov7.ktoml.Toml
+import com.akuleshov7.ktoml.TomlInputConfig
+import com.akuleshov7.ktoml.exceptions.TomlDecodingException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.fail
+import kotlinx.serialization.Serializable
+
+// Pins the ktoml-core 0.7.1 exception-message format that
+// `KtomlMessageParse.LINE_NO_REGEX` and the unknown-key regex rely on.
+// A ktoml major bump that reshapes either prefix surfaces here as a RED
+// test — that is the cue to revisit the regex / scope marker
+// (`KTOML_ROOT_SCOPE`) before line-number / Did-you-mean rendering
+// silently breaks in production.
+class ConfigParseMessageFormatTest {
+
+  @Serializable private data class TinyConfig(val name: String = "", val version: String = "")
+
+  private val strictToml = Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = false))
+
+  private fun decodeExpectingFailure(raw: String): String {
+    try {
+      strictToml.decodeFromString(TinyConfig.serializer(), raw)
+      fail("expected TomlDecodingException for input: $raw")
+    } catch (e: TomlDecodingException) {
+      return assertNotNull(e.message, "ktoml exception had null message")
+    }
+  }
+
+  @Test
+  fun syntaxErrorMessageStartsWithLinePrefix() {
+    // Unterminated string — ktoml flags the line.
+    val message = decodeExpectingFailure("name = \"unterminated\nversion = \"0.1\"\n")
+    val matched = LINE_NO_REGEX.find(message)
+    assertNotNull(matched, "ktoml syntax error did not match `^Line N: ` prefix; actual: $message")
+  }
+
+  @Test
+  fun unknownTopLevelKeyMessageMatchesUnknownKeyRegex() {
+    val raw = "name = \"x\"\nversion = \"0.1\"\nkoltn = \"stray\"\n"
+    val message = decodeExpectingFailure(raw)
+    val regex = Regex("Unknown key received: <([^>]+)> in scope <([^>]*)>")
+    val match = regex.find(message)
+    assertNotNull(
+      match,
+      "ktoml unknown-top-level message did not match expected format; actual: $message",
+    )
+    val (key, scope) = match.destructured
+    assertEquals("koltn", key, "full ktoml message: $message")
+    assertEquals("rootNode", scope, "expected TomlFile.name; full ktoml message: $message")
+  }
+
+  @Test
+  fun unknownNestedKeyMessageMatchesAndCarriesParentScope() {
+    @Serializable data class Inner(val a: String = "")
+    @Serializable data class Outer(val name: String = "", val nested: Inner = Inner())
+
+    val toml = Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = false))
+    val raw = "name = \"x\"\n[nested]\na = \"ok\"\nstray = \"unknown\"\n"
+    val message =
+      try {
+        toml.decodeFromString(Outer.serializer(), raw)
+        fail("expected TomlDecodingException")
+      } catch (e: TomlDecodingException) {
+        assertNotNull(e.message, "ktoml exception had null message")
+      }
+    val regex = Regex("Unknown key received: <([^>]+)> in scope <([^>]*)>")
+    val match = regex.find(message)
+    assertNotNull(
+      match,
+      "ktoml unknown-nested-key message did not match expected format; actual: $message",
+    )
+    val (key, scope) = match.destructured
+    assertEquals("stray", key, "full ktoml message: $message")
+    assertEquals("nested", scope, "full ktoml message: $message")
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
@@ -562,7 +562,7 @@ class ConfigTest {
   }
 
   @Test
-  fun unknownFieldsAreIgnored() {
+  fun unknownTopLevelFieldSurfacesParseFailure() {
     val toml =
       """
             name = "my-app"
@@ -579,8 +579,11 @@ class ConfigTest {
         """
         .trimIndent()
 
-    val config = assertNotNull(parseConfig(toml).get())
-    assertEquals("my-app", config.name)
+    val error = assertIs<ConfigError.ParseFailed>(parseConfig(toml).getError())
+    assertTrue(
+      error.message.contains("unknown_field"),
+      "expected ktoml to surface unknown_field; got: ${error.message}",
+    )
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/config/ExtractKtomlLineNoTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ExtractKtomlLineNoTest.kt
@@ -1,0 +1,43 @@
+package kolt.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExtractKtomlLineNoTest {
+  @Test
+  fun extractsLineNumberFromKtomlPrefix() {
+    assertEquals(5 to "foo", extractKtomlLineNo("Line 5: foo"))
+  }
+
+  @Test
+  fun returnsNullAndOriginalWhenNoPrefix() {
+    assertEquals(null to "foo", extractKtomlLineNo("foo"))
+  }
+
+  @Test
+  fun returnsNullAndEmptyWhenMessageIsNull() {
+    assertEquals(null to "", extractKtomlLineNo(null))
+  }
+
+  @Test
+  fun nonNumericLinePrefixIsNotMatched() {
+    // ktoml's `Line N:` prefix uses digits; a non-numeric variant must not match.
+    assertEquals(null to "Line abc: foo", extractKtomlLineNo("Line abc: foo"))
+  }
+
+  @Test
+  fun multiDigitLineNumber() {
+    assertEquals(123 to "syntax error here", extractKtomlLineNo("Line 123: syntax error here"))
+  }
+
+  @Test
+  fun emptyMessageReturnsNullPair() {
+    assertEquals(null to "", extractKtomlLineNo(""))
+  }
+
+  @Test
+  fun prefixWithoutSpaceDoesNotMatch() {
+    // `Line 5:foo` (no space after colon) should not match — ktoml emits a space.
+    assertEquals(null to "Line 5:foo", extractKtomlLineNo("Line 5:foo"))
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/ParseUnknownKeyTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ParseUnknownKeyTest.kt
@@ -1,0 +1,114 @@
+package kolt.config
+
+import com.akuleshov7.ktoml.Toml
+import com.akuleshov7.ktoml.TomlInputConfig
+import com.akuleshov7.ktoml.exceptions.TomlDecodingException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.fail
+import kotlinx.serialization.Serializable
+
+class ParseUnknownKeyTest {
+  @Test
+  fun topLevelTypoYieldsKeyAndSuggestion() {
+    // ktoml 0.7.1 names the root TOML node "rootNode" — top-level typos
+    // surface with `in scope <rootNode>`.
+    val (key, suggestion) =
+      parseUnknownKey(
+        "Unknown key received: <koltn> in scope <rootNode>. Switch the configuration option"
+      )
+    assertEquals("koltn", key)
+    assertEquals("kotlin", suggestion)
+  }
+
+  @Test
+  fun nestedUnknownKeyYieldsKeyButNoSuggestion() {
+    // Did-you-mean for nested keys is explicitly out of scope (R3.4 narrowed).
+    val (key, suggestion) =
+      parseUnknownKey(
+        "Unknown key received: <compilerr> in scope <kotlin>. Switch the configuration option"
+      )
+    assertEquals("compilerr", key)
+    assertNull(suggestion)
+  }
+
+  @Test
+  fun unrelatedMessageYieldsBothNull() {
+    val (key, suggestion) = parseUnknownKey("syntax error somewhere")
+    assertNull(key)
+    assertNull(suggestion)
+  }
+
+  @Test
+  fun topLevelKeyTooFarFromAnyKnownYieldsNoSuggestion() {
+    // "totallyunrelated" length 16 → adaptive threshold 2; no candidate
+    // within distance 2 of any KNOWN_TOP_LEVEL_SECTIONS entry.
+    val (key, suggestion) =
+      parseUnknownKey(
+        "Unknown key received: <totallyunrelated> in scope <rootNode>. Switch the configuration option"
+      )
+    assertEquals("totallyunrelated", key)
+    assertNull(suggestion)
+  }
+
+  @Test
+  fun emptyScopeIsTreatedAsNestedSinceKtomlEmitsRootNode() {
+    // Defensive: should ktoml ever emit `<>` as a scope, that is NOT the
+    // top-level root marker (real ktoml root is "rootNode"); the helper
+    // must not silently treat it as top-level.
+    val (key, suggestion) = parseUnknownKey("Unknown key received: <koltn> in scope <>")
+    assertEquals("koltn", key)
+    assertNull(suggestion)
+  }
+
+  @Test
+  fun knownTopLevelSectionsListIsAlphabetical() {
+    val sorted = KNOWN_TOP_LEVEL_SECTIONS.sorted()
+    assertEquals(sorted, KNOWN_TOP_LEVEL_SECTIONS)
+  }
+
+  @Test
+  fun knownTopLevelSectionsCoverAllRawConfigFields() {
+    // Drift guard: every section name a user might type at the top level
+    // (matched by the field-name / @SerialName of RawKoltConfig) is listed.
+    // Scalar fields (name / version / kind / package) are intentionally
+    // excluded — typos in those would surface as parse errors, not
+    // `[unknown]` section warnings, and offering Did-you-mean would mislead.
+    val expected =
+      setOf(
+        "build",
+        "cinterop",
+        "classpaths",
+        "dependencies",
+        "fmt",
+        "kotlin",
+        "repositories",
+        "run",
+        "test",
+        "test-dependencies",
+        "tools",
+      )
+    assertEquals(expected, KNOWN_TOP_LEVEL_SECTIONS.toSet())
+  }
+
+  // Empirical pin: invoke real ktoml 0.7.1 with strict-unknown-keys mode
+  // against a synthetic broken kolt.toml and assert the message format
+  // our regex assumes. This catches ktoml format drift on bumps.
+  @Serializable private data class TinySchema(val name: String = "")
+
+  @Test
+  fun ktomlEmitsExpectedUnknownKeyFormatForTopLevel() {
+    val toml = Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = false))
+    val raw = "[koltn]\nfoo = \"bar\"\n"
+    try {
+      toml.decodeFromString(TinySchema.serializer(), raw)
+      fail("expected TomlDecodingException")
+    } catch (e: TomlDecodingException) {
+      val message = e.message ?: fail("ktoml exception had null message")
+      val (key, suggestion) = parseUnknownKey(extractKtomlLineNo(message).second)
+      assertEquals("koltn", key, "actual ktoml message: $message")
+      assertEquals("kotlin", suggestion, "actual ktoml message: $message")
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/RenderConfigErrorTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RenderConfigErrorTest.kt
@@ -1,0 +1,96 @@
+package kolt.config
+
+import com.github.michaelbull.result.getError
+import kolt.infra.output.Severity
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RenderConfigErrorTest {
+
+  @Test
+  fun syntaxErrorIncludesLineNumberAndPath() {
+    val toml = "name = \"unclosed-string\nversion = \"0.1\"\n"
+    val err =
+      assertIs<ConfigError.ParseFailed>(parseConfig(toml, path = "/abs/kolt.toml").getError())
+    val diag = renderConfigError(err)
+    assertEquals(Severity.Error, diag.severity)
+    val first = diag.context.first()
+    assertTrue(first.contains("/abs/kolt.toml"), "missing path in: $first")
+    // Either path-only or path:lineNo, but lineNo should be there for syntax errors.
+    val lineNo = err.lineNo
+    assertNotNull(lineNo, "ktoml usually carries lineNo for syntax errors")
+    assertTrue(first.contains(":$lineNo"), "missing lineNo in: $first")
+  }
+
+  @Test
+  fun unknownTopLevelKeySurfacesSuggestion() {
+    // Unknown top-level scalar with a name close to a known section.
+    val toml =
+      """
+            name = "x"
+            version = "0.1"
+            koltn = "stray"
+
+            [kotlin]
+            version = "2.1.0"
+
+            [build]
+            target = "jvm"
+            sources = ["src"]
+            main = "com.example.main"
+        """
+        .trimIndent()
+    val err =
+      assertIs<ConfigError.ParseFailed>(parseConfig(toml, path = "/abs/kolt.toml").getError())
+    assertEquals("koltn", err.keyPath)
+    assertEquals("kotlin", err.suggestion)
+    val diag = renderConfigError(err)
+    assertContains(diag.context, "key: koltn")
+    assertEquals("Did you mean `kotlin`?", diag.hint)
+  }
+
+  @Test
+  fun unknownNestedKeyOmitsSuggestion() {
+    val toml =
+      """
+            name = "x"
+            version = "0.1"
+            [kotlin]
+            version = "2.1.0"
+            compilerr = "wrong"
+
+            [build]
+            target = "jvm"
+            sources = ["src"]
+            main = "com.example.main"
+        """
+        .trimIndent()
+    val err =
+      assertIs<ConfigError.ParseFailed>(parseConfig(toml, path = "/abs/kolt.toml").getError())
+    assertEquals("compilerr", err.keyPath, "expected nested unknown key path")
+    assertNull(err.suggestion, "nested unknowns must not surface a Did-you-mean")
+    val diag = renderConfigError(err)
+    assertContains(diag.context, "key: compilerr")
+    assertNull(diag.hint)
+  }
+
+  @Test
+  fun nullPathOmitsLocationLine() {
+    val err = ConfigError.ParseFailed("manual error", path = null, lineNo = null)
+    val diag = renderConfigError(err)
+    assertEquals(emptyList(), diag.context)
+    assertNull(diag.hint)
+  }
+
+  @Test
+  fun pathWithoutLineNoStillRendersLocation() {
+    val err = ConfigError.ParseFailed("manual error", path = "/abs/kolt.toml", lineNo = null)
+    val diag = renderConfigError(err)
+    assertContains(diag.context, "at /abs/kolt.toml")
+  }
+}

--- a/src/nativeTest/kotlin/kolt/infra/SpawnDetachedTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/SpawnDetachedTest.kt
@@ -61,4 +61,31 @@ class SpawnDetachedTest {
     val content = readFileAsString(logPath).get() ?: "<missing>"
     error("log capture failed. content so far:\n$content")
   }
+
+  // extraEnv lets callers inject NO_COLOR=1 (or similar) into a detached
+  // grandchild without contaminating the parent env. Verify the grandchild
+  // observes the entry by writing it through to a log file.
+  @Test
+  fun extraEnvIsVisibleInGrandchildEnvironment() {
+    val logPath = "$scratch.log"
+    deleteFile(logPath)
+    val result =
+      spawnDetached(
+        listOf("/bin/sh", "-c", "echo NO_COLOR=\$NO_COLOR"),
+        logPath = logPath,
+        extraEnv = mapOf("NO_COLOR" to "1"),
+      )
+    assertNull(result.getError(), "spawn failed: ${result.getError()}")
+    val deadline = kotlin.time.TimeSource.Monotonic.markNow().plus(kotlin.time.Duration.parse("2s"))
+    while (true) {
+      if (fileExists(logPath)) {
+        val content = readFileAsString(logPath).get() ?: ""
+        if (content.contains("NO_COLOR=1")) return
+      }
+      if (deadline.hasPassedNow()) break
+      platform.posix.usleep(20_000u)
+    }
+    val content = readFileAsString(logPath).get() ?: "<missing>"
+    error("extraEnv not propagated. log so far:\n$content")
+  }
 }

--- a/src/nativeTest/kotlin/kolt/infra/output/AnsiCodesTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/output/AnsiCodesTest.kt
@@ -1,0 +1,26 @@
+package kolt.infra.output
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AnsiCodesTest {
+  @Test
+  fun redIsCsi31m() {
+    assertEquals("[31m", AnsiCodes.RED)
+  }
+
+  @Test
+  fun yellowIsCsi33m() {
+    assertEquals("[33m", AnsiCodes.YELLOW)
+  }
+
+  @Test
+  fun cyanIsCsi36m() {
+    assertEquals("[36m", AnsiCodes.CYAN)
+  }
+
+  @Test
+  fun resetIsCsi0m() {
+    assertEquals("[0m", AnsiCodes.RESET)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/infra/output/AnsiStripperTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/output/AnsiStripperTest.kt
@@ -1,0 +1,39 @@
+package kolt.infra.output
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val ESC = ""
+
+class AnsiStripperTest {
+  @Test
+  fun stripsRedSequence() {
+    assertEquals("foo", AnsiStripper.strip("$ESC[31mfoo$ESC[0m"))
+  }
+
+  @Test
+  fun stripsMultipleSequencesInOneString() {
+    assertEquals(
+      "head body tail",
+      AnsiStripper.strip("$ESC[31mhead$ESC[0m $ESC[33mbody$ESC[0m $ESC[36mtail$ESC[0m"),
+    )
+  }
+
+  @Test
+  fun leavesPlainTextUnchanged() {
+    assertEquals("no escape here", AnsiStripper.strip("no escape here"))
+  }
+
+  @Test
+  fun stripsParameterizedCsi() {
+    assertEquals("emph", AnsiStripper.strip("$ESC[1;31memph$ESC[0m"))
+  }
+
+  @Test
+  fun preservesNewlinesAndPunctuation() {
+    assertEquals(
+      "line1\nline2: value",
+      AnsiStripper.strip("$ESC[31mline1$ESC[0m\n$ESC[33mline2:$ESC[0m value"),
+    )
+  }
+}

--- a/src/nativeTest/kotlin/kolt/infra/output/ColorPolicyTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/output/ColorPolicyTest.kt
@@ -1,0 +1,92 @@
+package kolt.infra.output
+
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ColorPolicyTest {
+  @AfterTest
+  fun resetGlobal() {
+    ColorPolicy.install(ColorPolicy.Never)
+  }
+
+  @Test
+  fun noColorFlagYieldsNever() {
+    val policy = resolveColorPolicy(noColorFlag = true, getEnv = { null }, isTty = { _ -> true })
+    assertEquals(ColorPolicy.Never, policy)
+  }
+
+  @Test
+  fun noColorEnvYieldsNever() {
+    val policy =
+      resolveColorPolicy(
+        noColorFlag = false,
+        getEnv = { if (it == "NO_COLOR") "1" else null },
+        isTty = { _ -> true },
+      )
+    assertEquals(ColorPolicy.Never, policy)
+  }
+
+  @Test
+  fun emptyNoColorEnvIsIgnored() {
+    // no-color.org spec: NO_COLOR must be set to a non-empty string to take effect.
+    val policy =
+      resolveColorPolicy(
+        noColorFlag = false,
+        getEnv = { if (it == "NO_COLOR") "" else null },
+        isTty = { _ -> true },
+      )
+    assertEquals(ColorPolicy.Auto(isStderrTty = true, isStdoutTty = true), policy)
+  }
+
+  @Test
+  fun bothFlagAndEnvYieldNever() {
+    val policy =
+      resolveColorPolicy(
+        noColorFlag = true,
+        getEnv = { if (it == "NO_COLOR") "1" else null },
+        isTty = { _ -> true },
+      )
+    assertEquals(ColorPolicy.Never, policy)
+  }
+
+  @Test
+  fun autoReflectsPerStreamTtyState() {
+    val policy =
+      resolveColorPolicy(
+        noColorFlag = false,
+        getEnv = { null },
+        // STDERR_FILENO=2, STDOUT_FILENO=1
+        isTty = { fd -> fd == 2 },
+      )
+    assertEquals(ColorPolicy.Auto(isStderrTty = true, isStdoutTty = false), policy)
+  }
+
+  @Test
+  fun shouldColorAlwaysReturnsTrue() {
+    assertTrue(ColorPolicy.Always.shouldColor(Stream.Stderr))
+    assertTrue(ColorPolicy.Always.shouldColor(Stream.Stdout))
+  }
+
+  @Test
+  fun shouldColorNeverReturnsFalse() {
+    assertEquals(false, ColorPolicy.Never.shouldColor(Stream.Stderr))
+    assertEquals(false, ColorPolicy.Never.shouldColor(Stream.Stdout))
+  }
+
+  @Test
+  fun shouldColorAutoUsesPerStreamTty() {
+    val policy = ColorPolicy.Auto(isStderrTty = true, isStdoutTty = false)
+    assertTrue(policy.shouldColor(Stream.Stderr))
+    assertEquals(false, policy.shouldColor(Stream.Stdout))
+  }
+
+  @Test
+  fun installAndCurrentRoundTrip() {
+    ColorPolicy.install(ColorPolicy.Always)
+    assertEquals(ColorPolicy.Always, ColorPolicy.current())
+    ColorPolicy.install(ColorPolicy.Never)
+    assertEquals(ColorPolicy.Never, ColorPolicy.current())
+  }
+}

--- a/src/nativeTest/kotlin/kolt/infra/output/DiagnosticWriterTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/output/DiagnosticWriterTest.kt
@@ -1,0 +1,204 @@
+package kolt.infra.output
+
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private val ESC = Char(0x1B).toString()
+
+class DiagnosticWriterTest {
+
+  @AfterTest
+  fun resetGlobal() {
+    ColorPolicy.install(ColorPolicy.Never)
+  }
+
+  // --- color disabled (Never) -----------------------------------------------
+
+  @Test
+  fun errorHeadlineOnlyPlain() {
+    val lines =
+      renderDiagnostic(RenderedDiagnostic(Severity.Error, "boom"), policy = ColorPolicy.Never)
+    assertEquals(listOf("error: boom"), lines)
+  }
+
+  @Test
+  fun warningHeadlineOnlyPlain() {
+    val lines =
+      renderDiagnostic(
+        RenderedDiagnostic(Severity.Warning, "stale lockfile"),
+        policy = ColorPolicy.Never,
+      )
+    assertEquals(listOf("warning: stale lockfile"), lines)
+  }
+
+  @Test
+  fun noteHeadlineOnlyPlain() {
+    val lines =
+      renderDiagnostic(RenderedDiagnostic(Severity.Note, "hint here"), policy = ColorPolicy.Never)
+    assertEquals(listOf("note: hint here"), lines)
+  }
+
+  @Test
+  fun headlinePlusContextIndents() {
+    val lines =
+      renderDiagnostic(
+        RenderedDiagnostic(
+          severity = Severity.Error,
+          headline = "parse failed",
+          context = listOf("at /tmp/kolt.toml:5", "key: kotlin"),
+        ),
+        policy = ColorPolicy.Never,
+      )
+    assertEquals(listOf("error: parse failed", "  at /tmp/kolt.toml:5", "  key: kotlin"), lines)
+  }
+
+  @Test
+  fun headlinePlusHintEmitsNoteLine() {
+    val lines =
+      renderDiagnostic(
+        RenderedDiagnostic(
+          severity = Severity.Error,
+          headline = "lockfile out of date",
+          hint = "Run `kolt update`",
+        ),
+        policy = ColorPolicy.Never,
+      )
+    assertEquals(listOf("error: lockfile out of date", "note: Run `kolt update`"), lines)
+  }
+
+  @Test
+  fun headlinePlusContextPlusHint() {
+    val lines =
+      renderDiagnostic(
+        RenderedDiagnostic(
+          severity = Severity.Error,
+          headline = "parse failed",
+          context = listOf("at /a.toml:1"),
+          hint = "Did you mean `kotlin`?",
+        ),
+        policy = ColorPolicy.Never,
+      )
+    assertEquals(
+      listOf("error: parse failed", "  at /a.toml:1", "note: Did you mean `kotlin`?"),
+      lines,
+    )
+  }
+
+  // --- color enabled (Always) -----------------------------------------------
+
+  @Test
+  fun errorHeadlineWrappedWithRedAnsi() {
+    val lines =
+      renderDiagnostic(RenderedDiagnostic(Severity.Error, "boom"), policy = ColorPolicy.Always)
+    assertEquals(listOf("$ESC[31merror:$ESC[0m boom"), lines)
+  }
+
+  @Test
+  fun warningHeadlineWrappedWithYellowAnsi() {
+    val lines =
+      renderDiagnostic(
+        RenderedDiagnostic(Severity.Warning, "be careful"),
+        policy = ColorPolicy.Always,
+      )
+    assertEquals(listOf("$ESC[33mwarning:$ESC[0m be careful"), lines)
+  }
+
+  @Test
+  fun noteHeadlineWrappedWithCyanAnsi() {
+    val lines =
+      renderDiagnostic(RenderedDiagnostic(Severity.Note, "fyi"), policy = ColorPolicy.Always)
+    assertEquals(listOf("$ESC[36mnote:$ESC[0m fyi"), lines)
+  }
+
+  @Test
+  fun hintLineUsesCyanNotePrefixWhenColorEnabled() {
+    val lines =
+      renderDiagnostic(
+        RenderedDiagnostic(
+          severity = Severity.Error,
+          headline = "lockfile out of date",
+          hint = "Run `kolt update`",
+        ),
+        policy = ColorPolicy.Always,
+      )
+    assertEquals(
+      listOf(
+        "$ESC[31merror:$ESC[0m lockfile out of date",
+        "$ESC[36mnote:$ESC[0m Run `kolt update`",
+      ),
+      lines,
+    )
+  }
+
+  @Test
+  fun contextLinesAreNotColored() {
+    val lines =
+      renderDiagnostic(
+        RenderedDiagnostic(severity = Severity.Error, headline = "h", context = listOf("c1", "c2")),
+        policy = ColorPolicy.Always,
+      )
+    assertEquals(listOf("$ESC[31merror:$ESC[0m h", "  c1", "  c2"), lines)
+  }
+
+  @Test
+  fun autoPolicyWritesToStderrAccordingToStderrTtyState() {
+    val lines =
+      renderDiagnostic(
+        RenderedDiagnostic(Severity.Error, "h"),
+        policy = ColorPolicy.Auto(isStderrTty = false, isStdoutTty = true),
+      )
+    assertEquals(listOf("error: h"), lines)
+  }
+
+  // --- public API uses default policy from ColorPolicy.current() ------------
+
+  @Test
+  fun defaultPolicyIsColorPolicyCurrent() {
+    ColorPolicy.install(ColorPolicy.Always)
+    val collected = mutableListOf<String>()
+    eprintDiagnostic(RenderedDiagnostic(Severity.Error, "h"), sink = { collected += it })
+    assertEquals(listOf("$ESC[31merror:$ESC[0m h"), collected)
+  }
+
+  @Test
+  fun explicitPolicyOverridesCurrent() {
+    ColorPolicy.install(ColorPolicy.Always)
+    val collected = mutableListOf<String>()
+    eprintDiagnostic(
+      RenderedDiagnostic(Severity.Error, "h"),
+      policy = ColorPolicy.Never,
+      sink = { collected += it },
+    )
+    assertEquals(listOf("error: h"), collected)
+  }
+
+  // --- thin convenience wrappers --------------------------------------------
+
+  @Test
+  fun eprintErrorDelegatesToDiagnostic() {
+    val collected = mutableListOf<String>()
+    eprintError(
+      "boom",
+      context = listOf("at /a"),
+      hint = "fix it",
+      policy = ColorPolicy.Never,
+      sink = { collected += it },
+    )
+    assertEquals(listOf("error: boom", "  at /a", "note: fix it"), collected)
+  }
+
+  @Test
+  fun eprintWarningDelegatesToDiagnostic() {
+    val collected = mutableListOf<String>()
+    eprintWarning("careful", policy = ColorPolicy.Never, sink = { collected += it })
+    assertEquals(listOf("warning: careful"), collected)
+  }
+
+  @Test
+  fun eprintNoteDelegatesToDiagnostic() {
+    val collected = mutableListOf<String>()
+    eprintNote("fyi", policy = ColorPolicy.Never, sink = { collected += it })
+    assertEquals(listOf("note: fyi"), collected)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/infra/output/MaybeStripAnsiTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/output/MaybeStripAnsiTest.kt
@@ -1,0 +1,51 @@
+package kolt.infra.output
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val ESC = ""
+
+class MaybeStripAnsiTest {
+  @Test
+  fun stripsAnsiWhenPolicyIsNever() {
+    assertEquals("error: foo\n", maybeStripAnsi("error: $ESC[31mfoo$ESC[0m\n", ColorPolicy.Never))
+  }
+
+  @Test
+  fun preservesAnsiWhenPolicyIsAlways() {
+    val body = "error: $ESC[31mfoo$ESC[0m\n"
+    assertEquals(body, maybeStripAnsi(body, ColorPolicy.Always))
+  }
+
+  @Test
+  fun stripsMultipleSequencesWhenPolicyIsNever() {
+    assertEquals(
+      "head body tail",
+      maybeStripAnsi(
+        "$ESC[31mhead$ESC[0m $ESC[33mbody$ESC[0m $ESC[36mtail$ESC[0m",
+        ColorPolicy.Never,
+      ),
+    )
+  }
+
+  @Test
+  fun leavesPlainTextUnchangedUnderEitherPolicy() {
+    val plain = "no escape here"
+    assertEquals(plain, maybeStripAnsi(plain, ColorPolicy.Never))
+    assertEquals(plain, maybeStripAnsi(plain, ColorPolicy.Always))
+  }
+
+  @Test
+  fun autoPolicyStripsWhenStderrIsNotTty() {
+    val body = "error: $ESC[31mfoo$ESC[0m\n"
+    val policy = ColorPolicy.Auto(isStderrTty = false, isStdoutTty = false)
+    assertEquals("error: foo\n", maybeStripAnsi(body, policy))
+  }
+
+  @Test
+  fun autoPolicyPreservesWhenStderrIsTty() {
+    val body = "error: $ESC[31mfoo$ESC[0m\n"
+    val policy = ColorPolicy.Auto(isStderrTty = true, isStdoutTty = false)
+    assertEquals(body, maybeStripAnsi(body, policy))
+  }
+}

--- a/src/nativeTest/kotlin/kolt/infra/output/RenderedDiagnosticTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/output/RenderedDiagnosticTest.kt
@@ -1,0 +1,50 @@
+package kolt.infra.output
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+class RenderedDiagnosticTest {
+  @Test
+  fun headlineOnlyHasEmptyContextAndNullHint() {
+    val diag = RenderedDiagnostic(Severity.Error, "boom")
+    assertEquals(Severity.Error, diag.severity)
+    assertEquals("boom", diag.headline)
+    assertEquals(emptyList(), diag.context)
+    assertNull(diag.hint)
+  }
+
+  @Test
+  fun fullShape() {
+    val diag =
+      RenderedDiagnostic(
+        severity = Severity.Warning,
+        headline = "stale lockfile",
+        context = listOf("at /tmp/kolt.lock", "key: dependencies"),
+        hint = "Run `kolt update`",
+      )
+    assertEquals("stale lockfile", diag.headline)
+    assertEquals(listOf("at /tmp/kolt.lock", "key: dependencies"), diag.context)
+    assertEquals("Run `kolt update`", diag.hint)
+  }
+
+  @Test
+  fun equalityIsValueBased() {
+    val a = RenderedDiagnostic(Severity.Note, "hi", listOf("x"), "y")
+    val b = RenderedDiagnostic(Severity.Note, "hi", listOf("x"), "y")
+    val c = RenderedDiagnostic(Severity.Note, "hi", listOf("x"), null)
+    assertEquals(a, b)
+    assertNotEquals(a, c)
+  }
+
+  @Test
+  fun copyKeepsUnspecifiedFields() {
+    val original = RenderedDiagnostic(Severity.Error, "first", listOf("a"), null)
+    val updated = original.copy(headline = "second")
+    assertEquals("second", updated.headline)
+    assertEquals(Severity.Error, updated.severity)
+    assertEquals(listOf("a"), updated.context)
+    assertNull(updated.hint)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/infra/output/SeverityTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/output/SeverityTest.kt
@@ -1,0 +1,22 @@
+package kolt.infra.output
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SeverityTest {
+  @Test
+  fun threeDistinctValues() {
+    assertEquals(3, Severity.entries.size)
+    assertNotEquals(Severity.Error, Severity.Warning)
+    assertNotEquals(Severity.Warning, Severity.Note)
+    assertNotEquals(Severity.Error, Severity.Note)
+  }
+
+  @Test
+  fun namesArePinned() {
+    assertEquals("Error", Severity.Error.name)
+    assertEquals("Warning", Severity.Warning.name)
+    assertEquals("Note", Severity.Note.name)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/infra/suggest/ClosestMatchTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/suggest/ClosestMatchTest.kt
@@ -1,0 +1,76 @@
+package kolt.infra.suggest
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ClosestMatchTest {
+  @Test
+  fun returnsExactMatchAtDistanceZero() {
+    assertEquals("build", closestMatch("build", listOf("build", "test", "fmt")))
+  }
+
+  @Test
+  fun returnsTransposedCandidateWithinThreshold() {
+    // "buidl" vs "build" is distance 2 (two substitutions, no transposition
+    // shortcut in plain Levenshtein); length 5 → adaptive threshold 2 → match.
+    assertEquals("build", closestMatch("buidl", listOf("build", "test", "fmt")))
+  }
+
+  @Test
+  fun returnsCandidateForLongerTypoWithinThreshold() {
+    // longer input, adaptive threshold 2.
+    assertEquals("dependencies", closestMatch("dependncies", listOf("dependencies")))
+  }
+
+  @Test
+  fun returnsNullWhenAllCandidatesExceedThreshold() {
+    // "zzzzz" vs "build" / "test" — distance > 2 for both, no match
+    assertNull(closestMatch("zzzzz", listOf("build", "test")))
+  }
+
+  @Test
+  fun returnsNullForEmptyCandidates() {
+    assertNull(closestMatch("anything", emptyList()))
+  }
+
+  @Test
+  fun returnsLexFirstForTiedDistances() {
+    // both "alpha" and "alphb" are distance 1 from "alphz"; sorted input
+    // returns the first encountered which happens to be lex-smallest.
+    val candidates = listOf("alpha", "alphb")
+    assertEquals("alpha", closestMatch("alphz", candidates))
+  }
+
+  @Test
+  fun shorterInputUsesTighterThreshold() {
+    // input length 3 (<=4) → threshold 1
+    // "abc" vs "xyz" is distance 3 → null even though longer-input mode would allow distance 2
+    assertNull(closestMatch("abc", listOf("xyz")))
+  }
+
+  @Test
+  fun explicitMaxDistanceOverridesAdaptive() {
+    // override threshold to 3 — "abc"/"xyz" distance 3 now matches.
+    assertEquals("xyz", closestMatch("abc", listOf("xyz"), maxDistance = 3))
+  }
+
+  @Test
+  fun adaptiveThresholdBoundary() {
+    // length 4 → threshold 1; length 5 → threshold 2.
+    assertEquals(1, adaptiveThreshold(4))
+    assertEquals(2, adaptiveThreshold(5))
+    assertEquals(1, adaptiveThreshold(1))
+    assertEquals(2, adaptiveThreshold(100))
+  }
+
+  @Test
+  fun deterministicOrderingFromCallerInput() {
+    // Same input with same candidate list always returns the same result.
+    // "buidl" → "build" exercises a length-5 input (adaptive threshold 2)
+    // matching at edit distance 2.
+    val candidates = listOf("build", "check", "clean", "fmt", "info", "run", "test")
+    assertEquals("build", closestMatch("buidl", candidates))
+    assertEquals("build", closestMatch("buidl", candidates))
+  }
+}

--- a/src/nativeTest/kotlin/kolt/infra/suggest/LevenshteinTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/suggest/LevenshteinTest.kt
@@ -1,0 +1,48 @@
+package kolt.infra.suggest
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LevenshteinTest {
+  @Test
+  fun identicalStringsHaveDistanceZero() {
+    assertEquals(0, levenshtein("foo", "foo"))
+  }
+
+  @Test
+  fun singleDeletionHasDistanceOne() {
+    assertEquals(1, levenshtein("foo", "fo"))
+  }
+
+  @Test
+  fun singleInsertionHasDistanceOne() {
+    assertEquals(1, levenshtein("fo", "foo"))
+  }
+
+  @Test
+  fun singleSubstitutionHasDistanceOne() {
+    assertEquals(1, levenshtein("foo", "fox"))
+  }
+
+  @Test
+  fun emptyVsNonEmptyEqualsLengthOfNonEmpty() {
+    assertEquals(3, levenshtein("", "abc"))
+    assertEquals(3, levenshtein("abc", ""))
+  }
+
+  @Test
+  fun bothEmptyEqualsZero() {
+    assertEquals(0, levenshtein("", ""))
+  }
+
+  @Test
+  fun mixedEditsCombineCorrectly() {
+    // "kitten" → "sitting" : 3 edits (k→s, e→i, +g)
+    assertEquals(3, levenshtein("kitten", "sitting"))
+  }
+
+  @Test
+  fun isSymmetric() {
+    assertEquals(levenshtein("alpha", "beta"), levenshtein("beta", "alpha"))
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -830,7 +830,7 @@ class NativeResolverTest {
     val error = assertIs<ResolveError.StrictVersionConflict>(result.getError())
     assertEquals("com.example:shared", error.groupArtifact)
     assertTrue(error.otherIsStrict)
-    assertTrue(formatResolveError(error).contains("conflicting strict versions"))
+    assertTrue(formatResolveError(error).headline.contains("conflicting strict versions"))
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveErrorFormatTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveErrorFormatTest.kt
@@ -2,9 +2,10 @@ package kolt.resolve
 
 import kolt.infra.DownloadError
 import kolt.infra.Sha256Error
+import kolt.infra.output.Severity
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ResolveErrorFormatTest {
@@ -12,7 +13,11 @@ class ResolveErrorFormatTest {
   @Test
   fun invalidDependencyFormat() {
     val error = ResolveError.InvalidDependency("bad:dep")
-    assertEquals("error: invalid dependency 'bad:dep'", formatResolveError(error))
+    val diag = formatResolveError(error)
+    assertEquals(Severity.Error, diag.severity)
+    assertEquals("invalid dependency 'bad:dep'", diag.headline)
+    assertEquals(emptyList(), diag.context)
+    assertNull(diag.hint)
   }
 
   @Test
@@ -23,10 +28,9 @@ class ResolveErrorFormatTest {
         expected = "abc123",
         actual = "def456",
       )
-    val result = formatResolveError(error)
-    assertTrue(result.contains("sha256 mismatch for com.example:lib"))
-    assertTrue(result.contains("expected: abc123"))
-    assertTrue(result.contains("got:      def456"))
+    val diag = formatResolveError(error)
+    assertEquals("sha256 mismatch for com.example:lib", diag.headline)
+    assertEquals(listOf("expected: abc123", "got:      def456"), diag.context)
   }
 
   @Test
@@ -46,10 +50,11 @@ class ResolveErrorFormatTest {
           )
         ),
       )
+    val diag = formatResolveError(error)
+    assertEquals("failed to download com.example:lib", diag.headline)
     assertEquals(
-      "error: failed to download com.example:lib\n" +
-        "  https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar -> 404",
-      formatResolveError(error),
+      listOf("https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar -> 404"),
+      diag.context,
     )
   }
 
@@ -71,12 +76,19 @@ class ResolveErrorFormatTest {
           )
         ),
       )
-    val rendered = formatResolveError(error)
-    assertTrue(rendered.contains("error: failed to download com.example:lib"))
+    val diag = formatResolveError(error)
+    assertEquals("failed to download com.example:lib", diag.headline)
+    assertEquals(2, diag.context.size)
     assertTrue(
-      rendered.contains("https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar -> 404")
+      diag.context.any {
+        it.contains("https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar -> 404")
+      }
     )
-    assertTrue(rendered.contains("https://jitpack.io/com/example/lib/1.0.0/lib-1.0.0.jar -> 404"))
+    assertTrue(
+      diag.context.any {
+        it.contains("https://jitpack.io/com/example/lib/1.0.0/lib-1.0.0.jar -> 404")
+      }
+    )
   }
 
   @Test
@@ -96,10 +108,11 @@ class ResolveErrorFormatTest {
           )
         ),
       )
+    val diag = formatResolveError(error)
+    assertEquals("failed to download com.example:lib", diag.headline)
     assertEquals(
-      "error: failed to download com.example:lib\n" +
-        "  https://example.com/lib-1.0.0.jar -> Could not resolve host",
-      formatResolveError(error),
+      listOf("https://example.com/lib-1.0.0.jar -> Could not resolve host"),
+      diag.context,
     )
   }
 
@@ -110,10 +123,11 @@ class ResolveErrorFormatTest {
         "com.example:lib",
         RepositoryDownloadFailure.NoRepositoriesConfigured,
       )
+    val diag = formatResolveError(error)
+    assertEquals("failed to download com.example:lib", diag.headline)
     assertEquals(
-      "error: failed to download com.example:lib\n" +
-        "  no repositories configured (add a `[repositories]` entry to kolt.toml)",
-      formatResolveError(error),
+      listOf("no repositories configured (add a `[repositories]` entry to kolt.toml)"),
+      diag.context,
     )
   }
 
@@ -134,9 +148,9 @@ class ResolveErrorFormatTest {
           )
         ),
       )
-    val rendered = formatResolveError(error)
-    assertTrue(rendered.contains("local write failed (/cache/lib-1.0.0.jar.tmp.42)"))
-    assertFalse(rendered.contains("write failed: "), "old framing must not regress")
+    val diag = formatResolveError(error)
+    assertTrue(diag.context.any { it.contains("local write failed (/cache/lib-1.0.0.jar.tmp.42)") })
+    assertTrue(diag.context.none { it.contains("write failed: ") }, "old framing must not regress")
   }
 
   @Test
@@ -153,10 +167,11 @@ class ResolveErrorFormatTest {
           )
         ),
       )
+    val diag = formatResolveError(error)
+    assertEquals("could not fetch metadata for com.example:lib", diag.headline)
     assertEquals(
-      "error: could not fetch metadata for com.example:lib\n" +
-        "  https://repo1.maven.org/maven2/com/example/lib/maven-metadata.xml -> 404",
-      formatResolveError(error),
+      listOf("https://repo1.maven.org/maven2/com/example/lib/maven-metadata.xml -> 404"),
+      diag.context,
     )
   }
 
@@ -167,49 +182,103 @@ class ResolveErrorFormatTest {
         "com.example:lib",
         RepositoryDownloadFailure.NoRepositoriesConfigured,
       )
+    val diag = formatResolveError(error)
+    assertEquals("could not fetch metadata for com.example:lib", diag.headline)
     assertEquals(
-      "error: could not fetch metadata for com.example:lib\n" +
-        "  no repositories configured (add a `[repositories]` entry to kolt.toml)",
-      formatResolveError(error),
+      listOf("no repositories configured (add a `[repositories]` entry to kolt.toml)"),
+      diag.context,
     )
   }
 
   @Test
   fun hashComputeFailedFormat() {
     val error = ResolveError.HashComputeFailed("com.example:lib", Sha256Error("/path/to/file"))
-    assertEquals("error: failed to compute hash for com.example:lib", formatResolveError(error))
+    val diag = formatResolveError(error)
+    assertEquals("failed to compute hash for com.example:lib", diag.headline)
+    assertEquals(emptyList(), diag.context)
   }
 
   @Test
   fun directoryCreateFailedFormat() {
     val error = ResolveError.DirectoryCreateFailed("/cache/dir")
-    assertEquals("error: could not create directory /cache/dir", formatResolveError(error))
+    val diag = formatResolveError(error)
+    assertEquals("could not create directory /cache/dir", diag.headline)
   }
 
   @Test
   fun noNativeVariantFormat() {
     val error = ResolveError.NoNativeVariant("com.example:lib", "linux_x64")
+    val diag = formatResolveError(error)
     assertEquals(
-      "error: com.example:lib has no Kotlin/Native variant for target 'linux_x64'",
-      formatResolveError(error),
+      "com.example:lib has no Kotlin/Native variant for target 'linux_x64'",
+      diag.headline,
     )
   }
 
   @Test
   fun metadataParseFailedFormat() {
     val error = ResolveError.MetadataParseFailed("com.example:lib")
-    assertEquals(
-      "error: failed to parse Gradle module metadata for com.example:lib",
-      formatResolveError(error),
-    )
+    val diag = formatResolveError(error)
+    assertEquals("failed to parse Gradle module metadata for com.example:lib", diag.headline)
   }
 
   @Test
   fun metadataFetchFailedFormat() {
     val error = ResolveError.MetadataFetchFailed("com.example:lib")
+    val diag = formatResolveError(error)
+    assertEquals("failed to read Gradle module metadata for com.example:lib", diag.headline)
+  }
+
+  @Test
+  fun strictVersionConflictBothStrict() {
+    val error =
+      ResolveError.StrictVersionConflict(
+        groupArtifact = "com.example:lib",
+        strictVersion = "1.0",
+        otherVersion = "2.0",
+        otherIsStrict = true,
+      )
+    val diag = formatResolveError(error)
+    assertEquals("conflicting strict versions on com.example:lib: 1.0 and 2.0", diag.headline)
+  }
+
+  @Test
+  fun strictVersionConflictMixed() {
+    val error =
+      ResolveError.StrictVersionConflict(
+        groupArtifact = "com.example:lib",
+        strictVersion = "1.0",
+        otherVersion = "2.0",
+        otherIsStrict = false,
+      )
+    val diag = formatResolveError(error)
     assertEquals(
-      "error: failed to read Gradle module metadata for com.example:lib",
-      formatResolveError(error),
+      "strict version conflict on com.example:lib: " +
+        "1.0 required strictly, but 2.0 also requested",
+      diag.headline,
     )
+  }
+
+  @Test
+  fun rejectedVersionResolvedFormat() {
+    val error = ResolveError.RejectedVersionResolved("com.example:lib", "1.0", "<2.0")
+    val diag = formatResolveError(error)
+    assertEquals("resolved com.example:lib:1.0 is rejected by constraint '<2.0'", diag.headline)
+  }
+
+  @Test
+  fun severityIsAlwaysError() {
+    val variants =
+      listOf(
+        ResolveError.InvalidDependency("a:b"),
+        ResolveError.Sha256Mismatch("a:b", "x", "y"),
+        ResolveError.HashComputeFailed("a:b", Sha256Error("/p")),
+        ResolveError.DirectoryCreateFailed("/p"),
+        ResolveError.MetadataParseFailed("a:b"),
+        ResolveError.MetadataFetchFailed("a:b"),
+      )
+    for (v in variants) {
+      assertEquals(Severity.Error, formatResolveError(v).severity, v::class.simpleName)
+    }
   }
 }

--- a/src/nativeTest/kotlin/kolt/usertool/ToolErrorTest.kt
+++ b/src/nativeTest/kotlin/kolt/usertool/ToolErrorTest.kt
@@ -20,8 +20,8 @@ class ToolErrorTest {
       ToolError.Parse(ToolSectionParseError.InvalidAlias(alias = "Foo", reason = "uppercase"))
     assertEquals(EXIT_CONFIG_ERROR, err.toExitCode())
     assertTrue(
-      err.formatStderr().startsWith("tool 'Foo': parse error:"),
-      "got: ${err.formatStderr()}",
+      err.render().headline.startsWith("tool 'Foo': parse error:"),
+      "got: ${err.render().headline}",
     )
   }
 
@@ -30,8 +30,8 @@ class ToolErrorTest {
     val err =
       ToolError.Parse(ToolSectionParseError.ForbiddenField(alias = "ktlint", field = "depends-on"))
     assertEquals(EXIT_CONFIG_ERROR, err.toExitCode())
-    assertTrue(err.formatStderr().startsWith("tool 'ktlint': parse error:"))
-    assertTrue(err.formatStderr().contains("depends-on"))
+    assertTrue(err.render().headline.startsWith("tool 'ktlint': parse error:"))
+    assertTrue(err.render().headline.contains("depends-on"))
   }
 
   @Test
@@ -41,21 +41,21 @@ class ToolErrorTest {
         ToolSectionParseError.MalformedCoords(alias = "ktlint", coords = "bogus", reason = "shape")
       )
     assertEquals(EXIT_CONFIG_ERROR, err.toExitCode())
-    assertTrue(err.formatStderr().startsWith("tool 'ktlint': parse error:"))
+    assertTrue(err.render().headline.startsWith("tool 'ktlint': parse error:"))
   }
 
   @Test
   fun parseMissingCoordsMapsToConfigExitCodeAndPrefix() {
     val err = ToolError.Parse(ToolSectionParseError.MissingCoords(alias = "ktlint"))
     assertEquals(EXIT_CONFIG_ERROR, err.toExitCode())
-    assertTrue(err.formatStderr().startsWith("tool 'ktlint': parse error:"))
+    assertTrue(err.render().headline.startsWith("tool 'ktlint': parse error:"))
   }
 
   @Test
   fun parseDuplicateAliasMapsToConfigExitCodeAndPrefix() {
     val err = ToolError.Parse(ToolSectionParseError.DuplicateAlias(alias = "ktlint"))
     assertEquals(EXIT_CONFIG_ERROR, err.toExitCode())
-    assertTrue(err.formatStderr().startsWith("tool 'ktlint': parse error:"))
+    assertTrue(err.render().headline.startsWith("tool 'ktlint': parse error:"))
   }
 
   // Resolve variants — surface as EXIT_DEPENDENCY_ERROR (network/integrity/lock semantics).
@@ -72,7 +72,7 @@ class ToolErrorTest {
         )
       )
     assertEquals(EXIT_DEPENDENCY_ERROR, err.toExitCode())
-    assertTrue(err.formatStderr().startsWith("tool 'ktlint': resolve failed:"))
+    assertTrue(err.render().headline.startsWith("tool 'ktlint': resolve failed:"))
   }
 
   @Test
@@ -87,12 +87,14 @@ class ToolErrorTest {
         )
       )
     assertEquals(EXIT_DEPENDENCY_ERROR, err.toExitCode())
-    assertTrue(err.formatStderr().startsWith("tool 'ktlint': integrity mismatch:"))
-    assertTrue(err.formatStderr().contains("abc"))
-    assertTrue(err.formatStderr().contains("def"))
+    assertTrue(err.render().headline.startsWith("tool 'ktlint': integrity mismatch:"))
+    assertTrue(err.render().headline.contains("abc"))
+    assertTrue(err.render().headline.contains("def"))
   }
 
-  // LockfileMismatch's stderr message is design-mandated verbatim — pin it.
+  // LockfileMismatch's stderr message is design-mandated — the headline pins
+  // the differs-from text and the hint slot carries the recovery command so
+  // the writer can render them as `error: ...` then `note: ...`.
   @Test
   fun resolveLockfileMismatchUsesDesignMandatedMessage() {
     val err =
@@ -106,11 +108,12 @@ class ToolErrorTest {
         )
       )
     assertEquals(EXIT_DEPENDENCY_ERROR, err.toExitCode())
+    val diag = err.render()
     assertEquals(
-      "tool 'ktlint': lockfile pin 'g:a:1.0' differs from kolt.toml 'g:a:1.1'. " +
-        "Run `kolt update` to refresh tool pins.",
-      err.formatStderr(),
+      "tool 'ktlint': lockfile pin 'g:a:1.0' differs from kolt.toml 'g:a:1.1'",
+      diag.headline,
     )
+    assertEquals("Run `kolt update` to refresh tool pins.", diag.hint)
   }
 
   @Test
@@ -125,11 +128,12 @@ class ToolErrorTest {
           lockedClassifier = "all",
         )
       )
+    val diag = err.render()
     assertEquals(
-      "tool 'ktlint': lockfile pin 'g:a:1.0:all' differs from kolt.toml 'g:a:1.1:all'. " +
-        "Run `kolt update` to refresh tool pins.",
-      err.formatStderr(),
+      "tool 'ktlint': lockfile pin 'g:a:1.0:all' differs from kolt.toml 'g:a:1.1:all'",
+      diag.headline,
     )
+    assertEquals("Run `kolt update` to refresh tool pins.", diag.hint)
   }
 
   // Launch variants — the only three that route through EXIT_TOOL_ERROR=7.
@@ -145,7 +149,7 @@ class ToolErrorTest {
         )
       )
     assertEquals(EXIT_TOOL_ERROR, err.toExitCode())
-    assertTrue(err.formatStderr().startsWith("tool 'ktlint': not a runnable jar"))
+    assertTrue(err.render().headline.startsWith("tool 'ktlint': not a runnable jar"))
   }
 
   @Test
@@ -153,14 +157,14 @@ class ToolErrorTest {
     val err =
       ToolError.Launch(ToolLaunchError.MainClassMissing(alias = "ktlint", jarPath = "/x/y.jar"))
     assertEquals(EXIT_TOOL_ERROR, err.toExitCode())
-    assertTrue(err.formatStderr().startsWith("tool 'ktlint': Main-Class missing"))
+    assertTrue(err.render().headline.startsWith("tool 'ktlint': Main-Class missing"))
   }
 
   @Test
   fun launchJdkUnavailableMapsToToolExitCodeAndPrefix() {
     val err = ToolError.Launch(ToolLaunchError.JdkUnavailable(cause = "install failed"))
     assertEquals(EXIT_TOOL_ERROR, err.toExitCode())
-    assertTrue(err.formatStderr().startsWith("tool: JDK unavailable:"))
+    assertTrue(err.render().headline.startsWith("tool: JDK unavailable:"))
   }
 
   // UnknownAlias is config-shaped — exit 2 — and surfaces known aliases.
@@ -168,7 +172,7 @@ class ToolErrorTest {
   fun unknownAliasMapsToConfigExitCodeAndListsKnownAliases() {
     val err = ToolError.UnknownAlias(alias = "ktl", knownAliases = listOf("ktlint", "detekt"))
     assertEquals(EXIT_CONFIG_ERROR, err.toExitCode())
-    val msg = err.formatStderr()
+    val msg = err.render().headline
     assertTrue(msg.startsWith("tool 'ktl': not declared in [tools]."))
     assertTrue(msg.contains("ktlint"))
     assertTrue(msg.contains("detekt"))


### PR DESCRIPTION
Closes #2.

Issue #2 (v1.0 Phase 5 DX) を spec `2-error-output-formatting` でまとめて完了。 全 22 サブタスク (1.1-8.4) を 25 commit に分けて積み、 cli の severity 統一・color 制御・kolt.toml enrichment・Did-you-mean・kotlinc/konanc NO_COLOR 連携を Cargo / Go bar で揃える。

PR は当初前半 (1.1-5.3) で開いた状態のまま、 後半 (6.1-8.4) を同 branch に追加した。 旧 body の前半 review note は依然有効、 以下は後半の追加分を補う。

## 後半で増えたもの

- subprocess 4 backend (`SubprocessCompilerBackend` / `NativeSubprocessBackend` / `DaemonCompilerBackend` / `NativeDaemonBackend`) に `colorPolicy: () -> ColorPolicy = ColorPolicy::current` の同形 seam を追加し、 `if (!colorPolicy().shouldColor(Stream.Stderr)) put(\"NO_COLOR\", \"1\")` を env injection。 caller (`BuildCommands` 等) は ColorPolicy を意識しない。
- `kolt.infra.spawnDetached` を `extraEnv: Map<String, String> = emptyMap()` 受けに拡張し、 `setenv` を `setsid()` 後 `execvp` 前に挿入。 `SpawnDetachedTest.extraEnvIsVisibleInGrandchildEnvironment` で grandchild (kotlinc / konanc) まで env が確実に伝わることを end-to-end 検証。
- daemon が string blob で返す stderr に対して `BuildCommands.kt:536/782/1179` の 3 forward 点で `maybeStripAnsi(body, policy)` を caller-side gate にかける。 R6.1 (kolt prefix を forwarded body に付けない) と R6.4 (1 headline + verbatim body) の ordering pattern は不変。
- `BuildCommands` / `DependencyCommands` + 13 cli ファイルで raw `eprintln(\"error: ...\")` / `eprintln(\"warning: ...\")` を typed writer に migrate (合計 139 箇所)。 round-1 review で multi-line literal straggler 3 件を見落とし→修正、 round-2 で APPROVED。
- E2E 4 IT (env-gated default offline-safe):
  - `NoColorE2EIT` (`KOLT_NOCOLOR_E2E=1`) — `--no-color` flag / `NO_COLOR=1` / stderr redirect / 任意 non-empty `NO_COLOR`
  - `DidYouMeanE2EIT` (`KOLT_DIDYOUMEAN_E2E=1`) — 未知 subcommand / 未知 flag / 距離超過 no-suggestion
  - `SubprocessColorForwardingE2EIT` (`KOLT_SUBPROC_COLOR_E2E=1`) — kotlinc 直接 / `--no-color` 経由 / JVM daemon / native daemon (konanc) で `NO_COLOR` honor を実機 pin
  - `InfoJsonAnsiE2EIT` (`KOLT_INFO_JSON_E2E=1`) — `kolt info --format=json` の stdout が color policy 不変で byte-identical
- gap fix (a2307ad): `/kiro-validate-impl` で task 4.4 が `WatchChangeDispatch.kt:76` と `InfoCommand.kt:380` の `.message` だけを使って enrichment を捨てていたのを発見。 `Config.kt` に `renderConfigErrorAsLine(e)` の single-line composite を追加し両 caller を経由化。 watch notification と `kolt info --format=json` の `parseError` field が `path:line` / key path / `Did you mean` を含むようになる。

## 後半 review 観点

- **R6.1 / R6.4 維持**: 3 daemon body forward site で、 `eprintln(maybeStripAnsi(body))` の直後に kolt headline (`eprintln(formatCompileError(...))` / `eprintln(formatNativeCompileError(...))`) が 1 つだけ続く順序が崩れていないか。 round-1 BuildCommands.kt:536/782/1179 を読み直して確認。
- **subprocess seam の対称性**: 4 backend が同形 (`buildMap` で `JAVA_HOME` / `NO_COLOR` 共存)、 一見 4 重複だが各 backend の Result chain や `JAVA_HOME` 注入条件が個別なので shared helper よりも対称コピー優先。 将来 env を追加した時 drift しないかは PR 単位で見ていく。
- **8.3 IT の fixture**: `main = \"main\"` で kolt 自身の `validateMainFqn` を通過させ、 kotlinc / konanc に到達することを意図 (round-1 reject の修正点)。 `assertTrue(stderr.contains(\"Main.kt\"))` で「kolt validator ではなく upstream compiler から来た diagnostic」を pin。 Kotlin / konanc bump で `NO_COLOR` honor が壊れたら RED 化する。
- **state-discipline**: `ColorPolicy.install` は startup 1 回限り。 全 IT・unit test が seam parameter / fake spawner 経由で policy を inject。 `git grep ColorPolicy.install src/nativeTest` で 0 hit。
- **gap fix の表現**: watch notification は単行、 info JSON `parseError` は構造化文字列。 `renderConfigErrorAsLine` は ` at /path:N (key: foo) -- Did you mean \`bar\`?` の format。 design.md の `renderConfigError` (multi-line `RenderedDiagnostic`) と意味的に等価だが flatten したもの、 R3.1/R3.2 を String 経路でも保つ。

## 検証

- `kolt build` green
- `kolt test` 1878 tests / 191 cases green (gate-OFF baseline)
- 全 4 IT gate-ON: `KOLT_NOCOLOR_E2E=1 KOLT_DIDYOUMEAN_E2E=1 KOLT_SUBPROC_COLOR_E2E=1 KOLT_INFO_JSON_E2E=1 kolt test` 1878/1878 pass、 ITs が実 fork+execvp で実行 (subprocess 系は 2-13s の現実的 timing)
- `grep -nE 'eprintln\\(\"(error|warning):' src/nativeMain/kotlin/kolt/cli/*.kt` 0 hit (multi-line PCRE 込み)
- `/kiro-validate-impl 2-error-output-formatting` GO (gap fix 後)