### PR TITLE
Surface per-artifact progress and retries during dependency resolve (#404)

### DIFF
--- a/.kiro/specs/404-resolver-progress/design.md
+++ b/.kiro/specs/404-resolver-progress/design.md
@@ -1,0 +1,393 @@
+# Design — 404-resolver-progress
+
+## Overview
+
+**Purpose**: Surface per-artifact JAR / klib download progress and per-attempt repository retries to stderr during dependency resolution, so users running `kolt build`, `kolt add`, `kolt fetch`, and `kolt update` can tell whether kolt is fetching, blocked on a slow mirror, or hung on DNS.
+
+**Users**: Anyone exercising the in-Kotlin resolver against an uncached or partially-cached dependency set, especially on slow / flaky networks or with multiple `[repositories]` entries.
+
+**Impact**: The resolver kernel and its CLI entry points gain a `ResolverProgressSink` injection point (defaulted to no-op for tests and other consumers). `kolt build / add / fetch / update` wire a stderr-backed sink. The existing `resolving dependencies…` / `resolving native dependencies…` / `updating dependencies…` banners move from stdout to stderr so stdout stays clean for command output.
+
+### Goals
+
+- A `[N/M] <group:artifact:version>` line on stderr before each network fetch of a JAR (JVM path) or klib (Native path).
+- Per-attempt retry annotation on stderr when an HTTP 404 falls through to the next configured repository.
+- Identical progress contract for the JVM transitive resolver, the Kotlin/Native target resolver, and `[classpaths.<name>]` bundle resolution.
+- Stdout free of progress and banners across the in-scope commands.
+- An emission contract usable when concurrent fetch lands later — the sink interface must allow a buffered or serialized implementation without changing resolver signatures.
+
+### Non-Goals
+
+- Implementing concurrent fetch in the resolver kernels.
+- A `--quiet` / `--no-progress` flag.
+- Progress lines for POM, `.module`, sources, or `maven-metadata.xml` fetches.
+- Changes to `formatResolveError` rendering on the failure path.
+- Sink integration in `kolt outdated`, plugin-jar fetch, BTA-impl fetch, or `kolt add`'s "find latest version" metadata probe.
+- Changes to `install.sh` (#405).
+
+## Boundary Commitments
+
+### This Spec Owns
+
+- A `ResolverProgressSink` interface in `kolt.resolve` and its `NoOp` companion default.
+- A stderr-backed sink implementation wired by the CLI for `kolt build`, `kolt add`, `kolt fetch`, `kolt update`.
+- A pre-count of materialize-loop fetch targets in JVM, Native, and Bundle paths so `M` is known before the first `[N/M]` line.
+- Routing the existing dependency-resolution banners (`resolving dependencies…`, `resolving native dependencies…`, `updating dependencies…`) from stdout to stderr.
+- Adding an `onRetry: (String) -> Unit = {}` parameter to `downloadFromRepositories`; only the JAR / klib materialize call sites pass a non-default callback.
+
+### Out of Boundary
+
+- Concurrent fetch in `materialize` / `resolveNative` (kept strictly serial in this spec).
+- Sink wiring in `kolt outdated` (`OutdatedCommand.kt`), `PluginJarFetcher`, `BtaImplFetcher`, and `resolveSourcesPath`.
+- `[N/M]` framing for `fetchLatestVersion` (`DependencyCommands.kt:142`) — this single-artifact metadata probe gets a one-shot `fetching latest version of <ga>...` line on stderr instead (see "Modified Files" → `DependencyCommands.kt` below).
+- Error-path rendering changes (covered by closed #355).
+- ANSI / TTY detection — progress is plain text on stderr.
+- `install.sh` progress (#405).
+
+### Allowed Dependencies
+
+- `kolt.infra.eprintln` for stderr writes.
+- `kolt.resolve.ResolverDeps` interface (unchanged shape).
+- `kolt.resolve.RepositoryDownloadFailure` / `RepositoryAttempt` (existing — unchanged).
+- No new external libraries. No coroutine usage.
+
+### Revalidation Triggers
+
+- Adding a new top-level resolver entry that performs its own materialize-style fetch loop (must wire the sink for parity).
+- Introducing concurrent fetch in any resolver path (must verify Req 3.1 by either serializing emission or buffering per-task and flushing atomically).
+- Changing the `[N/M]` line format or the retry annotation wording (downstream tooling could parse stderr).
+- Moving `downloadFromRepositories` away from `repos.indices`-style iteration in a way that loses the "next repo to retry against" handle needed by `onRetry`.
+
+## Architecture
+
+### Existing Architecture Analysis
+
+- `kolt.cli.DependencyResolution.{resolveDependencies, resolveNativeDependencies, resolveAllBundles}` is the single CLI integration surface for every dependency-resolution path.
+- The resolver kernel injects I/O through `ResolverDeps`. The same pattern is the natural seam for progress: a second injectable `ResolverProgressSink`, defaulted to NoOp.
+- `downloadFromRepositories` is the single function that handles 404 fall-through across `[repositories]` entries; nine call sites use it. Adding a defaulted retry callback lets only the in-scope call sites surface retries while the others stay silent.
+- Both `materialize` (JVM) and `resolveNative` already iterate `nodes` in strict serial `for` loops; Req 3 is satisfied by serialization in this spec, with the sink interface holding the contract for a future parallel rewrite.
+- `kolt.infra.output` already provides stderr writers (`eprintln`, `eprintDiagnostic`) with ANSI / color policy. The stderr sink reuses `eprintln` directly — diagnostic severity rendering is not appropriate for progress (no error / warning / note label).
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+  subgraph CLI
+    DepResolution[DependencyResolution]
+    DepCommands[DependencyCommands]
+    BuildCommands[BuildCommands]
+  end
+
+  subgraph Resolve_Kernel [kolt.resolve]
+    Resolver[Resolver]
+    Transitive[TransitiveResolver]
+    Native[NativeResolver]
+    Bundle[BundleResolver]
+    Sink[ResolverProgressSink]
+    DownloadFn[downloadFromRepositories]
+  end
+
+  subgraph Infra
+    Eprintln[kolt.infra.eprintln]
+  end
+
+  StderrSink[StderrProgressSink]
+  NoOpSink[NoOp]
+
+  DepResolution --> Resolver
+  DepResolution --> Bundle
+  DepResolution --> StderrSink
+  StderrSink -.implements.-> Sink
+  NoOpSink -.implements.-> Sink
+
+  Resolver --> Transitive
+  Resolver --> Native
+  Transitive --> DownloadFn
+  Native --> DownloadFn
+  Bundle --> DownloadFn
+
+  Transitive -- onArtifactStart --> Sink
+  Native -- onArtifactStart --> Sink
+  Bundle -- onArtifactStart --> Sink
+  DownloadFn -- onRetry --> Sink
+
+  StderrSink --> Eprintln
+
+  BuildCommands --> DepResolution
+  DepCommands --> DepResolution
+  DepCommands --> Bundle
+```
+
+**Key decisions** (not visible in the diagram):
+- `ResolverProgressSink` is dependency-injected into resolver entry points and defaults to `NoOp`. Existing tests and non-CLI consumers (`BtaImplFetcher`, `DaemonPreconditions`) inherit silent behavior without code changes.
+- `onArtifactStart` is emitted at the *materialize* layer, not inside `downloadFromRepositories`. Materialize knows artifact identity and the pre-counted total `M`; the inner download loop only knows URLs.
+- `onRetry` is emitted from inside `downloadFromRepositories` because that is the only function that holds the per-attempt failure / retry state. The callback fires after a 404 is recorded and before the next iteration begins, with the *next* repo as argument.
+- POM, `.module`, sources, and metadata-XML fetches stay silent. They go through `downloadFromRepositories` with the default `onRetry = {}`. The `resolving dependencies…` banner covers the metadata / graph-resolution phase implicitly.
+
+### Technology Stack
+
+| Layer | Choice | Role |
+| --- | --- | --- |
+| CLI | `kolt.cli` Kotlin/Native | Wires `StderrProgressSink` and relocates 3 banners from stdout to stderr |
+| Resolver kernel | `kolt.resolve` Kotlin/Native | Threads sink through `resolve()` → `materialize` / `resolveNative` / `resolveBundle`; adds `onRetry` to `downloadFromRepositories` |
+| Stderr writer | `kolt.infra.eprintln` (existing) | Single output primitive used by the production sink |
+
+No new dependencies. No version bumps.
+
+## File Structure Plan
+
+### New Files
+
+```
+src/nativeMain/kotlin/kolt/resolve/
+└── ResolverProgressSink.kt       # interface + NoOp companion (≈25 LoC)
+
+src/nativeTest/kotlin/kolt/resolve/
+└── ResolverProgressTest.kt       # recording-sink unit tests for the emission contract
+```
+
+### Modified Files
+
+- `src/nativeMain/kotlin/kolt/resolve/Resolver.kt` — add `progress: ResolverProgressSink = ResolverProgressSink.NoOp` to `resolve()`; thread to `resolveTransitive` / `resolveNative`.
+- `src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt` — add `onRetry` param (default `{}`) to `downloadFromRepositories`; emit on 404 fall-through. Thread `progress` into `resolveTransitive` and `materialize`. In `materialize`, pre-count uncached JAR nodes for `M` and call `progress.onArtifactStart(N, M, ga, version)` before each download. `resolveSourcesPath` keeps default `onRetry = {}` (silent).
+- `src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt` — thread `progress` into `resolveNative`. Pre-count uncached klib nodes; emit `onArtifactStart` before each klib `downloadFromRepositories`. `fetchAndRead` (used for `.module` fetches) keeps default `onRetry = {}` (silent).
+- `src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt` — accept `progress` in `resolveBundle`, `resolveSingleArtifact`, and `materialiseBundleJarsFromLock`; same materialize-style pre-count and `onArtifactStart` emission for bundle-direct deps. The lock-reuse path (`materialiseBundleJarsFromLock`) is included so a stale-cache + matching-lock combination still surfaces its re-download.
+- `src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt`:
+  - Provide an internal helper `newStderrProgressSink(): ResolverProgressSink` and use it in **both** `resolveDependencies` (passes to `resolve()` and `resolveAllBundles`) and `resolveNativeDependencies` (passes to `resolve()` at line 357). One sink instance per top-level resolver invocation.
+  - Move line 124 `println("resolving dependencies...")` to `eprintln(...)`.
+  - Move line 355 `println("resolving native dependencies...")` to `eprintln(...)`.
+  - The sink can live as a `private class` inside `DependencyResolution.kt` (one production implementation, no need for a public type yet).
+- `src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt`:
+  - Move line 248 `println("updating dependencies...")` to `eprintln(...)`.
+  - Pass a `newStderrProgressSink()` instance to the explicit `resolve()` and `resolveAllBundles` calls in `doUpdateInner`.
+  - In `fetchLatestVersion` (line 142), emit `eprintln("fetching latest version of $group:$artifact...")` once before the `downloadFromRepositories` call. No `[N/M]` framing — this is a single-artifact metadata probe, not a fetch loop. The line resolves the silent gap at the start of `kolt add com.example:lib` (no version) without expanding the sink contract.
+
+> Files outside this list (`OutdatedCommand.kt`, `PluginJarFetcher.kt`, `BtaImplFetcher.kt`, `DaemonPreconditions.kt`, `ToolCommands.kt`) remain unchanged. They obtain `ResolverDeps` and call `resolve()` / `downloadFromRepositories` with sink defaulted to NoOp and `onRetry` defaulted to `{}` — silent by inheritance.
+
+## System Flows
+
+### Per-artifact emission (success after 404 retry)
+
+```mermaid
+sequenceDiagram
+  participant CLI as DependencyResolution
+  participant Sink as StderrProgressSink
+  participant Mat as materialize loop
+  participant Dl as downloadFromRepositories
+
+  CLI->>Mat: resolve(progress=Sink)
+  Note over Mat: Pre-count uncached JARs in nodes -> M
+  Mat->>Sink: onArtifactStart(1, M, com.example:lib, 1.0)
+  Mat->>Dl: download with onRetry callback, repos=[A, B]
+  Dl->>Dl: try A -> 404
+  Dl->>Sink: onRetry(B)
+  Dl->>Dl: try B -> 200 OK
+  Dl-->>Mat: Ok
+  Mat->>Sink: onArtifactStart(2, M, ...)
+  Note over Mat: ... continue serial ...
+```
+
+### Cache-warm path (Req 1.3)
+
+When `M = 0` after the pre-count, the materialize loop emits no `onArtifactStart` calls. The `resolving dependencies…` banner remains the user's only confirmation that resolution ran.
+
+## Requirements Traceability
+
+| Req | Summary | Components | Interfaces / Calls | Flows |
+| --- | --- | --- | --- | --- |
+| 1.1 | `[N/M] ga:v` before each network fetch | `materialize` (JVM), `resolveNative` (klib), `resolveBundle` (bundle direct) | `ResolverProgressSink.onArtifactStart` | per-artifact emission flow |
+| 1.2 | cache hit silent | materialize / resolveNative — emission is inside `if (!fileExists(...))` branch | none | cache-warm path |
+| 1.3 | warm cache silent | materialize / resolveNative — pre-count yields `M = 0` | none | cache-warm path |
+| 1.4 | parity across JVM and Native | both materializers wire `progress` | `ResolverProgressSink` | both materialize flows |
+| 2.1 | retry annotation on 404 fall-through | `downloadFromRepositories` | `onRetry: (String) -> Unit` | per-artifact emission flow |
+| 2.2 | retry annotation after `[N/M]`, before next attempt | materialize emits `onArtifactStart` before calling `downloadFromRepositories`; the latter emits `onRetry` between attempts | sequential | per-artifact emission flow |
+| 2.3 | non-404 errors emit no retry annotation | `downloadFromRepositories` early-returns on non-404 before calling `onRetry` | conditional | per-artifact emission flow |
+| 2.4 | exactly one `[N/M]` per artifact | `onArtifactStart` is called from materialize *outside* `downloadFromRepositories`, so retries don't trigger duplicate emissions | structural | per-artifact emission flow |
+| 3.1 | non-interleaving (one artifact = contiguous block) | materialize is strictly serial today; sink interface is stateless on the emitter side, allowing the caller to swap to a buffered impl later | sink contract | — |
+| 3.2 | serial today, no buffering required | `StderrProgressSink` calls `eprintln` synchronously | direct dispatch | — |
+| 3.3 | future parallel safe | sink methods are pure callbacks; a buffered sink can be substituted without changing resolver signatures | sink contract | — |
+| 4.1 | progress on stderr | `StderrProgressSink` writes via `eprintln` | `eprintln` | — |
+| 4.2 | banner on stderr | `DependencyResolution.kt:124, 355` and `DependencyCommands.kt:248` move from `println` to `eprintln` | `eprintln` | — |
+| 4.3 | piped stdout clean | logical consequence of 4.1 + 4.2 | — | `kolt fetch > out.txt` keeps `fetch complete` only |
+| 5.1 | sources fetch silent | `resolveSourcesPath` calls `downloadFromRepositories` with default `onRetry = {}` and is not invoked from a materialize loop that emits `onArtifactStart` for sources | structural | — |
+| 5.2 | sources failure silent | `resolveSourcesPath` already returns `null` on failure; no error rendering added | structural | unchanged |
+
+## Components and Interfaces
+
+| Component | Domain / Layer | Intent | Req coverage | Key dependencies | Contracts |
+| --- | --- | --- | --- | --- | --- |
+| `ResolverProgressSink` | resolve | Two-method sink defining the progress emission contract; `NoOp` companion | 1.1, 2.1, 3.3 | none (P0) | Service |
+| `StderrProgressSink` (private to CLI) | cli | Production sink that writes `[N/M] …` and `  -> retry against …` to stderr via `eprintln` | 1.1, 2.1, 4.1 | `kolt.infra.eprintln` (P0), `ResolverProgressSink` (P0) | Service |
+| `materialize` (JVM) | resolve | Pre-counts uncached JARs and emits `onArtifactStart` before each network download; threads `onRetry` into `downloadFromRepositories` | 1.1, 1.2, 1.3, 1.4, 2.4 | `ResolverDeps` (P0), `downloadFromRepositories` (P0) | Service |
+| `resolveNative` | resolve | Pre-counts uncached klibs and emits `onArtifactStart` before each klib download | 1.1, 1.4 | `ResolverDeps` (P0), `downloadFromRepositories` (P0) | Service |
+| `resolveBundle` / `resolveSingleArtifact` / `materialiseBundleJarsFromLock` | resolve | Emits `onArtifactStart` for `[classpaths.<name>]` direct entries (including the lock-reuse re-download path) | 1.1, 1.4 | `ResolverDeps` (P0), `downloadFromRepositories` (P0) | Service |
+| `downloadFromRepositories` | resolve | Adds `onRetry: (String) -> Unit = {}`; fires the callback after a 404 and before the next iteration | 2.1, 2.2, 2.3 | `ResolverDeps.downloadFile` (P0) | Service |
+| `DependencyResolution` (CLI wiring) | cli | Constructs `StderrProgressSink` for **both** `resolveDependencies` (JVM transitive) and `resolveNativeDependencies` (Kotlin/Native), passes to `resolve()` and `resolveAllBundles`, relocates two banners | 1.4, 4.1, 4.2, 4.3 | `eprintln` (P0), `ResolverProgressSink` (P0) | Service |
+| `DependencyCommands` (CLI wiring) | cli | Same sink wiring for `kolt update`; relocates `updating dependencies...` banner; emits `fetching latest version of <ga>...` line in `fetchLatestVersion` to close the metadata-probe silent gap before `kolt add` enters `resolveDependencies` | 1.4, 4.1, 4.2, 4.3 | `eprintln` (P0), `ResolverProgressSink` (P0) | Service |
+
+### `ResolverProgressSink` — Service
+
+```kotlin
+package kolt.resolve
+
+interface ResolverProgressSink {
+  fun onArtifactStart(index: Int, total: Int, groupArtifact: String, version: String)
+  fun onRetryAgainst(repository: String)
+
+  companion object {
+    val NoOp: ResolverProgressSink = object : ResolverProgressSink {
+      override fun onArtifactStart(index: Int, total: Int, groupArtifact: String, version: String) {}
+      override fun onRetryAgainst(repository: String) {}
+    }
+  }
+}
+```
+
+**Preconditions**:
+- `onArtifactStart` is called exactly once per uncached JAR / klib in a single `resolve()` invocation.
+- `onArtifactStart` is called with `1 ≤ index ≤ total` and a stable `total` for the duration of one resolver invocation.
+- `onRetryAgainst` is called only after `onArtifactStart` for the same artifact and only when an HTTP 404 against one repository falls through to a non-empty next repository in the configured list.
+
+**Postconditions**:
+- The sink does not throw. Implementations must swallow stderr write failures.
+
+**Invariants**:
+- Implementations are not required to be thread-safe. The current resolver is serial; if a future change introduces concurrent fetch, the calling code is responsible for serializing emission or providing a thread-safe sink (Req 3.3).
+
+### `StderrProgressSink` — production implementation
+
+```kotlin
+private class StderrProgressSink(
+  private val emit: (String) -> Unit = ::eprintln,
+) : ResolverProgressSink {
+  override fun onArtifactStart(index: Int, total: Int, groupArtifact: String, version: String) {
+    emit("[$index/$total] $groupArtifact:$version")
+  }
+  override fun onRetryAgainst(repository: String) {
+    emit("  -> retry against $repository")
+  }
+}
+```
+
+**Output examples**:
+
+```
+resolving dependencies...
+[1/3] com.squareup.okio:okio-jvm:3.9.0
+[2/3] com.example:flaky:1.0.0
+  -> retry against https://repo.internal.example.com/maven2/
+[3/3] org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.0
+```
+
+The `emit` parameter is for unit testing — production wiring uses the `eprintln` default.
+
+### `downloadFromRepositories` — modified signature
+
+```kotlin
+internal fun downloadFromRepositories(
+  repos: List<String>,
+  destPath: String,
+  urlBuilder: (String) -> String,
+  download: (String, String) -> Result<Unit, DownloadError>,
+  onRetry: (String) -> Unit = {},
+): Result<Unit, RepositoryDownloadFailure>
+```
+
+Internal change: iterate `repos.indices`. After appending a 404 attempt, if the loop is about to advance to `repos[i+1]`, call `onRetry(repos[i+1])` exactly once before the next iteration begins. No callback on the final attempt that exhausts the list and on any non-404 error (preserves Req 2.3).
+
+### `resolve()` — modified signature
+
+```kotlin
+fun resolve(
+  config: KoltConfig,
+  existingLock: Lockfile?,
+  cacheBase: String,
+  deps: ResolverDeps,
+  mainSeeds: Map<String, String> = config.dependencies,
+  testSeeds: Map<String, String> = emptyMap(),
+  progress: ResolverProgressSink = ResolverProgressSink.NoOp,
+): Result<ResolveResult, ResolveError>
+```
+
+`resolveTransitive`, `resolveNative`, `materialize`, `resolveBundle`, and `resolveSingleArtifact` gain the same defaulted parameter and forward it.
+
+### Materialize pre-count and emission (JVM, applied analogously to Native and Bundle)
+
+```kotlin
+val toFetch = nodes.filter { node ->
+  val coord = parseCoordinate(redirects[node.groupArtifact] ?: node.groupArtifact, node.version)
+    .getOrElse { return@filter false }
+  !deps.fileExists("$cacheBase/${buildCachePath(coord)}")
+}
+val total = toFetch.size
+var index = 0
+
+for (node in nodes) {
+  // ... existing resolve / sha / lockfile bookkeeping ...
+  if (!binaryWasCached) {
+    index += 1
+    progress.onArtifactStart(index, total, node.groupArtifact, node.version)
+    downloadFromRepositories(
+      repos,
+      fullCachePath,
+      { buildDownloadUrl(coord, it) },
+      deps::downloadFile,
+      onRetry = progress::onRetryAgainst,
+    ).getOrElse { failure -> return Err(ResolveError.DownloadFailed(node.groupArtifact, failure)) }
+    lockChanged = true
+  }
+  // ... sha + sourcesPath unchanged; resolveSourcesPath stays silent ...
+}
+```
+
+**Notes**:
+- Pre-count adds `O(N)` extra `fileExists` calls. `fileExists` is a `stat` — the added cost is negligible against network I/O.
+- The `index` variable counts only emitted artifacts; cached nodes do not advance it.
+- `resolveSourcesPath` does not call the sink, satisfying Req 5.1 / 5.2.
+
+## Error Handling
+
+No new error categories. The existing `ResolveError` ADT and `formatResolveError` rendering are unchanged. When a fetch fails, the user sees the existing per-repository error dump after the `[N/M]` line and any `onRetryAgainst` annotations have been printed.
+
+## Testing Strategy
+
+### Unit Tests (new `ResolverProgressTest.kt`)
+
+Drives `resolveTransitive` / `resolveNative` / `resolveBundle` with a `RecordingSink` that captures `onArtifactStart` and `onRetryAgainst` calls in a list. Backed by the same anonymous `ResolverDeps` fakes already used in `TransitiveResolverTest`.
+
+1. **Happy path, all uncached** (Req 1.1, 1.4): three direct deps, no transitives, all uncached; assert exactly three `onArtifactStart` calls with `(1,3)`, `(2,3)`, `(3,3)` and matching GA / version.
+2. **Cache hit silence** (Req 1.2): two deps, one already in cache; assert one `onArtifactStart` for the uncached only and `total = 1`, not 2.
+3. **Warm cache** (Req 1.3): both deps cached; assert zero `onArtifactStart` calls.
+4. **Native parity** (Req 1.4): same shape as case 1 against `resolveNative` with klib fakes.
+5. **404 retry annotation** (Req 2.1, 2.4): two repos, first returns 404 for the JAR, second returns 200; assert exactly one `onArtifactStart` followed by exactly one `onRetryAgainst(repo[1])`.
+6. **Multi-hop retry** (Req 2.1): three repos, first two 404, third 200; assert two `onRetryAgainst` calls in order `[repo[1], repo[2]]`.
+7. **Non-404 silent retry** (Req 2.3): first repo returns `NetworkError`; assert no `onRetryAgainst` and the resolver returns `DownloadFailed` (existing behavior).
+8. **Sources silent** (Req 5.1, 5.2): force a sources fetch with the binary already cached; assert no `onArtifactStart` for sources.
+
+### Integration Smoke (existing test surface, augmented)
+
+- Reuse the existing CLI integration patterns (if a stderr-capture harness exists; otherwise this is manual). Run `kolt fetch` against a fixture project with one repo that 404s and a fallback repo that resolves; assert stderr contains `[1/1]` and `-> retry against …` lines and stdout is `fetch complete\n`.
+
+### Manual Verification
+
+- `rm -rf ~/.kolt/cache/<group>/...` then `kolt build` — observe the `[N/M]` count up the live download.
+- `kolt fetch > out.txt 2> err.txt` — confirm `out.txt` is `fetch complete\n` only, `err.txt` carries banner + progress.
+- Multi-repo fixture (`kolt.toml` with two `[repositories]` entries, second hosts a coordinate the first does not) — confirm `-> retry against …` line.
+
+## Performance & Scalability
+
+- Pre-count adds one extra `fileExists` per dep — `O(N)`, no I/O beyond `stat`.
+- Per uncached artifact: 1 `eprintln` for `onArtifactStart`, plus 0..R `eprintln` for retry where R = number of 404 fall-throughs (typically 0).
+- No effect on warm-cache `kolt build` latency: with `M = 0`, no sink methods fire and no extra `fileExists` calls happen beyond the existing ones (the pre-count short-circuits when `nodes.filter { !cached }` is empty).
+
+## Migration / Rollout
+
+- One-time PR. No data migration.
+- No flag, no opt-in. All users see the new lines on first fetch after upgrade.
+- Stdout-grep contracts: anyone parsing the previous `resolving dependencies…` line on stdout will break. The banner is informational and not in any documented contract; this is acceptable pre-v1 (per CLAUDE.md "no backward compatibility until v1.0").
+- Release-note entry: brief mention in the next bump-version PR's `docs/release-notes/v<X>.md`.
+
+## Open Questions
+
+- **Does `kolt update` benefit from the same per-artifact emission?** The design says yes — `doUpdateInner` already calls `resolve()` directly and now passes the sink. The `updating dependencies…` banner moves to stderr alongside the other two. If the maintainer prefers `kolt update` stay silent on per-artifact lines, drop the wiring at `DependencyCommands.kt:249` and keep the banner relocation only.
+- **Bundle progress vs. main resolve progress overlap**: the user sees one `[N/M]` sequence for main resolve, then independent `[N/M]` sequences per `[classpaths.<name>]` bundle. For typical projects (1–2 small bundles) this reads fine; for projects with many bundles the eye has to track resets. Aggregating into a global tally requires deferring `M` until all materialize loops have finished cache-checking — non-trivial and rejected for v1 of this feature. Revisit only if dogfood feedback warrants it.

--- a/.kiro/specs/404-resolver-progress/requirements.md
+++ b/.kiro/specs/404-resolver-progress/requirements.md
@@ -1,0 +1,73 @@
+# Requirements Document
+
+## Introduction
+
+`kolt build`, `kolt add`, and `kolt fetch` currently print `resolving dependencies...` and then go silent through the POM, `.module`, and JAR downloads. On a project with many dependencies that silence can run 10s+; the user cannot tell whether kolt is fetching, stuck on a slow mirror, or hung on DNS. Retries and mirror fallbacks are also invisible until the final success or failure line.
+
+This feature surfaces per-artifact progress on stderr during the in-Kotlin resolver's fetch loop, makes retries and mirror fallbacks visible, and keeps the emission contract readable when parallel fetch lands later. Stdout stays clean for command output.
+
+GitHub issue: #404 (label: dogfood). Related: #355 (failure-message rendering, already shipped — unchanged here), #405 (install.sh progress, separate workstream — out of scope).
+
+## Boundary Context
+
+- **In scope**:
+  - The in-Kotlin resolver path used by `kolt build`, `kolt add`, `kolt fetch`, and any other CLI entry that drives dependency resolution against a configured repository set.
+  - Both the JVM transitive resolution path and the Kotlin/Native target resolution path.
+  - Per-artifact progress lines, retry / mirror-fallback annotations, and a non-interleaving emission contract.
+  - Keeping stdout clean across the commands listed above.
+- **Out of scope**:
+  - `install.sh` progress (#405).
+  - Changes to the failure-message rendering itself (closed under #355).
+  - A new `--quiet` / `--no-progress` flag.
+  - Implementing parallel fetch in this feature.
+- **Adjacent expectations**:
+  - kolt's existing stderr writer surface (severity-tagged diagnostic helpers) is the integration point; this feature is expected to layer onto it rather than introduce a parallel writer.
+  - The existing failure-message rendering remains unchanged on the error path.
+
+## Requirements
+
+### Requirement 1: Per-artifact progress emission
+
+**Objective:** As a user running `kolt build`, `kolt add`, or `kolt fetch` against an uncached or partially-cached dependency set, I want to see which artifact is being fetched at each step, so I can tell whether kolt is making progress, blocked on a slow mirror, or hung.
+
+#### Acceptance Criteria
+1. When the resolver begins a network fetch for an artifact during a kolt command that drives dependency resolution, the kolt CLI shall emit a line of the form `[N/M] <group:artifact:version>` to stderr before the fetch starts, where `N` is the 1-indexed sequence number and `M` is the total number of artifacts the resolver will fetch over the network in this invocation.
+2. When the resolver finds an artifact already present in the local cache and skips its network fetch, the kolt CLI shall not emit a `[N/M]` line for that artifact.
+3. When the fetch loop has zero artifacts to download (fully warm cache), the kolt CLI shall emit no `[N/M]` lines.
+4. The kolt CLI shall apply the same progress emission to both the JVM transitive resolution path and the Kotlin/Native target resolution path.
+
+### Requirement 2: Retry and mirror-fallback visibility
+
+**Objective:** As a user with multiple `[repositories]` entries, I want a failed-then-retried fetch to be visible, so I can tell "first repo missed, second succeeded" from "single slow link".
+
+#### Acceptance Criteria
+1. When a fetch attempt against one configured repository fails with HTTP 404 and the resolver retries against the next configured repository for the same artifact, the kolt CLI shall emit a follow-up annotation line on stderr surfacing the retry, and the annotation shall identify the repository being retried against.
+2. When the retry annotation in 2.1 is emitted, the kolt CLI shall emit it after the artifact's primary `[N/M]` line and before the next attempt completes.
+3. If a fetch attempt fails with a non-404 error and the resolver does not continue to the next repository, the kolt CLI shall not emit a retry annotation for that artifact.
+4. When one or more retries succeed for a single artifact, the kolt CLI shall emit exactly one `[N/M]` line for that artifact plus its retry annotations and shall not emit a duplicate `[N/M]` line on retry.
+
+### Requirement 3: Non-interleaving emission contract
+
+**Objective:** As a maintainer, I want the emission contract to remain readable when parallel fetch lands later, so this feature does not have to be revisited.
+
+#### Acceptance Criteria
+1. The kolt CLI shall ensure that progress lines belonging to a single artifact (its `[N/M]` line and any retry annotations) form one contiguous block on stderr without lines from another artifact interleaved between them.
+2. While the resolver runs serially, the kolt CLI shall emit progress synchronously and is not required to buffer.
+3. Where a future change introduces concurrent network fetches in the resolver, the kolt CLI shall either serialize emission or buffer per-task lines and flush atomically on task completion, so that the property in 3.1 still holds.
+
+### Requirement 4: Stream isolation — progress on stderr
+
+**Objective:** As a user piping command output to a script or file, I want progress output not to corrupt my command output stream.
+
+#### Acceptance Criteria
+1. The kolt CLI shall write all progress lines and retry annotations introduced by this feature to stderr.
+2. The kolt CLI shall write the existing `resolving dependencies...` banner to stderr instead of stdout.
+3. When stdout is redirected (e.g. `kolt fetch > deps.txt`), the kolt CLI shall continue to emit progress to stderr and stdout shall contain only the command's primary output.
+
+### Requirement 5: Sources fetch silence
+
+**Objective:** As a user, I do not want best-effort sources downloads cluttering progress, since missing upstream sources are common and not actionable.
+
+#### Acceptance Criteria
+1. While the resolver performs the best-effort sources JAR fetch for a resolved binary, the kolt CLI shall not emit a `[N/M]` line for the sources fetch.
+2. If a sources fetch fails, the kolt CLI shall remain silent for that failure, preserving the current best-effort behavior.

--- a/.kiro/specs/404-resolver-progress/research.md
+++ b/.kiro/specs/404-resolver-progress/research.md
@@ -1,0 +1,166 @@
+# Gap Analysis — 404-resolver-progress
+
+## 1. Current State Investigation
+
+### CLI integration surface (single hop from user commands)
+
+- `kolt.cli.DependencyResolution.resolveDependencies()` (`DependencyResolution.kt:65`) — the JVM transitive entry. Called by `kolt build` (`BuildCommands.kt:316/443/468`), `kolt add` and `kolt remove` (via `DependencyCommands.kt:85`), `kolt fetch` / `kolt update` (`DependencyCommands.kt:203`).
+- `kolt.cli.DependencyResolution.resolveNativeDependencies()` (`DependencyResolution.kt:349`) — Kotlin/Native target entry. Called by `kolt build` for native (`BuildCommands.kt:660/1300`).
+- `kolt.cli.DependencyResolution.resolveAllBundles()` (`DependencyResolution.kt:213`) — `[classpaths.<name>]` bundle resolver, also called from build/fetch.
+- `kolt.cli.DependencyCommands` deep-fetch path (`DependencyCommands.kt:161/236/266`) and `kolt.cli.OutdatedCommand` (`OutdatedCommand.kt:82`) call `downloadFromRepositories` directly.
+
+### Resolver kernel
+
+- `kolt.resolve.resolve()` (`Resolver.kt:197`) dispatches by target: `resolveNative` for native targets, `resolveTransitive` otherwise.
+- JVM path `resolveTransitive` (`TransitiveResolver.kt:11`) → `materialize` (`TransitiveResolver.kt:199`) iterates `nodes` serially, downloading each missing JAR, then optionally `resolveSourcesPath`.
+- Native path `resolveNative` (`NativeResolver.kt:38`) iterates `nodes` serially, downloading each missing klib at line 79; metadata fetches happen in `fetchAndRead` (NativeResolver.kt:253).
+- `kolt.resolve.BundleResolver.resolveBundle` and `resolveSingleArtifact` follow the same materialize-loop shape.
+
+### Single physical retry / fallback site
+
+- `TransitiveResolver.downloadFromRepositories` (`TransitiveResolver.kt:83`) is the only place that loops over `repos`, falls through on HTTP 404, and aggregates `RepositoryAttempt`s. **All** repository-fallback retry visibility has to thread through this function or its callers.
+- 9 call sites of `downloadFromRepositories` — POM, JAR, `.module`, sources, klib, plugin jar, deep-fetch direct, outdated probe.
+
+### Dependency injection seam
+
+- `kolt.resolve.ResolverDeps` (`Resolver.kt:168`) is the single seam used by every resolver path: `fileExists`, `ensureDirectoryRecursive`, `downloadFile`, `computeSha256`, `readFileContent`.
+- `defaultResolverDeps()` wires real `kolt.infra` I/O. Tests build anonymous `object : ResolverDeps { … }` (e.g. `TransitiveResolverTest.kt:997, 1044, 1346, 1396, 1432`) and provide canned content via maps.
+
+### Stderr writer surface
+
+- `kolt.infra.output` (`AnsiCodes.kt`, `ColorPolicy.kt`, `DiagnosticWriter.kt`, `RenderedDiagnostic.kt`, `Severity.kt`) already provides `eprintln` (`kolt.infra.eprintln`) and `eprintDiagnostic` / `eprintError` / `eprintWarning` / `eprintNote` (all stderr-only by contract per `DiagnosticWriter.kt:28`).
+- `ColorPolicy.shouldColor(Stream.Stderr)` gates ANSI output per stream; `AnsiStripper` strips on non-color sinks.
+
+### Banner today
+
+- `DependencyResolution.kt:124` — `println("resolving dependencies...")` is on **stdout** (println, not eprintln).
+- `DependencyResolution.kt:355` — `println("resolving native dependencies...")` likewise on stdout.
+- Req 4.2 explicitly relocates these to stderr.
+
+### Concurrency
+
+- Both `materialize` (JVM) and `resolveNative` are strict `for (node in nodes)` loops — no coroutine launch, no `Mutex`, no parallelism today. Req 3 stays an emission-contract requirement, not a behavior one.
+
+## 2. Requirement-to-Asset Map
+
+| Req | Capability needed | Asset present | Gap |
+| --- | --- | --- | --- |
+| 1.1 `[N/M]` line before each network fetch | A sink the resolver calls at fetch start | None | **Missing**: progress sink interface + wiring through `resolve()` → `materialize` / `resolveNative` |
+| 1.2 cache hit silent | Cache short-circuit before fetch | `if (!deps.fileExists(...)) { … download … }` exists in materialize, resolveNative, sources, etc. | None — emit only inside the `!fileExists` branch |
+| 1.3 fully warm cache silent | Same as 1.2 | Same | None |
+| 1.4 JVM + native parity | Same sink wired to both kernels | Both use same ResolverDeps and same `downloadFromRepositories` | Single design covers both |
+| 2.1 retry annotation | Hook inside `downloadFromRepositories` repo loop | `attempts` list builds in-loop, but no callback | **Missing**: per-attempt callback alongside accumulating `attempts` |
+| 2.2 ordering (after `[N/M]`, before next attempt) | In-loop emission | Serial loop — natural | None |
+| 2.3 no retry annotation on non-404 | 404-only fallthrough | `if (error.statusCode != 404) return Err(...)` already enforces this | None |
+| 2.4 no duplicate `[N/M]` on retry | Single emission per artifact | Need to emit at the artifact-level call site, not inside the repo loop | **Constraint**: artifact-level emission must wrap the whole `downloadFromRepositories` call, not be inside it |
+| 3.1–3.2 non-interleaving (serial) | Synchronous emission | Serial today | None |
+| 3.3 non-interleaving (future parallel) | Buffered or serialized emission contract | None | **Constraint**: sink interface must keep "one artifact = contiguous block" achievable when caller buffers. Solvable by making the sink stateless from the resolver's POV — caller decides serialize vs. buffer. |
+| 4.1 progress on stderr | Stderr writers | `eprintln` exists | None |
+| 4.2 banner on stderr | Same | Currently `println` | **Missing**: 2-line change in `DependencyResolution.kt:124, 355` |
+| 4.3 piped stdout clean | Logical consequence of 4.1, 4.2 | — | None additional |
+| 5.1 sources fetch silent | Skip sink in `resolveSourcesPath` | `resolveSourcesPath` exists | None — sink not invoked for sources |
+| 5.2 sources failure silent | Same | `resolveSourcesPath` already swallows failure | None |
+
+Tags: **Missing** = code does not exist; **Constraint** = existing structure imposes a shape on the new code.
+
+### Out-of-scope but adjacent
+
+- `OutdatedCommand` and the deep-fetch path call `downloadFromRepositories` directly with no `[N/M]` framing. Issue scope is `build / add / fetch`. **Open question** for design: do `kolt outdated` and `kolt update` (which goes through `resolveDependencies`) need progress too? `update` goes through `resolveDependencies` so it gets it for free; `outdated` is its own loop and is not in the issue's enumerated commands.
+
+## 3. Implementation Approach Options
+
+### Option A: Inject a `ProgressSink` into resolver entry points
+
+Add a sink parameter (defaulted to no-op) to `resolve()`, `resolveTransitive`, `resolveNative`, `materialize`, `resolveBundle`, `resolveSingleArtifact`, and threaded into `downloadFromRepositories` for retry callbacks.
+
+```
+interface ProgressSink {
+  fun onArtifactStart(index: Int, total: Int, groupArtifact: String, version: String)
+  fun onRetryAgainst(repository: String)
+  companion object { val NoOp: ProgressSink = ... }
+}
+```
+
+- **Files touched**: `Resolver.kt`, `TransitiveResolver.kt`, `NativeResolver.kt`, `BundleResolver.kt`, `DependencyResolution.kt`. ~5 production files plus a new sink file.
+- **Wiring**: pre-count at materialize loop start (count uncached JARs/klibs), call `onArtifactStart` before each `downloadFromRepositories` JAR/klib call, pass an in-loop lambda into `downloadFromRepositories` that calls `onRetryAgainst` on each non-final 404.
+- **Test ergonomics**: sink default `NoOp` keeps existing tests green; new tests use a recording sink.
+- ✅ Pure interface, easy to mock.
+- ✅ Sources fetch (`resolveSourcesPath`) trivially silent — just don't call `onArtifactStart` for it.
+- ✅ Future parallelization can swap to a buffered sink without changing resolver signatures.
+- ❌ Threading a parameter through several function signatures.
+- ❌ POM / `.module` fetches happen *before* the materialize count is known; they are silent under this option (acceptable per Req 1.1's "before each fetch" reading: design call below).
+
+### Option B: Decorate `ResolverDeps.downloadFile`
+
+CLI wraps `defaultResolverDeps().downloadFile` with an emitting wrapper.
+
+- ❌ The wrapper sees one URL at a time, not artifact identity (`group:artifact:version`). Recovering identity from URL is fragile (different URL shapes for POM, JAR, klib).
+- ❌ `M` is not known to a per-call wrapper.
+- ❌ Retry annotation needs to be inside `downloadFromRepositories`, not at `downloadFile` — wrapper sees retries as independent calls.
+- ❌ Hard to keep sources fetch silent without URL pattern matching.
+- Rejected.
+
+### Option C: Hybrid — sink in resolver + retry callback in `downloadFromRepositories`
+
+Same as Option A in shape, but explicit about the two callback sites:
+- Artifact-level `onArtifactStart(N, M, ga, version)` at materialize / resolveNative call site (one per uncached JAR/klib).
+- Repo-level `onRetryAgainst(repo)` passed as a lambda into `downloadFromRepositories`, fired only on 404 fallthrough (i.e. between attempts that won't be the last).
+
+This is what Option A actually requires once Req 2 is honored — A and C are the same shape; calling out the second callback explicitly removes a design ambiguity.
+
+- ✅ Retries surface at the right granularity.
+- ✅ JVM and native paths share one sink interface.
+- ✅ `M` is the count of uncached materialize entries — known up front per kernel.
+- ❌ `downloadFromRepositories` signature grows by one optional parameter.
+
+**Preferred**: Option C. It is a strict extension of A and is what the requirements actually need.
+
+## 4. Effort & Risk
+
+- **Effort: S (1–3 days)**.
+  - Single new file (`ProgressSink.kt` or a sink type next to `Resolver.kt`).
+  - Threading a defaulted parameter through 4–6 functions.
+  - 2-line banner relocation in `DependencyResolution.kt`.
+  - CLI sink that calls `eprintln` (~30 LoC).
+  - ~6–10 unit tests (recording sink, count, retry, sources-silent, warm-cache-silent).
+- **Risk: Low**.
+  - No new dependencies, no concurrency rewrite, no error-handling change.
+  - Existing `ResolverDeps`-fake test pattern extends naturally.
+  - One acceptable judgment call (POM/`.module` silent vs. its own progress) does not block implementation; either choice is reversible.
+
+## 5. Research Items to Carry Into Design
+
+1. **Counting strategy**: confirm `M` = count of uncached JARs/klibs scheduled by `materialize` / `resolveNative`. POM/`.module` fetches are then silent. Alternative: dual progress prefixes (`metadata: …` then `[N/M] …`). Pick before tasks.
+2. **Sink interface shape**: a small interface (`ProgressSink`) vs. two function-typed parameters (`onStart`, `onRetry`). Interface scales better; functions are smaller in this PR.
+3. **Retry annotation text**: exact format. Issue suggests `… -> retry against <repo>`. Confirm wording, indent (`  -> retry against …` for 2-space indent matching `RenderedDiagnostic` context lines), and whether to truncate long URLs.
+4. **Banner final shape**: keep `resolving dependencies…` on stderr, drop it entirely once `[N/M]` exists, or condense to a single counted header. Keep simple unless data argues otherwise.
+5. **Adjacent commands**: `kolt outdated` and the deep-fetch `kolt fetch --refresh` path call `downloadFromRepositories` directly without the materialize loop. In or out for this spec? Issue scope says `build / add / fetch` — deep-fetch is part of `kolt fetch`, outdated is its own command. Recommend in-scope: deep-fetch; out-of-scope: outdated.
+6. **Bundle resolver parity**: `[classpaths.<name>]` bundles go through `resolveBundle` and the same materialize loop. Confirm sink wiring there for parity.
+7. **TTY / quiet mode**: explicitly out per requirements unless the design phase surfaces a strong reason. No action expected.
+
+---
+
+## Synthesis Decisions (post-design)
+
+Applied the three synthesis lenses to the requirements + gap findings before writing `design.md`.
+
+### Generalization
+
+- Req 1 (per-fetch start) and Req 2 (retry) are two events in the same artifact lifecycle, not independent capabilities. They unify into one `ResolverProgressSink` interface with two methods (`onArtifactStart`, `onRetryAgainst`). Req 3 is an emission *contract* on the sink usage, not a separate component — kept as documentation, not a class.
+- Req 1.4 (JVM + Native parity) is satisfied by sink injection: `materialize` (JVM), `resolveNative` (klib), and `resolveBundle` (bundle) all materialize through the same shape, so the same sink type covers all three.
+
+### Build vs. Adopt
+
+- No Kotlin/Native progress library exists in the project's dep set. `indicatif`-style libraries are Rust; we don't need rendering, only plain stderr lines.
+- Adopted `kolt.infra.eprintln` (existing) as the sole stderr writer. Did not adopt `eprintDiagnostic` / `RenderedDiagnostic` — those carry severity (error/warning/note) which is not appropriate for progress.
+- Did not adopt `ColorPolicy` integration. Progress is plain text; if styling is wanted later, it slots into the production sink without changing the resolver.
+
+### Simplification
+
+- Single `ResolverProgressSink` interface (not two separate function-typed parameters). Three benefits: cohesive intent (sink = "where progress goes"), one type to mock in tests via a recording fake, and one place to add a future method (e.g. `onArtifactComplete`) without churning every signature.
+- Pre-count `M` is computed at the start of each materialize loop via a one-pass `nodes.filter { !cached }`. Rejected the alternative `[N/?]` live-tally formats — issue mandates `[N/M]`.
+- POM / `.module` fetches are silent. Rationale: metadata fetches are typically faster than JAR / klib downloads (smaller files), the user-facing artifact identity is the JAR / klib, and the `resolving dependencies…` banner already covers the metadata phase implicitly. If users want metadata progress, follow-up issue.
+- `kolt outdated`, `fetchLatestVersion`, plugin-jar fetch, BTA-impl fetch, and `resolveSourcesPath` are not wired to the sink. They go through `downloadFromRepositories` with the default `onRetry = {}` and are silent by inheritance — no extra opt-out plumbing needed.
+- `StderrProgressSink` is a `private class` inside `DependencyResolution.kt` (not a public type). One production implementation; promotion to a public class is reversible if a second consumer appears.
+- Banner relocation is 3 lines (`println` → `eprintln` at `DependencyResolution.kt:124, 355` and `DependencyCommands.kt:248`). Other stdout writes (`fetch complete`, `no dependencies to update`) are command output and stay on stdout.
+

--- a/.kiro/specs/404-resolver-progress/spec.json
+++ b/.kiro/specs/404-resolver-progress/spec.json
@@ -1,9 +1,9 @@
 {
   "feature_name": "404-resolver-progress",
   "created_at": "2026-05-08T23:38:42Z",
-  "updated_at": "2026-05-09T00:50:00Z",
+  "updated_at": "2026-05-09T02:30:45Z",
   "language": "en",
-  "phase": "tasks-approved",
+  "phase": "implemented",
   "approvals": {
     "requirements": {
       "generated": true,

--- a/.kiro/specs/404-resolver-progress/spec.json
+++ b/.kiro/specs/404-resolver-progress/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "404-resolver-progress",
+  "created_at": "2026-05-08T23:38:42Z",
+  "updated_at": "2026-05-09T00:50:00Z",
+  "language": "en",
+  "phase": "tasks-approved",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/404-resolver-progress/tasks.md
+++ b/.kiro/specs/404-resolver-progress/tasks.md
@@ -4,7 +4,7 @@
 
 - [ ] 1. Foundation
 
-- [ ] 1.1 Define the resolver progress sink contract with a recording-sink test fixture
+- [x] 1.1 Define the resolver progress sink contract with a recording-sink test fixture
   - Establish a sink interface with two callbacks: one fired when an artifact's network fetch is about to start, one fired when a 404 advances the per-repository fall-through to the next repository.
   - Provide a no-op companion default so existing resolver consumers inherit silent behavior without code changes.
   - Add a recording-sink test fixture that captures every callback into an ordered list, plus a baseline test that drives the recording sink directly and asserts the recorded sequence matches a manually-constructed reference.

--- a/.kiro/specs/404-resolver-progress/tasks.md
+++ b/.kiro/specs/404-resolver-progress/tasks.md
@@ -31,7 +31,7 @@
 
 - [ ] 2. Core emission
 
-- [ ] 2.1 (P) JVM transitive materialize emits per-artifact and per-retry progress for JAR fetches
+- [x] 2.1 (P) JVM transitive materialize emits per-artifact and per-retry progress for JAR fetches
   - Pre-count uncached JAR nodes before the materialize loop so the total `M` is known up front.
   - Emit the artifact-start callback (with 1-based index `N`, total `M`, and the artifact's `groupArtifact:version`) immediately before each uncached-JAR network download, and forward the retry callback to the download function so 404 retries surface against the next repository.
   - Sources fetch path remains silent: it neither emits artifact-start nor forwards a non-default retry callback.

--- a/.kiro/specs/404-resolver-progress/tasks.md
+++ b/.kiro/specs/404-resolver-progress/tasks.md
@@ -12,7 +12,7 @@
   - _Requirements: 1.1, 2.1, 3.3_
   - _Boundary: ResolverProgressSink (new component)_
 
-- [ ] 1.2 Surface repository retries from the per-repository fall-through download loop
+- [x] 1.2 Surface repository retries from the per-repository fall-through download loop
   - Add a defaulted retry-against callback parameter to the download function that walks the configured repositories on 404 fall-through.
   - Fire the callback exactly when the loop is about to advance to a next repository after an HTTP 404 — never on non-404 errors and never after the final repository in the list (loop exhaustion).
   - TDD: write three failing unit tests using a list-capturing lambda — "404 then 200 fires once with the second repo", "non-404 first attempt fires zero times", "all repositories return 404 fires only on advances and not after the last" — then make them pass.

--- a/.kiro/specs/404-resolver-progress/tasks.md
+++ b/.kiro/specs/404-resolver-progress/tasks.md
@@ -49,7 +49,7 @@
   - _Requirements: 1.1, 1.4, 2.1, 2.4, 3.1_
   - _Boundary: NativeResolver — resolveNative_
 
-- [ ] 2.3 (P) Bundle resolver paths emit per-artifact and per-retry progress
+- [x] 2.3 (P) Bundle resolver paths emit per-artifact and per-retry progress
   - Apply the same pre-count + artifact-start + retry-callback pattern to the bundle declaration path, the single-artifact bundle path, and the bundle lock-reuse materialization path.
   - The lock-reuse path is included so a stale-cache + matching-lock scenario (lockfile present, JAR evicted from cache) surfaces re-downloads instead of going silent.
   - TDD: a "three uncached bundle entries record (1,3),(2,3),(3,3)" test and a "lock-reuse with one evicted JAR records (1,1)" test, both using the recording fixture.

--- a/.kiro/specs/404-resolver-progress/tasks.md
+++ b/.kiro/specs/404-resolver-progress/tasks.md
@@ -2,7 +2,7 @@
 
 ## Phase 1: Foundation — sink contract, retry callback, signature plumbing
 
-- [ ] 1. Foundation
+- [x] 1. Foundation
 
 - [x] 1.1 Define the resolver progress sink contract with a recording-sink test fixture
   - Establish a sink interface with two callbacks: one fired when an artifact's network fetch is about to start, one fired when a 404 advances the per-repository fall-through to the next repository.
@@ -29,7 +29,7 @@
 
 ## Phase 2: Core — materialize-level emission per resolver path
 
-- [ ] 2. Core emission
+- [x] 2. Core emission
 
 - [x] 2.1 (P) JVM transitive materialize emits per-artifact and per-retry progress for JAR fetches
   - Pre-count uncached JAR nodes before the materialize loop so the total `M` is known up front.
@@ -59,7 +59,7 @@
 
 ## Phase 3: Integration — production CLI wiring, banner relocation, metadata-probe line
 
-- [ ] 3. Integration
+- [x] 3. Integration
 
 - [x] 3.1 Add the production stderr sink and a CLI-internal constructor helper
   - Introduce a private CLI sink class that formats the artifact-start callback as `[N/M] groupArtifact:version` and the retry-against callback as `  -> retry against <repository>`, both via the existing stderr writer.

--- a/.kiro/specs/404-resolver-progress/tasks.md
+++ b/.kiro/specs/404-resolver-progress/tasks.md
@@ -61,7 +61,7 @@
 
 - [ ] 3. Integration
 
-- [ ] 3.1 Add the production stderr sink and a CLI-internal constructor helper
+- [x] 3.1 Add the production stderr sink and a CLI-internal constructor helper
   - Introduce a private CLI sink class that formats the artifact-start callback as `[N/M] groupArtifact:version` and the retry-against callback as `  -> retry against <repository>`, both via the existing stderr writer.
   - Provide an internal helper that constructs a fresh sink instance per top-level resolver invocation, so multiple CLI entries can share the wiring without duplicating it.
   - Add a unit test that injects a String-capturing emit lambda into the sink and asserts the exact two formatted lines for a synthetic `(2,5)` artifact-start and a sample retry against a repository URL.

--- a/.kiro/specs/404-resolver-progress/tasks.md
+++ b/.kiro/specs/404-resolver-progress/tasks.md
@@ -1,0 +1,86 @@
+# Implementation Plan
+
+## Phase 1: Foundation — sink contract, retry callback, signature plumbing
+
+- [ ] 1. Foundation
+
+- [ ] 1.1 Define the resolver progress sink contract with a recording-sink test fixture
+  - Establish a sink interface with two callbacks: one fired when an artifact's network fetch is about to start, one fired when a 404 advances the per-repository fall-through to the next repository.
+  - Provide a no-op companion default so existing resolver consumers inherit silent behavior without code changes.
+  - Add a recording-sink test fixture that captures every callback into an ordered list, plus a baseline test that drives the recording sink directly and asserts the recorded sequence matches a manually-constructed reference.
+  - Observable completion: the new sink-fixture test passes; `kolt build` and `kolt test` succeed with the new file in place.
+  - _Requirements: 1.1, 2.1, 3.3_
+  - _Boundary: ResolverProgressSink (new component)_
+
+- [ ] 1.2 Surface repository retries from the per-repository fall-through download loop
+  - Add a defaulted retry-against callback parameter to the download function that walks the configured repositories on 404 fall-through.
+  - Fire the callback exactly when the loop is about to advance to a next repository after an HTTP 404 — never on non-404 errors and never after the final repository in the list (loop exhaustion).
+  - TDD: write three failing unit tests using a list-capturing lambda — "404 then 200 fires once with the second repo", "non-404 first attempt fires zero times", "all repositories return 404 fires only on advances and not after the last" — then make them pass.
+  - Observable completion: three new unit tests pass; the existing call sites of the download function continue to compile against the default no-op callback (mechanical default-parameter compatibility).
+  - _Requirements: 2.1, 2.2, 2.3_
+  - _Boundary: TransitiveResolver — downloadFromRepositories signature only_
+
+- [ ] 1.3 Thread the sink (defaulted to no-op) through every resolver entry point with no behavior change
+  - Add the sink as a defaulted parameter on the top-level resolve dispatcher, the JVM transitive path, the Native target path, the bundle declaration path, the single-artifact bundle path, and the bundle lock-reuse materialization path. Each function forwards the parameter through dispatch only.
+  - Do not emit progress in this task and do not propagate the retry callback yet — the sole purpose is parameter wiring so subsequent tasks can land emission independently.
+  - Observable completion: `kolt build` and `kolt test` succeed; every existing resolver test continues to pass unchanged because the no-op default preserves prior behavior.
+  - _Requirements: 1.1, 1.4_
+  - _Boundary: Resolver, TransitiveResolver, NativeResolver, BundleResolver — explicit cross-boundary signature carrier_
+
+## Phase 2: Core — materialize-level emission per resolver path
+
+- [ ] 2. Core emission
+
+- [ ] 2.1 (P) JVM transitive materialize emits per-artifact and per-retry progress for JAR fetches
+  - Pre-count uncached JAR nodes before the materialize loop so the total `M` is known up front.
+  - Emit the artifact-start callback (with 1-based index `N`, total `M`, and the artifact's `groupArtifact:version`) immediately before each uncached-JAR network download, and forward the retry callback to the download function so 404 retries surface against the next repository.
+  - Sources fetch path remains silent: it neither emits artifact-start nor forwards a non-default retry callback.
+  - TDD with the recording fixture: tests for "three uncached deps record (1,3),(2,3),(3,3)", "one cached + one uncached records only (1,1)", "fully warm cache records nothing", "404 then 200 records one artifact-start followed by one retry-against the second repo", and "binary-cached + missing-sources records nothing for the sources fetch".
+  - Observable completion: five new unit tests pass; running the resolver against a fake `ResolverDeps` produces a recorded callback sequence that matches expectations.
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.4, 3.1, 3.2, 5.1, 5.2_
+  - _Boundary: TransitiveResolver — materialize loop_
+
+- [ ] 2.2 (P) Native target resolver emits per-artifact and per-retry progress for klib fetches
+  - Pre-count uncached klib nodes before the Native materialize loop.
+  - Emit the artifact-start callback before each uncached-klib download and forward the retry callback to the klib download function.
+  - Module metadata fetches remain silent: they keep the default no-op retry callback and emit no artifact-start.
+  - TDD: a Native-equivalent "three uncached klibs record (1,3),(2,3),(3,3)" test against a fake `ResolverDeps` configured for klib URLs, and a 404-then-200 test that asserts one retry-against callback.
+  - Observable completion: two new unit tests pass.
+  - _Requirements: 1.1, 1.4, 2.1, 2.4, 3.1_
+  - _Boundary: NativeResolver — resolveNative_
+
+- [ ] 2.3 (P) Bundle resolver paths emit per-artifact and per-retry progress
+  - Apply the same pre-count + artifact-start + retry-callback pattern to the bundle declaration path, the single-artifact bundle path, and the bundle lock-reuse materialization path.
+  - The lock-reuse path is included so a stale-cache + matching-lock scenario (lockfile present, JAR evicted from cache) surfaces re-downloads instead of going silent.
+  - TDD: a "three uncached bundle entries record (1,3),(2,3),(3,3)" test and a "lock-reuse with one evicted JAR records (1,1)" test, both using the recording fixture.
+  - Observable completion: two new unit tests pass.
+  - _Requirements: 1.1, 1.4, 2.1, 2.4, 3.1_
+  - _Boundary: BundleResolver_
+
+## Phase 3: Integration — production CLI wiring, banner relocation, metadata-probe line
+
+- [ ] 3. Integration
+
+- [ ] 3.1 Add the production stderr sink and a CLI-internal constructor helper
+  - Introduce a private CLI sink class that formats the artifact-start callback as `[N/M] groupArtifact:version` and the retry-against callback as `  -> retry against <repository>`, both via the existing stderr writer.
+  - Provide an internal helper that constructs a fresh sink instance per top-level resolver invocation, so multiple CLI entries can share the wiring without duplicating it.
+  - Add a unit test that injects a String-capturing emit lambda into the sink and asserts the exact two formatted lines for a synthetic `(2,5)` artifact-start and a sample retry against a repository URL.
+  - Observable completion: one new sink-formatting unit test passes.
+  - _Requirements: 4.1_
+  - _Boundary: DependencyResolution (CLI) — StderrProgressSink_
+
+- [ ] 3.2 (P) Wire the production sink through the JVM and Native CLI entries and relocate their banners
+  - Construct the sink at the JVM dependency-resolution entry and pass it to both the main resolve call and the bundle-resolve call.
+  - Construct the sink at the Native dependency-resolution entry and pass it to its resolve call so Native builds achieve parity with JVM.
+  - Move the two existing pre-resolve banners (`resolving dependencies...`, `resolving native dependencies...`) from stdout to stderr.
+  - Observable completion: a smoke run against an uncached cache prints `[N/M]` lines on stderr; redirecting stdout to a file (`kolt fetch > out.txt`, `kolt build > out.txt`) leaves the file free of progress and banners while stderr carries them — directly verifies Req 4.3 piping behavior.
+  - _Requirements: 1.4, 4.1, 4.2, 4.3_
+  - _Boundary: DependencyResolution (CLI)_
+
+- [ ] 3.3 (P) Wire the production sink through `kolt update`, relocate its banner, and add the metadata-probe line for `kolt add`
+  - Construct the sink at the update entry and pass it to the explicit resolve and bundle-resolve calls inside the update flow.
+  - Move the `updating dependencies...` banner from stdout to stderr.
+  - In the latest-version probe path used by `kolt add` without an explicit version, emit a single `fetching latest version of <group>:<artifact>...` line on stderr before the metadata-XML download. Do not introduce `[N/M]` framing — this is a single-artifact metadata fetch, not a fetch loop.
+  - Observable completion: `kolt update` against an uncached cache shows banner + `[N/M]` lines on stderr and `kolt update > out.txt` leaves `out.txt` containing only post-resolve command output (verifies Req 4.3); `kolt add com.example:lib` without a version prints the `fetching latest version of com.example:lib...` line on stderr before the resolve banner appears.
+  - _Requirements: 1.4, 4.1, 4.2, 4.3_
+  - _Boundary: DependencyCommands (CLI)_

--- a/.kiro/specs/404-resolver-progress/tasks.md
+++ b/.kiro/specs/404-resolver-progress/tasks.md
@@ -20,7 +20,7 @@
   - _Requirements: 2.1, 2.2, 2.3_
   - _Boundary: TransitiveResolver — downloadFromRepositories signature only_
 
-- [ ] 1.3 Thread the sink (defaulted to no-op) through every resolver entry point with no behavior change
+- [x] 1.3 Thread the sink (defaulted to no-op) through every resolver entry point with no behavior change
   - Add the sink as a defaulted parameter on the top-level resolve dispatcher, the JVM transitive path, the Native target path, the bundle declaration path, the single-artifact bundle path, and the bundle lock-reuse materialization path. Each function forwards the parameter through dispatch only.
   - Do not emit progress in this task and do not propagate the retry callback yet — the sole purpose is parameter wiring so subsequent tasks can land emission independently.
   - Observable completion: `kolt build` and `kolt test` succeed; every existing resolver test continues to pass unchanged because the no-op default preserves prior behavior.

--- a/.kiro/specs/404-resolver-progress/tasks.md
+++ b/.kiro/specs/404-resolver-progress/tasks.md
@@ -40,7 +40,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.4, 3.1, 3.2, 5.1, 5.2_
   - _Boundary: TransitiveResolver — materialize loop_
 
-- [ ] 2.2 (P) Native target resolver emits per-artifact and per-retry progress for klib fetches
+- [x] 2.2 (P) Native target resolver emits per-artifact and per-retry progress for klib fetches
   - Pre-count uncached klib nodes before the Native materialize loop.
   - Emit the artifact-start callback before each uncached-klib download and forward the retry callback to the klib download function.
   - Module metadata fetches remain silent: they keep the default no-op retry callback and emit no artifact-start.

--- a/.kiro/specs/404-resolver-progress/tasks.md
+++ b/.kiro/specs/404-resolver-progress/tasks.md
@@ -69,7 +69,7 @@
   - _Requirements: 4.1_
   - _Boundary: DependencyResolution (CLI) — StderrProgressSink_
 
-- [ ] 3.2 (P) Wire the production sink through the JVM and Native CLI entries and relocate their banners
+- [x] 3.2 (P) Wire the production sink through the JVM and Native CLI entries and relocate their banners
   - Construct the sink at the JVM dependency-resolution entry and pass it to both the main resolve call and the bundle-resolve call.
   - Construct the sink at the Native dependency-resolution entry and pass it to its resolve call so Native builds achieve parity with JVM.
   - Move the two existing pre-resolve banners (`resolving dependencies...`, `resolving native dependencies...`) from stdout to stderr.

--- a/.kiro/specs/404-resolver-progress/tasks.md
+++ b/.kiro/specs/404-resolver-progress/tasks.md
@@ -77,7 +77,7 @@
   - _Requirements: 1.4, 4.1, 4.2, 4.3_
   - _Boundary: DependencyResolution (CLI)_
 
-- [ ] 3.3 (P) Wire the production sink through `kolt update`, relocate its banner, and add the metadata-probe line for `kolt add`
+- [x] 3.3 (P) Wire the production sink through `kolt update`, relocate its banner, and add the metadata-probe line for `kolt add`
   - Construct the sink at the update entry and pass it to the explicit resolve and bundle-resolve calls inside the update flow.
   - Move the `updating dependencies...` banner from stdout to stderr.
   - In the latest-version probe path used by `kolt add` without an explicit version, emit a single `fetching latest version of <group>:<artifact>...` line on stderr before the metadata-XML download. Do not introduce `[N/M]` framing — this is a single-artifact metadata fetch, not a fetch loop.

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -51,7 +51,6 @@ private fun doAddInner(args: List<String>): Result<Unit, Int> {
     if (addArgs.version != null) {
       addArgs.version
     } else {
-      println("fetching latest version for ${addArgs.group}:${addArgs.artifact}...")
       fetchLatestVersion(addArgs.group, addArgs.artifact, config.repositories.values.toList())
         .getOrElse {
           return Err(it)
@@ -157,6 +156,7 @@ private fun fetchLatestVersion(
     return Err(EXIT_DEPENDENCY_ERROR)
   }
 
+  eprintln("fetching latest version of $group:$artifact...")
   val failure =
     downloadFromRepositories(
         repos,
@@ -245,7 +245,8 @@ private fun doUpdateInner(): Result<Unit, Int> {
     bundleEntryCount = 0
     mainAndBundleLockfile = buildLockfileFromResolved(config, deps = emptyList())
   } else {
-    println("updating dependencies...")
+    eprintln("updating dependencies...")
+    val progress = newStderrProgressSink()
     val resolveResult =
       resolve(
           config,
@@ -254,6 +255,7 @@ private fun doUpdateInner(): Result<Unit, Int> {
           resolverDeps,
           mainSeeds = mainSeeds,
           testSeeds = testSeeds,
+          progress = progress,
         )
         .getOrElse { error ->
           eprintDiagnostic(formatResolveError(error))
@@ -263,11 +265,17 @@ private fun doUpdateInner(): Result<Unit, Int> {
     // Bundles re-resolve with `existingLock = null` so `[classpaths.<name>]`
     // follow the same update policy as main / test.
     val bundleResolutions =
-      resolveAllBundles(config, existingLock = null, paths.cacheBase, resolverDeps).getOrElse {
-        error ->
-        eprintDiagnostic(formatResolveError(error))
-        return Err(EXIT_DEPENDENCY_ERROR)
-      }
+      resolveAllBundles(
+          config,
+          existingLock = null,
+          paths.cacheBase,
+          resolverDeps,
+          progress = progress,
+        )
+        .getOrElse { error ->
+          eprintDiagnostic(formatResolveError(error))
+          return Err(EXIT_DEPENDENCY_ERROR)
+        }
     val bundleDeps = bundleResolutions.mapValues { it.value.deps }
     depsCount = resolveResult.deps.size
     bundleEntryCount = bundleDeps.values.sumOf { it.size }
@@ -280,7 +288,7 @@ private fun doUpdateInner(): Result<Unit, Int> {
   val toolsBundles =
     if (config.tools.isEmpty()) emptyMap()
     else {
-      println("updating tools...")
+      eprintln("updating tools...")
       buildToolsBundleLockMap(config.tools) { coord, classifier, _ ->
           resolveSingleArtifact(
             coord = coord,

--- a/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
@@ -26,6 +26,22 @@ private const val WORKSPACE_JSON = "workspace.json"
 
 internal fun createResolverDeps(): ResolverDeps = defaultResolverDeps()
 
+private class StderrProgressSink(private val emit: (String) -> Unit = ::eprintln) :
+  ResolverProgressSink {
+  override fun onArtifactStart(index: Int, total: Int, groupArtifact: String, version: String) {
+    emit("[$index/$total] $groupArtifact:$version")
+  }
+
+  override fun onRetryAgainst(repository: String) {
+    emit("  -> retry against $repository")
+  }
+}
+
+internal fun newStderrProgressSink(): ResolverProgressSink = StderrProgressSink()
+
+internal fun newStderrProgressSinkForTest(emit: (String) -> Unit): ResolverProgressSink =
+  StderrProgressSink(emit)
+
 // Splits the resolved jars by origin so the JVM kind=app tail in BuildCommands
 // can emit the runtime classpath manifest (ADR 0027 §1) from main-only jars,
 // while `kolt test` can still build its compile/run classpath from the union.

--- a/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
@@ -137,8 +137,9 @@ internal fun resolveDependencies(
       }
     }
 
-  println("resolving dependencies...")
+  eprintln("resolving dependencies...")
   val resolverDeps = createResolverDeps()
+  val progress = newStderrProgressSink()
   val resolveResult =
     resolve(
         config,
@@ -147,6 +148,7 @@ internal fun resolveDependencies(
         resolverDeps,
         mainSeeds = mainSeeds,
         testSeeds = testSeeds,
+        progress = progress,
       )
       .getOrElse { error ->
         eprintDiagnostic(formatResolveError(error))
@@ -157,7 +159,8 @@ internal fun resolveDependencies(
       }
 
   val bundleResolutions =
-    resolveAllBundles(config, existingLock, paths.cacheBase, resolverDeps).getOrElse { error ->
+    resolveAllBundles(config, existingLock, paths.cacheBase, resolverDeps, progress).getOrElse {
+      error ->
       eprintDiagnostic(formatResolveError(error))
       if (error is ResolveError.Sha256Mismatch) {
         eprintln("delete the cached jar and rebuild to re-download")
@@ -231,6 +234,7 @@ internal fun resolveAllBundles(
   existingLock: Lockfile?,
   cacheBase: String,
   resolverDeps: ResolverDeps,
+  progress: ResolverProgressSink = ResolverProgressSink.NoOp,
 ): Result<Map<String, BundleResolution>, ResolveError> {
   if (config.classpaths.isEmpty()) return Ok(emptyMap())
 
@@ -262,6 +266,7 @@ internal fun resolveAllBundles(
           existingLock = existingLock,
           cacheBase = cacheBase,
           deps = resolverDeps,
+          progress = progress,
         )
         .getOrElse { error ->
           return Err(error)
@@ -368,12 +373,19 @@ internal fun resolveNativeDependencies(
 ): Result<List<String>, Int> {
   if (config.dependencies.isEmpty()) return Ok(emptyList())
 
-  println("resolving native dependencies...")
+  eprintln("resolving native dependencies...")
   val result =
-    resolve(config, existingLock = null, paths.cacheBase, createResolverDeps()).getOrElse { error ->
-      eprintDiagnostic(formatResolveError(error))
-      return Err(EXIT_DEPENDENCY_ERROR)
-    }
+    resolve(
+        config,
+        existingLock = null,
+        paths.cacheBase,
+        createResolverDeps(),
+        progress = newStderrProgressSink(),
+      )
+      .getOrElse { error ->
+        eprintDiagnostic(formatResolveError(error))
+        return Err(EXIT_DEPENDENCY_ERROR)
+      }
   return Ok(result.deps.map { it.cachePath })
 }
 

--- a/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyResolution.kt
@@ -250,6 +250,7 @@ internal fun resolveAllBundles(
             bundleName,
             cacheBase,
             resolverDeps,
+            progress,
           )
           .getOrElse {
             return Err(it)

--- a/src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt
@@ -120,11 +120,13 @@ fun resolveSingleArtifact(
     deps.ensureDirectoryRecursive(parentDir).getOrElse {
       return Err(ResolveError.DirectoryCreateFailed(parentDir))
     }
+    progress.onArtifactStart(1, 1, groupArtifact, coord.version)
     downloadFromRepositories(
         repos,
         cachePath,
         { repo -> "$repo/$relativePath" },
         deps::downloadFile,
+        onRetry = progress::onRetryAgainst,
       )
       .getOrElse { failure ->
         return Err(ResolveError.DownloadFailed(groupArtifact, failure))
@@ -177,6 +179,10 @@ internal fun materialiseBundleJarsFromLock(
   val locked = existingLock.classpathBundles[bundleName] ?: return Ok(Unit)
   val repos = config.repositories.values.toList()
   val cachePrefix = "$cacheBase/"
+  // Pre-count uncached locked jars so the total `M` is known before any
+  // emission. Cache-warm jars do not advance the index and stay silent.
+  val total = resolution.deps.count { !deps.fileExists(it.cachePath) }
+  var index = 0
   for (dep in resolution.deps) {
     if (deps.fileExists(dep.cachePath)) continue
     val relativePath =
@@ -186,11 +192,14 @@ internal fun materialiseBundleJarsFromLock(
     deps.ensureDirectoryRecursive(parentDir).getOrElse {
       return Err(ResolveError.DirectoryCreateFailed(parentDir))
     }
+    index += 1
+    progress.onArtifactStart(index, total, dep.groupArtifact, dep.version)
     downloadFromRepositories(
         repos,
         dep.cachePath,
         { repo -> "$repo/$relativePath" },
         deps::downloadFile,
+        onRetry = progress::onRetryAgainst,
       )
       .getOrElse { failure ->
         return Err(ResolveError.DownloadFailed(dep.groupArtifact, failure))

--- a/src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt
@@ -31,6 +31,7 @@ internal fun resolveBundle(
   existingLock: Lockfile?,
   cacheBase: String,
   deps: ResolverDeps,
+  progress: ResolverProgressSink = ResolverProgressSink.NoOp,
 ): Result<BundleResolution, ResolveError> {
   // materialize() consults existingLock.dependencies for sha-mismatch and
   // lockChanged tracking. Project the bundle's own sub-map (not main/test's)
@@ -53,6 +54,7 @@ internal fun resolveBundle(
       deps = deps,
       mainSeeds = bundleSeeds,
       testSeeds = emptyMap(),
+      progress = progress,
     )
     .map { result ->
       val jars =
@@ -107,6 +109,7 @@ fun resolveSingleArtifact(
   repos: List<String>,
   cacheBase: String,
   deps: ResolverDeps,
+  progress: ResolverProgressSink = ResolverProgressSink.NoOp,
 ): Result<SingleArtifact, ResolveError> {
   val groupArtifact = "${coord.group}:${coord.artifact}"
   val relativePath = buildRelativeJarPath(coord, classifier)
@@ -169,6 +172,7 @@ internal fun materialiseBundleJarsFromLock(
   bundleName: String,
   cacheBase: String,
   deps: ResolverDeps,
+  progress: ResolverProgressSink = ResolverProgressSink.NoOp,
 ): Result<Unit, ResolveError> {
   val locked = existingLock.classpathBundles[bundleName] ?: return Ok(Unit)
   val repos = config.repositories.values.toList()

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -39,6 +39,7 @@ fun resolveNative(
   config: KoltConfig,
   cacheBase: String,
   deps: ResolverDeps,
+  progress: ResolverProgressSink = ResolverProgressSink.NoOp,
 ): Result<ResolveResult, ResolveError> {
   val nativeTarget = konanTargetGradleName(config.build.target)
   val repos = config.repositories.values.toList()

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -63,6 +63,20 @@ fun resolveNative(
     }
 
   val resolvedDeps = mutableListOf<ResolvedDep>()
+
+  // Pre-count uncached klib nodes so the total `M` is known before any
+  // emission. Nodes whose redirect metadata is missing are excluded from
+  // `M` here; the main loop returns `MetadataParseFailed` for them before
+  // any emission happens.
+  val total =
+    nodes.count { node ->
+      val resolved = processed["${node.groupArtifact}:${node.version}"] ?: return@count false
+      val targetCoord =
+        Coordinate(resolved.redirect.group, resolved.redirect.module, resolved.redirect.version)
+      !deps.fileExists("$cacheBase/${buildKlibCachePath(targetCoord)}")
+    }
+  var index = 0
+
   for (node in nodes) {
     val resolved =
       processed["${node.groupArtifact}:${node.version}"]
@@ -77,11 +91,14 @@ fun resolveNative(
       deps.ensureDirectoryRecursive(parentDir).getOrElse {
         return Err(ResolveError.DirectoryCreateFailed(parentDir))
       }
+      index += 1
+      progress.onArtifactStart(index, total, node.groupArtifact, node.version)
       downloadFromRepositories(
           repos,
           klibCachePath,
           { buildKlibDownloadUrl(targetCoord, it) },
           deps::downloadFile,
+          onRetry = progress::onRetryAgainst,
         )
         .getOrElse { failure ->
           return Err(ResolveError.DownloadFailed(node.groupArtifact, failure))

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -201,8 +201,9 @@ fun resolve(
   deps: ResolverDeps,
   mainSeeds: Map<String, String> = config.dependencies,
   testSeeds: Map<String, String> = emptyMap(),
+  progress: ResolverProgressSink = ResolverProgressSink.NoOp,
 ): Result<ResolveResult, ResolveError> =
-  if (config.build.target in NATIVE_TARGETS) resolveNative(config, cacheBase, deps)
+  if (config.build.target in NATIVE_TARGETS) resolveNative(config, cacheBase, deps, progress)
   else
     resolveTransitive(
       config,
@@ -211,6 +212,7 @@ fun resolve(
       deps,
       mainSeeds = mainSeeds,
       testSeeds = testSeeds,
+      progress = progress,
     )
 
 fun buildLockfileFromResolved(

--- a/src/nativeMain/kotlin/kolt/resolve/ResolverProgressSink.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/ResolverProgressSink.kt
@@ -1,0 +1,21 @@
+package kolt.resolve
+
+interface ResolverProgressSink {
+  fun onArtifactStart(index: Int, total: Int, groupArtifact: String, version: String)
+
+  fun onRetryAgainst(repository: String)
+
+  companion object {
+    val NoOp: ResolverProgressSink =
+      object : ResolverProgressSink {
+        override fun onArtifactStart(
+          index: Int,
+          total: Int,
+          groupArtifact: String,
+          version: String,
+        ) {}
+
+        override fun onRetryAgainst(repository: String) {}
+      }
+  }
+}

--- a/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
@@ -215,6 +215,21 @@ private fun materialize(
   var lockChanged = false
   val resolvedDeps = mutableListOf<ResolvedDep>()
 
+  // Pre-count uncached JAR nodes so the total `M` is known before any
+  // emission. A node whose coordinate fails to parse is excluded from `M`
+  // here; the main loop returns `InvalidDependency` for it before any
+  // emission happens.
+  val total =
+    nodes.count { node ->
+      val jarGa = redirects[node.groupArtifact] ?: node.groupArtifact
+      val coord =
+        parseCoordinate(jarGa, node.version).getOrElse {
+          return@count false
+        }
+      !deps.fileExists("$cacheBase/${buildCachePath(coord)}")
+    }
+  var index = 0
+
   for (node in nodes) {
     val jarGroupArtifact = redirects[node.groupArtifact] ?: node.groupArtifact
     val coord =
@@ -232,11 +247,14 @@ private fun materialize(
       deps.ensureDirectoryRecursive(parentDir).getOrElse {
         return Err(ResolveError.DirectoryCreateFailed(parentDir))
       }
+      index += 1
+      progress.onArtifactStart(index, total, node.groupArtifact, node.version)
       downloadFromRepositories(
           repos,
           fullCachePath,
           { buildDownloadUrl(coord, it) },
           deps::downloadFile,
+          onRetry = progress::onRetryAgainst,
         )
         .getOrElse { failure ->
           return Err(ResolveError.DownloadFailed(node.groupArtifact, failure))

--- a/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
@@ -85,16 +85,21 @@ internal fun downloadFromRepositories(
   destPath: String,
   urlBuilder: (String) -> String,
   download: (String, String) -> Result<Unit, DownloadError>,
+  onRetry: (String) -> Unit = {},
 ): Result<Unit, RepositoryDownloadFailure> {
   if (repos.isEmpty()) return Err(RepositoryDownloadFailure.NoRepositoriesConfigured)
   val attempts = mutableListOf<RepositoryAttempt>()
-  for (repo in repos) {
+  for (i in repos.indices) {
+    val repo = repos[i]
     val url = urlBuilder(repo)
     val error = download(url, destPath).getError()
     if (error == null) return Ok(Unit)
     attempts.add(RepositoryAttempt(url, error))
     if (error !is DownloadError.HttpFailed || error.statusCode != 404) {
       return Err(RepositoryDownloadFailure.AllAttemptsFailed(attempts))
+    }
+    if (i + 1 < repos.size) {
+      onRetry(repos[i + 1])
     }
   }
   return Err(RepositoryDownloadFailure.AllAttemptsFailed(attempts))

--- a/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
@@ -15,6 +15,7 @@ fun resolveTransitive(
   deps: ResolverDeps,
   mainSeeds: Map<String, String> = config.dependencies,
   testSeeds: Map<String, String> = emptyMap(),
+  progress: ResolverProgressSink = ResolverProgressSink.NoOp,
 ): Result<ResolveResult, ResolveError> {
   val repos = config.repositories.values.toList()
 
@@ -44,7 +45,7 @@ fun resolveTransitive(
         return Err(error)
       }
 
-  return materialize(nodes, redirects, config, existingLock, cacheBase, deps, repos)
+  return materialize(nodes, redirects, config, existingLock, cacheBase, deps, repos, progress)
 }
 
 // Best-effort sources fetch. Sources are editor UX — missing upstream
@@ -209,6 +210,7 @@ private fun materialize(
   cacheBase: String,
   deps: ResolverDeps,
   repos: List<String>,
+  progress: ResolverProgressSink = ResolverProgressSink.NoOp,
 ): Result<ResolveResult, ResolveError> {
   var lockChanged = false
   val resolvedDeps = mutableListOf<ResolvedDep>()

--- a/src/nativeTest/kotlin/kolt/cli/StderrProgressSinkTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/StderrProgressSinkTest.kt
@@ -1,0 +1,18 @@
+package kolt.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StderrProgressSinkTest {
+  @Test
+  fun stderrProgressSinkFormatsArtifactStartAndRetryAgainst() {
+    val captured = mutableListOf<String>()
+    val sink = newStderrProgressSinkForTest { captured.add(it) }
+    sink.onArtifactStart(2, 5, "com.example:lib", "1.0.0")
+    sink.onRetryAgainst("https://repo.example.com/maven2/")
+    assertEquals(
+      listOf("[2/5] com.example:lib:1.0.0", "  -> retry against https://repo.example.com/maven2/"),
+      captured,
+    )
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/BundleResolverProgressTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/BundleResolverProgressTest.kt
@@ -1,0 +1,193 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kolt.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class BundleResolverProgressTest {
+
+  // Bundle declaration path: three uncached direct deps must surface as
+  // (1,3),(2,3),(3,3) ArtifactStart events. resolveBundle delegates to
+  // resolveTransitive, so the materialize loop is responsible for the
+  // emission — this test pins that the wiring is intact end-to-end through
+  // the bundle entry point. Pin for Req 1.1, 1.4.
+  @Test
+  fun threeUncachedBundleEntriesEmitOneOfThreeTwoOfThreeThreeOfThree() {
+    val config = testConfig()
+    val aPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>a</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+    val bPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>b</artifactId><version>2.0.0</version></project>
+        """
+        .trimIndent()
+    val cPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>c</artifactId><version>3.0.0</version></project>
+        """
+        .trimIndent()
+
+    val deps =
+      fakeBundleDeps(
+        sha256Results =
+          mapOf(
+            "/cache/com/example/a/1.0.0/a-1.0.0.jar" to "hashA",
+            "/cache/com/example/b/2.0.0/b-2.0.0.jar" to "hashB",
+            "/cache/com/example/c/3.0.0/c-3.0.0.jar" to "hashC",
+          ),
+        pomContents =
+          mapOf(
+            "/cache/com/example/a/1.0.0/a-1.0.0.pom" to aPom,
+            "/cache/com/example/b/2.0.0/b-2.0.0.pom" to bPom,
+            "/cache/com/example/c/3.0.0/c-3.0.0.pom" to cPom,
+          ),
+      )
+    val sink = RecordingResolverProgressSink()
+
+    val result =
+      resolveBundle(
+        config = config,
+        bundleName = "tools",
+        bundleSeeds =
+          mapOf("com.example:a" to "1.0.0", "com.example:b" to "2.0.0", "com.example:c" to "3.0.0"),
+        existingLock = null,
+        cacheBase = "/cache",
+        deps = deps,
+        progress = sink,
+      )
+    assertNotNull(result.get())
+
+    val artifactStarts = sink.events.filterIsInstance<RecordedProgressEvent.ArtifactStart>()
+    assertEquals(3, artifactStarts.size)
+    val gaToEvent = artifactStarts.associateBy { it.groupArtifact }
+    assertEquals(
+      RecordedProgressEvent.ArtifactStart(1, 3, "com.example:a", "1.0.0"),
+      gaToEvent["com.example:a"],
+    )
+    assertEquals(
+      RecordedProgressEvent.ArtifactStart(2, 3, "com.example:b", "2.0.0"),
+      gaToEvent["com.example:b"],
+    )
+    assertEquals(
+      RecordedProgressEvent.ArtifactStart(3, 3, "com.example:c", "3.0.0"),
+      gaToEvent["com.example:c"],
+    )
+    val indices = artifactStarts.map { it.index }
+    assertEquals(listOf(1, 2, 3), indices)
+  }
+
+  // Lock-reuse path: lockfile matches kolt.toml so the resolver kernel is
+  // skipped, but a JAR was evicted from ~/.kolt/cache. The re-download must
+  // surface as a single (1,1) ArtifactStart so the user sees activity rather
+  // than silence. Pin for Req 1.1, 1.4 on the materialiseBundleJarsFromLock
+  // path.
+  @Test
+  fun lockReuseWithOneEvictedJarEmitsOneOfOne() {
+    val config = testConfig().copy(repositories = mapOf("primary" to "https://repo.example.com"))
+
+    // Two bundle deps locked: one cached, one evicted.
+    val cachedDep =
+      ResolvedDep(
+        groupArtifact = "com.example:warm",
+        version = "1.0.0",
+        sha256 = "hashWarm",
+        cachePath = "/cache/com/example/warm/1.0.0/warm-1.0.0.jar",
+      )
+    val evictedDep =
+      ResolvedDep(
+        groupArtifact = "com.example:cold",
+        version = "2.0.0",
+        sha256 = "hashCold",
+        cachePath = "/cache/com/example/cold/2.0.0/cold-2.0.0.jar",
+      )
+
+    val resolution =
+      BundleResolution(jars = emptyList(), classpath = "", deps = listOf(cachedDep, evictedDep))
+
+    val existingLock =
+      Lockfile(
+        version = LOCKFILE_VERSION,
+        kotlin = config.kotlin.version,
+        jvmTarget = config.build.jvmTarget,
+        dependencies = emptyMap(),
+        classpathBundles =
+          mapOf(
+            "tools" to
+              mapOf(
+                "com.example:warm" to LockEntry(version = "1.0.0", sha256 = "hashWarm"),
+                "com.example:cold" to LockEntry(version = "2.0.0", sha256 = "hashCold"),
+              )
+          ),
+      )
+
+    val deps =
+      fakeBundleDeps(
+        // Only the warm jar is on disk. The cold jar must be re-downloaded
+        // and that re-download must surface as a (1,1) progress event.
+        cachedFiles = mutableSetOf("/cache/com/example/warm/1.0.0/warm-1.0.0.jar"),
+        sha256Results =
+          mapOf(
+            "/cache/com/example/warm/1.0.0/warm-1.0.0.jar" to "hashWarm",
+            "/cache/com/example/cold/2.0.0/cold-2.0.0.jar" to "hashCold",
+          ),
+      )
+    val sink = RecordingResolverProgressSink()
+
+    val result =
+      materialiseBundleJarsFromLock(
+        resolution = resolution,
+        config = config,
+        existingLock = existingLock,
+        bundleName = "tools",
+        cacheBase = "/cache",
+        deps = deps,
+        progress = sink,
+      )
+    assertNotNull(result.get())
+
+    val expected =
+      listOf<RecordedProgressEvent>(
+        RecordedProgressEvent.ArtifactStart(1, 1, "com.example:cold", "2.0.0")
+      )
+    assertEquals(expected, sink.events)
+  }
+
+  private fun fakeBundleDeps(
+    cachedFiles: MutableSet<String> = mutableSetOf(),
+    sha256Results: Map<String, String> = emptyMap(),
+    pomContents: Map<String, String> = emptyMap(),
+  ): ResolverDeps {
+    return object : ResolverDeps {
+      override fun fileExists(path: String): Boolean = path in cachedFiles
+
+      override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        cachedFiles.add(destPath)
+        return Ok(Unit)
+      }
+
+      override fun computeSha256(filePath: String): Result<String, Sha256Error> {
+        val hash = sha256Results[filePath] ?: return Err(Sha256Error(filePath))
+        return Ok(hash)
+      }
+
+      override fun readFileContent(path: String): Result<String, OpenFailed> {
+        val content = pomContents[path] ?: return Err(OpenFailed(path))
+        return Ok(content)
+      }
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/MaterializeProgressTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/MaterializeProgressTest.kt
@@ -1,0 +1,277 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import kolt.config.MAVEN_CENTRAL_BASE
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kolt.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class MaterializeProgressTest {
+
+  @Test
+  fun threeUncachedDepsEmitOneOfThreeTwoOfThreeThreeOfThree() {
+    val config =
+      testConfig()
+        .copy(
+          dependencies =
+            mapOf(
+              "com.example:a" to "1.0.0",
+              "com.example:b" to "2.0.0",
+              "com.example:c" to "3.0.0",
+            )
+        )
+    val aPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>a</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+    val bPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>b</artifactId><version>2.0.0</version></project>
+        """
+        .trimIndent()
+    val cPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>c</artifactId><version>3.0.0</version></project>
+        """
+        .trimIndent()
+
+    val deps =
+      fakeDeps(
+        sha256Results =
+          mapOf(
+            "/cache/com/example/a/1.0.0/a-1.0.0.jar" to "hashA",
+            "/cache/com/example/b/2.0.0/b-2.0.0.jar" to "hashB",
+            "/cache/com/example/c/3.0.0/c-3.0.0.jar" to "hashC",
+          ),
+        pomContents =
+          mapOf(
+            "/cache/com/example/a/1.0.0/a-1.0.0.pom" to aPom,
+            "/cache/com/example/b/2.0.0/b-2.0.0.pom" to bPom,
+            "/cache/com/example/c/3.0.0/c-3.0.0.pom" to cPom,
+          ),
+      )
+    val sink = RecordingResolverProgressSink()
+
+    val result = resolveTransitive(config, null, "/cache", deps, progress = sink)
+    assertNotNull(result.get())
+
+    val artifactStarts = sink.events.filterIsInstance<RecordedProgressEvent.ArtifactStart>()
+    assertEquals(3, artifactStarts.size)
+    val gaToEvent = artifactStarts.associateBy { it.groupArtifact }
+    assertEquals(
+      RecordedProgressEvent.ArtifactStart(1, 3, "com.example:a", "1.0.0"),
+      gaToEvent["com.example:a"],
+    )
+    assertEquals(
+      RecordedProgressEvent.ArtifactStart(2, 3, "com.example:b", "2.0.0"),
+      gaToEvent["com.example:b"],
+    )
+    assertEquals(
+      RecordedProgressEvent.ArtifactStart(3, 3, "com.example:c", "3.0.0"),
+      gaToEvent["com.example:c"],
+    )
+    val indices = artifactStarts.map { it.index }
+    assertEquals(listOf(1, 2, 3), indices)
+  }
+
+  @Test
+  fun oneCachedAndOneUncachedEmitsOnlyOneOfOne() {
+    val config =
+      testConfig()
+        .copy(dependencies = mapOf("com.example:cached" to "1.0.0", "com.example:fresh" to "1.0.0"))
+    val cachedPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>cached</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+    val freshPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>fresh</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+
+    val deps =
+      fakeDeps(
+        cachedFiles =
+          mutableSetOf(
+            "/cache/com/example/cached/1.0.0/cached-1.0.0.jar",
+            "/cache/com/example/cached/1.0.0/cached-1.0.0.pom",
+          ),
+        sha256Results =
+          mapOf(
+            "/cache/com/example/cached/1.0.0/cached-1.0.0.jar" to "hashCached",
+            "/cache/com/example/fresh/1.0.0/fresh-1.0.0.jar" to "hashFresh",
+          ),
+        pomContents =
+          mapOf(
+            "/cache/com/example/cached/1.0.0/cached-1.0.0.pom" to cachedPom,
+            "/cache/com/example/fresh/1.0.0/fresh-1.0.0.pom" to freshPom,
+          ),
+      )
+    val sink = RecordingResolverProgressSink()
+
+    val result = resolveTransitive(config, null, "/cache", deps, progress = sink)
+    assertNotNull(result.get())
+
+    val artifactStarts = sink.events.filterIsInstance<RecordedProgressEvent.ArtifactStart>()
+    assertEquals(1, artifactStarts.size)
+    val event = artifactStarts.single()
+    assertEquals(1, event.index)
+    assertEquals(1, event.total)
+    assertEquals("com.example:fresh", event.groupArtifact)
+    assertEquals("1.0.0", event.version)
+  }
+
+  @Test
+  fun fullyWarmCacheEmitsNothing() {
+    val config = testConfig().copy(dependencies = mapOf("com.example:lib" to "1.0.0"))
+    val libPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>lib</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+
+    val deps =
+      fakeDeps(
+        cachedFiles =
+          mutableSetOf(
+            "/cache/com/example/lib/1.0.0/lib-1.0.0.jar",
+            "/cache/com/example/lib/1.0.0/lib-1.0.0.pom",
+          ),
+        sha256Results = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.jar" to "hash1"),
+        pomContents = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.pom" to libPom),
+      )
+    val sink = RecordingResolverProgressSink()
+
+    val result = resolveTransitive(config, null, "/cache", deps, progress = sink)
+    assertNotNull(result.get())
+
+    assertEquals(emptyList(), sink.events)
+  }
+
+  @Test
+  fun fourOhFourThenTwoHundredEmitsArtifactStartFollowedByRetryAgainstSecondRepo() {
+    val repo1 = "https://repo1.example.com"
+    val repo2 = "https://repo2.example.com"
+    val config =
+      testConfig(
+        dependencies = mapOf("com.example:lib" to "1.0.0"),
+        repositories = mapOf("primary" to repo1, "fallback" to repo2),
+      )
+    val pomXml =
+      """
+            <project><groupId>com.example</groupId><artifactId>lib</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+
+    val cachedFiles = mutableSetOf<String>()
+    val deps =
+      object : ResolverDeps {
+        val pomContents = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.pom" to pomXml)
+
+        override fun fileExists(path: String): Boolean = path in cachedFiles
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          if (destPath.endsWith(".jar") && url.startsWith(repo1)) {
+            return Err(DownloadError.HttpFailed(url, 404))
+          }
+          cachedFiles.add(destPath)
+          return Ok(Unit)
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> = Ok("hashLib")
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> {
+          val content = pomContents[path] ?: return Err(OpenFailed(path))
+          return Ok(content)
+        }
+      }
+    val sink = RecordingResolverProgressSink()
+
+    val result = resolveTransitive(config, null, "/cache", deps, progress = sink)
+    assertNotNull(result.get())
+
+    val expected =
+      listOf<RecordedProgressEvent>(
+        RecordedProgressEvent.ArtifactStart(1, 1, "com.example:lib", "1.0.0"),
+        RecordedProgressEvent.RetryAgainst(repo2),
+      )
+    assertEquals(expected, sink.events)
+  }
+
+  @Test
+  fun binaryCachedAndMissingSourcesEmitsNothingForSourcesFetch() {
+    val config = testConfig().copy(dependencies = mapOf("com.example:lib" to "1.0.0"))
+    val libPom =
+      """
+            <project><groupId>com.example</groupId><artifactId>lib</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+
+    // Binary cached, sources NOT cached. Per resolveSourcesPath semantics: when
+    // binaryWasCached is true and sources is not on disk, no network probe runs;
+    // the sink must remain silent regardless. This pins Req 5.1.
+    val deps =
+      fakeDeps(
+        cachedFiles =
+          mutableSetOf(
+            "/cache/com/example/lib/1.0.0/lib-1.0.0.jar",
+            "/cache/com/example/lib/1.0.0/lib-1.0.0.pom",
+          ),
+        sha256Results = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.jar" to "hash1"),
+        pomContents = mapOf("/cache/com/example/lib/1.0.0/lib-1.0.0.pom" to libPom),
+      )
+    val sink = RecordingResolverProgressSink()
+
+    val result = resolveTransitive(config, null, "/cache", deps, progress = sink)
+    assertNotNull(result.get())
+
+    assertEquals(emptyList(), sink.events)
+  }
+
+  private fun fakeDeps(
+    cachedFiles: MutableSet<String> = mutableSetOf(),
+    sha256Results: Map<String, String> = emptyMap(),
+    pomContents: Map<String, String> = emptyMap(),
+    downloadErrors: Map<String, DownloadError> = emptyMap(),
+  ): ResolverDeps {
+    return object : ResolverDeps {
+      override fun fileExists(path: String): Boolean = path in cachedFiles
+
+      override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        val forcedError = downloadErrors[url]
+        if (forcedError != null) return Err(forcedError)
+        cachedFiles.add(destPath)
+        return Ok(Unit)
+      }
+
+      override fun computeSha256(filePath: String): Result<String, Sha256Error> {
+        val hash = sha256Results[filePath] ?: return Err(Sha256Error(filePath))
+        return Ok(hash)
+      }
+
+      override fun readFileContent(path: String): Result<String, OpenFailed> {
+        val content = pomContents[path] ?: return Err(OpenFailed(path))
+        return Ok(content)
+      }
+    }
+  }
+
+  // Maven Central base is referenced just to keep the import linked in case a
+  // future test uses it; resolved tests above use explicit repositories or
+  // testConfig defaults.
+  @Suppress("unused") private val mavenCentralBase = MAVEN_CENTRAL_BASE
+}

--- a/src/nativeTest/kotlin/kolt/resolve/RecordingResolverProgressSink.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/RecordingResolverProgressSink.kt
@@ -1,0 +1,27 @@
+package kolt.resolve
+
+sealed class RecordedProgressEvent {
+  data class ArtifactStart(
+    val index: Int,
+    val total: Int,
+    val groupArtifact: String,
+    val version: String,
+  ) : RecordedProgressEvent()
+
+  data class RetryAgainst(val repository: String) : RecordedProgressEvent()
+}
+
+class RecordingResolverProgressSink : ResolverProgressSink {
+  private val recorded = mutableListOf<RecordedProgressEvent>()
+
+  val events: List<RecordedProgressEvent>
+    get() = recorded.toList()
+
+  override fun onArtifactStart(index: Int, total: Int, groupArtifact: String, version: String) {
+    recorded += RecordedProgressEvent.ArtifactStart(index, total, groupArtifact, version)
+  }
+
+  override fun onRetryAgainst(repository: String) {
+    recorded += RecordedProgressEvent.RetryAgainst(repository)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveNativeProgressTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveNativeProgressTest.kt
@@ -1,0 +1,229 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kolt.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ResolveNativeProgressTest {
+
+  @Test
+  fun threeUncachedKlibsEmitOneOfThreeTwoOfThreeThreeOfThree() {
+    val config =
+      testConfig(target = "linuxX64")
+        .copy(
+          dependencies =
+            mapOf(
+              "com.example:a" to "1.0.0",
+              "com.example:b" to "2.0.0",
+              "com.example:c" to "3.0.0",
+            )
+        )
+
+    val aRoot = rootModuleJson("com.example", "a-linuxx64", "1.0.0")
+    val aPlatform = platformModuleJson("a-linuxx64-1.0.0.klib", "h-a")
+    val bRoot = rootModuleJson("com.example", "b-linuxx64", "2.0.0")
+    val bPlatform = platformModuleJson("b-linuxx64-2.0.0.klib", "h-b")
+    val cRoot = rootModuleJson("com.example", "c-linuxx64", "3.0.0")
+    val cPlatform = platformModuleJson("c-linuxx64-3.0.0.klib", "h-c")
+
+    val deps =
+      fakeDeps(
+        contents =
+          mapOf(
+            "/cache/com/example/a/1.0.0/a-1.0.0.module" to aRoot,
+            "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.module" to aPlatform,
+            "/cache/com/example/b/2.0.0/b-2.0.0.module" to bRoot,
+            "/cache/com/example/b-linuxx64/2.0.0/b-linuxx64-2.0.0.module" to bPlatform,
+            "/cache/com/example/c/3.0.0/c-3.0.0.module" to cRoot,
+            "/cache/com/example/c-linuxx64/3.0.0/c-linuxx64-3.0.0.module" to cPlatform,
+          ),
+        sha256 =
+          mapOf(
+            "/cache/com/example/a-linuxx64/1.0.0/a-linuxx64-1.0.0.klib" to "h-a",
+            "/cache/com/example/b-linuxx64/2.0.0/b-linuxx64-2.0.0.klib" to "h-b",
+            "/cache/com/example/c-linuxx64/3.0.0/c-linuxx64-3.0.0.klib" to "h-c",
+          ),
+      )
+
+    val sink = RecordingResolverProgressSink()
+
+    val result = resolveNative(config, "/cache", deps, progress = sink)
+    assertNotNull(result.get())
+
+    val artifactStarts = sink.events.filterIsInstance<RecordedProgressEvent.ArtifactStart>()
+    assertEquals(3, artifactStarts.size)
+    val gaToEvent = artifactStarts.associateBy { it.groupArtifact }
+    assertEquals(
+      RecordedProgressEvent.ArtifactStart(1, 3, "com.example:a", "1.0.0"),
+      gaToEvent["com.example:a"],
+    )
+    assertEquals(
+      RecordedProgressEvent.ArtifactStart(2, 3, "com.example:b", "2.0.0"),
+      gaToEvent["com.example:b"],
+    )
+    assertEquals(
+      RecordedProgressEvent.ArtifactStart(3, 3, "com.example:c", "3.0.0"),
+      gaToEvent["com.example:c"],
+    )
+    val indices = artifactStarts.map { it.index }
+    assertEquals(listOf(1, 2, 3), indices)
+  }
+
+  @Test
+  fun fourOhFourThenTwoHundredEmitsArtifactStartFollowedByRetryAgainstSecondRepo() {
+    val repo1 = "https://repo1.example.com"
+    val repo2 = "https://repo2.example.com"
+    val config =
+      testConfig(
+        target = "linuxX64",
+        dependencies = mapOf("com.example:lib" to "1.0.0"),
+        repositories = mapOf("primary" to repo1, "fallback" to repo2),
+      )
+
+    val rootModule = rootModuleJson("com.example", "lib-linuxx64", "1.0.0")
+    val platformModule = platformModuleJson("lib-linuxx64-1.0.0.klib", "hashLib")
+
+    // Pre-cache the .module files so only the klib download exercises the
+    // 404-then-200 retry path. This isolates the test to the materialize
+    // loop's klib `downloadFromRepositories` call (the one that should
+    // forward `progress::onRetryAgainst`); module metadata fetches must
+    // stay silent regardless.
+    val cachedFiles =
+      mutableSetOf(
+        "/cache/com/example/lib/1.0.0/lib-1.0.0.module",
+        "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module",
+      )
+    val contents =
+      mapOf(
+        "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to rootModule,
+        "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to platformModule,
+      )
+
+    val deps =
+      object : ResolverDeps {
+        override fun fileExists(path: String): Boolean = path in cachedFiles
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          if (destPath.endsWith(".klib") && url.startsWith(repo1)) {
+            return Err(DownloadError.HttpFailed(url, 404))
+          }
+          cachedFiles.add(destPath)
+          return Ok(Unit)
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> = Ok("hashLib")
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> {
+          val content = contents[path] ?: return Err(OpenFailed(path))
+          return Ok(content)
+        }
+      }
+
+    val sink = RecordingResolverProgressSink()
+
+    val result = resolveNative(config, "/cache", deps, progress = sink)
+    assertNotNull(result.get())
+
+    val expected =
+      listOf<RecordedProgressEvent>(
+        RecordedProgressEvent.ArtifactStart(1, 1, "com.example:lib", "1.0.0"),
+        RecordedProgressEvent.RetryAgainst(repo2),
+      )
+    assertEquals(expected, sink.events)
+  }
+
+  private fun rootModuleJson(
+    redirectGroup: String,
+    redirectModule: String,
+    redirectVersion: String,
+  ): String =
+    """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../$redirectModule/$redirectVersion/$redirectModule-$redirectVersion.module",
+                "group": "$redirectGroup",
+                "module": "$redirectModule",
+                "version": "$redirectVersion"
+              }
+            }
+          ]
+        }
+    """
+      .trimIndent()
+
+  private fun platformModuleJson(klibFileName: String, klibSha256: String): String =
+    """
+            {
+              "formatVersion": "1.1",
+              "variants": [
+                {
+                  "name": "linuxX64ApiElements-published",
+                  "attributes": {
+                    "org.gradle.category": "library",
+                    "org.gradle.usage": "kotlin-api",
+                    "org.jetbrains.kotlin.native.target": "linux_x64",
+                    "org.jetbrains.kotlin.platform.type": "native"
+                  },
+                  "dependencies": [],
+                  "files": [
+                    {
+                      "name": "inner.klib",
+                      "url": "$klibFileName",
+                      "sha256": "$klibSha256"
+                    }
+                  ]
+                }
+              ]
+            }
+        """
+      .trimIndent()
+
+  private fun fakeDeps(
+    cachedFiles: MutableSet<String> = mutableSetOf(),
+    contents: Map<String, String> = emptyMap(),
+    sha256: Map<String, String> = emptyMap(),
+  ): ResolverDeps {
+    cachedFiles.addAll(contents.keys)
+    return object : ResolverDeps {
+      override fun fileExists(path: String): Boolean = path in cachedFiles
+
+      override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        cachedFiles.add(destPath)
+        return Ok(Unit)
+      }
+
+      override fun computeSha256(filePath: String): Result<String, Sha256Error> {
+        val hash = sha256[filePath] ?: return Err(Sha256Error(filePath))
+        return Ok(hash)
+      }
+
+      override fun readFileContent(path: String): Result<String, OpenFailed> {
+        val content = contents[path] ?: return Err(OpenFailed(path))
+        return Ok(content)
+      }
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/ResolverProgressSinkTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolverProgressSinkTest.kt
@@ -1,0 +1,46 @@
+package kolt.resolve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ResolverProgressSinkTest {
+
+  @Test
+  fun noOpSinkSwallowsCallbacks() {
+    val sink = ResolverProgressSink.NoOp
+    sink.onArtifactStart(1, 3, "com.example:lib", "1.0.0")
+    sink.onRetryAgainst("https://repo.example.com/maven2/")
+  }
+
+  @Test
+  fun recordingSinkCapturesCallbacksInOrder() {
+    val sink = RecordingResolverProgressSink()
+
+    sink.onArtifactStart(1, 3, "com.example:a", "1.0.0")
+    sink.onArtifactStart(2, 3, "com.example:b", "2.0.0")
+    sink.onRetryAgainst("https://repo.internal.example.com/maven2/")
+    sink.onArtifactStart(3, 3, "com.example:c", "3.0.0")
+
+    val expected =
+      listOf<RecordedProgressEvent>(
+        RecordedProgressEvent.ArtifactStart(1, 3, "com.example:a", "1.0.0"),
+        RecordedProgressEvent.ArtifactStart(2, 3, "com.example:b", "2.0.0"),
+        RecordedProgressEvent.RetryAgainst("https://repo.internal.example.com/maven2/"),
+        RecordedProgressEvent.ArtifactStart(3, 3, "com.example:c", "3.0.0"),
+      )
+    assertEquals(expected, sink.events)
+  }
+
+  @Test
+  fun recordingSinkEventsViewIsImmutableSnapshot() {
+    val sink = RecordingResolverProgressSink()
+    sink.onArtifactStart(1, 1, "com.example:lib", "1.0.0")
+    val snapshot = sink.events
+    sink.onRetryAgainst("https://repo.example.com/maven2/")
+
+    assertEquals(1, snapshot.size)
+    assertEquals(2, sink.events.size)
+    assertTrue(snapshot[0] is RecordedProgressEvent.ArtifactStart)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
@@ -1324,6 +1324,69 @@ class TransitiveResolverTest {
   }
 
   @Test
+  fun downloadFromRepositoriesOnRetryFiresOnceWithSecondRepoOn404Then200() {
+    val coord = Coordinate("com.example", "lib", "1.0.0")
+    val repo1 = "https://repo1.example.com"
+    val repo2 = "https://repo2.example.com"
+    val captured = mutableListOf<String>()
+
+    val result =
+      downloadFromRepositories(
+        repos = listOf(repo1, repo2),
+        destPath = "/cache/lib.jar",
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
+        download = { url, _ ->
+          if (url.startsWith(repo1)) Err(DownloadError.HttpFailed(url, 404)) else Ok(Unit)
+        },
+        onRetry = { repo -> captured.add(repo) },
+      )
+
+    assertNotNull(result.get())
+    assertEquals(listOf(repo2), captured)
+  }
+
+  @Test
+  fun downloadFromRepositoriesOnRetryFiresZeroTimesOnNon404FirstAttempt() {
+    val coord = Coordinate("com.example", "lib", "1.0.0")
+    val repo1 = "https://repo1.example.com"
+    val repo2 = "https://repo2.example.com"
+    val captured = mutableListOf<String>()
+
+    val result =
+      downloadFromRepositories(
+        repos = listOf(repo1, repo2),
+        destPath = "/cache/lib.jar",
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
+        download = { url, _ -> Err(DownloadError.NetworkError(url, "connection refused")) },
+        onRetry = { repo -> captured.add(repo) },
+      )
+
+    assertIs<RepositoryDownloadFailure.AllAttemptsFailed>(result.getError())
+    assertEquals(emptyList(), captured)
+  }
+
+  @Test
+  fun downloadFromRepositoriesOnRetryFiresOnlyOnAdvancesNotAfterLastWhenAll404() {
+    val coord = Coordinate("com.example", "lib", "1.0.0")
+    val repo1 = "https://repo1.example.com"
+    val repo2 = "https://repo2.example.com"
+    val repo3 = "https://repo3.example.com"
+    val captured = mutableListOf<String>()
+
+    val result =
+      downloadFromRepositories(
+        repos = listOf(repo1, repo2, repo3),
+        destPath = "/cache/lib.jar",
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
+        download = { url, _ -> Err(DownloadError.HttpFailed(url, 404)) },
+        onRetry = { repo -> captured.add(repo) },
+      )
+
+    assertIs<RepositoryDownloadFailure.AllAttemptsFailed>(result.getError())
+    assertEquals(listOf(repo2, repo3), captured)
+  }
+
+  @Test
   fun resolveWithCustomRepositoryUrl() {
     val customRepoBase = "https://nexus.example.com/repository/maven-public"
     val config =


### PR DESCRIPTION
Closes #404.

The in-Kotlin resolver now emits `[N/M] group:artifact:version` on stderr before each JAR/klib network fetch and surfaces 404→next-repo fallthroughs as `  -> retry against <repo>` annotations. Empty-cache `kolt build`, `kolt fetch`, `kolt update`, and the no-version `kolt add` path no longer go silent through 10s+ of POM/jar downloads. The three pre-resolve banners (`resolving dependencies...`, `resolving native dependencies...`, `updating dependencies...`) move from stdout to stderr alongside the new lines, plus `updating tools...` is brought along for consistency. `kolt fetch > out.txt` now leaves `out.txt` containing only `fetch complete` — Req 4.3.

The contract lives in a small `ResolverProgressSink` (two callbacks, `NoOp` companion default) injected through every resolver entry. CLI constructs one stderr-backed sink per top-level invocation and threads the same instance into both `resolve()` and `resolveAllBundles()` so main + bundle resolution share one `[N/M]` sequence. `downloadFromRepositories` gains a defaulted `onRetry: (String) -> Unit = {}` parameter, fired only on 404 fallthrough — non-404 errors and the final-repo 404 stay silent. Out-of-scope consumers (`BtaImplFetcher`, `DaemonPreconditions`, `OutdatedCommand`, `PluginJarFetcher`, `ToolCommands`, `resolveSourcesPath`, native `fetchAndRead`, POM/`.module` lookups) inherit `NoOp` and stay silent without explicit opt-out. Issue #355's failure-message rendering is untouched on the error path; install.sh progress is #405.

## Reviewer focus

- **Two-callsite emission shape**: `progress.onArtifactStart` lives in materialize (`TransitiveResolver`, `NativeResolver`, `BundleResolver`); `progress.onRetryAgainst` lives inside `downloadFromRepositories`. The two are deliberately split so retries can never produce a duplicate `[N/M]` (Req 2.4) — pinned structurally rather than by tests. Worth confirming the seam holds for all five emission paths.
- **`materialiseBundleJarsFromLock` wiring**: caught a silent-in-prod gap during `/kiro-validate-impl` — the kernel emits but the CLI dispatcher (`resolveAllBundles`) wasn't forwarding `progress` to it (commit `de07118`). Per-task reviewers didn't catch it because `BundleResolverProgressTest` calls the function directly. The fix is a one-arg forward; whether to add a CLI-level integration regression test for this specific seam is a judgment call left for review.
- **Pre-existing duplicate `println`**: `doAddInner` previously announced `fetching latest version for ...` on stdout right before `fetchLatestVersion`, which now announces `fetching latest version of ...` on stderr. Removed the older one (Req 4.3 + design's "single line"). The relocated `updating tools...` was a non-blocker observation from review folded into 3.3 to keep the Req 4.3 surface consistent in one round.
- **Counting strategy**: design doc closes the open question (POM / `.module` / sources / metadata-XML stay silent — only JAR/klib fetches earn a `[N/M]` line). The `resolving dependencies...` banner now implicitly covers the metadata phase. If you'd prefer a separate metadata progress prefix, follow-up issue territory.
- **Pre-count cost**: each materialize call now does one extra `fileExists` per node before the loop. Negligible vs. network I/O; warm-cache `kolt build` short-circuits before any pre-count work.

## Verification

`kolt test` 1909/1909 (baseline 1896 → +13: 3 in `ResolverProgressSinkTest`, 3 in `TransitiveResolverTest` for the retry callback, 5 in `MaterializeProgressTest`, 2 in `ResolveNativeProgressTest`, 2 in `BundleResolverProgressTest`, 1 in `StderrProgressSinkTest`). Recording sink fixture (`RecordingResolverProgressSink`) captures both callbacks into a sealed-event ordered list and is reusable across the per-path tests. End-to-end smoke against a real fetch is dogfood territory and not in CI.