### PR TITLE
Polish kolt new + init UX: arrow prompt, colored options, next-step block (#407)

### DIFF
--- a/src/nativeMain/kotlin/kolt/cli/InitCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/InitCommand.kt
@@ -1,6 +1,7 @@
 package kolt.cli
 
 import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.config.inferProjectName
@@ -57,8 +58,11 @@ internal fun doInit(
       return Err(EXIT_CONFIG_ERROR)
     }
 
-  return scaffoldProject(
-    ".",
-    ScaffoldOptions(projectName, resolved.kind, resolved.target, resolved.group),
-  )
+  scaffoldProject(".", ScaffoldOptions(projectName, resolved.kind, resolved.target, resolved.group))
+    .getOrElse {
+      return Err(it)
+    }
+
+  printNextSteps(io, cdTarget = null, resolved.kind, policy)
+  return Ok(Unit)
 }

--- a/src/nativeMain/kotlin/kolt/cli/InitCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/InitCommand.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.config.inferProjectName
 import kolt.infra.fileExists
+import kolt.infra.output.ColorPolicy
 import kolt.infra.output.eprintError
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -15,7 +16,11 @@ import platform.posix.PATH_MAX
 import platform.posix.getcwd
 
 @OptIn(ExperimentalForeignApi::class)
-internal fun doInit(args: List<String>, io: ScaffoldIO = SystemScaffoldIO): Result<Unit, Int> {
+internal fun doInit(
+  args: List<String>,
+  io: ScaffoldIO = SystemScaffoldIO,
+  policy: ColorPolicy = ColorPolicy.current(),
+): Result<Unit, Int> {
   val parsed =
     parseInitArgs(args).getOrElse { msg ->
       eprintError(msg)
@@ -47,7 +52,7 @@ internal fun doInit(args: List<String>, io: ScaffoldIO = SystemScaffoldIO): Resu
   }
 
   val resolved =
-    resolveInteractive(parsed, io).getOrElse { msg ->
+    resolveInteractive(parsed, io, policy).getOrElse { msg ->
       eprintError(msg)
       return Err(EXIT_CONFIG_ERROR)
     }

--- a/src/nativeMain/kotlin/kolt/cli/NewCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/NewCommand.kt
@@ -62,16 +62,18 @@ internal fun doNew(
       return Err(it)
     }
 
-  printNextSteps(io, projectName, resolved.kind, policy)
+  printNextSteps(io, cdTarget = projectName, resolved.kind, policy)
   return Ok(Unit)
 }
 
 // Routed through ScaffoldIO so tests can capture the block; SystemScaffoldIO
 // writes to real stdout. Cyan emphasis matches the note severity in the
-// stderr writer — same family signal in a different channel.
-private fun printNextSteps(
+// stderr writer — same family signal in a different channel. `cdTarget` is
+// null for `kolt init` (already in target dir) and the project name for
+// `kolt new` (where the user must `cd` into the freshly-created subdir).
+internal fun printNextSteps(
   io: ScaffoldIO,
-  projectName: String,
+  cdTarget: String?,
   kind: ScaffoldKind,
   policy: ColorPolicy,
 ) {
@@ -85,6 +87,6 @@ private fun printNextSteps(
 
   io.println("")
   io.println("next steps:")
-  io.println("  ${emph("cd $projectName")}")
+  if (cdTarget != null) io.println("  ${emph("cd $cdTarget")}")
   io.println("  ${emph(cmd)}")
 }

--- a/src/nativeMain/kotlin/kolt/cli/NewCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/NewCommand.kt
@@ -1,14 +1,23 @@
 package kolt.cli
 
 import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
+import kolt.config.ScaffoldKind
 import kolt.infra.ensureDirectory
 import kolt.infra.eprintln
 import kolt.infra.fileExists
+import kolt.infra.output.AnsiCodes
+import kolt.infra.output.ColorPolicy
+import kolt.infra.output.Stream
 import kolt.infra.output.eprintError
 
-internal fun doNew(args: List<String>, io: ScaffoldIO = SystemScaffoldIO): Result<Unit, Int> {
+internal fun doNew(
+  args: List<String>,
+  io: ScaffoldIO = SystemScaffoldIO,
+  policy: ColorPolicy = ColorPolicy.current(),
+): Result<Unit, Int> {
   val parsed =
     parseInitArgs(args).getOrElse { msg ->
       eprintError(msg)
@@ -35,7 +44,7 @@ internal fun doNew(args: List<String>, io: ScaffoldIO = SystemScaffoldIO): Resul
   }
 
   val resolved =
-    resolveInteractive(parsed, io).getOrElse { msg ->
+    resolveInteractive(parsed, io, policy).getOrElse { msg ->
       eprintError(msg)
       return Err(EXIT_CONFIG_ERROR)
     }
@@ -45,8 +54,37 @@ internal fun doNew(args: List<String>, io: ScaffoldIO = SystemScaffoldIO): Resul
     return Err(EXIT_BUILD_ERROR)
   }
 
-  return scaffoldProject(
-    projectName,
-    ScaffoldOptions(projectName, resolved.kind, resolved.target, resolved.group),
-  )
+  scaffoldProject(
+      projectName,
+      ScaffoldOptions(projectName, resolved.kind, resolved.target, resolved.group),
+    )
+    .getOrElse {
+      return Err(it)
+    }
+
+  printNextSteps(io, projectName, resolved.kind, policy)
+  return Ok(Unit)
+}
+
+// Routed through ScaffoldIO so tests can capture the block; SystemScaffoldIO
+// writes to real stdout. Cyan emphasis matches the note severity in the
+// stderr writer — same family signal in a different channel.
+private fun printNextSteps(
+  io: ScaffoldIO,
+  projectName: String,
+  kind: ScaffoldKind,
+  policy: ColorPolicy,
+) {
+  val cmd =
+    when (kind) {
+      ScaffoldKind.APP -> "kolt run"
+      ScaffoldKind.LIB -> "kolt build"
+    }
+  val color = policy.shouldColor(Stream.Stdout)
+  fun emph(s: String): String = if (color) "${AnsiCodes.CYAN}$s${AnsiCodes.RESET}" else s
+
+  io.println("")
+  io.println("next steps:")
+  io.println("  ${emph("cd $projectName")}")
+  io.println("  ${emph(cmd)}")
 }

--- a/src/nativeMain/kotlin/kolt/cli/Prompt.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Prompt.kt
@@ -84,10 +84,16 @@ private fun promptKind(io: ScaffoldIO, policy: ColorPolicy): Result<ScaffoldKind
 
 private fun promptTarget(io: ScaffoldIO, policy: ColorPolicy): Result<String, String> {
   io.println("Targets:")
+  var nativeHeaderEmitted = false
   PROMPT_TARGETS.forEachIndexed { idx, name ->
-    val color = if (name == DEFAULT_SCAFFOLD_TARGET) AnsiCodes.CYAN else AnsiCodes.YELLOW
+    val isJvm = name == DEFAULT_SCAFFOLD_TARGET
+    if (!isJvm && !nativeHeaderEmitted) {
+      io.println("  -- native --")
+      nativeHeaderEmitted = true
+    }
+    val color = if (isJvm) AnsiCodes.CYAN else AnsiCodes.YELLOW
     val coloredName = colored(name, color, policy)
-    val suffix = if (name == DEFAULT_SCAFFOLD_TARGET) " (default)" else ""
+    val suffix = if (isJvm) " (default)" else ""
     io.println("  ${idx + 1}) $coloredName$suffix")
   }
   io.println(">")

--- a/src/nativeMain/kotlin/kolt/cli/Prompt.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Prompt.kt
@@ -8,6 +8,9 @@ import kolt.config.DEFAULT_SCAFFOLD_TARGET
 import kolt.config.NATIVE_TARGETS
 import kolt.config.ScaffoldKind
 import kolt.config.isValidGroup
+import kolt.infra.output.AnsiCodes
+import kolt.infra.output.ColorPolicy
+import kolt.infra.output.Stream
 
 internal data class ResolvedScaffoldOptions(
   val kind: ScaffoldKind,
@@ -18,13 +21,14 @@ internal data class ResolvedScaffoldOptions(
 internal fun resolveInteractive(
   parsed: ParsedInitArgs,
   io: ScaffoldIO,
+  policy: ColorPolicy = ColorPolicy.current(),
 ): Result<ResolvedScaffoldOptions, String> {
   val tty = io.isStdinTty()
 
   val kind =
     parsed.kind
       ?: if (tty) {
-        promptKind(io).getOrElse {
+        promptKind(io, policy).getOrElse {
           return Err(it)
         }
       } else ScaffoldKind.APP
@@ -32,7 +36,7 @@ internal fun resolveInteractive(
   val target =
     parsed.target
       ?: if (tty) {
-        promptTarget(io).getOrElse {
+        promptTarget(io, policy).getOrElse {
           return Err(it)
         }
       } else DEFAULT_SCAFFOLD_TARGET
@@ -50,39 +54,43 @@ internal fun resolveInteractive(
 
 private val PROMPT_TARGETS = listOf(DEFAULT_SCAFFOLD_TARGET) + NATIVE_TARGETS.toList().sorted()
 
-private fun promptKind(io: ScaffoldIO): Result<ScaffoldKind, String> {
-  io.println("Project kind:")
-  io.println("  1) app (default)")
-  io.println("  2) lib")
+// Wrap value in ANSI when policy enables stdout color. Prompt output goes to
+// stdout (kotlin.io.println), so the stream key is Stdout — distinct from the
+// stderr-only diagnostic writer.
+private fun colored(value: String, color: String, policy: ColorPolicy): String =
+  if (policy.shouldColor(Stream.Stdout)) "$color$value${AnsiCodes.RESET}" else value
+
+private fun promptKind(io: ScaffoldIO, policy: ColorPolicy): Result<ScaffoldKind, String> {
+  val app = colored("app", AnsiCodes.CYAN, policy)
+  val lib = colored("lib", AnsiCodes.YELLOW, policy)
+  io.println("Kinds: $app (default) | $lib")
+  io.println("> kind [app]:")
   val raw = io.readLine()?.trim().orEmpty()
   return when (raw) {
     "",
-    "1",
     "app" -> Ok(ScaffoldKind.APP)
-    "2",
     "lib" -> Ok(ScaffoldKind.LIB)
-    else -> Err("invalid kind '$raw' (expected 1, 2, app, or lib)")
+    else -> Err("invalid kind '$raw' (expected app or lib)")
   }
 }
 
-private fun promptTarget(io: ScaffoldIO): Result<String, String> {
-  io.println("Target:")
-  PROMPT_TARGETS.forEachIndexed { idx, name ->
-    val suffix = if (name == DEFAULT_SCAFFOLD_TARGET) " (default)" else ""
-    io.println("  ${idx + 1}) $name$suffix")
-  }
+private fun promptTarget(io: ScaffoldIO, policy: ColorPolicy): Result<String, String> {
+  val labels =
+    PROMPT_TARGETS.joinToString(" | ") { name ->
+      val color = if (name == DEFAULT_SCAFFOLD_TARGET) AnsiCodes.CYAN else AnsiCodes.YELLOW
+      val coloredName = colored(name, color, policy)
+      if (name == DEFAULT_SCAFFOLD_TARGET) "$coloredName (default)" else coloredName
+    }
+  io.println("Targets: $labels")
+  io.println("> target [$DEFAULT_SCAFFOLD_TARGET]:")
   val raw = io.readLine()?.trim().orEmpty()
   if (raw.isEmpty()) return Ok(DEFAULT_SCAFFOLD_TARGET)
-  val byNumber = raw.toIntOrNull()?.let { PROMPT_TARGETS.getOrNull(it - 1) }
-  if (byNumber != null) return Ok(byNumber)
   if (raw in PROMPT_TARGETS) return Ok(raw)
-  return Err(
-    "invalid target '$raw' (expected 1..${PROMPT_TARGETS.size} or one of ${PROMPT_TARGETS.joinToString(", ")})"
-  )
+  return Err("invalid target '$raw' (expected one of ${PROMPT_TARGETS.joinToString(", ")})")
 }
 
 private fun promptGroup(io: ScaffoldIO): Result<String?, String> {
-  io.println("Group (e.g. com.example, blank for none):")
+  io.println("> group [none]:")
   val raw = io.readLine()?.trim().orEmpty()
   if (raw.isEmpty()) return Ok(null)
   if (!isValidGroup(raw)) {

--- a/src/nativeMain/kotlin/kolt/cli/Prompt.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Prompt.kt
@@ -52,7 +52,12 @@ internal fun resolveInteractive(
   return Ok(ResolvedScaffoldOptions(kind, target, group))
 }
 
+// JVM target appears first so its index 1 lines up with the default; native
+// targets follow in alphabetical order. Caller iterates indices for prompt
+// numbering AND for input parsing — same list, single source of truth.
 private val PROMPT_TARGETS = listOf(DEFAULT_SCAFFOLD_TARGET) + NATIVE_TARGETS.toList().sorted()
+
+private val PROMPT_KINDS = listOf(ScaffoldKind.APP, ScaffoldKind.LIB)
 
 // Wrap value in ANSI when policy enables stdout color. Prompt output goes to
 // stdout (kotlin.io.println), so the stream key is Stdout — distinct from the
@@ -61,36 +66,44 @@ private fun colored(value: String, color: String, policy: ColorPolicy): String =
   if (policy.shouldColor(Stream.Stdout)) "$color$value${AnsiCodes.RESET}" else value
 
 private fun promptKind(io: ScaffoldIO, policy: ColorPolicy): Result<ScaffoldKind, String> {
-  val app = colored("app", AnsiCodes.CYAN, policy)
-  val lib = colored("lib", AnsiCodes.YELLOW, policy)
-  io.println("Kinds: $app (default) | $lib")
-  io.println("> kind [app]:")
-  val raw = io.readLine()?.trim().orEmpty()
-  return when (raw) {
-    "",
-    "app" -> Ok(ScaffoldKind.APP)
-    "lib" -> Ok(ScaffoldKind.LIB)
-    else -> Err("invalid kind '$raw' (expected app or lib)")
+  io.println("Kinds:")
+  PROMPT_KINDS.forEachIndexed { idx, kind ->
+    val name = kind.tomlValue
+    val color = if (kind == ScaffoldKind.APP) AnsiCodes.CYAN else AnsiCodes.YELLOW
+    val coloredName = colored(name, color, policy)
+    val suffix = if (kind == ScaffoldKind.APP) " (default)" else ""
+    io.println("  ${idx + 1}) $coloredName$suffix")
   }
+  io.println(">")
+  val raw = io.readLine()?.trim().orEmpty()
+  if (raw.isEmpty()) return Ok(ScaffoldKind.APP)
+  val byNumber = raw.toIntOrNull()?.let { PROMPT_KINDS.getOrNull(it - 1) }
+  if (byNumber != null) return Ok(byNumber)
+  return Err("invalid kind '$raw' (expected 1..${PROMPT_KINDS.size})")
 }
 
 private fun promptTarget(io: ScaffoldIO, policy: ColorPolicy): Result<String, String> {
-  val labels =
-    PROMPT_TARGETS.joinToString(" | ") { name ->
-      val color = if (name == DEFAULT_SCAFFOLD_TARGET) AnsiCodes.CYAN else AnsiCodes.YELLOW
-      val coloredName = colored(name, color, policy)
-      if (name == DEFAULT_SCAFFOLD_TARGET) "$coloredName (default)" else coloredName
-    }
-  io.println("Targets: $labels")
-  io.println("> target [$DEFAULT_SCAFFOLD_TARGET]:")
+  io.println("Targets:")
+  PROMPT_TARGETS.forEachIndexed { idx, name ->
+    val color = if (name == DEFAULT_SCAFFOLD_TARGET) AnsiCodes.CYAN else AnsiCodes.YELLOW
+    val coloredName = colored(name, color, policy)
+    val suffix = if (name == DEFAULT_SCAFFOLD_TARGET) " (default)" else ""
+    io.println("  ${idx + 1}) $coloredName$suffix")
+  }
+  io.println(">")
   val raw = io.readLine()?.trim().orEmpty()
   if (raw.isEmpty()) return Ok(DEFAULT_SCAFFOLD_TARGET)
-  if (raw in PROMPT_TARGETS) return Ok(raw)
-  return Err("invalid target '$raw' (expected one of ${PROMPT_TARGETS.joinToString(", ")})")
+  val byNumber = raw.toIntOrNull()?.let { PROMPT_TARGETS.getOrNull(it - 1) }
+  if (byNumber != null) return Ok(byNumber)
+  return Err("invalid target '$raw' (expected 1..${PROMPT_TARGETS.size})")
 }
 
+// Group is free-form text by nature (e.g. com.example), so the input must
+// stay string-typed; the "blank for none" hint goes in the header rather
+// than the prompt line so the input arrow stays consistent with kind/target.
 private fun promptGroup(io: ScaffoldIO): Result<String?, String> {
-  io.println("> group [none]:")
+  io.println("Group (e.g. com.example, blank for none):")
+  io.println(">")
   val raw = io.readLine()?.trim().orEmpty()
   if (raw.isEmpty()) return Ok(null)
   if (!isValidGroup(raw)) {

--- a/src/nativeTest/kotlin/kolt/cli/DoInitTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DoInitTest.kt
@@ -5,6 +5,8 @@ import com.github.michaelbull.result.getOrElse
 import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.executeCommand
 import kolt.infra.fileExists
+import kolt.infra.output.AnsiCodes
+import kolt.infra.output.ColorPolicy
 import kolt.infra.readFileAsString
 import kolt.infra.removeDirectoryRecursive
 import kolt.infra.writeFileAsString
@@ -27,6 +29,20 @@ import platform.posix.getcwd
 import platform.posix.mkdtemp
 import platform.posix.setenv
 import platform.posix.unsetenv
+
+private class CapturingScaffoldIO(private val tty: Boolean, inputs: List<String> = emptyList()) :
+  ScaffoldIO {
+  private val iter = inputs.iterator()
+  val outputs = mutableListOf<String>()
+
+  override fun isStdinTty(): Boolean = tty
+
+  override fun readLine(): String? = if (iter.hasNext()) iter.next() else null
+
+  override fun println(msg: String) {
+    outputs += msg
+  }
+}
 
 @OptIn(ExperimentalForeignApi::class)
 class DoInitTest {
@@ -375,6 +391,47 @@ class DoInitTest {
     doInit(listOf("my-app")).getOrElse { error("doInit failed: exit=$it") }
 
     assertFalse(fileExists(".git"), "nested .git must not be created inside an existing worktree")
+  }
+
+  @Test
+  fun initPrintsNextStepBlockForAppWithoutCdLine() {
+    val io = CapturingScaffoldIO(tty = false)
+
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    assertTrue(joined.contains("next steps:"), "missing next-step header: $joined")
+    assertFalse(joined.contains("cd "), "init must omit cd line (already in target dir): $joined")
+    assertTrue(joined.contains("kolt run"), "app must point to kolt run: $joined")
+    assertFalse(joined.contains("kolt build"), "app must not point to kolt build: $joined")
+  }
+
+  @Test
+  fun initPrintsNextStepBlockForLibPointingToKoltBuild() {
+    val io = CapturingScaffoldIO(tty = false)
+
+    doInit(listOf("mylib", "--lib"), io, ColorPolicy.Never).getOrElse {
+      error("doInit failed: exit=$it")
+    }
+
+    val joined = io.outputs.joinToString("\n")
+    assertTrue(joined.contains("next steps:"), "missing next-step header: $joined")
+    assertFalse(joined.contains("cd "), "init must omit cd line: $joined")
+    assertTrue(joined.contains("kolt build"), "lib must point to kolt build: $joined")
+    assertFalse(joined.contains("kolt run"), "lib must not point to kolt run: $joined")
+  }
+
+  @Test
+  fun initNextStepBlockColorsCommandWhenPolicyAllows() {
+    val io = CapturingScaffoldIO(tty = false)
+
+    doInit(listOf("myapp"), io, ColorPolicy.Always).getOrElse { error("doInit failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    assertTrue(
+      joined.contains("${AnsiCodes.CYAN}kolt run${AnsiCodes.RESET}"),
+      "expected cyan-wrapped kolt run: $joined",
+    )
   }
 
   private fun createTempDir(prefix: String): String {

--- a/src/nativeTest/kotlin/kolt/cli/DoNewTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/DoNewTest.kt
@@ -5,6 +5,8 @@ import com.github.michaelbull.result.getOrElse
 import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.executeCommand
 import kolt.infra.fileExists
+import kolt.infra.output.AnsiCodes
+import kolt.infra.output.ColorPolicy
 import kolt.infra.readFileAsString
 import kolt.infra.removeDirectoryRecursive
 import kolt.infra.writeFileAsString
@@ -27,6 +29,20 @@ import platform.posix.getcwd
 import platform.posix.mkdtemp
 import platform.posix.setenv
 import platform.posix.unsetenv
+
+private class RecordingScaffoldIO(private val tty: Boolean, inputs: List<String> = emptyList()) :
+  ScaffoldIO {
+  private val iter = inputs.iterator()
+  val outputs = mutableListOf<String>()
+
+  override fun isStdinTty(): Boolean = tty
+
+  override fun readLine(): String? = if (iter.hasNext()) iter.next() else null
+
+  override fun println(msg: String) {
+    outputs += msg
+  }
+}
 
 @OptIn(ExperimentalForeignApi::class)
 class DoNewTest {
@@ -142,6 +158,61 @@ class DoNewTest {
     assertFalse(
       fileExists("myapp/.git"),
       "nested .git must not be created inside an existing worktree",
+    )
+  }
+
+  @Test
+  fun newPrintsNextStepBlockForAppPointingToKoltRun() {
+    val io = RecordingScaffoldIO(tty = false)
+
+    doNew(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doNew failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    assertTrue(joined.contains("next steps:"), "missing next-step header: $joined")
+    assertTrue(joined.contains("cd myapp"), "missing cd line: $joined")
+    assertTrue(joined.contains("kolt run"), "app must point to kolt run: $joined")
+    assertFalse(joined.contains("kolt build"), "app must not point to kolt build: $joined")
+  }
+
+  @Test
+  fun newPrintsNextStepBlockForLibPointingToKoltBuild() {
+    val io = RecordingScaffoldIO(tty = false)
+
+    doNew(listOf("mylib", "--lib"), io, ColorPolicy.Never).getOrElse {
+      error("doNew failed: exit=$it")
+    }
+
+    val joined = io.outputs.joinToString("\n")
+    assertTrue(joined.contains("next steps:"), "missing next-step header: $joined")
+    assertTrue(joined.contains("cd mylib"), "missing cd line: $joined")
+    assertTrue(joined.contains("kolt build"), "lib must point to kolt build: $joined")
+    assertFalse(joined.contains("kolt run"), "lib must not point to kolt run: $joined")
+  }
+
+  @Test
+  fun newNextStepBlockHasNoAnsiWhenColorDisabled() {
+    val io = RecordingScaffoldIO(tty = false)
+
+    doNew(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doNew failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    assertFalse(joined.contains("["), "color disabled must not emit ANSI: $joined")
+  }
+
+  @Test
+  fun newNextStepBlockColorsCommandsWhenPolicyAllows() {
+    val io = RecordingScaffoldIO(tty = false)
+
+    doNew(listOf("myapp"), io, ColorPolicy.Always).getOrElse { error("doNew failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    assertTrue(
+      joined.contains("${AnsiCodes.CYAN}cd myapp${AnsiCodes.RESET}"),
+      "expected cyan-wrapped cd: $joined",
+    )
+    assertTrue(
+      joined.contains("${AnsiCodes.CYAN}kolt run${AnsiCodes.RESET}"),
+      "expected cyan-wrapped kolt run: $joined",
     )
   }
 

--- a/src/nativeTest/kotlin/kolt/cli/PromptTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/PromptTest.kt
@@ -104,6 +104,21 @@ class PromptTest {
   }
 
   @Test
+  fun ttyTargetPromptSeparatesJvmFromNativeWithMarker() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
+
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    val markerIdx = joined.indexOf("-- native --")
+    val jvmIdx = joined.indexOf("1) jvm")
+    val firstNativeIdx = joined.indexOf("2) linuxArm64")
+    assertTrue(markerIdx >= 0, "native separator missing: $joined")
+    assertTrue(markerIdx > jvmIdx, "separator must come after jvm line: $joined")
+    assertTrue(markerIdx < firstNativeIdx, "separator must precede first native line: $joined")
+  }
+
+  @Test
   fun ttyKindPromptAcceptsNumericInput() {
     val io = FakeScaffoldIO(tty = true, inputs = listOf("2", "", ""))
 

--- a/src/nativeTest/kotlin/kolt/cli/PromptTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/PromptTest.kt
@@ -178,7 +178,12 @@ class PromptTest {
 
     doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
 
-    assertTrue(io.outputs.isEmpty(), "non-TTY must not print prompts: ${io.outputs}")
+    val joined = io.outputs.joinToString("\n")
+    assertFalse(joined.contains("Kinds:"), "non-TTY must not print kind prompt: $joined")
+    assertFalse(joined.contains("Targets:"), "non-TTY must not print target prompt: $joined")
+    assertFalse(joined.contains("> kind"), "non-TTY must not print kind arrow: $joined")
+    assertFalse(joined.contains("> target"), "non-TTY must not print target arrow: $joined")
+    assertFalse(joined.contains("> group"), "non-TTY must not print group arrow: $joined")
     assertTrue(fileExists("src/Main.kt"))
     val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
     assertFalse(toml.contains("kind = \"lib\""))

--- a/src/nativeTest/kotlin/kolt/cli/PromptTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/PromptTest.kt
@@ -3,6 +3,8 @@ package kolt.cli
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
 import kolt.infra.fileExists
+import kolt.infra.output.AnsiCodes
+import kolt.infra.output.ColorPolicy
 import kolt.infra.readFileAsString
 import kolt.infra.removeDirectoryRecursive
 import kotlin.test.AfterTest
@@ -67,22 +69,34 @@ class PromptTest {
   fun ttyNoFlagsPromptsKindThenTargetThenGroup() {
     val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
 
-    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
 
     val joined = io.outputs.joinToString("\n")
-    val kindIdx = joined.indexOf("Project kind:")
-    val targetIdx = joined.indexOf("Target:")
-    val groupIdx = joined.indexOf("Group ")
+    val kindIdx = joined.indexOf("Kinds:")
+    val targetIdx = joined.indexOf("Targets:")
+    val groupIdx = joined.indexOf("> group ")
     assertTrue(kindIdx >= 0, "kind prompt missing: $joined")
     assertTrue(targetIdx > kindIdx, "target must follow kind: $joined")
     assertTrue(groupIdx > targetIdx, "group must follow target: $joined")
   }
 
   @Test
+  fun ttyKindPromptHasArrowAndDefaultBracket() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
+
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    assertTrue(joined.contains("> kind [app]:"), "missing arrow + default bracket: $joined")
+    assertTrue(joined.contains("> target [jvm]:"), "missing target arrow + default: $joined")
+    assertTrue(joined.contains("> group [none]:"), "missing group arrow + default: $joined")
+  }
+
+  @Test
   fun ttyKindPromptDefaultIsApp() {
     val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
 
-    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
 
     assertTrue(fileExists("src/Main.kt"), "blank kind input must default to app")
     val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
@@ -92,49 +106,29 @@ class PromptTest {
 
   @Test
   fun ttyKindPromptExplicitLib() {
-    val io = FakeScaffoldIO(tty = true, inputs = listOf("2", "", ""))
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("lib", "", ""))
 
-    doInit(listOf("mylib"), io).getOrElse { error("doInit failed: exit=$it") }
+    doInit(listOf("mylib"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
 
     assertTrue(fileExists("src/Lib.kt"))
     assertFalse(fileExists("src/Main.kt"))
   }
 
   @Test
-  fun ttyKindPromptAcceptsTextualLib() {
-    val io = FakeScaffoldIO(tty = true, inputs = listOf("lib", "", ""))
-
-    doInit(listOf("mylib"), io).getOrElse { error("doInit failed: exit=$it") }
-
-    assertTrue(fileExists("src/Lib.kt"))
-  }
-
-  @Test
   fun ttyTargetPromptDefaultIsJvm() {
     val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
 
-    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
 
     val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
     assertTrue(toml.contains("target = \"jvm\""), "blank target must default to jvm")
   }
 
   @Test
-  fun ttyTargetPromptByNumberPicksNativeTarget() {
-    // Targets are listed: 1=jvm, 2=linuxArm64, 3=linuxX64, 4=macosArm64, 5=macosX64, 6=mingwX64
-    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "3", ""))
-
-    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
-
-    val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
-    assertTrue(toml.contains("target = \"linuxX64\""), "expected linuxX64, got: $toml")
-  }
-
-  @Test
-  fun ttyTargetPromptByNameAccepted() {
+  fun ttyTargetPromptByNameAcceptsNativeTarget() {
     val io = FakeScaffoldIO(tty = true, inputs = listOf("", "linuxX64", ""))
 
-    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
 
     val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
     assertTrue(toml.contains("target = \"linuxX64\""))
@@ -144,7 +138,7 @@ class PromptTest {
   fun ttyGroupPromptBlankMeansNoGroup() {
     val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
 
-    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
 
     assertTrue(fileExists("src/Main.kt"))
     val source = readFileAsString("src/Main.kt").getOrElse { error("read failed") }
@@ -155,7 +149,7 @@ class PromptTest {
   fun ttyGroupPromptValidValueNestsSource() {
     val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", "com.example"))
 
-    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
 
     assertTrue(fileExists("src/com/example/myapp/Main.kt"))
   }
@@ -165,12 +159,14 @@ class PromptTest {
     // --lib supplied → only target + group prompted
     val io = FakeScaffoldIO(tty = true, inputs = listOf("", "com.example"))
 
-    doNew(listOf("mylib", "--lib"), io).getOrElse { error("doNew failed: exit=$it") }
+    doNew(listOf("mylib", "--lib"), io, ColorPolicy.Never).getOrElse {
+      error("doNew failed: exit=$it")
+    }
 
     val joined = io.outputs.joinToString("\n")
-    assertFalse(joined.contains("Project kind:"), "kind must not be prompted when --lib given")
-    val targetIdx = joined.indexOf("Target:")
-    val groupIdx = joined.indexOf("Group ")
+    assertFalse(joined.contains("Kinds:"), "kind must not be prompted when --lib given")
+    val targetIdx = joined.indexOf("Targets:")
+    val groupIdx = joined.indexOf("> group ")
     assertTrue(targetIdx >= 0, "target prompt missing")
     assertTrue(groupIdx > targetIdx, "target must precede group even when kind is fixed")
     assertTrue(fileExists("mylib/src/com/example/mylib/Lib.kt"))
@@ -180,7 +176,7 @@ class PromptTest {
   fun nonTtyNoPromptsAndDefaultsApply() {
     val io = FakeScaffoldIO(tty = false, inputs = emptyList())
 
-    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
 
     assertTrue(io.outputs.isEmpty(), "non-TTY must not print prompts: ${io.outputs}")
     assertTrue(fileExists("src/Main.kt"))
@@ -194,7 +190,7 @@ class PromptTest {
   fun ttyKindInvalidInputExitsNonZero() {
     val io = FakeScaffoldIO(tty = true, inputs = listOf("bogus"))
 
-    val exit = doInit(listOf("myapp"), io).getError()
+    val exit = doInit(listOf("myapp"), io, ColorPolicy.Never).getError()
 
     assertEquals(EXIT_CONFIG_ERROR, exit)
     assertFalse(fileExists("kolt.toml"), "no scaffold output on invalid prompt")
@@ -204,7 +200,7 @@ class PromptTest {
   fun ttyTargetInvalidInputExitsNonZero() {
     val io = FakeScaffoldIO(tty = true, inputs = listOf("", "wasm"))
 
-    val exit = doInit(listOf("myapp"), io).getError()
+    val exit = doInit(listOf("myapp"), io, ColorPolicy.Never).getError()
 
     assertEquals(EXIT_CONFIG_ERROR, exit)
   }
@@ -213,7 +209,7 @@ class PromptTest {
   fun ttyGroupInvalidInputExitsNonZero() {
     val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", "9bad"))
 
-    val exit = doInit(listOf("myapp"), io).getError()
+    val exit = doInit(listOf("myapp"), io, ColorPolicy.Never).getError()
 
     assertEquals(EXIT_CONFIG_ERROR, exit)
   }
@@ -225,7 +221,7 @@ class PromptTest {
     // produce the default scaffold (app/jvm/no group) without erroring.
     val io = FakeScaffoldIO(tty = true, inputs = emptyList())
 
-    doInit(listOf("myapp"), io).getOrElse { error("doInit failed: exit=$it") }
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
 
     assertTrue(fileExists("src/Main.kt"))
     val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
@@ -236,11 +232,55 @@ class PromptTest {
 
   @Test
   fun ttyDoNewPromptsWhenFlagsOmitted() {
-    val io = FakeScaffoldIO(tty = true, inputs = listOf("2", "", ""))
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("lib", "", ""))
 
-    doNew(listOf("mylib"), io).getOrElse { error("doNew failed: exit=$it") }
+    doNew(listOf("mylib"), io, ColorPolicy.Never).getOrElse { error("doNew failed: exit=$it") }
 
     assertTrue(fileExists("mylib/src/Lib.kt"))
+  }
+
+  @Test
+  fun ttyKindPromptColorsAppCyanAndLibYellowWhenPolicyAllows() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
+
+    doInit(listOf("myapp"), io, ColorPolicy.Always).getOrElse { error("doInit failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    assertTrue(
+      joined.contains("${AnsiCodes.CYAN}app${AnsiCodes.RESET}"),
+      "expected cyan-wrapped app: $joined",
+    )
+    assertTrue(
+      joined.contains("${AnsiCodes.YELLOW}lib${AnsiCodes.RESET}"),
+      "expected yellow-wrapped lib: $joined",
+    )
+  }
+
+  @Test
+  fun ttyKindPromptHasNoAnsiWhenPolicyDisables() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
+
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    assertFalse(joined.contains("["), "color disabled must not emit ANSI: $joined")
+  }
+
+  @Test
+  fun ttyTargetPromptColorsJvmCyanAndNativeYellowWhenPolicyAllows() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
+
+    doInit(listOf("myapp"), io, ColorPolicy.Always).getOrElse { error("doInit failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    assertTrue(
+      joined.contains("${AnsiCodes.CYAN}jvm${AnsiCodes.RESET}"),
+      "expected cyan-wrapped jvm: $joined",
+    )
+    assertTrue(
+      joined.contains("${AnsiCodes.YELLOW}linuxX64${AnsiCodes.RESET}"),
+      "expected yellow-wrapped linuxX64: $joined",
+    )
   }
 
   private fun createTempDir(prefix: String): String {

--- a/src/nativeTest/kotlin/kolt/cli/PromptTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/PromptTest.kt
@@ -74,22 +74,70 @@ class PromptTest {
     val joined = io.outputs.joinToString("\n")
     val kindIdx = joined.indexOf("Kinds:")
     val targetIdx = joined.indexOf("Targets:")
-    val groupIdx = joined.indexOf("> group ")
+    val groupIdx = joined.indexOf("Group (")
     assertTrue(kindIdx >= 0, "kind prompt missing: $joined")
     assertTrue(targetIdx > kindIdx, "target must follow kind: $joined")
     assertTrue(groupIdx > targetIdx, "group must follow target: $joined")
   }
 
   @Test
-  fun ttyKindPromptHasArrowAndDefaultBracket() {
+  fun ttyKindPromptListsOptionsOnePerLineWithNumbers() {
     val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
 
     doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
 
     val joined = io.outputs.joinToString("\n")
-    assertTrue(joined.contains("> kind [app]:"), "missing arrow + default bracket: $joined")
-    assertTrue(joined.contains("> target [jvm]:"), "missing target arrow + default: $joined")
-    assertTrue(joined.contains("> group [none]:"), "missing group arrow + default: $joined")
+    assertTrue(joined.contains("  1) app (default)"), "missing numbered app line: $joined")
+    assertTrue(joined.contains("  2) lib"), "missing numbered lib line: $joined")
+  }
+
+  @Test
+  fun ttyTargetPromptListsOptionsOnePerLineWithNumbers() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
+
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
+
+    val joined = io.outputs.joinToString("\n")
+    assertTrue(joined.contains("  1) jvm (default)"), "missing numbered jvm line: $joined")
+    assertTrue(joined.contains("  2) linuxArm64"), "missing numbered linuxArm64 line: $joined")
+    assertTrue(joined.contains("  3) linuxX64"), "missing numbered linuxX64 line: $joined")
+  }
+
+  @Test
+  fun ttyKindPromptAcceptsNumericInput() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("2", "", ""))
+
+    doInit(listOf("mylib"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
+
+    assertTrue(fileExists("src/Lib.kt"), "numeric '2' must select lib")
+    assertFalse(fileExists("src/Main.kt"))
+  }
+
+  @Test
+  fun ttyTargetPromptAcceptsNumericInput() {
+    // Targets ordering: 1) jvm, 2) linuxArm64, 3) linuxX64, 4) macosArm64, 5) macosX64, 6) mingwX64
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "3", ""))
+
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
+
+    val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
+    assertTrue(toml.contains("target = \"linuxX64\""), "numeric '3' must select linuxX64: $toml")
+  }
+
+  @Test
+  fun ttyPromptUsesPlainArrowInputLine() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "", ""))
+
+    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
+
+    // The arrow is printed as its own line after each option list. Three
+    // prompts (kind, target, group) -> three `>` lines.
+    val arrowLines = io.outputs.count { it == ">" }
+    assertEquals(3, arrowLines, "expected 3 arrow lines (one per prompt), got: ${io.outputs}")
+    assertTrue(
+      io.outputs.any { it.startsWith("Group (") && it.contains("blank for none") },
+      "group prompt header missing 'blank for none' hint: ${io.outputs}",
+    )
   }
 
   @Test
@@ -105,13 +153,23 @@ class PromptTest {
   }
 
   @Test
-  fun ttyKindPromptExplicitLib() {
-    val io = FakeScaffoldIO(tty = true, inputs = listOf("lib", "", ""))
+  fun ttyKindPromptExplicitLibViaNumber() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("2", "", ""))
 
     doInit(listOf("mylib"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
 
     assertTrue(fileExists("src/Lib.kt"))
     assertFalse(fileExists("src/Main.kt"))
+  }
+
+  @Test
+  fun ttyKindPromptRejectsNamedInput() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("lib"))
+
+    val exit = doInit(listOf("myapp"), io, ColorPolicy.Never).getError()
+
+    assertEquals(EXIT_CONFIG_ERROR, exit, "named input must be rejected; only numeric accepted")
+    assertFalse(fileExists("kolt.toml"), "no scaffold output on rejected input")
   }
 
   @Test
@@ -125,13 +183,12 @@ class PromptTest {
   }
 
   @Test
-  fun ttyTargetPromptByNameAcceptsNativeTarget() {
-    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "linuxX64", ""))
+  fun ttyTargetPromptRejectsNamedInput() {
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("", "linuxX64"))
 
-    doInit(listOf("myapp"), io, ColorPolicy.Never).getOrElse { error("doInit failed: exit=$it") }
+    val exit = doInit(listOf("myapp"), io, ColorPolicy.Never).getError()
 
-    val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
-    assertTrue(toml.contains("target = \"linuxX64\""))
+    assertEquals(EXIT_CONFIG_ERROR, exit, "named input must be rejected; only numeric accepted")
   }
 
   @Test
@@ -166,7 +223,7 @@ class PromptTest {
     val joined = io.outputs.joinToString("\n")
     assertFalse(joined.contains("Kinds:"), "kind must not be prompted when --lib given")
     val targetIdx = joined.indexOf("Targets:")
-    val groupIdx = joined.indexOf("> group ")
+    val groupIdx = joined.indexOf("Group (")
     assertTrue(targetIdx >= 0, "target prompt missing")
     assertTrue(groupIdx > targetIdx, "target must precede group even when kind is fixed")
     assertTrue(fileExists("mylib/src/com/example/mylib/Lib.kt"))
@@ -181,9 +238,8 @@ class PromptTest {
     val joined = io.outputs.joinToString("\n")
     assertFalse(joined.contains("Kinds:"), "non-TTY must not print kind prompt: $joined")
     assertFalse(joined.contains("Targets:"), "non-TTY must not print target prompt: $joined")
-    assertFalse(joined.contains("> kind"), "non-TTY must not print kind arrow: $joined")
-    assertFalse(joined.contains("> target"), "non-TTY must not print target arrow: $joined")
-    assertFalse(joined.contains("> group"), "non-TTY must not print group arrow: $joined")
+    assertFalse(joined.contains("Group ("), "non-TTY must not print group prompt: $joined")
+    assertFalse(io.outputs.contains(">"), "non-TTY must not print arrow input line: $joined")
     assertTrue(fileExists("src/Main.kt"))
     val toml = readFileAsString("kolt.toml").getOrElse { error("read failed") }
     assertFalse(toml.contains("kind = \"lib\""))
@@ -237,7 +293,7 @@ class PromptTest {
 
   @Test
   fun ttyDoNewPromptsWhenFlagsOmitted() {
-    val io = FakeScaffoldIO(tty = true, inputs = listOf("lib", "", ""))
+    val io = FakeScaffoldIO(tty = true, inputs = listOf("2", "", ""))
 
     doNew(listOf("mylib"), io, ColorPolicy.Never).getOrElse { error("doNew failed: exit=$it") }
 


### PR DESCRIPTION
Closes #407.

#2 で導入した typed writer / `ColorPolicy` / `AnsiCodes` を直接活用し、 `kolt new` と `kolt init` の対話 UX を整える。

## 何が変わるか

**プロンプト** — 1 option per line + 番号 + plain \`>\`:

\`\`\`
Kinds:
  1) app (default)
  2) lib
>

Targets:
  1) jvm (default)
  2) linuxArm64
  3) linuxX64
  4) macosArm64
  5) macosX64
  6) mingwX64
>

Group (e.g. com.example, blank for none):
>
\`\`\`

- 1 行 1 オプション + 番号で discover しやすい layout
- 入力は **numeric only** (kind / target)、 空入力で default
- group は性質上 free-form text なので string 受付、 hint は header 行に
- color: jvm / app は cyan、 lib / 各 native target は yellow。 `--no-color` / `NO_COLOR` / 非 TTY では plain
- prompt 行は `>` 単独 — 「default は option 行で見える」ので prompt に詰め込まない

**Next-step block** — scaffolding 完了後に出力:
- `kolt new <name>`: `next steps:` ヘッダ + `cd <name>` + `kolt run` (app) / `kolt build` (lib)
- `kolt init`: 同じヘッダ + `cd` 抜き + コマンド (already in target dir)
- `ScaffoldIO` 経由なのでテスト可能。 commands は color-on で cyan ハイライト

**testability seam** — `resolveInteractive` / `doInit` / `doNew` に `policy: ColorPolicy = ColorPolicy.current()` パラメータを追加 (#2 の writer pattern)。 テストは `ColorPolicy.Always` / `ColorPolicy.Never` を明示注入し、 single-write-at-startup の install 契約を破らない。

## レビュー観点

- **named input 廃止**: 旧実装が \`app\` / \`lib\` / \`linuxX64\` 等の named を受け付けていたが、 番号表示が discoverability の主役になったので named は廃止し numeric only に。 \`PromptTest.ttyKindPromptRejectsNamedInput\` / \`ttyTargetPromptRejectsNamedInput\` で reject 契約を pin。
- **non-TTY での next-step**: issue DoD third bullet 「After scaffolding, print a next-step block」は無条件、 fourth bullet 「Non-TTY stdin skips prompting silently」は **prompting** に限定なので両立。 \`PromptTest.nonTtyNoPromptsAndDefaultsApply\` を「prompt header / arrow が出ていないこと」に refine。
- **stdout vs stderr**: prompt と next-step は stdout 経由 (kotlin.io.println、 ScaffoldIO.println が wrapper)。 #2 の DiagnosticWriter は stderr 専用なので別チャネル。 \`Stream.Stdout\` で色判定しているのが意図通り。
- **next-step block の channel 選択**: scaffoldProject の既存 \`created X\` ログは raw println、 next-step block は io.println。 一貫性は崩れているが scope (NewCommand.kt + InitCommand.kt) を守るため scaffoldProject 側は触っていない。 後続で scaffoldProject も io 経由に揃える価値はある (別 PR 候補)。
- **init 拡張の妥当性**: 元 issue scope は \`kolt.cli.NewCommand\` のみだったが、 \`resolveInteractive\` を共有する都合と「init でも同じ仕組みになるか」という dogfood 質問を受けて scope を init 側にも広げた。 \`cd\` 行を出さないので「すでに target dir にいる」セマンティクスは保たれる。

## 検証

- \`kolt build\` green
- \`kolt test\` 1892 tests / 191 cases green
- 実機 smoke:
  - \`kolt new myapp\` → 番号入力で kind/target 選択、 next-step block で \`cd myapp\` + \`kolt run\`
  - \`kolt init --lib\` → \`cd\` 抜きで \`kolt build\` のみ出力
  - prompt/option 色は TTY 環境で cyan/yellow 確認