### PR TITLE
Bump bootstrap to v0.19.1

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 env:
-  KOLT_BOOTSTRAP_TAG: v0.19.0
+  KOLT_BOOTSTRAP_TAG: v0.19.1
   # Run the bootstrap kolt from inside the extracted release tree so
   # `DaemonJarResolver` can find `libexec/<daemon>/*.jar` siblings and
   # spawn the warm daemon. Copying the binary out (as the original

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 env:
-  KOLT_BOOTSTRAP_TAG: v0.19.0
+  KOLT_BOOTSTRAP_TAG: v0.19.1
   # Run the bootstrap kolt from inside the extracted release tree so
   # `DaemonJarResolver` can find `libexec/<daemon>/*.jar` siblings and
   # spawn the warm daemon. Copying the binary out (as the original


### PR DESCRIPTION
Routine post-release bump. Pins CI's self-bootstrap kolt to the just-published v0.19.1, which now ships the `${project.groupId}` / `${project.version}` parent-inheritance fix from #422.