### PR TITLE
Bump bootstrap to v0.19.0

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 env:
-  KOLT_BOOTSTRAP_TAG: v0.18.1
+  KOLT_BOOTSTRAP_TAG: v0.19.0
   # Run the bootstrap kolt from inside the extracted release tree so
   # `DaemonJarResolver` can find `libexec/<daemon>/*.jar` siblings and
   # spawn the warm daemon. Copying the binary out (as the original

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 env:
-  KOLT_BOOTSTRAP_TAG: v0.18.1
+  KOLT_BOOTSTRAP_TAG: v0.19.0
   # Run the bootstrap kolt from inside the extracted release tree so
   # `DaemonJarResolver` can find `libexec/<daemon>/*.jar` siblings and
   # spawn the warm daemon. Copying the binary out (as the original


### PR DESCRIPTION
v0.19.0 was published from `release.yml` (run 25605368951, smoke green). Bumps `KOLT_BOOTSTRAP_TAG` from `v0.18.1` to `v0.19.0` in `unit-tests.yml` and `self-host-smoke.yml` so the next CI cycle's bootstrap kolt carries the diagnostics overhaul (#2), resolver progress (#404), `kolt new` 4-preset flow (#412 / #407), and install.sh download progress (#406) shipped in v0.19.0.

`release.yml`'s own `KOLT_BOOTSTRAP_TAG` (currently `v0.16.3`) is left alone — that pin trails by more than one release on purpose so a broken pinned tag does not block the release pipeline.

No `ungate` follow-up here: nothing in HEAD is gated behind a `KOLT_*_TEST=1` env that the v0.19.0 bootstrap newly unblocks. The bootstrap-gated IT pattern (`KOLT_DAEMON_JAR`, etc.) is daemon-jar-presence gated, not version gated.

Mechanical change. Two YAML lines.