### PR TITLE
Resolve ${project.groupId}/version through <parent> in PomParser

### DIFF
--- a/src/nativeMain/kotlin/kolt/resolve/PomParser.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/PomParser.kt
@@ -50,19 +50,26 @@ fun parsePom(xml: String): Result<PomInfo, PomParseError> {
     }
   }
 
-  val interpolationMap = buildInterpolationMap(properties, projectGroupId, projectVersion)
-
+  // Maven effective-model rule: a child POM that omits <groupId> / <version>
+  // inherits them from <parent>, and ${project.groupId} / ${project.version}
+  // bind to the *effective* values. The parent block itself can still
+  // reference <properties>-defined keys, so we interpolate it against a
+  // properties-only map before deriving effective coordinates for deps.
   val parent =
     root.child("parent")?.let { p ->
       val pg = p.childText("groupId") ?: return Err(PomParseError("Parent missing <groupId>"))
       val pa = p.childText("artifactId") ?: return Err(PomParseError("Parent missing <artifactId>"))
       val pv = p.childText("version") ?: return Err(PomParseError("Parent missing <version>"))
       PomParent(
-        interpolate(pg, interpolationMap),
-        interpolate(pa, interpolationMap),
-        interpolate(pv, interpolationMap),
+        interpolate(pg, properties),
+        interpolate(pa, properties),
+        interpolate(pv, properties),
       )
     }
+
+  val effectiveGroupId = projectGroupId ?: parent?.groupId
+  val effectiveVersion = projectVersion ?: parent?.version
+  val interpolationMap = buildInterpolationMap(properties, effectiveGroupId, effectiveVersion)
 
   val depMgmt =
     root

--- a/src/nativeTest/kotlin/kolt/resolve/PomParserTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/PomParserTest.kt
@@ -279,6 +279,36 @@ class PomParserTest {
   }
 
   @Test
+  fun parsePomInheritsProjectGroupIdAndVersionFromParent() {
+    // netty-codec-http2-style child POM: omits its own <groupId> / <version>
+    // and inherits them from <parent>. ${project.groupId} / ${project.version}
+    // must resolve through the parent block, not survive as literals.
+    val xml =
+      """
+            <project>
+                <parent>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-parent</artifactId>
+                    <version>4.2.12.Final</version>
+                </parent>
+                <artifactId>netty-codec-http2</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>${'$'}{project.groupId}</groupId>
+                        <artifactId>netty-common</artifactId>
+                        <version>${'$'}{project.version}</version>
+                    </dependency>
+                </dependencies>
+            </project>
+        """
+        .trimIndent()
+
+    val pom = assertNotNull(parsePom(xml).get())
+    assertEquals("io.netty", pom.dependencies[0].groupId)
+    assertEquals("4.2.12.Final", pom.dependencies[0].version)
+  }
+
+  @Test
   fun parsePomWithExclusions() {
     val xml =
       """

--- a/src/nativeTest/kotlin/kolt/resolve/PomParserTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/PomParserTest.kt
@@ -309,6 +309,37 @@ class PomParserTest {
   }
 
   @Test
+  fun parsePomInheritsOnlyMissingProjectCoordinatesFromParent() {
+    // Maven's effective-model rule fires field-by-field. A child can declare
+    // its own <version> while inheriting <groupId> from <parent>; only the
+    // missing coordinate falls back.
+    val xml =
+      """
+            <project>
+                <parent>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-parent</artifactId>
+                    <version>4.2.12.Final</version>
+                </parent>
+                <artifactId>netty-child</artifactId>
+                <version>4.3.0.Beta</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>${'$'}{project.groupId}</groupId>
+                        <artifactId>netty-common</artifactId>
+                        <version>${'$'}{project.version}</version>
+                    </dependency>
+                </dependencies>
+            </project>
+        """
+        .trimIndent()
+
+    val pom = assertNotNull(parsePom(xml).get())
+    assertEquals("io.netty", pom.dependencies[0].groupId)
+    assertEquals("4.3.0.Beta", pom.dependencies[0].version)
+  }
+
+  @Test
   fun parsePomWithExclusions() {
     val xml =
       """


### PR DESCRIPTION
Closes #421.

`parsePom` builds the `${project.*}` interpolation map after parsing `<parent>`, then falls back to `parent.groupId` / `parent.version` when the child POM omits its own elements — Maven's effective-model rule. The parent block itself is still interpolated against `<properties>` only (the interpolation map for `${project.*}` is not yet built at that point), preserving prior behavior.

Reviewer focus:
- `PomParser.kt:53-68` — order-of-operations: parent must be parsed before the interpolation map. The parent's own coords are interpolated against properties-only to keep the previous "you can use a `<properties>` key inside `<parent>`" path intact.
- The returned `PomInfo.groupId` / `PomInfo.version` stay raw (null when inherited). Only the dep-interpolation map sees the effective values, so `Resolution.kt`'s parent traversal is unchanged.

Smoke-tested by `kolt add io.ktor:ktor-server-netty-jvm` against the patched binary — all 20 transitives resolve cleanly (was 404 on `${project.groupId}:netty-common` before).