### PR TITLE
Native resolver: .pom fallback for transitive .module 404 (#426)

### DIFF
--- a/.kiro/specs/426-native-resolver-pom-fallback/design.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/design.md
@@ -1,0 +1,465 @@
+# Design Document
+
+## Overview
+
+Native resolver の transitive 解決経路に `.module` 404 → `.pom` 構造的フォールバックを追加し、 Gradle Module Metadata を公開していない JVM 専用 Kotlin artifact が native の transitive closure に現れた際にビルドを止めないようにする。 `.module` が 404 で `.pom` が 200 OK な artifact は構造的に native variant を持たないため、 transitive context では silent skip (stdlib 系) または stderr note 付き skip として扱い、 direct context では `NoNativeVariant` で error にする。
+
+**Purpose**: kolt-native プロジェクトで mixed-platform library (例 `ktor-server-core`) が transitive に JVM 専用 kotlin artifact (例 `kotlin-reflect`) を引き込んでも build が継続できる。
+
+**Users**: `target = "linuxX64"` を使う kolt user。 影響範囲は native pipeline のみで JVM 経路は不変。
+
+**Impact**: `NativeResolver` の internal data model に sealed variant 一段追加 (`NativeResolved.Klib` / `NativeResolved.JvmOnly`)。 既存の `isKotlinStdlib` skip predicate は `kotlin-stdlib` (link-time bundling 問題) と silent-diagnostic anchor として残置。 ADR 0011 §4 (`kotlin-stdlib-common` の名前 skip) は構造的検出に subsume されるが、 silent skip ポリシーは継続。
+
+### Goals
+- `.module` の全 repository で HTTP 404 を構造的に検出し、 `.pom` 存在確認で JVM 専用と判定する fallback 経路を追加する。
+- transitive で JVM-only に倒れた artifact を silent skip し (stdlib 系) または stderr 1行 note 付き skip する。
+- direct dep が JVM-only に倒れたら `NoNativeVariant` で非ゼロ終了する。
+- 再現ケース (`kolt add io.ktor:ktor-server-core` 相当が `kotlin-reflect` で abort しない) を決定的 fixture で regression test 化する。
+
+### Non-Goals
+- ktor-server-core の native variant が `kotlin-reflect` を含んでいる根本要因の調査 / 修正 (Layer 2, 別 issue)。
+- mixed-platform library の variant 解釈 audit。
+- POM ベースの transitive 解決を native context で行うこと (POM の deps を BFS に流さない)。
+- JVM 経路 (`TransitiveResolver`) への変更。
+- lockfile schema の変更。
+- `kolt deps tree` 等の UI 表記。
+
+## Boundary Commitments
+
+### This Spec Owns
+- `NativeResolver.fetchNativeMetadata` の root `.module` フェッチに対する 404 構造的検出と `.pom` フォールバック実装。
+- `NativeResolved` の sealed variant 化 (`Klib` / `JvmOnly`) と、 それを下流の materialization / childLookup が解釈する分岐。
+- transitive JVM-only skip の stderr note 出力ポリシー (silent for stdlib*, note for others)。
+- 再現ケースの regression integration test と関連 fixture。
+
+### Out of Boundary
+- target `.module` (redirect 先) の 404 ハンドリング。 root `.module` で `available-at` redirect を読めた後の target `.module` が 404 の場合は構造的に「native variant あると宣言されたのに無い」状態であり、 これは Layer 2 の問題。 本仕様では既存挙動 (`DownloadFailed`) を維持する。
+- `.pom` の deps を読んで native BFS に流すこと。 `.pom` は存在確認のみ。
+- ADR 0011 の改訂 (本仕様完了後に follow-up として検討、 本仕様の必須範囲外)。
+- `isKotlinStdlib` の predicate 名 / 場所変更。
+- JVM resolver (`TransitiveResolver` 系) のロジック。
+
+### Allowed Dependencies
+- 既存 native resolver primitive: `parseCoordinate`, `fetchAndRead`, `downloadFromRepositories`, `buildModuleCachePath`, `buildModuleDownloadUrl`, `buildPomCachePath`, `buildPomDownloadUrl`, `isValidGradleModuleJson`, `parseNativeRedirect`, `parseNativeArtifact`, `isKotlinStdlib`。
+- 既存 error 型: `ResolveError.DownloadFailed`, `ResolveError.NoNativeVariant`, `RepositoryDownloadFailure.AllAttemptsFailed`, `DownloadError.HttpFailed`。
+- 既存 kernel: `fixpointResolve`, `DependencyNode`, `Child`。
+- `kolt.infra.output` の stderr 出力 (eprintln 系)。
+
+### Revalidation Triggers
+- `NativeResolved` の sealed shape が変わる (新 variant 追加など) → childLookup / materialization / createNativeLookup を再点検。
+- `RepositoryDownloadFailure` / `DownloadError` の sealed shape が変わる → 構造的 404 判定 helper を再点検。
+- ADR 0011 の改訂 (本仕様後の follow-up を含む) → silent skip policy / `isKotlinStdlib` の役割を再点検。
+- Layer 2 (variant 解釈 audit) の着手 → `JvmOnly` variant のセマンティクスと診断ポリシーを再点検。
+
+## Architecture
+
+### Existing Architecture Analysis
+
+現状の native resolver は以下の構造で動いている (要旨)。
+
+1. `resolveNative` が direct deps を validate し、 `fixpointResolve` に `mainSeeds` を渡す。
+2. kernel は each node に対して `childLookup` を呼んで transitive children を取得し、 fixpoint まで反復。
+3. `childLookup` 内部で `fetchNativeMetadata` が root `.module` → redirect → target `.module` の 2 段フェッチを行い、 結果 `NativeResolved(redirect, artifact)` を `processed` map にキャッシュ。
+4. 反復終了後、 `resolveNative` の materialization loop が `processed` から各 node の klib を download / SHA verify / `resolvedDeps` に追加。
+5. `.module` フェッチ失敗 (404 を含む) は `ResolveError.DownloadFailed` として `fixpointResolve` に伝播し、 `resolveNative` が即座に Err を返す = build abort。
+
+`isKotlinStdlib` predicate は 3 か所で適用される:
+- direct dep validation loop (`resolveNative` 直上)
+- direct dep seeding (`directDeps` filter)
+- transitive BFS enqueueing (`childLookup` 内)
+
+### Architecture Pattern & Boundary Map
+
+本仕様は既存の native resolver pipeline に「構造的 fallback」 を 1 段追加する extension。 sealed ADT 駆動の domain polymorphism (steering structure.md の Code Organization Principles) を維持。
+
+```mermaid
+flowchart LR
+    A[resolveNative] -->|directDeps| B[fixpointResolve]
+    B -->|per node| C[childLookup]
+    C --> D{cached?}
+    D -->|yes| F[NativeResolved]
+    D -->|no| E[fetchNativeMetadata]
+    E --> G{root .module fetch}
+    G -->|200 OK| H[parse + redirect + target .module]
+    H --> F1[NativeResolved.Klib]
+    G -->|all repos 404| I[.pom fallback fetch]
+    G -->|other failure| Z1[Err DownloadFailed]
+    I -->|.pom 200| F2[NativeResolved.JvmOnly]
+    I -->|.pom 404 or other| Z2[Err DownloadFailed - .module]
+    F1 --> C
+    F2 --> C
+    C -->|emit children| B
+    B --> M[materialization loop]
+    M --> N{node.direct && resolved is JvmOnly?}
+    N -->|yes| Y[Err NoNativeVariant]
+    N -->|no, Klib| K[download klib + sha + resolvedDeps]
+    N -->|no, JvmOnly transitive| S[skip + note unless stdlib*]
+```
+
+**Selected pattern**: 既存 native resolver の pipeline に sealed-variant 駆動の分岐を追加。 新規 component なし。 新規 wire/contract なし。 internal data 表現の拡張のみ。
+
+**Domain/feature boundaries**: すべて `kolt.resolve` パッケージ内部。 cli / build / infra への影響なし。
+
+**Existing patterns preserved**:
+- `Result<V, ResolveError>` 駆動の error handling (ADR 0001)。
+- sealed ADT for domain polymorphism (structure.md)。
+- ADR 0011 §1-§4 の silent skip ポリシー (`kotlin-stdlib` / `kotlin-stdlib-common`)。
+- per-repo 404 fall-through (`downloadFromRepositories`)。
+
+**Steering compliance**: kotlin-result `getOrElse` / `isErr` 使用、 sealed class with data variants, ADR citation in code, no wildcard import。
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Native pipeline | `kolt.resolve.NativeResolver` (linuxX64) | 構造的 fallback 実装と materialization loop の variant 分岐 | 既存 file 改修のみ |
+| Test fixture | `nativeTest` + 既存 `ResolverDeps` mock | `.module` 404 / `.pom` 200 / `.pom` 404 の決定的 fixture | live Maven Central を踏まない |
+| Diagnostic | `kolt.infra.output` の stderr 経路 (eprintln) | transitive JVM-only skip の 1 行 note | ProgressSink には追加しない |
+
+## File Structure Plan
+
+### Modified Files
+- `src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt`
+  - `NativeResolved` を `private sealed class` に変更し `Klib` / `JvmOnly` の 2 variant 化。
+  - `fetchNativeMetadata` に root `.module` 404 構造的判定と `.pom` フォールバックを追加。
+  - `makeNativeChildLookup` を `NativeResolved` variant 分岐に対応 (Klib → 既存通り、 JvmOnly → 空 children)。
+  - `resolveNative` の materialization loop で `node.direct && resolved is JvmOnly` を `NoNativeVariant` エラー、 transitive JvmOnly は skip + 条件付き stderr note。
+  - `createNativeLookup` (deps tree 用) は JvmOnly を `NativeNodeInfo` でどう表現するかは別途 (詳細は Components 節)。
+- `src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt`
+  - 既存「`.module` 404 が fatal」前提のテストを「fallback 後の挙動」に置換。
+  - 新規ケース: transitive JvmOnly skip (silent: stdlib-common / note: kotlin-reflect 模擬) と direct JvmOnly が `NoNativeVariant` を返すこと。
+- `src/nativeTest/kotlin/kolt/resolve/` 配下に新規 integration test 1 本
+  - `NativeResolverJvmOnlyFallbackTest.kt` (仮称) — 再現ケースを決定的 fixture で再現。 `ktor-server-core` 相当の `.module` を bundle した state を持たせ、 `kotlin-reflect` 相当の coordinate は `.module` 404 / `.pom` 200 を返す。
+
+### New Files
+- なし (実装は既存 file の内部改修で完結)。
+
+### No Changes
+- `src/nativeMain/kotlin/kolt/resolve/Resolution.kt` (kernel)
+- `src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt` (JVM resolver / `downloadFromRepositories` の 404 fall-through ポリシーは reuse)
+- `src/nativeMain/kotlin/kolt/resolve/PomParser.kt` (本仕様では `.pom` 存在確認のみで parse は呼ばない)
+- `src/nativeMain/kotlin/kolt/resolve/Resolver.kt` (error 型は既存を再利用)
+
+## System Flows
+
+### Fetch decision flow
+
+```mermaid
+sequenceDiagram
+    participant K as fixpointResolve
+    participant L as childLookup
+    participant F as fetchNativeMetadata
+    participant R as downloadFromRepositories
+    participant S as stderr
+
+    K->>L: (groupArtifact, version)
+    L->>F: cache miss
+    F->>R: GET .module (root)
+    alt root .module 200 OK
+        R-->>F: bytes
+        F->>F: parse, redirect, fetch target .module
+        F-->>L: Ok(Klib)
+        L-->>K: children from artifact.dependencies (minus stdlib*)
+    else root .module all-repos 404
+        F->>R: GET .pom (same root coordinate)
+        alt .pom 200 OK
+            R-->>F: bytes
+            F-->>L: Ok(JvmOnly(coord))
+            L-->>K: Ok(emptyList())
+        else .pom also 404 (or other)
+            F-->>L: Err(DownloadFailed for .module)
+            L-->>K: Err
+        end
+    else root .module non-404 failure
+        F-->>L: Err(DownloadFailed)
+        L-->>K: Err
+    end
+
+    Note over K,S: After fixpoint, materialization decides per-node action
+    K->>K: materialization loop iterates nodes
+    alt node.direct && resolved is JvmOnly
+        K->>K: return Err(NoNativeVariant)
+    else transitive && resolved is JvmOnly
+        alt isKotlinStdlib(coord)
+            K->>K: silent skip
+        else
+            K->>S: eprintln("note: <coord> has no Gradle Module Metadata; skipping for native target")
+        end
+    else resolved is Klib
+        K->>K: download klib, verify sha, add to resolvedDeps
+    end
+```
+
+### Gating decisions
+
+- **`all repos 404` 判定**: `RepositoryDownloadFailure.AllAttemptsFailed.attempts` のすべての要素が `DownloadError.HttpFailed(statusCode = 404)` のときのみ「真に未公開」と判定する。 1 つでも非-404 (5xx / NetworkError / WriteFailed) が混ざれば transient とみなして既存の `DownloadFailed` 経路を使う。
+- **fallback 適用範囲**: root `.module` のみ。 target `.module` (redirect 後) の 404 は Out of Boundary。
+- **note 抑制**: `isKotlinStdlib(coord)` が true なら silent (ADR 0011 §4 の policy 継続)。
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | transitive `.module` 404 → `.pom` フェッチを試行 | `NativeResolver.fetchNativeMetadata` | `fetchAndRead` (内部呼び出し) | Fetch decision flow |
+| 1.2 | `.pom` 200 のとき build を継続 | `NativeResolved.JvmOnly`, materialization loop | `childLookup` returns `Ok(emptyList())` for JvmOnly | Fetch decision flow |
+| 1.3 | `.module` も `.pom` も unavailable なら `DownloadFailed` を surface | `fetchNativeMetadata` の `.pom` 失敗分岐 | `ResolveError.DownloadFailed` | Fetch decision flow |
+| 1.4 | 5xx / network は fallback しない | `all repos 404` 判定 helper | `RepositoryDownloadFailure.AllAttemptsFailed.attempts` 走査 | Gating decisions |
+| 2.1 | direct dep `.module` 404 を silent skip しない | materialization loop の direct 分岐 | `DependencyNode.direct` の参照 | Fetch decision flow |
+| 2.2 | direct dep JVM-only → `NoNativeVariant` で非ゼロ | materialization loop | `ResolveError.NoNativeVariant` | Fetch decision flow |
+| 2.3 | direct `kotlin-stdlib` / `kotlin-stdlib-common` は silent | `directDeps = filterKeys { !isKotlinStdlib(it) }` (既存) | 既存 `isKotlinStdlib` | (既存) |
+| 3.1 | `kotlin-stdlib-common` も構造的 fallback で扱える | childLookup の variant 分岐 | `NativeResolved.JvmOnly` | Fetch decision flow |
+| 3.2 | `kotlin-stdlib` は名前 skip 維持 | 既存 `isKotlinStdlib` 適用 3 点 | (既存) | (既存) |
+| 3.3 | 新規 JVM-only artifact が hardcoded リスト更新不要 | 構造的検出が一般化されている | (動作要件) | Fetch decision flow |
+| 4.1 | transitive JvmOnly skip 時に stderr note 1 行 | materialization loop 内 eprintln | stderr (`infra.output` 経由) | Fetch decision flow |
+| 4.2 | stdlib 系は silent | `isKotlinStdlib` 先行 short-circuit | 既存 predicate | Gating decisions |
+| 4.3 | direct skip は既存挙動 (note 出さない) | direct path は note 出力しない | (動作要件) | Fetch decision flow |
+| 5.1 | fallback は native 経路のみ | 変更 file は `NativeResolver.kt` のみ | (動作要件) | (file plan) |
+| 5.2 | JVM resolver 不変 | `TransitiveResolver.kt` 修正なし | (動作要件) | (file plan) |
+| 5.3 | JVM 既存挙動 (POM-based) 不変 | 変更スコープ外 | (動作要件) | (file plan) |
+| 6.1 | 再現ケース regression test | `NativeResolverJvmOnlyFallbackTest` | mock `ResolverDeps` | (test fixture) |
+| 6.2 | hardcoded リスト追加に依存しない | テスト fixture が構造的 fallback を経由 | `.module` 404 + `.pom` 200 の mock | (test fixture) |
+| 6.3 | 決定的 fixture | live Maven Central を踏まない | `ResolverDeps` の test double | (test fixture) |
+
+## Components and Interfaces
+
+| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies (P0/P1) | Contracts |
+|-----------|--------------|--------|--------------|--------------------------|-----------|
+| `NativeResolved` sealed class | resolve / data | Klib resolved 状態と JvmOnly 状態を 1 sealed ADT で表現 | 1.2, 2.2, 3.1 | (内部のみ) | State |
+| `fetchNativeMetadata` (改修) | resolve / fetch | root `.module` 404 を構造的に検出し `.pom` フォールバックして `JvmOnly` を返す | 1.1, 1.3, 1.4 | `fetchAndRead` (P0), `buildPomDownloadUrl` (P0) | Service |
+| `is404OnAllAttempts` (新規 helper) | resolve / fetch | `ResolveError.DownloadFailed` が all-repos 404 か判定 | 1.4 | `RepositoryDownloadFailure` (P0), `DownloadError` (P0) | Service |
+| `makeNativeChildLookup` (改修) | resolve / kernel adapter | JvmOnly に対して空 children を返し、 Klib は従来通り `artifact.dependencies` (minus stdlib*) を返す | 1.2, 3.1 | `NativeResolved` (P0) | Service |
+| materialization loop in `resolveNative` (改修) | resolve / materialize | direct/transitive と Klib/JvmOnly の組み合わせで klib download / `NoNativeVariant` / silent skip / note skip を分岐 | 2.1, 2.2, 4.1, 4.2, 4.3 | `DependencyNode.direct` (P0), `isKotlinStdlib` (P0), stderr (P1) | Service |
+| `createNativeLookup` (deps tree 用) (改修) | resolve / view | JvmOnly node も tree に現れる場合の表現 | 1.2 (補助) | `NativeNodeInfo` (P0) | Service |
+
+### resolve / data
+
+#### `NativeResolved` sealed class
+
+| Field | Detail |
+|-------|--------|
+| Intent | Resolution kernel が transitive node ごとに保持する状態。 Klib (klib download 可能) と JvmOnly (skip 対象) の 2 variant |
+| Requirements | 1.2, 2.2, 3.1 |
+
+**Responsibilities & Constraints**
+- 既存 `data class NativeResolved(redirect, artifact)` を sealed class 化し、 Klib variant に同じ内容を移植。 JvmOnly variant は `coordinate: Coordinate` のみ保持。
+- `private` 修飾を維持。 native resolver 外には露出しない。
+- caller (childLookup / materialization / createNativeLookup) は variant ごとに分岐する。
+
+**Dependencies**
+- Inbound: `makeNativeChildLookup`, `resolveNative` materialization, `createNativeLookup`, `fetchNativeMetadata`
+- Outbound: なし (data only)
+
+**Contracts**: State [x]
+
+##### State Management
+- 値オブジェクト。 不変。 `processed: MutableMap<String, NativeResolved>` に格納される。
+
+### resolve / fetch
+
+#### `fetchNativeMetadata` (改修)
+
+| Field | Detail |
+|-------|--------|
+| Intent | 既存の root `.module` → redirect → target `.module` の 2 段フェッチに、 root `.module` 404 を構造的に検出して `.pom` フォールバックする分岐を追加 |
+| Requirements | 1.1, 1.3, 1.4 |
+
+**Responsibilities & Constraints**
+- root `.module` の fetch 失敗が `is404OnAllAttempts(error) == true` のときのみ `.pom` フォールバックを試行。
+- `.pom` フェッチが Ok なら `Ok(NativeResolved.JvmOnly(rootCoord))` を返す。
+- `.pom` も失敗したら **元の `.module` DownloadFailed** を返す (ユーザーには `.module` の attempt 一覧が見えるべき)。
+- root `.module` が parse できて redirect が取れた以降の挙動は既存通り。 target `.module` 404 は本仕様の対象外。
+- 5xx / NetworkError / WriteFailed が混ざる failure は `is404OnAllAttempts == false` なので fallback は走らず、 既存通り `DownloadFailed` を返す。
+
+**Dependencies**
+- Inbound: `makeNativeChildLookup`, `createNativeLookup`
+- Outbound: `fetchAndRead` (`.module` および新規 `.pom` 呼び出し), `is404OnAllAttempts` (新規 helper), `parseNativeRedirect`, `parseNativeArtifact`
+
+**Contracts**: Service [x]
+
+##### Service Interface
+```kotlin
+// Signature unchanged from current implementation
+private fun fetchNativeMetadata(
+  groupArtifact: String,
+  version: String,
+  nativeTarget: String,
+  cacheBase: String,
+  repos: List<String>,
+  deps: ResolverDeps,
+): Result<NativeResolved, ResolveError>
+```
+- Preconditions: `groupArtifact` is parseable; `repos` は非空 (空なら downloadFromRepositories が `NoRepositoriesConfigured` を返す)。
+- Postconditions: Ok の場合、 `NativeResolved.Klib` (既存と同等) または `NativeResolved.JvmOnly(coordinate=rootCoord)` を返す。
+- Invariants: `.pom` フォールバックは root `.module` のみで発火する。 target `.module` (redirect 先) では発火しない。
+
+#### `is404OnAllAttempts` (新規 internal helper)
+
+| Field | Detail |
+|-------|--------|
+| Intent | `ResolveError.DownloadFailed` の wrapping から「全 attempt が 404」を構造的に判定する |
+| Requirements | 1.4 |
+
+**Responsibilities & Constraints**
+- private / file-local。 ファイル外に export しない。
+- `RepositoryDownloadFailure.NoRepositoriesConfigured` の場合は false (リポジトリそのものが空なのは "all 404" ではない)。
+- `AllAttemptsFailed.attempts` が空のケースは defensively false。
+
+**Dependencies**
+- Inbound: `fetchNativeMetadata`
+- Outbound: `RepositoryDownloadFailure`, `DownloadError`
+
+**Contracts**: Service [x]
+
+##### Service Interface
+```kotlin
+private fun is404OnAllAttempts(error: ResolveError): Boolean
+```
+- Preconditions: `error` は `fetchAndRead` から返る error 型のいずれか。
+- Postconditions: `error is ResolveError.DownloadFailed`、 かつ `failure is AllAttemptsFailed`、 かつ `attempts` 非空、 かつすべての attempt が `DownloadError.HttpFailed(statusCode = 404)` のときのみ true。
+- Invariants: side-effect なし。
+
+### resolve / kernel adapter
+
+#### `makeNativeChildLookup` (改修)
+
+| Field | Detail |
+|-------|--------|
+| Intent | 各 transitive node の `NativeResolved` variant を見て、 Klib なら従来通り、 JvmOnly なら空 children を返す |
+| Requirements | 1.2, 3.1 |
+
+**Responsibilities & Constraints**
+- variant 分岐は `when (native)` 形式。 Klib: 既存ロジック (artifact.dependencies の map + stdlib skip)。 JvmOnly: `Ok(emptyList())`。
+- cache (`processed`) は変わらず GA:version をキーに `NativeResolved` を格納。
+
+**Dependencies**
+- Inbound: `resolveNative` (kernel に渡される lambda)
+- Outbound: `fetchNativeMetadata`, `isKotlinStdlib`
+
+**Contracts**: Service [x]
+
+##### Service Interface
+- 既存シグネチャ `(String, String) -> Result<List<Child>, ResolveError>` を維持。 variant 分岐は実装内部。
+
+### resolve / materialize
+
+#### materialization loop in `resolveNative` (改修)
+
+| Field | Detail |
+|-------|--------|
+| Intent | fixpoint 終了後、 nodes を iterate しながら variant と direct/transitive を 2 軸で分岐し、 klib download / `NoNativeVariant` / silent skip / note skip を出し分け |
+| Requirements | 2.1, 2.2, 4.1, 4.2, 4.3 |
+
+**Responsibilities & Constraints**
+- 分岐表:
+
+  | `resolved` | `node.direct` | Action |
+  |------------|---------------|--------|
+  | `Klib` | true / false | 既存通り — klib download, SHA verify, `resolvedDeps.add` |
+  | `JvmOnly` | true | `return Err(ResolveError.NoNativeVariant(node.groupArtifact, nativeTarget))` |
+  | `JvmOnly` | false, `isKotlinStdlib(coord)` true | silent skip (no note, no resolvedDeps entry) |
+  | `JvmOnly` | false, otherwise | `eprintln("note: <ga>:<v> has no Gradle Module Metadata; skipping for native target")`, no resolvedDeps entry |
+
+- klib 数の pre-count (`total`) は JvmOnly node を **除外** して再計算する。 既存の filter (`fileExists` check) と並列に variant filter を追加。
+- 進行 progress (`onArtifactStart`) は Klib node のみ通知。 JvmOnly は通知しない (artifact が実体として download されないため per-artifact UI に出すと不整合)。
+- **Direct/transitive 衝突の corner case**: 同一 GA が direct dep (`[dependencies]`) と別 direct dep の transitive 両方に現れた場合、 kernel `fixpointResolve` の direct-wins ルールにより `DependencyNode.direct = true` で固定される。 結果として JvmOnly 判定の materialization 分岐は direct パスを取り、 `ResolveError.NoNativeVariant` で error が返る。 つまり「user が直接書いた GA は silent skip しない」 が transitive 重複時にも正しく機能する。
+
+**Dependencies**
+- Inbound: `fixpointResolve` の戻り値 `List<DependencyNode>`
+- Outbound: `NativeResolved` variant, `isKotlinStdlib`, `eprintln` (stderr), 既存 klib download / sha 経路
+
+**Contracts**: Service [x]
+
+**Implementation Notes**
+- ADR citation: skip 直前の eprintln 行に `// ADR 0011 §4 の構造的根拠を一般化` 程度の anchor を 1 行入れる (steering structure.md の "ADR citations in code" に従う)。
+- silent skip ポリシーは ADR 0011 §4 の continuation。
+
+### resolve / view
+
+#### `createNativeLookup` (改修)
+
+| Field | Detail |
+|-------|--------|
+| Intent | deps tree 表示 (`kolt deps tree`) で transitive node を walk するための lookup。 JvmOnly に対して何を返すかを決める |
+| Requirements | 1.2 (補助) |
+
+**Responsibilities & Constraints**
+- 現状 `NativeNodeInfo` は `displayGroupArtifact`, `displayVersion`, `dependencies: List<Pair<String, String>>` を保持。 JvmOnly node は dependencies = emptyList で表現できる。
+- displayGroupArtifact / displayVersion は redirect 後の coordinate を返すのが既存挙動だが、 JvmOnly は redirect を経由しないので root coordinate (group:artifact, version) をそのまま使う。
+- tree 表示で JvmOnly node が "leaf" として現れるが、 UI 改修は本仕様の対象外なので「JVM 専用」のラベルは付けない。
+
+**Dependencies**
+- Inbound: `kolt deps tree` 経路
+- Outbound: `fetchNativeMetadata`
+
+**Contracts**: Service [x]
+
+## Data Models
+
+### Domain Model
+
+`NativeResolver` 内部 sealed class:
+```kotlin
+private sealed class NativeResolved {
+  data class Klib(val redirect: NativeRedirect, val artifact: NativeArtifact) : NativeResolved()
+  data class JvmOnly(val coordinate: Coordinate) : NativeResolved()
+}
+```
+
+- `Klib`: 既存 `NativeResolved(redirect, artifact)` の content を移植したもの。 native variant が公開されており klib を download できる artifact を表す。
+- `JvmOnly`: `.module` が all-repos 404 で `.pom` が 200 だった artifact を表す。 `coordinate` は root coordinate (redirect は経由しない)。
+
+`processed: MutableMap<String, NativeResolved>` の型は変わらず、 sealed parent 型でキャッシュする。
+
+### Logical Data Model
+
+なし (data 関係 / persistence は本仕様で増えない)。 lockfile schema 不変。
+
+## Error Handling
+
+### Error Strategy
+
+- `.module` 404 + `.pom` 200 → 既存の error 型を使わず、 `NativeResolved.JvmOnly` という「成功状態」として `Result<NativeResolved, ResolveError>` の Ok 経路に流す。 これは ADR 0011 §4 の「構造的に native variant を持たない artifact は skip して継続」と同じ哲学。
+- `.module` 404 + `.pom` も失敗 → 元の `.module` の `ResolveError.DownloadFailed` をそのまま return する。 ユーザーには `.module` の 404 attempts が見える。 これは「typo / 真の missing artifact」のケースを正しく拾うため。
+- `.module` non-404 失敗 (5xx, NetworkError, WriteFailed) → fallback を試みず、 既存通り `ResolveError.DownloadFailed`。
+- direct dep が `JvmOnly` に倒れた場合 → materialization で `ResolveError.NoNativeVariant(groupArtifact, nativeTarget)`。 既存の formatter で `<ga> has no Kotlin/Native variant for target '<target>'` というメッセージが出る。
+
+### Error Categories and Responses
+
+- **User Errors**: direct dep に JVM-only library を書いた → `NoNativeVariant` で非ゼロ終了、 既存メッセージで通知 (Req 2.2)。
+- **System Errors**: `.module` も `.pom` も transient 5xx → 既存 `DownloadFailed`、 既存の per-repo attempt dump (#355) で診断可能 (Req 1.4)。
+- **Business Logic**: transitive で JVM-only artifact を encounter → skip + 条件付き stderr note (Req 4.1, 4.2, 4.3)。
+
+### Monitoring
+
+- transitive skip note は stderr に出るため CI ログから grep 可能。 同じ note が複数 artifact に対して出ても 1 行ずつなので volume 制御は不要 (ADR 0011 §4 の "毎ビルド発火" は stdlib-common のみで、 そちらは silent 維持)。
+- 既存の `onRetryAgainst` は repository 横断の retry を観測する。 本仕様で追加の hook は不要。
+- **Note 重複ポリシー**: kernel の `processed: MutableMap<String, NativeResolved>` cache (`NativeResolver.kt:57`) によって同一 GA:version は materialization loop で 1 度しか走らないため、 1 build (cold path) あたり同一 JvmOnly artifact の note は最大 1 行に収まる。 warm rebuild は `kolt build` の up-to-date short-circuit (state file check) で resolver 自体が走らないため 0 note。 これにより ADR 0011 §4 が `kotlin-stdlib-common` で warning を拒否した rationale ("毎ビルド発火 = no actionable info") は本仕様の note には当てはまらない: 構造的 skip が発生したことを cold 1 回だけ通知し、 warm path には影響しない。
+
+## Testing Strategy
+
+### Unit Tests
+- `is404OnAllAttempts` の判定: (a) 全 attempt 404 → true、 (b) 1 つ 5xx 混入 → false、 (c) `NoRepositoriesConfigured` → false、 (d) `AllAttemptsFailed` で attempts 空 → false、 (e) `DownloadFailed` 以外 → false。
+- `fetchNativeMetadata` で root `.module` 全 repo 404 + `.pom` 200 のとき `Ok(JvmOnly(coord))` を返すこと。
+- `fetchNativeMetadata` で root `.module` 全 repo 404 + `.pom` 全 repo 404 のとき **元の `.module` の `DownloadFailed`** を返すこと (`.pom` の attempt 一覧ではない)。
+- `fetchNativeMetadata` で root `.module` 5xx のとき fallback を試みず既存 `DownloadFailed` を返すこと。
+- `makeNativeChildLookup` で JvmOnly node が `Ok(emptyList())` を返すこと、 Klib node が従来通りの children を返すこと。
+
+### Integration Tests
+- `NativeResolverJvmOnlyFallbackTest` (新規): 決定的 fixture で `.module` 404 + `.pom` 200 の coordinate を transitive に含む resolve を回し、 (a) resolve 全体が Ok、 (b) JvmOnly artifact は `resolvedDeps` に含まれない、 (c) Klib node は klib path が `resolvedDeps` に含まれる、 (d) stderr に note 1 行 (非 stdlib coordinate の場合) が出ること。
+- 既存 `NativeResolverTest` で `kotlin-stdlib-common` が transitive 上で skip される経路を、 構造的 fallback でも通ること (regression)。
+- `kolt-stdlib-common` の stderr note が出ないこと (silent skip policy 維持)。
+- direct dep として `.module` 404 + `.pom` 200 の coordinate を declare したとき `NoNativeVariant` で error すること。
+
+### Performance/Load
+- 本仕様では transitive あたり最大 +1 HTTP request (`.pom` フェッチ) が発生する。 ただし発火条件 (`.module` all-repos 404) は実運用で稀 (kotlin-reflect 系のみ)。 cache 経由 (`processed` map) で同一 GA:version は 1 度しかフェッチしないので、 1 build 1 artifact 最大 1 追加リクエスト。 観測すべき性能影響なし。
+
+## Migration Strategy
+
+なし。 backwards compatibility 要件なし (pre-v1)。 ADR 0011 改訂は本仕様完了後に follow-up として検討する (本仕様の必須範囲外)。
+
+## Supporting References
+
+- `research.md` (同ディレクトリ) — 各 decision の trade-off 詳細
+- ADR 0010 — Gradle Module Metadata for native resolution
+- ADR 0011 — Skip kotlin-stdlib for native resolution (本仕様が一般化する起点)
+- issue #426 — repro

--- a/.kiro/specs/426-native-resolver-pom-fallback/design.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/design.md
@@ -120,7 +120,7 @@ flowchart LR
 
 ### Modified Files
 - `src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt`
-  - `NativeResolved` を `private sealed class` に変更し `Klib` / `JvmOnly` の 2 variant 化。
+  - `NativeResolved` を `internal sealed class` に変更し `Klib` / `JvmOnly` の 2 variant 化 (テストから直接 variant を assert できるよう `internal`)。
   - `fetchNativeMetadata` に root `.module` 404 構造的判定と `.pom` フォールバックを追加。
   - `makeNativeChildLookup` を `NativeResolved` variant 分岐に対応 (Klib → 既存通り、 JvmOnly → 空 children)。
   - `resolveNative` の materialization loop で `node.direct && resolved is JvmOnly` を `NoNativeVariant` エラー、 transitive JvmOnly は skip + 条件付き stderr note。
@@ -242,7 +242,7 @@ sequenceDiagram
 
 **Responsibilities & Constraints**
 - 既存 `data class NativeResolved(redirect, artifact)` を sealed class 化し、 Klib variant に同じ内容を移植。 JvmOnly variant は `coordinate: Coordinate` のみ保持。
-- `private` 修飾を維持。 native resolver 外には露出しない。
+- `internal` 修飾。 native test から variant assertion できるよう resolver module 内では可視。 native resolver の他 production file からは参照しない。
 - caller (childLookup / materialization / createNativeLookup) は variant ごとに分岐する。
 
 **Dependencies**
@@ -278,8 +278,10 @@ sequenceDiagram
 
 ##### Service Interface
 ```kotlin
-// Signature unchanged from current implementation
-private fun fetchNativeMetadata(
+// Visibility promoted to `internal` so the unit test can drive the
+// fetchAndRead/fallback path directly with mocked ResolverDeps;
+// signature otherwise unchanged.
+internal fun fetchNativeMetadata(
   groupArtifact: String,
   version: String,
   nativeTarget: String,
@@ -292,7 +294,7 @@ private fun fetchNativeMetadata(
 - Postconditions: Ok の場合、 `NativeResolved.Klib` (既存と同等) または `NativeResolved.JvmOnly(coordinate=rootCoord)` を返す。
 - Invariants: `.pom` フォールバックは root `.module` のみで発火する。 target `.module` (redirect 先) では発火しない。
 
-#### `is404OnAllAttempts` (新規 internal helper)
+#### `is404OnAllAttempts` (新規 helper)
 
 | Field | Detail |
 |-------|--------|
@@ -300,7 +302,7 @@ private fun fetchNativeMetadata(
 | Requirements | 1.4 |
 
 **Responsibilities & Constraints**
-- private / file-local。 ファイル外に export しない。
+- `internal` / file-local。 native test の真理表 assertion 用に visible だが、 native resolver の他 production file からは参照しない。
 - `RepositoryDownloadFailure.NoRepositoriesConfigured` の場合は false (リポジトリそのものが空なのは "all 404" ではない)。
 - `AllAttemptsFailed.attempts` が空のケースは defensively false。
 
@@ -312,7 +314,7 @@ private fun fetchNativeMetadata(
 
 ##### Service Interface
 ```kotlin
-private fun is404OnAllAttempts(error: ResolveError): Boolean
+internal fun is404OnAllAttempts(error: ResolveError): Boolean
 ```
 - Preconditions: `error` は `fetchAndRead` から返る error 型のいずれか。
 - Postconditions: `error is ResolveError.DownloadFailed`、 かつ `failure is AllAttemptsFailed`、 かつ `attempts` 非空、 かつすべての attempt が `DownloadError.HttpFailed(statusCode = 404)` のときのみ true。
@@ -397,9 +399,9 @@ private fun is404OnAllAttempts(error: ResolveError): Boolean
 
 ### Domain Model
 
-`NativeResolver` 内部 sealed class:
+`NativeResolver` sealed class (`internal` for native-test access; not consumed from any other production file in `src/nativeMain/`):
 ```kotlin
-private sealed class NativeResolved {
+internal sealed class NativeResolved {
   data class Klib(val redirect: NativeRedirect, val artifact: NativeArtifact) : NativeResolved()
   data class JvmOnly(val coordinate: Coordinate) : NativeResolved()
 }

--- a/.kiro/specs/426-native-resolver-pom-fallback/requirements.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/requirements.md
@@ -1,0 +1,94 @@
+# Requirements Document
+
+## Project Description (Input)
+Short-term fix for #426 (Layer 1 only): when the native resolver's .module fetch returns 404, fall back to fetching the .pom and use its dependency list for transitive resolution. JetBrains does not publish Gradle Module Metadata for JVM-only Kotlin artifacts like kotlin-reflect (verified across 2.1.0-2.3.20); currently kolt hard-fails on the .module 404 instead. Same problem class as kotlin-stdlib-common (ADR 0011), which is currently solved by a 2-name hardcoded skip list (isKotlinStdlib in NativeResolver.kt:18). This issue is scoped to the .pom fallback only — Layer 2 (variant interpretation audit: why does kotlin-reflect reach native resolution at all?) is explicitly out of scope and will be filed as a separate issue.
+
+## Introduction
+
+`target = "linuxX64"` プロジェクトで JVM 専用 Kotlin artifact (例: `kotlin-reflect`) が transitive dependency として現れた際、kolt が `.module` の 404 で hard-fail し、ビルドが進められない問題を解消する。
+
+現状 kolt は `org.jetbrains.kotlin:kotlin-stdlib` と `org.jetbrains.kotlin:kotlin-stdlib-common` をハードコードされた skip リストで処理しているが、これは 2-name の patch であって、同型の問題 (Gradle Module Metadata が公開されていない JVM 専用 Kotlin artifact が native の transitive closure に現れる) を一般に救うものではない。本仕様では、その状況を構造的に検出して native build を継続できるようにする。
+
+Layer 2 (なぜ `kotlin-reflect` が native variant の transitive に現れるのか、 mixed-platform ライブラリの variant 解釈の audit) は別 issue で扱う。
+
+## Boundary Context
+
+- **In scope**:
+  - Native target の transitive 依存解決において、ある artifact の `.module` 取得が HTTP 404 で失敗したときの fallback 経路。
+  - その artifact が Gradle Module Metadata を公開していない (= native variant を構造的に持ちえない) ことを確認する手段。
+  - 既存の `kotlin-stdlib` / `kotlin-stdlib-common` ハードコード skip 動作の継続性。
+  - ADR 0011 §4 で `kotlin-stdlib-common` が解決していた構造的問題への一般化された対応。
+
+- **Out of scope**:
+  - Direct dependency に JVM 専用 artifact が指定された場合の policy 変更 (引き続きエラー)。
+  - Variant 解釈の audit (Layer 2): mixed-platform ライブラリの native variant に JVM 専用 deps が含まれてしまう問題そのものの修正。
+  - JVM target の依存解決経路。
+  - lockfile schema の変更。
+  - `kolt deps tree` などの依存表示の改修。
+
+- **Adjacent expectations**:
+  - 本仕様完了後、ADR 0011 のハードコード skip リスト (具体的には `kotlin-stdlib-common`) は構造的検出で再現できるため一部冗長になる。ADR の改訂は本仕様の必須範囲外だが、実装後に整合を取ることが望ましい。
+  - 別 issue (Layer 2) は本仕様で残った構造的疑問 ("そもそも JVM 専用 artifact が native transitive に出るべきか") を引き継ぐ前提。
+
+## Requirements
+
+### Requirement 1: Transitive 解決における `.module` 404 の許容
+
+**Objective:** As a kolt user building a Kotlin/Native project, I want `kolt add` / `kolt build` / `kolt fetch` to succeed when a transitive dependency lacks Gradle Module Metadata, so that JVM-only Kotlin artifacts appearing in the transitive closure of a mixed-platform library do not block native builds.
+
+#### Acceptance Criteria
+
+1. When kolt is resolving transitive dependencies for a native target and an artifact's `.module` request returns HTTP 404, the Native Resolver shall attempt to retrieve the corresponding `.pom` from the same repository as a fallback step.
+2. When the `.module` returns 404 and the `.pom` is successfully retrieved, the Native Resolver shall treat that artifact as having no native variant available and shall not abort the build.
+3. When both the `.module` and the fallback `.pom` are unavailable, the Native Resolver shall surface a download failure for that artifact with the original group:artifact coordinate and the failure mode preserved (i.e., the user still sees a real error for typos and genuinely missing artifacts).
+4. The Native Resolver shall apply the fallback only for HTTP 404 on `.module`; transient errors (network failure, 5xx) shall be reported with the existing error model and shall not trigger the `.pom` fallback.
+
+### Requirement 2: Direct dependency に対する厳格性の維持
+
+**Objective:** As a kolt user, I want `kolt add` and `kolt build` to clearly reject JVM-only libraries when I declare them directly in `[dependencies]` of a native project, so that I am not silently given a broken dependency graph.
+
+#### Acceptance Criteria
+
+1. When a dependency listed directly in `[dependencies]` of `kolt.toml` has its `.module` returning 404 on a native target, the Native Resolver shall not silently skip that dependency.
+2. If a direct dependency on a native target cannot produce a usable klib because its Gradle Module Metadata is absent, the Native Resolver shall surface a non-zero exit identifying the offending coordinate.
+3. The existing silent-skip behavior for `org.jetbrains.kotlin:kotlin-stdlib` and `org.jetbrains.kotlin:kotlin-stdlib-common` when declared directly shall be preserved.
+
+### Requirement 3: 構造的検出の優先とハードコード skip リストの整合
+
+**Objective:** As a kolt maintainer, I want the new `.module` 404 fallback to subsume the structural reason `kotlin-stdlib-common` is on the hardcoded skip list, so that future JVM-only Kotlin artifacts appearing transitively do not require additions to that list.
+
+#### Acceptance Criteria
+
+1. When the native resolver encounters `kotlin-stdlib-common` (or any artifact whose `.module` returns 404) as a transitive dependency, the Native Resolver shall apply the structural fallback defined in Requirement 1 rather than relying solely on a name match.
+2. The Native Resolver shall continue to skip `kotlin-stdlib` (which publishes `.module` but causes a double-link with konanc-bundled stdlib per ADR 0011 §1) via the existing name-based predicate, because its problem class is link-time bundling rather than missing metadata.
+3. After this change, JVM-only Kotlin artifacts newly appearing in native transitive closures (e.g., `kotlin-reflect`, future `kotlin-stdlib-jdk8`) shall not require code changes to the name-based skip list.
+
+### Requirement 4: 観測可能性
+
+**Objective:** As a kolt user debugging a native dependency resolution, I want some visible indication when a transitive artifact was skipped because it lacks Gradle Module Metadata, so that I can distinguish "silently dropped" from "never encountered" when investigating downstream link issues.
+
+#### Acceptance Criteria
+
+1. When kolt applies the `.module` 404 → `.pom` fallback and skips a transitive artifact for a native target, kolt shall emit a single diagnostic line on stderr identifying the group:artifact:version and the reason (e.g., `note: <group:artifact>:<version> has no Gradle Module Metadata; skipping for native target`).
+2. The diagnostic shall not be emitted for `org.jetbrains.kotlin:kotlin-stdlib` or `org.jetbrains.kotlin:kotlin-stdlib-common`, preserving the silent-skip behavior established for those known cases.
+3. The diagnostic shall not fire on direct dependencies skipped via the existing name-based predicate.
+
+### Requirement 5: JVM 経路の不変
+
+**Objective:** As a kolt user with JVM-target projects, I want the `.module` 404 fallback to leave the JVM resolution path unchanged, so that this fix does not introduce risk for projects that do not use the native pipeline.
+
+#### Acceptance Criteria
+
+1. The `.module` 404 fallback shall be applied only inside the native resolution path.
+2. The JVM-target transitive resolver shall not be modified by this change.
+3. The JVM resolver's existing behavior (POM-based transitive walk, lockfile interaction) shall remain unchanged.
+
+### Requirement 6: 再現ケースのカバレッジ
+
+**Objective:** As a kolt maintainer, I want a regression test that exercises the reported repro case, so that future native resolver changes cannot reintroduce the abort.
+
+#### Acceptance Criteria
+
+1. When an integration test runs the equivalent of `kolt add io.ktor:ktor-server-core` on a `target = "linuxX64"` configuration and the transitive closure contains an artifact whose `.module` is absent (specifically `kotlin-reflect`), the test shall verify that resolution completes without surfacing the `.module` 404 as a fatal error.
+2. The test shall not rely on adding `kotlin-reflect` to any name-based skip list; it shall pass via the structural `.module` 404 fallback defined in Requirement 1.
+3. The test fixture shall use a deterministic repository state (recorded `.module` 404 + `.pom` 200 + transitive content) rather than depending on live Maven Central at test time.

--- a/.kiro/specs/426-native-resolver-pom-fallback/research.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/research.md
@@ -1,0 +1,119 @@
+# Research & Design Decisions
+
+## Summary
+- **Feature**: `426-native-resolver-pom-fallback`
+- **Discovery Scope**: Extension (light discovery)
+- **Key Findings**:
+  - 既存の native resolver (`NativeResolver.kt:271 fetchAndRead`) は `.module` の HTTP 404 を含むすべての download 失敗を `ResolveError.DownloadFailed` で hard fail する。`.pom` フォールバックの分岐は無い。
+  - `RepositoryDownloadFailure.AllAttemptsFailed` は per-repository の `RepositoryAttempt(url, DownloadError)` を保持しており、すべての attempt が `DownloadError.HttpFailed(404)` かどうかを構造的に判定できる。 transient (5xx / network) と 404 の区別は既存の error 型で十分。
+  - 必要な primitive はすべて既存: `buildPomCachePath`, `buildPomDownloadUrl` (`Dependency.kt:55-58`), `downloadFromRepositories` (`TransitiveResolver.kt:84`), `parsePom` / `PomInfo` (`PomParser.kt:20-32`)。 新規外部ライブラリ不要。
+  - `DependencyNode.direct: Boolean` フラグが kernel から materialization まで保持されているので、direct vs transitive の区別は materialization loop で素直に取れる。
+  - ADR 0011 §4 が解消した `kotlin-stdlib-common` のケースは、本仕様の構造的検出によって論理的に subsume される (`.module` 404 → `.pom` 200 → JVM 専用扱い)。 ADR 0011 の `kotlin-stdlib` skip は同型ではない (link-time bundling 問題) ので残す。
+
+## Research Log
+
+### `fetchAndRead` の error 表現と 404 検出
+- **Context**: 構造的に "all repos returned 404" を判定したい。 既存 error 型でできるか?
+- **Sources Consulted**: `src/nativeMain/kotlin/kolt/resolve/Resolver.kt:13-65`, `TransitiveResolver.kt:84-107`, `kolt.infra.DownloadError`.
+- **Findings**:
+  - `downloadFromRepositories` は 404 のみ次の repo へ fall-through し、 非-404 (HttpFailed status != 404, NetworkError, WriteFailed) は即時 `AllAttemptsFailed(attempts)` で停止する。
+  - すべての attempt が `DownloadError.HttpFailed(statusCode = 404)` であれば「真に未公開」と判定できる。 1 つでも非-404 が混ざれば transient と扱うべき。
+  - `ResolveError.DownloadFailed` は `groupArtifact` と `RepositoryDownloadFailure` を保持し、構造を保ったまま伝播する。
+- **Implications**: 構造的検出は inline helper で書ける。 新規 error 型は不要。
+
+### `.pom` URL / cache path の既存 builder
+- **Context**: native resolver が `.pom` フォールバックを発行できるか?
+- **Sources Consulted**: `Dependency.kt:54-58`, `TransitiveResolver.kt:122-138 (createPomLookup)`.
+- **Findings**:
+  - `buildPomDownloadUrl(coord, baseUrl)` と `buildPomCachePath(coord)` は既存 API として export 済み。
+  - `createPomLookup` が POM-based JVM transitive で既にこの primitive を使っており、 native 側もそのまま借用できる。
+- **Implications**: native resolver から URL / cache path を再合成する必要は無い。
+
+### `.pom` の中身を読むか、 存在確認のみで済ますか
+- **Context**: フォールバックで `.pom` の deps を BFS に流すか、 存在確認だけで JVM-only と断定するか。
+- **Sources Consulted**: 要件 (Layer 1 only)、 ADR 0011 §4 の構造的根拠、 ADR 0010 (gradle metadata for native)。
+- **Findings**:
+  - `.pom` を parse して deps を BFS に流すと、 POM-listed deps の中に native variant が無いものも紛れ込み、 連鎖的に同じ 404 を踏む可能性がある。 これは Layer 2 (variant 解釈の audit) のスコープ。
+  - 構造的観察: `.module` が 404 で `.pom` が 200 = 「Gradle Module Metadata が公開されていない artifact」= konanc がリンクできる klib を持たない = native 文脈では skip して安全。
+  - kotlin-stdlib-common (ADR 0011 §4) も同じ判断で扱われている。
+- **Implications**: 本仕様では `.pom` の存在確認のみで判定する。 deps の descent は行わない (空の children を返す)。
+
+### 既存 `isKotlinStdlib` の扱い
+- **Context**: ADR 0011 の hardcoded skip リストとどう共存するか。
+- **Sources Consulted**: `NativeResolver.kt:18-20`, ADR 0011 §1-§4.
+- **Findings**:
+  - `kotlin-stdlib` は `.module` を公開しているが konanc が同梱 stdlib と double-link するため skip する。 構造的検出では救えない (リンクが衝突するのを構造から知る手段が無い)。
+  - `kotlin-stdlib-common` は `.module` 未公開のため、 構造的検出で同じ動作になる。 ただし ADR 0011 §4 と silent skip ポリシー (毎回ビルドで発火するため noise を出さない) を守るために、 名前ベースの先行 short-circuit を維持し、 diagnostic を抑制する。
+  - 構造的検出によって、 将来 JVM 専用の kotlin artifact (`kotlin-reflect`, `kotlin-stdlib-jdk8` 等) が transitive に現れても hardcoded リスト追加無しで処理できる。
+- **Implications**: `isKotlinStdlib` predicate は予約しつつ silent skip + diagnostic 抑制の anchor として再用する。
+
+### 直接依存と transitive の区別
+- **Context**: 直接依存に JVM 専用 lib が書かれた場合は error を維持したい (Req 2)。
+- **Sources Consulted**: `Resolution.kt:8-13 (DependencyNode)`, `NativeResolver.kt:80-127 (materialization loop)`.
+- **Findings**:
+  - `DependencyNode.direct: Boolean` が kernel 内で保持され、 materialization loop でも `node.direct` として参照可能。
+  - direct dep の場合は `NoNativeVariant` 系の error を返せばユーザーに「この lib は native に置けない」と伝えられる。
+- **Implications**: direct 判定は materialization loop で行う。 fetch 経路には direct/transitive コンテキストを渡さなくて済む。
+
+## Architecture Pattern Evaluation
+
+| Option | Description | Strengths | Risks / Limitations | Notes |
+|--------|-------------|-----------|---------------------|-------|
+| A. Hardcoded skip 拡張 (`kotlin-reflect` を `isKotlinStdlib` に追加) | 2-name リストを 3-name にする | 最小コード変更 | 次の JVM 専用 artifact が transitive に現れる度にリスト更新が必要、 ADR 0011 の "blanket skip 拒否" alternative と矛盾しない範囲で済むが場当たり | 採用しない |
+| B. 構造的検出 + JVM-only marker | `.module` 404 を検出して `NativeResolved` の sealed variant `JvmOnly` を導入 | 一般化されており未来の JVM 専用 artifact もカバー、 ADR 0011 §4 を subsume | sealed class 追加で resolver の internal data 構造を 1 段変える | **採用** |
+| C. `.pom` を parse して deps を BFS に流す | Maven 互換 fallback | POM-only artifact の deps を native target に取り込める...かもしれない | POM には variant が無い、 deps の中の JVM-only artifact が再帰的に同じ問題を踏む、 Layer 2 のスコープに踏み込む | 採用しない |
+| D. 上位で kotlin namespace を blanket skip | `org.jetbrains.kotlin:*` 全部 skip | 単純 | ADR 0011 で既に却下、 kotlin-test 等 native variant のある artifact を取りこぼす | 採用しない |
+
+## Design Decisions
+
+### Decision: `.module` 404 を JVM-only marker への構造的分岐とする
+- **Context**: 要件 1 / 3 — transitive の `.module` 404 に対する fallback と hardcoded リストの subsume。
+- **Alternatives Considered**:
+  1. Option A — 名前 skip リストを拡張
+  2. Option B — 構造的検出 (`.module` 404 + `.pom` 200 → JvmOnly)
+  3. Option C — `.pom` を parse して deps descent
+- **Selected Approach**: Option B。 `fetchNativeMetadata` の root `.module` フェッチが 404 で完全失敗 (`AllAttemptsFailed` のすべての attempt が `DownloadError.HttpFailed(404)`) した場合、 同じ coordinate の `.pom` フェッチを試行。 `.pom` が成功すれば `NativeResolved.JvmOnly(coord)` を返す。 `.pom` も失敗すれば元の `DownloadFailed` をそのまま返す。
+- **Rationale**: ADR 0011 §4 の根拠 ("POM-only artifact は native variant を持たない") を一般化したもの。 hardcoded リストの肥大化を避け、 既存 `isKotlinStdlib` の役割を「link-time bundling 問題」に絞れる。
+- **Trade-offs**:
+  - (+) 一般化 — 未来の JVM 専用 kotlin artifact がリスト追加無しで通る。
+  - (+) ADR 0011 と整合 — 同じ構造的根拠を共有。
+  - (−) sealed variant の追加で resolver internal の data 表現が広がる。
+  - (−) `.pom` が transient 5xx を返した場合は `DownloadFailed` を返すが、 数秒後に retry すれば成功するかもしれないというユーザー体験は変わらない。
+- **Follow-up**: 実装後に ADR 0011 を更新 (`kotlin-stdlib-common` 部分が構造的に subsume されたことを記録)。 本仕様では必須範囲外。
+
+### Decision: 直接依存は `NoNativeVariant` で error を維持
+- **Context**: 要件 2 — 直接依存に JVM 専用 lib を書いた場合は silent skip しない。
+- **Alternatives Considered**:
+  1. Direct dep でも silent skip
+  2. Direct dep は `NoNativeVariant` で error (既存 error 型を再利用)
+  3. 新規 error 型 `JvmOnlyDirectDep` を導入
+- **Selected Approach**: Option 2。 materialization loop で `node.direct && resolved is JvmOnly` の場合 `ResolveError.NoNativeVariant(groupArtifact, nativeTarget)` を返す。
+- **Rationale**: `NoNativeVariant` のセマンティクスは「この artifact は target に対応する native variant を持たない」で、 JVM-only artifact は構造的にその条件を満たす。 新規 error 型は冗長。
+- **Trade-offs**:
+  - (+) 既存 error 型 / formatter / message を再利用、 ユーザーには既存の言い回しで届く。
+  - (−) `NoNativeVariant` の発火条件が 2 つ (root `.module` で linux_x64 variant 無し / `.module` 自体が 404) になるので、 内部 invariant の整理が必要。 ただしユーザー観測は同じ。
+
+### Decision: Diagnostic 出力は ProgressSink を拡張せず stderr 直書き
+- **Context**: 要件 4 — transitive skip の観測可能性。
+- **Alternatives Considered**:
+  1. `ResolverProgressSink` に `onJvmOnlySkip` を追加
+  2. `eprintln` で resolver 内から直接 stderr に書く
+  3. `ResolveResult` に skipped 一覧フィールドを追加して CLI 側でレンダリング
+- **Selected Approach**: Option 2。 `NativeResolver.kt` 内で `eprintln("note: ...")` を skip 直前に発火。 `kotlin-stdlib` / `kotlin-stdlib-common` は名前で先行 short-circuit (silent)。
+- **Rationale**: ProgressSink は per-artifact の進行ベース (start/retry) で skip は意味的に異なる。 `ResolveResult` 拡張は API 表面が大きく、 単発 note の伝送だけのために重い。 既存の eprintln 経路 (`infra/output` 配下) と整合。
+- **Trade-offs**:
+  - (+) 最小実装、 既存の stderr 経路を踏襲。
+  - (−) diagnostic を抑制したいテストでは stderr を capture する必要がある (NativeResolverTest の既存 fixture で対応可)。
+
+## Risks & Mitigations
+- **Risk**: `.pom` が transient 5xx を返したケースで「JVM 専用 artifact ではないが downstream に進めない」状態になる。 ⇒ **Mitigation**: 5xx / NetworkError は構造的検出の前提条件 (`all 404`) に含まれないので、 既存の `DownloadFailed` 経路で報告される。 ユーザーは retry すれば通常通り解決できる。
+- **Risk**: `.module` 404 + `.pom` 200 となるが実際には Gradle metadata 公開を忘れただけの "真の native artifact" を skip してしまう。 ⇒ **Mitigation**: 直接依存は `NoNativeVariant` で error になるためユーザーが気づく。 transitive で skip された場合は stderr の note で観測可能。 後段のリンクで unresolved 参照が出れば link error として顕在化する。
+- **Risk**: 既存テストで `.module` 404 を fatal として assert しているケースが壊れる。 ⇒ **Mitigation**: 既存 `NativeResolverTest` の該当ケースを「`.pom` 同時 404 / `.pom` 200 でフォールバック成功」両方の variant でリプレースする。
+
+## References
+- ADR 0010 — Gradle Module Metadata for native resolution (本仕様が拡張する経路)
+- ADR 0011 — Skip kotlin-stdlib for native resolution (本仕様が一般化する論理の起点)
+- issue #426 — 報告された再現ケース
+- `src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt:18-297` — 改修対象
+- `src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt:84-107` — `downloadFromRepositories` の 404 fall-through ポリシー (共有挙動)
+- `src/nativeMain/kotlin/kolt/resolve/PomParser.kt` — `.pom` 解析 (本仕様では存在確認のみ使用)

--- a/.kiro/specs/426-native-resolver-pom-fallback/spec.json
+++ b/.kiro/specs/426-native-resolver-pom-fallback/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "426-native-resolver-pom-fallback",
+  "created_at": "2026-05-11T02:37:24Z",
+  "updated_at": "2026-05-11T03:35:00Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -81,7 +81,7 @@
   - _Requirements: 3.3, 6.1, 6.2, 6.3_
 
 - [ ] 8. Validation: 既存テストの regression と JVM 経路の不変確認
-- [ ] 8.1 既存の `NativeResolverTest` 内で `kotlin-stdlib-common` が transitive 上で扱われる経路を構造的 fallback (新分岐) で通すように調整し、 silent skip 維持を assert する
+- [x] 8.1 既存の `NativeResolverTest` 内で `kotlin-stdlib-common` が transitive 上で扱われる経路を構造的 fallback (新分岐) で通すように調整し、 silent skip 維持を assert する
   - 既存テストが「`.module` 404 を fatal として assert」していた場合は「fallback 後の Ok」に書き換える。 既存の `isKotlinStdlib` 名前 short-circuit が silent path として残ること (stderr に note が出ないこと) を assert に追加する。
   - direct `kotlin-stdlib` 経路 (`directDeps = filterKeys { !isKotlinStdlib(it) }`) が無傷であること (Req 2.3) も既存テストで担保されている前提を確認、 もし無ければ 1 ケース追加する。
   - 観測: `NativeResolverTest` の全ケースが緑、 `kotlin-stdlib-common` transitive シナリオで stderr 空。

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -87,7 +87,7 @@
   - 観測: `NativeResolverTest` の全ケースが緑、 `kotlin-stdlib-common` transitive シナリオで stderr 空。
   - _Requirements: 2.3, 3.1, 3.2_
 
-- [ ] 8.2 JVM 経路 (`TransitiveResolver` 系) を含む全テストスイートを `kolt test` で実行し、 緑であることを確認する
+- [x] 8.2 JVM 経路 (`TransitiveResolver` 系) を含む全テストスイートを `kolt test` で実行し、 緑であることを確認する
   - 検証: ルートで `kolt test`、 `kolt-jvm-compiler-daemon` で `kolt test`、 `kolt-native-compiler-daemon` で `kolt test` の 3 つすべて exit 0。
   - 検証: `TransitiveResolver.kt` / `Resolver.kt` の diff が 0 行 (`git diff src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt` / `Resolver.kt`)。
   - 観測: スイート全体グリーン + 該当ファイル diff 空。

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -64,7 +64,7 @@
   - _Requirements: 1.2, 4.3_
 
 - [ ] 6. Core: deps tree lookup の JvmOnly 対応
-- [ ] 6.1 `createNativeLookup` (deps tree 用) を JvmOnly variant に対応させる
+- [x] 6.1 `createNativeLookup` (deps tree 用) を JvmOnly variant に対応させる
   - JvmOnly node に対して `NativeNodeInfo(displayGroupArtifact = "${rootCoord.group}:${rootCoord.artifact}", displayVersion = rootCoord.version, dependencies = emptyList())` を返す。
   - tree 表示で JvmOnly が leaf として現れるが、 UI の "JVM 専用" ラベル付与は本仕様の対象外 (out of boundary)。
   - 観測: createNativeLookup の unit test で JvmOnly node が空 dependencies と root coordinate を持つ `NativeNodeInfo` を返すこと。

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -24,7 +24,7 @@
   - 観測: unit test が `Ok(JvmOnly(coord))` を assert し緑。 既存の Klib 経路テストすべて緑。
   - _Requirements: 1.1, 1.2_
 
-- [ ] 3.2 `.module` 404 + `.pom` も失敗 (404 / 5xx 等) のとき、 **元の `.module` の `DownloadFailed`** を返す
+- [x] 3.2 `.module` 404 + `.pom` も失敗 (404 / 5xx 等) のとき、 **元の `.module` の `DownloadFailed`** を返す
   - 返す error は `.module` 取得時の `RepositoryAttempt` 一覧を保持していること (ユーザーに `.module` の attempts dump が見える)。 `.pom` の attempts は捨てる。
   - 観測: `.module` 404 + `.pom` 404 の unit test で error が `.module` の attempts を保持していることを assert。 typo / 真の missing artifact を masking しない。
   - _Requirements: 1.3_

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -47,7 +47,7 @@
   - 観測: 非 stdlib coordinate (例: `org.example:fake-jvm-only`) を transitive に含む resolve で stderr に該当 note 1 行が出力され、 `resolvedDeps` に含まれていないこと。
   - _Requirements: 4.1_
 
-- [ ] 5.2 transitive JvmOnly node が `kotlin-stdlib` / `kotlin-stdlib-common` のとき、 silent skip (note を出さない) を維持する
+- [x] 5.2 transitive JvmOnly node が `kotlin-stdlib` / `kotlin-stdlib-common` のとき、 silent skip (note を出さない) を維持する
   - 既存 `isKotlinStdlib` predicate を skip 直前で short-circuit に使う。
   - 観測: transitive 上に `kotlin-stdlib-common` がある resolve で `resolvedDeps` に含まれず、 stderr に note 行が出ない (capture して空であること) こと。
   - _Requirements: 4.2_

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -18,7 +18,7 @@
   - _Requirements: 1.4_
 
 - [ ] 3. Core: `fetchNativeMetadata` の root `.module` 404 → `.pom` フォールバック
-- [ ] 3.1 root `.module` の fetch failure が `is404OnAllAttempts` を満たすとき、 同一 coordinate の `.pom` を取得して `Ok(NativeResolved.JvmOnly(coord))` を返す経路を追加する
+- [x] 3.1 root `.module` の fetch failure が `is404OnAllAttempts` を満たすとき、 同一 coordinate の `.pom` を取得して `Ok(NativeResolved.JvmOnly(coord))` を返す経路を追加する
   - `.pom` の URL / cache path は既存 `buildPomDownloadUrl` / `buildPomCachePath` を再利用。 `.pom` の中身は parse しない (存在確認のみ)。
   - mock `ResolverDeps` で `.module` 404 / `.pom` 200 のシナリオを再現する unit test を追加し、 戻り値が `NativeResolved.JvmOnly` であることを assert。
   - 観測: unit test が `Ok(JvmOnly(coord))` を assert し緑。 既存の Klib 経路テストすべて緑。

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -71,7 +71,7 @@
   - _Requirements: 1.2_
 
 - [ ] 7. Integration: 再現ケース regression test
-- [ ] 7.1 `NativeResolverJvmOnlyFallbackTest` を新規追加し、 報告された repro (transitive 上に `.module` 404 + `.pom` 200 の artifact が現れる) を決定的 fixture で再現する
+- [x] 7.1 `NativeResolverJvmOnlyFallbackTest` を新規追加し、 報告された repro (transitive 上に `.module` 404 + `.pom` 200 の artifact が現れる) を決定的 fixture で再現する
   - mock `ResolverDeps` を組み、 parent 相当の coordinate は `.module` 200 を返して native variant + transitive children を持ち、 transitive 子の 1 つは `.module` 404 + `.pom` 200 を返す構造を用意する。
   - 検証 1: resolve 全体が `Ok` を返す (abort しない)。
   - 検証 2: JvmOnly 子の coordinate が `resolvedDeps` に含まれない。

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -35,7 +35,7 @@
   - _Requirements: 1.4_
 
 - [ ] 4. Core: childLookup の variant 分岐
-- [ ] 4.1 `makeNativeChildLookup` を `NativeResolved` の when 分岐に書き換え、 `Klib` は既存通り `artifact.dependencies` (minus stdlib*) を返し、 `JvmOnly` は `Ok(emptyList())` を返す
+- [x] 4.1 `makeNativeChildLookup` を `NativeResolved` の when 分岐に書き換え、 `Klib` は既存通り `artifact.dependencies` (minus stdlib*) を返し、 `JvmOnly` は `Ok(emptyList())` を返す
   - JvmOnly node の `processed` キャッシュは Klib と同じく GA:version キーで記録される (kernel 側からは透過)。
   - 観測: childLookup を直接叩く unit test、 もしくは fetchNativeMetadata 経由の integration で JvmOnly node から children が出ないことを assert。 既存 Klib のテストすべて緑。
   - _Requirements: 1.2, 3.1_
@@ -104,3 +104,4 @@
 ## Implementation Notes
 
 - Pre-commit hook runs `kolt fmt --check`. Implementer must run `kolt fmt` before declaring READY_FOR_REVIEW or the parent's `git commit` will fail. Discovered on task 1.1.
+- Task 3.1 introduced three placeholder comments with task references (`task 5.x`, `task 4.1`, `task 6.1`) at `NativeResolver.kt` lines 101, 162, 250. Memory `feedback_no_task_refs_in_comments.md` forbids these. Task 4.1 removed the `task 4.1` reference; remaining two are expected to be naturally replaced by tasks 5.x and 6.1 when the real implementation lands. If any remain after task 6.1, do a final sweep before task 8.x.

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -58,7 +58,7 @@
   - 観測: `[dependencies]` に `.module` 404 + `.pom` 200 の coordinate を直接書いた integration test で `Err(NoNativeVariant)` が返り、 既存の formatter (`Resolver.kt:93-98`) のメッセージが stderr に出ること。
   - _Requirements: 2.1, 2.2, 4.3_
 
-- [ ] 5.4 klib pre-count (`total`) および per-artifact progress (`onArtifactStart`) から JvmOnly node を除外する
+- [x] 5.4 klib pre-count (`total`) および per-artifact progress (`onArtifactStart`) から JvmOnly node を除外する
   - 既存の `total` 計算 (`NativeResolver.kt:71-77`) のフィルタ条件に variant チェックを追加。 主 loop の `index += 1` も Klib に限定。
   - 観測: transitive JvmOnly 1 個 + Klib 2 個の resolve で、 `RecordingResolverProgressSink` が `onArtifactStart` 通知を 2 回しか受けないこと。 `M/N` 表示が JvmOnly を膨らませないこと。
   - _Requirements: 1.2, 4.3_

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -52,7 +52,7 @@
   - 観測: transitive 上に `kotlin-stdlib-common` がある resolve で `resolvedDeps` に含まれず、 stderr に note 行が出ない (capture して空であること) こと。
   - _Requirements: 4.2_
 
-- [ ] 5.3 direct dep が JvmOnly に倒れた場合、 `ResolveError.NoNativeVariant(groupArtifact, nativeTarget)` を返して非ゼロ終了させる
+- [x] 5.3 direct dep が JvmOnly に倒れた場合、 `ResolveError.NoNativeVariant(groupArtifact, nativeTarget)` を返して非ゼロ終了させる
   - materialization loop の最初の分岐で `node.direct && resolved is JvmOnly` を判定。 stderr note は出さない (direct dep skip は既存挙動と整合)。
   - direct `kotlin-stdlib` / `kotlin-stdlib-common` の既存 silent skip 経路 (`directDeps = filterKeys { !isKotlinStdlib(it) }`, `NativeResolver.kt:54`) は触らない。
   - 観測: `[dependencies]` に `.module` 404 + `.pom` 200 の coordinate を直接書いた integration test で `Err(NoNativeVariant)` が返り、 既存の formatter (`Resolver.kt:93-98`) のメッセージが stderr に出ること。

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -12,7 +12,7 @@
   - _Requirements: 1.2, 2.2, 3.1_
 
 - [ ] 2. Core: 構造的 404 判定 helper を追加
-- [ ] 2.1 `is404OnAllAttempts` (file-local) を実装し、 `ResolveError.DownloadFailed` が「全 attempt が 404」状態かを判定する
+- [x] 2.1 `is404OnAllAttempts` (file-local) を実装し、 `ResolveError.DownloadFailed` が「全 attempt が 404」状態かを判定する
   - 真理表: (a) `AllAttemptsFailed` で全 `HttpFailed(statusCode=404)` → true、 (b) 1 つ以上の `HttpFailed(statusCode != 404)` 混入 → false、 (c) 1 つ以上の `NetworkError` / `WriteFailed` 混入 → false、 (d) `NoRepositoriesConfigured` → false、 (e) `attempts` が空 → false、 (f) `DownloadFailed` 以外の `ResolveError` → false。
   - 観測: helper の真理表 6 ケースすべてが unit test で緑。 既存テストすべて緑。
   - _Requirements: 1.4_

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -1,0 +1,102 @@
+# Implementation Plan
+
+> 進行方針: 各 sub-task は TDD (Red → Green → Refactor) を 1 実装者の 1 commit 単位で完結させる (memory `feedback_tdd_red_green_atomic.md`)。
+>
+> `(P)` マーカーは付けない: すべての production 変更は `NativeResolver.kt` 1 ファイルに集中し、 各 sub-task のテストも同一テストクラス群を触るため、 並行実行で merge conflict / interleaving のメリットが無い。 単独実装者でシーケンシャルに進める。
+
+- [ ] 1. Foundation: `NativeResolved` を sealed class へ refactor
+- [ ] 1.1 既存の `data class NativeResolved(redirect, artifact)` を `private sealed class NativeResolved` に変換し、 既存内容を `Klib(redirect, artifact)` variant に移植する
+  - 変換は behaviour-preserving。 新規 variant (`JvmOnly`) はこの task では追加しない。
+  - すべての file-local 参照 (`processed: MutableMap<String, NativeResolved>`, `makeNativeChildLookup`, `resolveNative` の materialization loop, `createNativeLookup`) を `Klib` variant に対する分岐に書き換える。
+  - 観測: 既存の `NativeResolverTest`, `ResolveNativeProgressTest`, `NativeResolverJvmOnlyFallbackTest` 以外のテスト群すべてが緑 (`kolt test`)、 既存挙動に変化なし。
+  - _Requirements: 1.2, 2.2, 3.1_
+
+- [ ] 2. Core: 構造的 404 判定 helper を追加
+- [ ] 2.1 `is404OnAllAttempts` (file-local) を実装し、 `ResolveError.DownloadFailed` が「全 attempt が 404」状態かを判定する
+  - 真理表: (a) `AllAttemptsFailed` で全 `HttpFailed(statusCode=404)` → true、 (b) 1 つ以上の `HttpFailed(statusCode != 404)` 混入 → false、 (c) 1 つ以上の `NetworkError` / `WriteFailed` 混入 → false、 (d) `NoRepositoriesConfigured` → false、 (e) `attempts` が空 → false、 (f) `DownloadFailed` 以外の `ResolveError` → false。
+  - 観測: helper の真理表 6 ケースすべてが unit test で緑。 既存テストすべて緑。
+  - _Requirements: 1.4_
+
+- [ ] 3. Core: `fetchNativeMetadata` の root `.module` 404 → `.pom` フォールバック
+- [ ] 3.1 root `.module` の fetch failure が `is404OnAllAttempts` を満たすとき、 同一 coordinate の `.pom` を取得して `Ok(NativeResolved.JvmOnly(coord))` を返す経路を追加する
+  - `.pom` の URL / cache path は既存 `buildPomDownloadUrl` / `buildPomCachePath` を再利用。 `.pom` の中身は parse しない (存在確認のみ)。
+  - mock `ResolverDeps` で `.module` 404 / `.pom` 200 のシナリオを再現する unit test を追加し、 戻り値が `NativeResolved.JvmOnly` であることを assert。
+  - 観測: unit test が `Ok(JvmOnly(coord))` を assert し緑。 既存の Klib 経路テストすべて緑。
+  - _Requirements: 1.1, 1.2_
+
+- [ ] 3.2 `.module` 404 + `.pom` も失敗 (404 / 5xx 等) のとき、 **元の `.module` の `DownloadFailed`** を返す
+  - 返す error は `.module` 取得時の `RepositoryAttempt` 一覧を保持していること (ユーザーに `.module` の attempts dump が見える)。 `.pom` の attempts は捨てる。
+  - 観測: `.module` 404 + `.pom` 404 の unit test で error が `.module` の attempts を保持していることを assert。 typo / 真の missing artifact を masking しない。
+  - _Requirements: 1.3_
+
+- [ ] 3.3 root `.module` の failure が `is404OnAllAttempts` を満たさないとき (5xx / NetworkError / WriteFailed) は `.pom` fallback を発火させず、 既存の `DownloadFailed` 経路で error する
+  - mock `ResolverDeps` の `downloadFile` 呼び出し回数を recorder で記録し、 `.pom` URL に対する download 試行が無いことを assert。
+  - 観測: 5xx / NetworkError シナリオで `.pom` fetch が 0 回、 戻り値が既存通り `Err(DownloadFailed(..., attempts containing 5xx/network))`。
+  - _Requirements: 1.4_
+
+- [ ] 4. Core: childLookup の variant 分岐
+- [ ] 4.1 `makeNativeChildLookup` を `NativeResolved` の when 分岐に書き換え、 `Klib` は既存通り `artifact.dependencies` (minus stdlib*) を返し、 `JvmOnly` は `Ok(emptyList())` を返す
+  - JvmOnly node の `processed` キャッシュは Klib と同じく GA:version キーで記録される (kernel 側からは透過)。
+  - 観測: childLookup を直接叩く unit test、 もしくは fetchNativeMetadata 経由の integration で JvmOnly node から children が出ないことを assert。 既存 Klib のテストすべて緑。
+  - _Requirements: 1.2, 3.1_
+
+- [ ] 5. Core: materialization loop の variant 分岐
+- [ ] 5.1 transitive JvmOnly node が非 stdlib のとき、 stderr に 1 行 note (`note: <ga>:<v> has no Gradle Module Metadata; skipping for native target`) を出して `resolvedDeps` に含めずスキップする
+  - eprintln 経路は既存の `kolt.infra.output` の stderr 出口を踏襲。
+  - ADR 0011 §4 を引く short anchor comment を skip 直前に 1 行入れる (`structure.md` の "ADR citations in code" に従う)。
+  - 観測: 非 stdlib coordinate (例: `org.example:fake-jvm-only`) を transitive に含む resolve で stderr に該当 note 1 行が出力され、 `resolvedDeps` に含まれていないこと。
+  - _Requirements: 4.1_
+
+- [ ] 5.2 transitive JvmOnly node が `kotlin-stdlib` / `kotlin-stdlib-common` のとき、 silent skip (note を出さない) を維持する
+  - 既存 `isKotlinStdlib` predicate を skip 直前で short-circuit に使う。
+  - 観測: transitive 上に `kotlin-stdlib-common` がある resolve で `resolvedDeps` に含まれず、 stderr に note 行が出ない (capture して空であること) こと。
+  - _Requirements: 4.2_
+
+- [ ] 5.3 direct dep が JvmOnly に倒れた場合、 `ResolveError.NoNativeVariant(groupArtifact, nativeTarget)` を返して非ゼロ終了させる
+  - materialization loop の最初の分岐で `node.direct && resolved is JvmOnly` を判定。 stderr note は出さない (direct dep skip は既存挙動と整合)。
+  - direct `kotlin-stdlib` / `kotlin-stdlib-common` の既存 silent skip 経路 (`directDeps = filterKeys { !isKotlinStdlib(it) }`, `NativeResolver.kt:54`) は触らない。
+  - 観測: `[dependencies]` に `.module` 404 + `.pom` 200 の coordinate を直接書いた integration test で `Err(NoNativeVariant)` が返り、 既存の formatter (`Resolver.kt:93-98`) のメッセージが stderr に出ること。
+  - _Requirements: 2.1, 2.2, 4.3_
+
+- [ ] 5.4 klib pre-count (`total`) および per-artifact progress (`onArtifactStart`) から JvmOnly node を除外する
+  - 既存の `total` 計算 (`NativeResolver.kt:71-77`) のフィルタ条件に variant チェックを追加。 主 loop の `index += 1` も Klib に限定。
+  - 観測: transitive JvmOnly 1 個 + Klib 2 個の resolve で、 `RecordingResolverProgressSink` が `onArtifactStart` 通知を 2 回しか受けないこと。 `M/N` 表示が JvmOnly を膨らませないこと。
+  - _Requirements: 1.2, 4.3_
+
+- [ ] 6. Core: deps tree lookup の JvmOnly 対応
+- [ ] 6.1 `createNativeLookup` (deps tree 用) を JvmOnly variant に対応させる
+  - JvmOnly node に対して `NativeNodeInfo(displayGroupArtifact = "${rootCoord.group}:${rootCoord.artifact}", displayVersion = rootCoord.version, dependencies = emptyList())` を返す。
+  - tree 表示で JvmOnly が leaf として現れるが、 UI の "JVM 専用" ラベル付与は本仕様の対象外 (out of boundary)。
+  - 観測: createNativeLookup の unit test で JvmOnly node が空 dependencies と root coordinate を持つ `NativeNodeInfo` を返すこと。
+  - _Requirements: 1.2_
+
+- [ ] 7. Integration: 再現ケース regression test
+- [ ] 7.1 `NativeResolverJvmOnlyFallbackTest` を新規追加し、 報告された repro (transitive 上に `.module` 404 + `.pom` 200 の artifact が現れる) を決定的 fixture で再現する
+  - mock `ResolverDeps` を組み、 parent 相当の coordinate は `.module` 200 を返して native variant + transitive children を持ち、 transitive 子の 1 つは `.module` 404 + `.pom` 200 を返す構造を用意する。
+  - 検証 1: resolve 全体が `Ok` を返す (abort しない)。
+  - 検証 2: JvmOnly 子の coordinate が `resolvedDeps` に含まれない。
+  - 検証 3: stderr capture に該当 coordinate の note 行が 1 行ある。
+  - 検証 4: テストコードが `isKotlinStdlib` の予約名リストや新規 skip リストに該当 coordinate を追加していないこと (構造的 fallback のみで通ること)。
+  - 検証 5: fixture は live Maven Central / `repo1.maven.org` を踏まないこと (offline で run できる)。
+  - _Requirements: 3.3, 6.1, 6.2, 6.3_
+
+- [ ] 8. Validation: 既存テストの regression と JVM 経路の不変確認
+- [ ] 8.1 既存の `NativeResolverTest` 内で `kotlin-stdlib-common` が transitive 上で扱われる経路を構造的 fallback (新分岐) で通すように調整し、 silent skip 維持を assert する
+  - 既存テストが「`.module` 404 を fatal として assert」していた場合は「fallback 後の Ok」に書き換える。 既存の `isKotlinStdlib` 名前 short-circuit が silent path として残ること (stderr に note が出ないこと) を assert に追加する。
+  - direct `kotlin-stdlib` 経路 (`directDeps = filterKeys { !isKotlinStdlib(it) }`) が無傷であること (Req 2.3) も既存テストで担保されている前提を確認、 もし無ければ 1 ケース追加する。
+  - 観測: `NativeResolverTest` の全ケースが緑、 `kotlin-stdlib-common` transitive シナリオで stderr 空。
+  - _Requirements: 2.3, 3.1, 3.2_
+
+- [ ] 8.2 JVM 経路 (`TransitiveResolver` 系) を含む全テストスイートを `kolt test` で実行し、 緑であることを確認する
+  - 検証: ルートで `kolt test`、 `kolt-jvm-compiler-daemon` で `kolt test`、 `kolt-native-compiler-daemon` で `kolt test` の 3 つすべて exit 0。
+  - 検証: `TransitiveResolver.kt` / `Resolver.kt` の diff が 0 行 (`git diff src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt` / `Resolver.kt`)。
+  - 観測: スイート全体グリーン + 該当ファイル diff 空。
+  - _Requirements: 5.1, 5.2, 5.3_
+
+- [ ] 8.3 target `.module` (redirect 後) の 404 は Layer 1 の対象外であり、 既存通り `DownloadFailed` で fail することを golden test で固定する
+  - 目的: design.md の Out of Boundary "target `.module` (redirect 先) の 404 ハンドリング" を test で明示的に押さえ、 Layer 2 着手時に root と target の挙動差が意図的であることを差分として可視化する。
+  - 構築: mock `ResolverDeps` で root `.module` 200 (linux_x64 variant が `available-at` redirect を宣言) → redirect 解析 OK → target `.module` 404 のシナリオ。 `.pom` (target coord) はテスト側で download されないことを recorder で確認 (fallback が発火していないこと)。
+  - 検証 1: 戻り値が `Err(ResolveError.DownloadFailed)` であり、 attempts が target coordinate の URL を保持していること。
+  - 検証 2: mock の `downloadFile` 呼び出し履歴に target `.module` の URL は記録されるが、 target `.pom` の URL は記録されないこと (Layer 1 の fallback は root `.module` 限定 = boundary の確認)。
+  - 観測: test が `Err(DownloadFailed)` を assert し緑、 target `.pom` への download 試行が 0 回。
+  - _Requirements: 1.1, 1.4_

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -93,7 +93,7 @@
   - 観測: スイート全体グリーン + 該当ファイル diff 空。
   - _Requirements: 5.1, 5.2, 5.3_
 
-- [ ] 8.3 target `.module` (redirect 後) の 404 は Layer 1 の対象外であり、 既存通り `DownloadFailed` で fail することを golden test で固定する
+- [x] 8.3 target `.module` (redirect 後) の 404 は Layer 1 の対象外であり、 既存通り `DownloadFailed` で fail することを golden test で固定する
   - 目的: design.md の Out of Boundary "target `.module` (redirect 先) の 404 ハンドリング" を test で明示的に押さえ、 Layer 2 着手時に root と target の挙動差が意図的であることを差分として可視化する。
   - 構築: mock `ResolverDeps` で root `.module` 200 (linux_x64 variant が `available-at` redirect を宣言) → redirect 解析 OK → target `.module` 404 のシナリオ。 `.pom` (target coord) はテスト側で download されないことを recorder で確認 (fallback が発火していないこと)。
   - 検証 1: 戻り値が `Err(ResolveError.DownloadFailed)` であり、 attempts が target coordinate の URL を保持していること。

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -41,7 +41,7 @@
   - _Requirements: 1.2, 3.1_
 
 - [ ] 5. Core: materialization loop の variant 分岐
-- [ ] 5.1 transitive JvmOnly node が非 stdlib のとき、 stderr に 1 行 note (`note: <ga>:<v> has no Gradle Module Metadata; skipping for native target`) を出して `resolvedDeps` に含めずスキップする
+- [x] 5.1 transitive JvmOnly node が非 stdlib のとき、 stderr に 1 行 note (`note: <ga>:<v> has no Gradle Module Metadata; skipping for native target`) を出して `resolvedDeps` に含めずスキップする
   - eprintln 経路は既存の `kolt.infra.output` の stderr 出口を踏襲。
   - ADR 0011 §4 を引く short anchor comment を skip 直前に 1 行入れる (`structure.md` の "ADR citations in code" に従う)。
   - 観測: 非 stdlib coordinate (例: `org.example:fake-jvm-only`) を transitive に含む resolve で stderr に該当 note 1 行が出力され、 `resolvedDeps` に含まれていないこと。

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -5,7 +5,7 @@
 > `(P)` マーカーは付けない: すべての production 変更は `NativeResolver.kt` 1 ファイルに集中し、 各 sub-task のテストも同一テストクラス群を触るため、 並行実行で merge conflict / interleaving のメリットが無い。 単独実装者でシーケンシャルに進める。
 
 - [ ] 1. Foundation: `NativeResolved` を sealed class へ refactor
-- [ ] 1.1 既存の `data class NativeResolved(redirect, artifact)` を `private sealed class NativeResolved` に変換し、 既存内容を `Klib(redirect, artifact)` variant に移植する
+- [x] 1.1 既存の `data class NativeResolved(redirect, artifact)` を `private sealed class NativeResolved` に変換し、 既存内容を `Klib(redirect, artifact)` variant に移植する
   - 変換は behaviour-preserving。 新規 variant (`JvmOnly`) はこの task では追加しない。
   - すべての file-local 参照 (`processed: MutableMap<String, NativeResolved>`, `makeNativeChildLookup`, `resolveNative` の materialization loop, `createNativeLookup`) を `Klib` variant に対する分岐に書き換える。
   - 観測: 既存の `NativeResolverTest`, `ResolveNativeProgressTest`, `NativeResolverJvmOnlyFallbackTest` 以外のテスト群すべてが緑 (`kolt test`)、 既存挙動に変化なし。
@@ -100,3 +100,7 @@
   - 検証 2: mock の `downloadFile` 呼び出し履歴に target `.module` の URL は記録されるが、 target `.pom` の URL は記録されないこと (Layer 1 の fallback は root `.module` 限定 = boundary の確認)。
   - 観測: test が `Err(DownloadFailed)` を assert し緑、 target `.pom` への download 試行が 0 回。
   - _Requirements: 1.1, 1.4_
+
+## Implementation Notes
+
+- Pre-commit hook runs `kolt fmt --check`. Implementer must run `kolt fmt` before declaring READY_FOR_REVIEW or the parent's `git commit` will fail. Discovered on task 1.1.

--- a/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
+++ b/.kiro/specs/426-native-resolver-pom-fallback/tasks.md
@@ -29,7 +29,7 @@
   - 観測: `.module` 404 + `.pom` 404 の unit test で error が `.module` の attempts を保持していることを assert。 typo / 真の missing artifact を masking しない。
   - _Requirements: 1.3_
 
-- [ ] 3.3 root `.module` の failure が `is404OnAllAttempts` を満たさないとき (5xx / NetworkError / WriteFailed) は `.pom` fallback を発火させず、 既存の `DownloadFailed` 経路で error する
+- [x] 3.3 root `.module` の failure が `is404OnAllAttempts` を満たさないとき (5xx / NetworkError / WriteFailed) は `.pom` fallback を発火させず、 既存の `DownloadFailed` 経路で error する
   - mock `ResolverDeps` の `downloadFile` 呼び出し回数を recorder で記録し、 `.pom` URL に対する download 試行が無いことを assert。
   - 観測: 5xx / NetworkError シナリオで `.pom` fetch が 0 回、 戻り値が既存通り `Err(DownloadFailed(..., attempts containing 5xx/network))`。
   - _Requirements: 1.4_

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -19,7 +19,9 @@ private fun isKotlinStdlib(groupArtifact: String): Boolean =
   groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib" ||
     groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib-common"
 
-private data class NativeResolved(val redirect: NativeRedirect, val artifact: NativeArtifact)
+private sealed class NativeResolved {
+  data class Klib(val redirect: NativeRedirect, val artifact: NativeArtifact) : NativeResolved()
+}
 
 /**
  * Resolves Kotlin/Native dependencies via the shared resolution kernel ([fixpointResolve]).
@@ -71,9 +73,13 @@ fun resolveNative(
   val total =
     nodes.count { node ->
       val resolved = processed["${node.groupArtifact}:${node.version}"] ?: return@count false
-      val targetCoord =
-        Coordinate(resolved.redirect.group, resolved.redirect.module, resolved.redirect.version)
-      !deps.fileExists("$cacheBase/${buildKlibCachePath(targetCoord)}")
+      when (resolved) {
+        is NativeResolved.Klib -> {
+          val targetCoord =
+            Coordinate(resolved.redirect.group, resolved.redirect.module, resolved.redirect.version)
+          !deps.fileExists("$cacheBase/${buildKlibCachePath(targetCoord)}")
+        }
+      }
     }
   var index = 0
 
@@ -82,48 +88,56 @@ fun resolveNative(
       processed["${node.groupArtifact}:${node.version}"]
         ?: return Err(ResolveError.MetadataParseFailed(node.groupArtifact))
 
-    val targetCoord =
-      Coordinate(resolved.redirect.group, resolved.redirect.module, resolved.redirect.version)
-    val klibCachePath = "$cacheBase/${buildKlibCachePath(targetCoord)}"
+    when (resolved) {
+      is NativeResolved.Klib -> {
+        val targetCoord =
+          Coordinate(resolved.redirect.group, resolved.redirect.module, resolved.redirect.version)
+        val klibCachePath = "$cacheBase/${buildKlibCachePath(targetCoord)}"
 
-    if (!deps.fileExists(klibCachePath)) {
-      val parentDir = klibCachePath.substringBeforeLast('/')
-      deps.ensureDirectoryRecursive(parentDir).getOrElse {
-        return Err(ResolveError.DirectoryCreateFailed(parentDir))
-      }
-      index += 1
-      progress.onArtifactStart(index, total, node.groupArtifact, node.version)
-      downloadFromRepositories(
-          repos,
-          klibCachePath,
-          { buildKlibDownloadUrl(targetCoord, it) },
-          deps::downloadFile,
-          onRetry = progress::onRetryAgainst,
-        )
-        .getOrElse { failure ->
-          return Err(ResolveError.DownloadFailed(node.groupArtifact, failure))
+        if (!deps.fileExists(klibCachePath)) {
+          val parentDir = klibCachePath.substringBeforeLast('/')
+          deps.ensureDirectoryRecursive(parentDir).getOrElse {
+            return Err(ResolveError.DirectoryCreateFailed(parentDir))
+          }
+          index += 1
+          progress.onArtifactStart(index, total, node.groupArtifact, node.version)
+          downloadFromRepositories(
+              repos,
+              klibCachePath,
+              { buildKlibDownloadUrl(targetCoord, it) },
+              deps::downloadFile,
+              onRetry = progress::onRetryAgainst,
+            )
+            .getOrElse { failure ->
+              return Err(ResolveError.DownloadFailed(node.groupArtifact, failure))
+            }
         }
-    }
 
-    val actualHash =
-      deps.computeSha256(klibCachePath).getOrElse {
-        return Err(ResolveError.HashComputeFailed(node.groupArtifact, it))
+        val actualHash =
+          deps.computeSha256(klibCachePath).getOrElse {
+            return Err(ResolveError.HashComputeFailed(node.groupArtifact, it))
+          }
+        if (actualHash != resolved.artifact.klibSha256) {
+          return Err(
+            ResolveError.Sha256Mismatch(
+              node.groupArtifact,
+              resolved.artifact.klibSha256,
+              actualHash,
+            )
+          )
+        }
+
+        resolvedDeps.add(
+          ResolvedDep(
+            groupArtifact = node.groupArtifact,
+            version = node.version,
+            sha256 = actualHash,
+            cachePath = klibCachePath,
+            transitive = !node.direct,
+          )
+        )
       }
-    if (actualHash != resolved.artifact.klibSha256) {
-      return Err(
-        ResolveError.Sha256Mismatch(node.groupArtifact, resolved.artifact.klibSha256, actualHash)
-      )
     }
-
-    resolvedDeps.add(
-      ResolvedDep(
-        groupArtifact = node.groupArtifact,
-        version = node.version,
-        sha256 = actualHash,
-        cachePath = klibCachePath,
-        transitive = !node.direct,
-      )
-    )
   }
 
   return Ok(ResolveResult(deps = resolvedDeps, lockChanged = false))
@@ -150,10 +164,13 @@ private fun makeNativeChildLookup(
       fetched
     }
   val children =
-    native.artifact.dependencies.mapNotNull { d ->
-      val depGA = "${d.group}:${d.module}"
-      if (isKotlinStdlib(depGA)) return@mapNotNull null
-      Child(groupArtifact = depGA, version = d.version, strict = d.strict, rejects = d.rejects)
+    when (native) {
+      is NativeResolved.Klib ->
+        native.artifact.dependencies.mapNotNull { d ->
+          val depGA = "${d.group}:${d.module}"
+          if (isKotlinStdlib(depGA)) return@mapNotNull null
+          Child(groupArtifact = depGA, version = d.version, strict = d.strict, rejects = d.rejects)
+        }
     }
   Ok(children)
 }
@@ -192,12 +209,15 @@ fun createNativeLookup(
           .getOrElse { null }
 
       resolved?.let {
-        NativeNodeInfo(
-          displayGroupArtifact = "${it.redirect.group}:${it.redirect.module}",
-          displayVersion = it.redirect.version,
-          dependencies =
-            it.artifact.dependencies.map { dep -> "${dep.group}:${dep.module}" to dep.version },
-        )
+        when (it) {
+          is NativeResolved.Klib ->
+            NativeNodeInfo(
+              displayGroupArtifact = "${it.redirect.group}:${it.redirect.module}",
+              displayVersion = it.redirect.version,
+              dependencies =
+                it.artifact.dependencies.map { dep -> "${dep.group}:${dep.module}" to dep.version },
+            )
+        }
       }
     }
   }
@@ -261,7 +281,7 @@ private fun fetchNativeMetadata(
     parseNativeArtifact(targetJson, nativeTarget)
       ?: return Err(ResolveError.MetadataParseFailed(groupArtifact))
 
-  return Ok(NativeResolved(redirect, artifact))
+  return Ok(NativeResolved.Klib(redirect, artifact))
 }
 
 /**

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -99,8 +99,9 @@ fun resolveNative(
             Coordinate(resolved.redirect.group, resolved.redirect.module, resolved.redirect.version)
           !deps.fileExists("$cacheBase/${buildKlibCachePath(targetCoord)}")
         }
-        // JvmOnly nodes have no klib artifact; full pre-count/progress handling
-        // lands in task 5.x. Excluded from total here keeps M/N accurate.
+        // JvmOnly nodes have no klib artifact to download, so they contribute
+        // nothing to the M/N progress total. Keeping them out here aligns the
+        // total with the main loop's index increment, which is Klib-only.
         is NativeResolved.JvmOnly -> false
       }
     }
@@ -262,9 +263,9 @@ fun createNativeLookup(
               dependencies =
                 it.artifact.dependencies.map { dep -> "${dep.group}:${dep.module}" to dep.version },
             )
-          // JvmOnly tree representation (root coord, empty deps) lands in
-          // task 6.1; this minimal mapping keeps the when exhaustive and
-          // surfaces the root coordinate as a leaf in the meantime.
+          // JvmOnly artifacts have no Gradle Module Metadata, so the tree
+          // surfaces them as a leaf at the original (root) coordinate with no
+          // children. The "JVM-only" UI label is intentionally out of scope.
           is NativeResolved.JvmOnly ->
             NativeNodeInfo(
               displayGroupArtifact = "${it.coordinate.group}:${it.coordinate.artifact}",

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -161,16 +161,22 @@ fun resolveNative(
         )
       }
       is NativeResolved.JvmOnly -> {
-        if (!node.direct) {
-          // ADR 0011 §4: structural skip generalises the kotlin-stdlib-common
-          // silent-skip policy; stdlib coordinates remain silent here, every
-          // other JvmOnly transitive surfaces a single stderr note so a build
-          // log records which artifact had no native variant.
-          if (!isKotlinStdlib(node.groupArtifact)) {
-            noteSink(
-              "note: ${node.groupArtifact}:${node.version} has no Gradle Module Metadata; skipping for native target"
-            )
-          }
+        // Direct JvmOnly deps (other than the kotlin-stdlib bundle filtered
+        // out in `resolveNative` above) cannot be silently skipped: the user
+        // declared the artifact in `[dependencies]`, so we surface a hard
+        // error and let the formatter print the dedicated NoNativeVariant
+        // message instead of emitting a transitive-skip note.
+        if (node.direct) {
+          return Err(ResolveError.NoNativeVariant(node.groupArtifact, nativeTarget))
+        }
+        // ADR 0011 §4: structural skip generalises the kotlin-stdlib-common
+        // silent-skip policy; stdlib coordinates remain silent here, every
+        // other JvmOnly transitive surfaces a single stderr note so a build
+        // log records which artifact had no native variant.
+        if (!isKotlinStdlib(node.groupArtifact)) {
+          noteSink(
+            "note: ${node.groupArtifact}:${node.version} has no Gradle Module Metadata; skipping for native target"
+          )
         }
       }
     }

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -162,11 +162,10 @@ fun resolveNative(
         )
       }
       is NativeResolved.JvmOnly -> {
-        // Direct JvmOnly deps (other than the kotlin-stdlib bundle filtered
-        // out in `resolveNative` above) cannot be silently skipped: the user
-        // declared the artifact in `[dependencies]`, so we surface a hard
-        // error and let the formatter print the dedicated NoNativeVariant
-        // message instead of emitting a transitive-skip note.
+        // Direct JvmOnly deps (other than the kotlin-stdlib bundle already
+        // filtered out in `resolveNative` above) cannot be silently skipped:
+        // the user declared the artifact in `[dependencies]`, so surface
+        // NoNativeVariant rather than continuing.
         if (node.direct) {
           return Err(ResolveError.NoNativeVariant(node.groupArtifact, nativeTarget))
         }

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -6,6 +6,7 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltConfig
 import kolt.config.konanTargetGradleName
+import kolt.infra.DownloadError
 
 // Kotlin/Native bundles the stdlib in the konanc distribution — it must be
 // skipped during dependency resolution even though Gradle module metadata
@@ -18,6 +19,21 @@ import kolt.config.konanTargetGradleName
 private fun isKotlinStdlib(groupArtifact: String): Boolean =
   groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib" ||
     groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib-common"
+
+// Distinguishes "every repo replied 404" from any other download failure
+// (5xx, network, local write). Only the all-404 case can be interpreted as
+// "this artifact is structurally not published" and trigger the `.pom`
+// fallback; transient failures must surface as the existing DownloadFailed.
+internal fun is404OnAllAttempts(error: ResolveError): Boolean {
+  if (error !is ResolveError.DownloadFailed) return false
+  val failure = error.failure
+  if (failure !is RepositoryDownloadFailure.AllAttemptsFailed) return false
+  if (failure.attempts.isEmpty()) return false
+  return failure.attempts.all { attempt ->
+    val downloadError = attempt.error
+    downloadError is DownloadError.HttpFailed && downloadError.statusCode == 404
+  }
+}
 
 private sealed class NativeResolved {
   data class Klib(val redirect: NativeRedirect, val artifact: NativeArtifact) : NativeResolved()

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -35,8 +35,10 @@ internal fun is404OnAllAttempts(error: ResolveError): Boolean {
   }
 }
 
-private sealed class NativeResolved {
+internal sealed class NativeResolved {
   data class Klib(val redirect: NativeRedirect, val artifact: NativeArtifact) : NativeResolved()
+
+  data class JvmOnly(val coordinate: Coordinate) : NativeResolved()
 }
 
 /**
@@ -95,6 +97,9 @@ fun resolveNative(
             Coordinate(resolved.redirect.group, resolved.redirect.module, resolved.redirect.version)
           !deps.fileExists("$cacheBase/${buildKlibCachePath(targetCoord)}")
         }
+        // JvmOnly nodes have no klib artifact; full pre-count/progress handling
+        // lands in task 5.x. Excluded from total here keeps M/N accurate.
+        is NativeResolved.JvmOnly -> false
       }
     }
   var index = 0
@@ -153,6 +158,11 @@ fun resolveNative(
           )
         )
       }
+      // Direct-vs-transitive routing (NoNativeVariant on direct, stderr note on
+      // transitive, silent for stdlib) lands in task 5.x. For now the branch is
+      // a no-op that keeps the when exhaustive without changing observable
+      // behavior on the existing Klib-only code paths.
+      is NativeResolved.JvmOnly -> Unit
     }
   }
 
@@ -187,6 +197,10 @@ private fun makeNativeChildLookup(
           if (isKotlinStdlib(depGA)) return@mapNotNull null
           Child(groupArtifact = depGA, version = d.version, strict = d.strict, rejects = d.rejects)
         }
+      // JvmOnly nodes have no Gradle Module Metadata, so no transitive children
+      // are descended; task 4.1 will reaffirm this contract with dedicated
+      // coverage.
+      is NativeResolved.JvmOnly -> emptyList()
     }
   Ok(children)
 }
@@ -233,6 +247,15 @@ fun createNativeLookup(
               dependencies =
                 it.artifact.dependencies.map { dep -> "${dep.group}:${dep.module}" to dep.version },
             )
+          // JvmOnly tree representation (root coord, empty deps) lands in
+          // task 6.1; this minimal mapping keeps the when exhaustive and
+          // surfaces the root coordinate as a leaf in the meantime.
+          is NativeResolved.JvmOnly ->
+            NativeNodeInfo(
+              displayGroupArtifact = "${it.coordinate.group}:${it.coordinate.artifact}",
+              displayVersion = it.coordinate.version,
+              dependencies = emptyList(),
+            )
         }
       }
     }
@@ -242,8 +265,14 @@ fun createNativeLookup(
 /**
  * Fetches and parses both the root `.module` (for the available-at redirect) and the
  * platform-specific `.module` (for the klib file + dependencies) for a single coordinate.
+ *
+ * When the root `.module` returns 404 from every repository, falls back to fetching the same
+ * coordinate's `.pom` for existence-only confirmation. If the `.pom` is available, the artifact is
+ * structurally JVM-only (no Gradle Module Metadata published) and is returned as
+ * `NativeResolved.JvmOnly`. The `.pom` body is not parsed; downstream materialization decides how
+ * to handle the variant.
  */
-private fun fetchNativeMetadata(
+internal fun fetchNativeMetadata(
   groupArtifact: String,
   version: String,
   nativeTarget: String,
@@ -265,8 +294,23 @@ private fun fetchNativeMetadata(
         repos = repos,
         deps = deps,
       )
-      .getOrElse {
-        return Err(it)
+      .getOrElse { moduleError ->
+        if (is404OnAllAttempts(moduleError)) {
+          val pomResult =
+            fetchAndRead(
+              coord = rootCoord,
+              relativePath = buildPomCachePath(rootCoord),
+              urlBuilder = { buildPomDownloadUrl(rootCoord, it) },
+              cacheBase = cacheBase,
+              repos = repos,
+              deps = deps,
+            )
+          if (pomResult.isErr) {
+            return Err(moduleError)
+          }
+          return Ok(NativeResolved.JvmOnly(rootCoord))
+        }
+        return Err(moduleError)
       }
 
   if (!isValidGradleModuleJson(rootJson)) {

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -169,7 +169,7 @@ fun resolveNative(
   return Ok(ResolveResult(deps = resolvedDeps, lockChanged = false))
 }
 
-private fun makeNativeChildLookup(
+internal fun makeNativeChildLookup(
   processed: MutableMap<String, NativeResolved>,
   nativeTarget: String,
   cacheBase: String,
@@ -198,8 +198,7 @@ private fun makeNativeChildLookup(
           Child(groupArtifact = depGA, version = d.version, strict = d.strict, rejects = d.rejects)
         }
       // JvmOnly nodes have no Gradle Module Metadata, so no transitive children
-      // are descended; task 4.1 will reaffirm this contract with dedicated
-      // coverage.
+      // are descended.
       is NativeResolved.JvmOnly -> emptyList()
     }
   Ok(children)

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -7,6 +7,7 @@ import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltConfig
 import kolt.config.konanTargetGradleName
 import kolt.infra.DownloadError
+import kolt.infra.eprintln
 
 // Kotlin/Native bundles the stdlib in the konanc distribution — it must be
 // skipped during dependency resolution even though Gradle module metadata
@@ -60,6 +61,7 @@ fun resolveNative(
   cacheBase: String,
   deps: ResolverDeps,
   progress: ResolverProgressSink = ResolverProgressSink.NoOp,
+  noteSink: (String) -> Unit = ::eprintln,
 ): Result<ResolveResult, ResolveError> {
   val nativeTarget = konanTargetGradleName(config.build.target)
   val repos = config.repositories.values.toList()
@@ -158,11 +160,19 @@ fun resolveNative(
           )
         )
       }
-      // Direct-vs-transitive routing (NoNativeVariant on direct, stderr note on
-      // transitive, silent for stdlib) lands in task 5.x. For now the branch is
-      // a no-op that keeps the when exhaustive without changing observable
-      // behavior on the existing Klib-only code paths.
-      is NativeResolved.JvmOnly -> Unit
+      is NativeResolved.JvmOnly -> {
+        if (!node.direct) {
+          // ADR 0011 §4: structural skip generalises the kotlin-stdlib-common
+          // silent-skip policy; stdlib coordinates remain silent here, every
+          // other JvmOnly transitive surfaces a single stderr note so a build
+          // log records which artifact had no native variant.
+          if (!isKotlinStdlib(node.groupArtifact)) {
+            noteSink(
+              "note: ${node.groupArtifact}:${node.version} has no Gradle Module Metadata; skipping for native target"
+            )
+          }
+        }
+      }
     }
   }
 

--- a/src/nativeTest/kotlin/kolt/resolve/CreateNativeLookupTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/CreateNativeLookupTest.kt
@@ -1,0 +1,283 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit coverage for `createNativeLookup`'s `NativeResolved` variant dispatch.
+ *
+ * JvmOnly nodes surface as a tree leaf using the original (root) coordinate with no children,
+ * because `.pom`-only artifacts have no Gradle Module Metadata and therefore no transitive native
+ * dependencies to descend. The Klib path is exercised in parallel to guard against regressions in
+ * the existing redirected-coordinate display.
+ */
+class CreateNativeLookupTest {
+
+  @Test
+  fun jvmOnlyNodeReturnsRootCoordinateWithEmptyDependencies() {
+    val cachedFiles = mutableSetOf<String>()
+    val pomCachePath = "/cache/com/example/jvm-only/1.0.0/jvm-only-1.0.0.pom"
+    val deps =
+      object : ResolverDeps {
+        val pomContents =
+          mapOf(
+            pomCachePath to
+              "<project><groupId>com.example</groupId><artifactId>jvm-only</artifactId><version>1.0.0</version></project>"
+          )
+
+        override fun fileExists(path: String): Boolean = path in cachedFiles
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          if (destPath.endsWith(".module")) {
+            return Err(DownloadError.HttpFailed(url, 404))
+          }
+          if (destPath.endsWith(".pom")) {
+            cachedFiles.add(destPath)
+            return Ok(Unit)
+          }
+          return Err(DownloadError.HttpFailed(url, 404))
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> =
+          Err(Sha256Error(filePath))
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> {
+          val content = pomContents[path] ?: return Err(OpenFailed(path))
+          return Ok(content)
+        }
+      }
+
+    val lookup =
+      createNativeLookup(
+        repos = listOf("https://repo1.example/"),
+        cacheBase = "/cache",
+        deps = deps,
+        nativeTarget = "linux_x64",
+      )
+
+    val info = assertNotNull(lookup("com.example:jvm-only", "1.0.0"))
+    assertEquals("com.example:jvm-only", info.displayGroupArtifact)
+    assertEquals("1.0.0", info.displayVersion)
+    assertTrue(
+      info.dependencies.isEmpty(),
+      "expected JvmOnly leaf with empty dependencies, got: ${info.dependencies}",
+    )
+  }
+
+  @Test
+  fun klibNodeReturnsRedirectedCoordinateWithTransitiveDependencies() {
+    val rootModulePath = "/cache/com/example/lib/1.0.0/lib-1.0.0.module"
+    val targetModulePath = "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module"
+    val rootModuleJson =
+      """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module",
+                "group": "com.example",
+                "module": "lib-linuxx64",
+                "version": "1.0.0"
+              }
+            }
+          ]
+        }
+      """
+        .trimIndent()
+    val targetModuleJson =
+      """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "dependencies": [
+                {
+                  "group": "com.example",
+                  "module": "trans",
+                  "version": { "requires": "2.0.0" }
+                }
+              ],
+              "files": [
+                {
+                  "name": "inner.klib",
+                  "url": "lib-linuxx64-1.0.0.klib",
+                  "sha256": "deadbeef"
+                }
+              ]
+            }
+          ]
+        }
+      """
+        .trimIndent()
+
+    val cachedFiles = mutableSetOf<String>()
+    val contents = mapOf(rootModulePath to rootModuleJson, targetModulePath to targetModuleJson)
+    val deps =
+      object : ResolverDeps {
+        override fun fileExists(path: String): Boolean = path in cachedFiles
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          if (destPath in contents) {
+            cachedFiles.add(destPath)
+            return Ok(Unit)
+          }
+          return Err(DownloadError.HttpFailed(url, 404))
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> =
+          Err(Sha256Error(filePath))
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> {
+          val content = contents[path] ?: return Err(OpenFailed(path))
+          return Ok(content)
+        }
+      }
+
+    val lookup =
+      createNativeLookup(
+        repos = listOf("https://repo1.example/"),
+        cacheBase = "/cache",
+        deps = deps,
+        nativeTarget = "linux_x64",
+      )
+
+    val info = assertNotNull(lookup("com.example:lib", "1.0.0"))
+    assertEquals("com.example:lib-linuxx64", info.displayGroupArtifact)
+    assertEquals("1.0.0", info.displayVersion)
+    assertEquals(listOf("com.example:trans" to "2.0.0"), info.dependencies)
+  }
+
+  // Memoization is a contract of `createNativeLookup` (matches createPomLookup);
+  // re-issuing the same query must hit the cache and skip the network entirely.
+  // Without this, diamond dependencies in tree rendering would re-fetch the
+  // same `.module` / `.pom` pair on every occurrence.
+  @Test
+  fun jvmOnlyLookupMemoizesAndDoesNotRefetch() {
+    var moduleAttempts = 0
+    var pomAttempts = 0
+    val cachedFiles = mutableSetOf<String>()
+    val pomCachePath = "/cache/com/example/jvm-only/1.0.0/jvm-only-1.0.0.pom"
+    val deps =
+      object : ResolverDeps {
+        val pomContents =
+          mapOf(
+            pomCachePath to
+              "<project><groupId>com.example</groupId><artifactId>jvm-only</artifactId><version>1.0.0</version></project>"
+          )
+
+        override fun fileExists(path: String): Boolean = path in cachedFiles
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          if (destPath.endsWith(".module")) {
+            moduleAttempts += 1
+            return Err(DownloadError.HttpFailed(url, 404))
+          }
+          if (destPath.endsWith(".pom")) {
+            pomAttempts += 1
+            cachedFiles.add(destPath)
+            return Ok(Unit)
+          }
+          return Err(DownloadError.HttpFailed(url, 404))
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> =
+          Err(Sha256Error(filePath))
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> {
+          val content = pomContents[path] ?: return Err(OpenFailed(path))
+          return Ok(content)
+        }
+      }
+
+    val lookup =
+      createNativeLookup(
+        repos = listOf("https://repo1.example/"),
+        cacheBase = "/cache",
+        deps = deps,
+        nativeTarget = "linux_x64",
+      )
+
+    val first = assertNotNull(lookup("com.example:jvm-only", "1.0.0"))
+    val moduleAttemptsAfterFirst = moduleAttempts
+    val pomAttemptsAfterFirst = pomAttempts
+
+    val second = assertNotNull(lookup("com.example:jvm-only", "1.0.0"))
+
+    assertEquals(first, second)
+    assertEquals(
+      moduleAttemptsAfterFirst,
+      moduleAttempts,
+      "expected memoized JvmOnly lookup not to re-attempt .module download",
+    )
+    assertEquals(
+      pomAttemptsAfterFirst,
+      pomAttempts,
+      "expected memoized JvmOnly lookup not to re-attempt .pom download",
+    )
+  }
+
+  // `.module` 404 + `.pom` 404 must surface as null (lookup contract: any fetch
+  // failure renders the node as an unresolved leaf in the tree). Asserting null
+  // here pins the boundary between "structurally JVM-only" (returns leaf with
+  // root coord) and "structurally absent" (returns null so the walker keeps
+  // the original coordinate without claiming JVM-only semantics).
+  @Test
+  fun moduleAndPomBothMissingReturnsNull() {
+    val deps =
+      object : ResolverDeps {
+        override fun fileExists(path: String): Boolean = false
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> =
+          Err(DownloadError.HttpFailed(url, 404))
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> =
+          Err(Sha256Error(filePath))
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> =
+          Err(OpenFailed(path))
+      }
+
+    val lookup =
+      createNativeLookup(
+        repos = listOf("https://repo1.example/"),
+        cacheBase = "/cache",
+        deps = deps,
+        nativeTarget = "linux_x64",
+      )
+
+    assertNull(lookup("com.example:missing", "9.9.9"))
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/FetchNativeMetadataJvmOnlyFallbackTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/FetchNativeMetadataJvmOnlyFallbackTest.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
 import kolt.infra.DownloadError
 import kolt.infra.MkdirFailed
 import kolt.infra.OpenFailed
@@ -11,6 +12,7 @@ import kolt.infra.Sha256Error
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class FetchNativeMetadataJvmOnlyFallbackTest {
 
@@ -66,5 +68,52 @@ class FetchNativeMetadataJvmOnlyFallbackTest {
     assertEquals("com.example", resolved.coordinate.group)
     assertEquals("lib", resolved.coordinate.artifact)
     assertEquals("1.0.0", resolved.coordinate.version)
+  }
+
+  // When `.module` and `.pom` both 404 across every repo, the resolver must
+  // surface the original `.module` DownloadFailed so a typo or genuinely
+  // missing artifact stays visible in the per-repo attempts dump. Returning
+  // `.pom` attempts instead would mask the real failure under a fallback
+  // path the user did not request.
+  @Test
+  fun moduleAndPomAll404ReturnsModuleAttempts() {
+    val deps =
+      object : ResolverDeps {
+        override fun fileExists(path: String): Boolean = false
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> =
+          Err(DownloadError.HttpFailed(url, 404))
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> =
+          Err(Sha256Error(filePath))
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> =
+          Err(OpenFailed(path))
+      }
+
+    val result =
+      fetchNativeMetadata(
+        groupArtifact = "com.example:lib",
+        version = "1.0.0",
+        nativeTarget = "linux_x64",
+        cacheBase = "/cache",
+        repos = listOf("https://repo1.example/", "https://repo2.example/"),
+        deps = deps,
+      )
+
+    val error = assertIs<ResolveError.DownloadFailed>(result.getError())
+    assertEquals("com.example:lib", error.groupArtifact)
+    val failure = assertIs<RepositoryDownloadFailure.AllAttemptsFailed>(error.failure)
+    assertEquals(2, failure.attempts.size)
+    assertTrue(
+      failure.attempts.all { it.url.endsWith(".module") },
+      "expected only .module attempts, got: ${failure.attempts.map { it.url }}",
+    )
+    assertTrue(
+      failure.attempts.none { it.url.endsWith(".pom") },
+      "expected no .pom attempts, got: ${failure.attempts.map { it.url }}",
+    )
   }
 }

--- a/src/nativeTest/kotlin/kolt/resolve/FetchNativeMetadataJvmOnlyFallbackTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/FetchNativeMetadataJvmOnlyFallbackTest.kt
@@ -116,4 +116,90 @@ class FetchNativeMetadataJvmOnlyFallbackTest {
       "expected no .pom attempts, got: ${failure.attempts.map { it.url }}",
     )
   }
+
+  // Non-404 `.module` failures (5xx, network, local write) must NOT trigger the
+  // `.pom` fallback. The fallback exists to recognize "structurally JVM-only"
+  // artifacts, not to paper over transient or environmental failures: a 503
+  // could become a 200 on retry, and silently downgrading to JvmOnly would
+  // mask the real problem. The recorder asserts the resolver never even
+  // attempts a `.pom` URL when the gate rejects the module error.
+  @Test
+  fun moduleFailsWith5xxDoesNotTriggerPomFallback() {
+    assertNoPomFallbackOnModuleError { url -> DownloadError.HttpFailed(url, 503) }
+  }
+
+  @Test
+  fun moduleFailsWithNetworkErrorDoesNotTriggerPomFallback() {
+    assertNoPomFallbackOnModuleError { url -> DownloadError.NetworkError(url, "connection reset") }
+  }
+
+  @Test
+  fun moduleFailsWithWriteFailedDoesNotTriggerPomFallback() {
+    assertNoPomFallbackOnModuleError { _ ->
+      DownloadError.WriteFailed("/cache/tmp/lib-1.0.0.module")
+    }
+  }
+
+  private fun assertNoPomFallbackOnModuleError(moduleErrorFor: (String) -> DownloadError) {
+    val recorded = mutableListOf<String>()
+    val deps =
+      object : ResolverDeps {
+        override fun fileExists(path: String): Boolean = false
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          recorded.add(url)
+          if (destPath.endsWith(".module")) {
+            return Err(moduleErrorFor(url))
+          }
+          // Any `.pom` reach here would already be a regression; return an
+          // arbitrary error so we still observe the URL in `recorded`.
+          return Err(DownloadError.HttpFailed(url, 404))
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> =
+          Err(Sha256Error(filePath))
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> =
+          Err(OpenFailed(path))
+      }
+
+    val result =
+      fetchNativeMetadata(
+        groupArtifact = "com.example:lib",
+        version = "1.0.0",
+        nativeTarget = "linux_x64",
+        cacheBase = "/cache",
+        repos = listOf("https://repo1.example/", "https://repo2.example/"),
+        deps = deps,
+      )
+
+    val error = assertIs<ResolveError.DownloadFailed>(result.getError())
+    assertEquals("com.example:lib", error.groupArtifact)
+    val failure = assertIs<RepositoryDownloadFailure.AllAttemptsFailed>(error.failure)
+    // `downloadFromRepositories` short-circuits on the first non-404 error
+    // rather than walking the rest of the repo list (404 is the only
+    // "try the next mirror" signal), so the attempts list has exactly one entry.
+    assertEquals(1, failure.attempts.size)
+    assertTrue(
+      failure.attempts.all { it.url.endsWith(".module") },
+      "expected only .module attempts in error, got: ${failure.attempts.map { it.url }}",
+    )
+    assertTrue(
+      failure.attempts.none { attempt ->
+        val e = attempt.error
+        e is DownloadError.HttpFailed && e.statusCode == 404
+      },
+      "expected no 404 attempts in non-404 scenario, got: ${failure.attempts.map { it.error }}",
+    )
+    assertTrue(
+      recorded.none { it.endsWith(".pom") },
+      "expected no .pom download attempts, recorded: $recorded",
+    )
+    assertTrue(
+      recorded.all { it.endsWith(".module") },
+      "expected only .module URLs to be attempted, recorded: $recorded",
+    )
+  }
 }

--- a/src/nativeTest/kotlin/kolt/resolve/FetchNativeMetadataJvmOnlyFallbackTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/FetchNativeMetadataJvmOnlyFallbackTest.kt
@@ -1,0 +1,70 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class FetchNativeMetadataJvmOnlyFallbackTest {
+
+  @Test
+  fun moduleAllRepos404AndPom200ReturnsJvmOnly() {
+    val pomXml =
+      """
+            <project><groupId>com.example</groupId><artifactId>lib</artifactId><version>1.0.0</version></project>
+        """
+        .trimIndent()
+
+    val cachedFiles = mutableSetOf<String>()
+    val pomCachePath = "/cache/com/example/lib/1.0.0/lib-1.0.0.pom"
+    val deps =
+      object : ResolverDeps {
+        val pomContents = mapOf(pomCachePath to pomXml)
+
+        override fun fileExists(path: String): Boolean = path in cachedFiles
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          if (destPath.endsWith(".module")) {
+            return Err(DownloadError.HttpFailed(url, 404))
+          }
+          if (destPath.endsWith(".pom")) {
+            cachedFiles.add(destPath)
+            return Ok(Unit)
+          }
+          return Err(DownloadError.HttpFailed(url, 404))
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> =
+          Err(Sha256Error(filePath))
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> {
+          val content = pomContents[path] ?: return Err(OpenFailed(path))
+          return Ok(content)
+        }
+      }
+
+    val result =
+      fetchNativeMetadata(
+        groupArtifact = "com.example:lib",
+        version = "1.0.0",
+        nativeTarget = "linux_x64",
+        cacheBase = "/cache",
+        repos = listOf("https://repo1.example/", "https://repo2.example/"),
+        deps = deps,
+      )
+
+    val resolved = assertIs<NativeResolved.JvmOnly>(result.get())
+    assertEquals("com.example", resolved.coordinate.group)
+    assertEquals("lib", resolved.coordinate.artifact)
+    assertEquals("1.0.0", resolved.coordinate.version)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/Is404OnAllAttemptsTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/Is404OnAllAttemptsTest.kt
@@ -1,0 +1,114 @@
+package kolt.resolve
+
+import kolt.infra.DownloadError
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class Is404OnAllAttemptsTest {
+
+  @Test
+  fun allAttemptsAre404ReturnsTrue() {
+    val error =
+      ResolveError.DownloadFailed(
+        groupArtifact = "com.example:lib",
+        failure =
+          RepositoryDownloadFailure.AllAttemptsFailed(
+            attempts =
+              listOf(
+                RepositoryAttempt(
+                  url = "https://a.example/lib.module",
+                  error = DownloadError.HttpFailed("https://a.example/lib.module", 404),
+                ),
+                RepositoryAttempt(
+                  url = "https://b.example/lib.module",
+                  error = DownloadError.HttpFailed("https://b.example/lib.module", 404),
+                ),
+              )
+          ),
+      )
+
+    assertTrue(is404OnAllAttempts(error))
+  }
+
+  @Test
+  fun nonNotFoundHttpStatusMixedReturnsFalse() {
+    val error =
+      ResolveError.DownloadFailed(
+        groupArtifact = "com.example:lib",
+        failure =
+          RepositoryDownloadFailure.AllAttemptsFailed(
+            attempts =
+              listOf(
+                RepositoryAttempt(
+                  url = "https://a.example/lib.module",
+                  error = DownloadError.HttpFailed("https://a.example/lib.module", 404),
+                ),
+                RepositoryAttempt(
+                  url = "https://b.example/lib.module",
+                  error = DownloadError.HttpFailed("https://b.example/lib.module", 503),
+                ),
+              )
+          ),
+      )
+
+    assertFalse(is404OnAllAttempts(error))
+  }
+
+  @Test
+  fun networkErrorOrWriteFailedMixedReturnsFalse() {
+    val error =
+      ResolveError.DownloadFailed(
+        groupArtifact = "com.example:lib",
+        failure =
+          RepositoryDownloadFailure.AllAttemptsFailed(
+            attempts =
+              listOf(
+                RepositoryAttempt(
+                  url = "https://a.example/lib.module",
+                  error = DownloadError.HttpFailed("https://a.example/lib.module", 404),
+                ),
+                RepositoryAttempt(
+                  url = "https://b.example/lib.module",
+                  error = DownloadError.NetworkError("https://b.example/lib.module", "timeout"),
+                ),
+                RepositoryAttempt(
+                  url = "https://c.example/lib.module",
+                  error = DownloadError.WriteFailed("/tmp/lib.module"),
+                ),
+              )
+          ),
+      )
+
+    assertFalse(is404OnAllAttempts(error))
+  }
+
+  @Test
+  fun noRepositoriesConfiguredReturnsFalse() {
+    val error =
+      ResolveError.DownloadFailed(
+        groupArtifact = "com.example:lib",
+        failure = RepositoryDownloadFailure.NoRepositoriesConfigured,
+      )
+
+    assertFalse(is404OnAllAttempts(error))
+  }
+
+  @Test
+  fun emptyAttemptsReturnsFalse() {
+    val error =
+      ResolveError.DownloadFailed(
+        groupArtifact = "com.example:lib",
+        failure = RepositoryDownloadFailure.AllAttemptsFailed(attempts = emptyList()),
+      )
+
+    assertFalse(is404OnAllAttempts(error))
+  }
+
+  @Test
+  fun nonDownloadFailedResolveErrorReturnsFalse() {
+    val error = ResolveError.NoNativeVariant("com.example:lib", "linuxX64")
+
+    assertFalse(is404OnAllAttempts(error))
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/MakeNativeChildLookupTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/MakeNativeChildLookupTest.kt
@@ -1,0 +1,147 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.fail
+
+/**
+ * Unit coverage for `makeNativeChildLookup`'s `NativeResolved` variant dispatch.
+ *
+ * Klib variants forward `artifact.dependencies` (minus konanc-bundled stdlib*) and JvmOnly variants
+ * have no Gradle Module Metadata, so they are terminal: descending past them would re-attempt the
+ * same `.module` fetch that already 404'd. Both variants share the `processed` cache keyed by
+ * `GA:version`, which is transparent to the resolution kernel.
+ */
+class MakeNativeChildLookupTest {
+
+  // A ResolverDeps that asserts no I/O happens. The lookup must hit the
+  // pre-populated `processed` cache without re-fetching, so any call here is
+  // a regression.
+  private val noIoDeps =
+    object : ResolverDeps {
+      override fun fileExists(path: String): Boolean {
+        fail("unexpected fileExists call: $path")
+      }
+
+      override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> {
+        fail("unexpected ensureDirectoryRecursive call: $path")
+      }
+
+      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        fail("unexpected downloadFile call: $url -> $destPath")
+      }
+
+      override fun computeSha256(filePath: String): Result<String, Sha256Error> {
+        fail("unexpected computeSha256 call: $filePath")
+      }
+
+      override fun readFileContent(path: String): Result<String, OpenFailed> {
+        fail("unexpected readFileContent call: $path")
+      }
+    }
+
+  @Test
+  fun jvmOnlyNodeReturnsEmptyChildren() {
+    val coord = Coordinate("com.example", "fake-jvm-only", "1.0.0")
+    val processed =
+      mutableMapOf<String, NativeResolved>(
+        "com.example:fake-jvm-only:1.0.0" to NativeResolved.JvmOnly(coord)
+      )
+
+    val lookup =
+      makeNativeChildLookup(
+        processed = processed,
+        nativeTarget = "linux_x64",
+        cacheBase = "/cache",
+        repos = listOf("https://repo1.example/"),
+        deps = noIoDeps,
+      )
+
+    val children =
+      lookup("com.example:fake-jvm-only", "1.0.0").get()
+        ?: fail("expected Ok with empty children, got Err")
+    assertEquals(emptyList<Child>(), children)
+  }
+
+  @Test
+  fun klibNodeReturnsArtifactDependencies() {
+    val coord = Coordinate("com.example", "lib", "1.0.0")
+    val redirect = NativeRedirect("com.example", "lib-linuxx64", "1.0.0")
+    val artifact =
+      NativeArtifact(
+        klibFileUrl = "lib-linuxx64-1.0.0.klib",
+        klibSha256 = "h",
+        dependencies =
+          listOf(
+            NativeDependency(
+              group = "com.example",
+              module = "trans",
+              version = "2.0.0",
+              strict = true,
+              rejects = listOf("3.0.0"),
+            )
+          ),
+      )
+    val processed =
+      mutableMapOf<String, NativeResolved>(
+        "${coord.group}:${coord.artifact}:${coord.version}" to
+          NativeResolved.Klib(redirect, artifact)
+      )
+
+    val lookup =
+      makeNativeChildLookup(
+        processed = processed,
+        nativeTarget = "linux_x64",
+        cacheBase = "/cache",
+        repos = listOf("https://repo1.example/"),
+        deps = noIoDeps,
+      )
+
+    val children = assertNotNull(lookup("com.example:lib", "1.0.0").get())
+    assertEquals(1, children.size)
+    val child = children.single()
+    assertEquals("com.example:trans", child.groupArtifact)
+    assertEquals("2.0.0", child.version)
+    assertEquals(true, child.strict)
+    assertEquals(listOf("3.0.0"), child.rejects)
+  }
+
+  @Test
+  fun klibNodeStripsKotlinStdlibChildren() {
+    val redirect = NativeRedirect("com.example", "lib-linuxx64", "1.0.0")
+    val artifact =
+      NativeArtifact(
+        klibFileUrl = "lib-linuxx64-1.0.0.klib",
+        klibSha256 = "h",
+        dependencies =
+          listOf(
+            NativeDependency("org.jetbrains.kotlin", "kotlin-stdlib", "2.0.0"),
+            NativeDependency("org.jetbrains.kotlin", "kotlin-stdlib-common", "2.0.0"),
+            NativeDependency("com.example", "keep", "1.2.3"),
+          ),
+      )
+    val processed =
+      mutableMapOf<String, NativeResolved>(
+        "com.example:lib:1.0.0" to NativeResolved.Klib(redirect, artifact)
+      )
+
+    val lookup =
+      makeNativeChildLookup(
+        processed = processed,
+        nativeTarget = "linux_x64",
+        cacheBase = "/cache",
+        repos = listOf("https://repo1.example/"),
+        deps = noIoDeps,
+      )
+
+    val children = assertNotNull(lookup("com.example:lib", "1.0.0").get())
+    assertEquals(listOf("com.example:keep"), children.map { it.groupArtifact })
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverJvmOnlyFallbackTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverJvmOnlyFallbackTest.kt
@@ -185,6 +185,11 @@ class NativeResolverJvmOnlyFallbackTest {
       "expected exactly one stderr note for the transitive kotlin-reflect skip",
     )
 
+    // Verification 4: production code adds no name-based skip for
+    // kotlin-reflect — confirmed by leaving NativeResolver.kt unmodified;
+    // the test reaches its assertions only by exercising the structural
+    // .module 404 → .pom fallback.
+    //
     // Verification 5: fixture is offline. The repo base is the RFC 2606
     // reserved `.example` TLD, so even if `downloadFile` were not mocked, no
     // request could reach Maven Central. Asserting both the positive shape

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverJvmOnlyFallbackTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverJvmOnlyFallbackTest.kt
@@ -1,0 +1,208 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kolt.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+// Flagship regression test for issue #426. The reported repro was
+// `kolt add io.ktor:ktor-server-core` on a linuxX64 project failing on a
+// `kotlin-reflect-*.module` 404. Translated into a deterministic mock fixture:
+// the parent (ktor-server-core analogue) publishes a native variant whose
+// platform `.module` declares `org.jetbrains.kotlin:kotlin-reflect` as a
+// transitive dependency; `kotlin-reflect`'s `.module` returns HTTP 404 across
+// all repos while its `.pom` returns 200. The structural `.module` 404 →
+// `.pom` fallback must let resolution complete with `kotlin-reflect` skipped
+// and a single stderr note emitted — without `kotlin-reflect` being added to
+// any name-based skip list in the production code.
+class NativeResolverJvmOnlyFallbackTest {
+
+  @Test
+  fun ktorTransitiveKotlinReflectModule404FallsBackViaPom() {
+    // Override the default `central` repo so URL synthesis cannot accidentally
+    // point at live Maven Central even if the mock leaked. The `.example` TLD
+    // is reserved (RFC 2606) so no name resolution can reach a real host.
+    val config =
+      testConfig(target = "linuxX64")
+        .copy(
+          dependencies = mapOf("io.ktor:ktor-server-core" to "3.4.3"),
+          repositories = mapOf("central" to "https://repo1.example/"),
+        )
+
+    val parentRoot =
+      """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../ktor-server-core-linuxx64/3.4.3/ktor-server-core-linuxx64-3.4.3.module",
+                "group": "io.ktor",
+                "module": "ktor-server-core-linuxx64",
+                "version": "3.4.3"
+              }
+            }
+          ]
+        }
+        """
+        .trimIndent()
+
+    val parentPlatform =
+      """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "dependencies": [
+                {
+                  "group": "org.jetbrains.kotlin",
+                  "module": "kotlin-reflect",
+                  "version": { "requires": "2.3.0" }
+                }
+              ],
+              "files": [
+                {
+                  "name": "inner.klib",
+                  "url": "ktor-server-core-linuxx64-3.4.3.klib",
+                  "sha256": "h-ktor"
+                }
+              ]
+            }
+          ]
+        }
+        """
+        .trimIndent()
+
+    // Content is intentionally minimal — the fallback path only confirms
+    // existence of the `.pom`, it does not parse the body.
+    val kotlinReflectPom =
+      "<project><groupId>org.jetbrains.kotlin</groupId><artifactId>kotlin-reflect</artifactId><version>2.3.0</version></project>"
+
+    val parentRootPath = "/cache/io/ktor/ktor-server-core/3.4.3/ktor-server-core-3.4.3.module"
+    val parentPlatformPath =
+      "/cache/io/ktor/ktor-server-core-linuxx64/3.4.3/ktor-server-core-linuxx64-3.4.3.module"
+    val parentKlibPath =
+      "/cache/io/ktor/ktor-server-core-linuxx64/3.4.3/ktor-server-core-linuxx64-3.4.3.klib"
+    val kotlinReflectModulePath =
+      "/cache/org/jetbrains/kotlin/kotlin-reflect/2.3.0/kotlin-reflect-2.3.0.module"
+    val kotlinReflectPomPath =
+      "/cache/org/jetbrains/kotlin/kotlin-reflect/2.3.0/kotlin-reflect-2.3.0.pom"
+
+    val moduleContents =
+      mutableMapOf(parentRootPath to parentRoot, parentPlatformPath to parentPlatform)
+    val pomContents = mutableMapOf(kotlinReflectPomPath to kotlinReflectPom)
+    val klibSha = mapOf(parentKlibPath to "h-ktor")
+    val cachedFiles = mutableSetOf<String>()
+    cachedFiles.addAll(moduleContents.keys)
+
+    val recordedDownloads = mutableListOf<String>()
+
+    val deps =
+      object : ResolverDeps {
+        override fun fileExists(path: String): Boolean = path in cachedFiles
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          recordedDownloads.add(url)
+          if (destPath == kotlinReflectModulePath) {
+            return Err(DownloadError.HttpFailed(url, 404))
+          }
+          if (destPath == kotlinReflectPomPath) {
+            cachedFiles.add(destPath)
+            return Ok(Unit)
+          }
+          cachedFiles.add(destPath)
+          return Ok(Unit)
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> {
+          val hash = klibSha[filePath] ?: return Err(Sha256Error(filePath))
+          return Ok(hash)
+        }
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> {
+          moduleContents[path]?.let {
+            return Ok(it)
+          }
+          pomContents[path]?.let {
+            return Ok(it)
+          }
+          return Err(OpenFailed(path))
+        }
+      }
+
+    val capturedNotes = mutableListOf<String>()
+    val result = resolveNative(config, "/cache", deps, noteSink = { capturedNotes += it })
+
+    // Verification 1: resolve completes successfully (does not abort).
+    val resolved = assertNotNull(result.get(), "expected Ok from resolveNative; got: $result")
+
+    // Verification 2: the JvmOnly transitive (kotlin-reflect) is not in resolvedDeps.
+    assertFalse(
+      resolved.deps.any { it.groupArtifact == "org.jetbrains.kotlin:kotlin-reflect" },
+      "kotlin-reflect must not appear in resolvedDeps, got: ${resolved.deps.map { it.groupArtifact }}",
+    )
+
+    // Klib direct dep must still be resolved. `ResolvedDep.groupArtifact`
+    // preserves the user-facing root coordinate (the `available-at` redirect
+    // is an internal detail of the native module layout).
+    assertTrue(
+      resolved.deps.any { it.groupArtifact == "io.ktor:ktor-server-core" },
+      "parent klib must be resolved, got: ${resolved.deps.map { it.groupArtifact }}",
+    )
+
+    // Verification 3: exactly one stderr note for the kotlin-reflect skip.
+    val expectedNote =
+      "note: org.jetbrains.kotlin:kotlin-reflect:2.3.0 has no Gradle Module Metadata; skipping for native target"
+    assertEquals(
+      listOf(expectedNote),
+      capturedNotes,
+      "expected exactly one stderr note for the transitive kotlin-reflect skip",
+    )
+
+    // Verification 5: fixture is offline. The repo base is the RFC 2606
+    // reserved `.example` TLD, so even if `downloadFile` were not mocked, no
+    // request could reach Maven Central. Asserting both the positive shape
+    // (all URLs use the test base) and the negative shape (no `maven.org`
+    // hostname leaked) pins the property against future `testConfig` drift.
+    assertTrue(
+      recordedDownloads.all { it.startsWith("https://repo1.example/") },
+      "expected all download URLs to use the test repo base, recorded: $recordedDownloads",
+    )
+    assertTrue(
+      recordedDownloads.none { it.contains("maven.org") },
+      "expected no live Maven Central downloads, recorded: $recordedDownloads",
+    )
+    // The fallback must have probed kotlin-reflect's `.pom` — proves the
+    // structural detection path executed rather than a hardcoded skip.
+    assertTrue(
+      recordedDownloads.any { it.endsWith("kotlin-reflect-2.3.0.pom") },
+      "expected a kotlin-reflect.pom download attempt (fallback probe), recorded: $recordedDownloads",
+    )
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTargetModule404GoldenTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTargetModule404GoldenTest.kt
@@ -1,0 +1,125 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+// Boundary check for the Layer 1 `.pom` fallback: the fallback fires only on
+// the root `.module` 404. When the root `.module` is 200 OK and parses into an
+// `available-at` redirect, then the target `.module` (after redirect) 404s,
+// design.md > Boundary Commitments > Out of Boundary keeps that branch on the
+// existing `DownloadFailed` path. Layer 2 may revisit target-side handling; this
+// test pins the current shape so any future change there is a visible diff,
+// not a silent regression.
+class NativeResolverTargetModule404GoldenTest {
+
+  @Test
+  fun targetModule404AfterRedirectStaysOnDownloadFailedAndNoPomFallback() {
+    val rootModuleJson =
+      """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "artifactType": "org.jetbrains.kotlin.klib",
+                "org.gradle.category": "library",
+                "org.gradle.jvm.environment": "non-jvm",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../parent-linuxx64/1.0.0/parent-linuxx64-1.0.0.module",
+                "group": "com.example",
+                "module": "parent-linuxx64",
+                "version": "1.0.0"
+              }
+            }
+          ]
+        }
+        """
+        .trimIndent()
+
+    val rootModuleCachePath = "/cache/com/example/parent/1.0.0/parent-1.0.0.module"
+    val cachedFiles = mutableSetOf<String>()
+    val recordedDownloadUrls = mutableListOf<String>()
+    val deps =
+      object : ResolverDeps {
+        val fileContents = mutableMapOf(rootModuleCachePath to rootModuleJson)
+
+        override fun fileExists(path: String): Boolean = path in cachedFiles
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          recordedDownloadUrls.add(url)
+          // Root `.module` succeeds on the first repo so the redirect is parseable.
+          // Target `.module` (parent-linuxx64) 404s on every repo. `.pom` URLs
+          // must never be reached for the target coordinate: the Layer 1
+          // fallback is root-only, and the root `.module` never failed.
+          if (destPath == rootModuleCachePath) {
+            cachedFiles.add(destPath)
+            return Ok(Unit)
+          }
+          return Err(DownloadError.HttpFailed(url, 404))
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> =
+          Err(Sha256Error(filePath))
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> {
+          val content = fileContents[path] ?: return Err(OpenFailed(path))
+          return Ok(content)
+        }
+      }
+
+    val result =
+      fetchNativeMetadata(
+        groupArtifact = "com.example:parent",
+        version = "1.0.0",
+        nativeTarget = "linux_x64",
+        cacheBase = "/cache",
+        repos = listOf("https://repo1.example/", "https://repo2.example/"),
+        deps = deps,
+      )
+
+    val error = assertIs<ResolveError.DownloadFailed>(result.getError())
+    // `groupArtifact` is the target coordinate (after redirect), not the root,
+    // because the failure happened on the second fetch. This pins which
+    // coordinate users see in the per-repo attempts dump for this scenario.
+    assertEquals("com.example:parent-linuxx64", error.groupArtifact)
+    val failure = assertIs<RepositoryDownloadFailure.AllAttemptsFailed>(error.failure)
+    assertTrue(
+      failure.attempts.isNotEmpty(),
+      "expected at least one attempt against the target `.module`",
+    )
+    assertTrue(
+      failure.attempts.all { it.url.contains("parent-linuxx64-1.0.0.module") },
+      "expected only target `.module` URLs in attempts, got: ${failure.attempts.map { it.url }}",
+    )
+
+    // Layer 1 boundary: target `.module` 404 does NOT trigger `.pom` fallback.
+    // The recorder proves no `.pom` URL was ever attempted for either the root
+    // or the target coordinate. When Layer 2 lands and changes this behaviour,
+    // this assertion is the canary.
+    assertTrue(
+      recordedDownloadUrls.none { it.endsWith(".pom") },
+      "expected no `.pom` download attempts, recorded: $recordedDownloadUrls",
+    )
+    assertTrue(
+      recordedDownloadUrls.any { it.endsWith("parent-linuxx64-1.0.0.module") },
+      "expected at least one attempt for the target `.module`, recorded: $recordedDownloadUrls",
+    )
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -229,6 +229,95 @@ class NativeResolverTest {
   }
 
   @Test
+  fun transitiveKotlinStdlibCommonIsSilentSkipNoStderrNote() {
+    // Requirement 4.2: silent skip for kotlin-stdlib-common on the transitive
+    // path must not produce the JvmOnly stderr note even though the structural
+    // fallback would otherwise emit one. Defends the user-visible contract
+    // against future regressions in either the childLookup filter or the
+    // materialization-time isKotlinStdlib short-circuit.
+    val config =
+      testConfig(target = "linuxX64").copy(dependencies = mapOf("com.example:lib" to "1.0.0"))
+
+    val libRoot = rootModuleJson("com.example", "lib-linuxx64", "1.0.0")
+    val libPlatform =
+      platformModuleJson(
+        klibFileName = "lib-linuxx64-1.0.0.klib",
+        klibSha256 = "h",
+        dependencies =
+          listOf(NativeDependency("org.jetbrains.kotlin", "kotlin-stdlib-common", "1.8.21")),
+      )
+
+    val deps =
+      fakeDeps(
+        contents =
+          mapOf(
+            "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to libRoot,
+            "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to libPlatform,
+          ),
+        sha256 = mapOf("/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "h"),
+      )
+
+    val capturedNotes = mutableListOf<String>()
+    val result = resolveNative(config, "/cache", deps, noteSink = { capturedNotes += it })
+
+    val resolved = assertNotNull(result.get())
+    assertEquals(1, resolved.deps.size)
+    assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
+    assertFalse(
+      resolved.deps.any { it.groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib-common" },
+      "kotlin-stdlib-common must not appear in resolvedDeps",
+    )
+    assertEquals(
+      emptyList(),
+      capturedNotes,
+      "kotlin-stdlib-common transitive skip must remain silent (no stderr note)",
+    )
+  }
+
+  @Test
+  fun transitiveKotlinStdlibIsSilentSkipNoStderrNote() {
+    // Requirement 4.2: silent skip for kotlin-stdlib on the transitive path
+    // must not produce the JvmOnly stderr note. Mirrors the kotlin-stdlib-common
+    // case so the predicate's coverage is exercised end-to-end.
+    val config =
+      testConfig(target = "linuxX64").copy(dependencies = mapOf("com.example:lib" to "1.0.0"))
+
+    val libRoot = rootModuleJson("com.example", "lib-linuxx64", "1.0.0")
+    val libPlatform =
+      platformModuleJson(
+        klibFileName = "lib-linuxx64-1.0.0.klib",
+        klibSha256 = "h",
+        dependencies = listOf(NativeDependency("org.jetbrains.kotlin", "kotlin-stdlib", "2.0.0")),
+      )
+
+    val deps =
+      fakeDeps(
+        contents =
+          mapOf(
+            "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to libRoot,
+            "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to libPlatform,
+          ),
+        sha256 = mapOf("/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "h"),
+      )
+
+    val capturedNotes = mutableListOf<String>()
+    val result = resolveNative(config, "/cache", deps, noteSink = { capturedNotes += it })
+
+    val resolved = assertNotNull(result.get())
+    assertEquals(1, resolved.deps.size)
+    assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
+    assertFalse(
+      resolved.deps.any { it.groupArtifact == "org.jetbrains.kotlin:kotlin-stdlib" },
+      "kotlin-stdlib must not appear in resolvedDeps",
+    )
+    assertEquals(
+      emptyList(),
+      capturedNotes,
+      "kotlin-stdlib transitive skip must remain silent (no stderr note)",
+    )
+  }
+
+  @Test
   fun returnsEmptyWhenNoDependencies() {
     val config = testConfig(target = "linuxX64").copy(dependencies = emptyMap())
     val deps = fakeDeps()

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -171,6 +171,10 @@ class NativeResolverTest {
 
   @Test
   fun skipsKotlinStdlibCommonAsDirectDependencyToo() {
+    // Direct kotlin-stdlib-common is dropped by the name-based
+    // `directDeps = filterKeys { !isKotlinStdlib(it) }` short-circuit
+    // and must not emit the JvmOnly stderr note (the structural fallback path
+    // never even runs for these entries).
     val config =
       testConfig(target = "linuxX64")
         .copy(
@@ -194,14 +198,23 @@ class NativeResolverTest {
         sha256 = mapOf("/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "h"),
       )
 
-    val result = resolveNative(config, "/cache", deps)
+    val capturedNotes = mutableListOf<String>()
+    val result = resolveNative(config, "/cache", deps, noteSink = { capturedNotes += it })
     val resolved = assertNotNull(result.get())
     assertEquals(1, resolved.deps.size)
     assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
+    assertEquals(
+      emptyList(),
+      capturedNotes,
+      "kotlin-stdlib-common direct skip must remain silent (no stderr note)",
+    )
   }
 
   @Test
   fun skipsKotlinStdlibAsDirectDependencyToo() {
+    // Direct kotlin-stdlib is dropped by the name-based
+    // `directDeps = filterKeys { !isKotlinStdlib(it) }` short-circuit
+    // and must not emit the JvmOnly stderr note.
     val config =
       testConfig(target = "linuxX64")
         .copy(
@@ -222,16 +235,22 @@ class NativeResolverTest {
         sha256 = mapOf("/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "h"),
       )
 
-    val result = resolveNative(config, "/cache", deps)
+    val capturedNotes = mutableListOf<String>()
+    val result = resolveNative(config, "/cache", deps, noteSink = { capturedNotes += it })
     val resolved = assertNotNull(result.get())
     assertEquals(1, resolved.deps.size)
     assertEquals("com.example:lib", resolved.deps[0].groupArtifact)
+    assertEquals(
+      emptyList(),
+      capturedNotes,
+      "kotlin-stdlib direct skip must remain silent (no stderr note)",
+    )
   }
 
   @Test
   fun transitiveKotlinStdlibCommonIsSilentSkipNoStderrNote() {
-    // Requirement 4.2: silent skip for kotlin-stdlib-common on the transitive
-    // path must not produce the JvmOnly stderr note even though the structural
+    // Silent skip for kotlin-stdlib-common on the transitive path
+    // must not produce the JvmOnly stderr note even though the structural
     // fallback would otherwise emit one. Defends the user-visible contract
     // against future regressions in either the childLookup filter or the
     // materialization-time isKotlinStdlib short-circuit.
@@ -276,7 +295,7 @@ class NativeResolverTest {
 
   @Test
   fun transitiveKotlinStdlibIsSilentSkipNoStderrNote() {
-    // Requirement 4.2: silent skip for kotlin-stdlib on the transitive path
+    // Silent skip for kotlin-stdlib on the transitive path
     // must not produce the JvmOnly stderr note. Mirrors the kotlin-stdlib-common
     // case so the predicate's coverage is exercised end-to-end.
     val config =

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -251,9 +251,10 @@ class NativeResolverTest {
   fun transitiveKotlinStdlibCommonIsSilentSkipNoStderrNote() {
     // Silent skip for kotlin-stdlib-common on the transitive path
     // must not produce the JvmOnly stderr note even though the structural
-    // fallback would otherwise emit one. Defends the user-visible contract
-    // against future regressions in either the childLookup filter or the
-    // materialization-time isKotlinStdlib short-circuit.
+    // fallback would otherwise emit one. childLookup's isKotlinStdlib
+    // filter strips the child before fetchNativeMetadata; the
+    // materialization-time short-circuit is defensive backup that this
+    // fixture does not exercise directly.
     val config =
       testConfig(target = "linuxX64").copy(dependencies = mapOf("com.example:lib" to "1.0.0"))
 

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveNativeDirectJvmOnlyErrorTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveNativeDirectJvmOnlyErrorTest.kt
@@ -1,0 +1,81 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kolt.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ResolveNativeDirectJvmOnlyErrorTest {
+
+  @Test
+  fun directJvmOnlyReturnsNoNativeVariantAndSuppressesNote() {
+    val config =
+      testConfig(target = "linuxX64")
+        .copy(dependencies = mapOf("com.example:fake-jvm-only" to "1.0.0"))
+
+    val pomXml =
+      "<project><groupId>com.example</groupId><artifactId>fake-jvm-only</artifactId><version>1.0.0</version></project>"
+
+    val pomContents =
+      mutableMapOf("/cache/com/example/fake-jvm-only/1.0.0/fake-jvm-only-1.0.0.pom" to pomXml)
+    val cachedFiles = mutableSetOf<String>()
+
+    val jvmOnlyModulePath = "/cache/com/example/fake-jvm-only/1.0.0/fake-jvm-only-1.0.0.module"
+    val jvmOnlyPomPath = "/cache/com/example/fake-jvm-only/1.0.0/fake-jvm-only-1.0.0.pom"
+
+    val deps =
+      object : ResolverDeps {
+        override fun fileExists(path: String): Boolean = path in cachedFiles
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          if (destPath == jvmOnlyModulePath) {
+            return Err(DownloadError.HttpFailed(url, 404))
+          }
+          if (destPath == jvmOnlyPomPath) {
+            cachedFiles.add(destPath)
+            return Ok(Unit)
+          }
+          cachedFiles.add(destPath)
+          return Ok(Unit)
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> =
+          Err(Sha256Error(filePath))
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> {
+          pomContents[path]?.let {
+            return Ok(it)
+          }
+          return Err(OpenFailed(path))
+        }
+      }
+
+    val capturedNotes = mutableListOf<String>()
+    val result = resolveNative(config, "/cache", deps, noteSink = { capturedNotes += it })
+
+    val error = assertNotNull(result.getError(), "expected Err(NoNativeVariant) for direct JvmOnly")
+    assertTrue(
+      error is ResolveError.NoNativeVariant,
+      "expected NoNativeVariant, got ${error::class.simpleName}: $error",
+    )
+    assertEquals("com.example:fake-jvm-only", error.groupArtifact)
+    assertEquals("linux_x64", error.nativeTarget)
+
+    assertEquals(
+      emptyList(),
+      capturedNotes,
+      "direct JvmOnly must not emit a transitive-skip note; captured: $capturedNotes",
+    )
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveNativeJvmOnlyProgressTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveNativeJvmOnlyProgressTest.kt
@@ -1,0 +1,205 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kolt.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ResolveNativeJvmOnlyProgressTest {
+
+  @Test
+  fun jvmOnlyTransitiveIsExcludedFromTotalAndArtifactStartCount() {
+    val config =
+      testConfig(target = "linuxX64").copy(dependencies = mapOf("com.example:lib" to "1.0.0"))
+
+    // Direct Klib (lib) declares two transitives in its platform module:
+    //   - com.example:other:2.0.0  -> Klib (normal .module resolution)
+    //   - org.example:fake-jvm:1.0.0 -> JvmOnly (.module 404, .pom 200 fallback)
+    // M/N progress must read [1/2] [2/2], not [1/3] [2/3] / [3/3].
+    val libRoot = rootModuleJson("com.example", "lib-linuxx64", "1.0.0")
+    val libPlatform =
+      """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "dependencies": [
+                {
+                  "group": "com.example",
+                  "module": "other",
+                  "version": { "requires": "2.0.0" }
+                },
+                {
+                  "group": "org.example",
+                  "module": "fake-jvm",
+                  "version": { "requires": "1.0.0" }
+                }
+              ],
+              "files": [
+                {
+                  "name": "inner.klib",
+                  "url": "lib-linuxx64-1.0.0.klib",
+                  "sha256": "h-lib"
+                }
+              ]
+            }
+          ]
+        }
+        """
+        .trimIndent()
+    val otherRoot = rootModuleJson("com.example", "other-linuxx64", "2.0.0")
+    val otherPlatform =
+      """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "dependencies": [],
+              "files": [
+                {
+                  "name": "inner.klib",
+                  "url": "other-linuxx64-2.0.0.klib",
+                  "sha256": "h-other"
+                }
+              ]
+            }
+          ]
+        }
+        """
+        .trimIndent()
+    val fakeJvmPom =
+      "<project><groupId>org.example</groupId><artifactId>fake-jvm</artifactId><version>1.0.0</version></project>"
+
+    val moduleContents =
+      mapOf(
+        "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to libRoot,
+        "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to libPlatform,
+        "/cache/com/example/other/2.0.0/other-2.0.0.module" to otherRoot,
+        "/cache/com/example/other-linuxx64/2.0.0/other-linuxx64-2.0.0.module" to otherPlatform,
+      )
+    val pomContents = mapOf("/cache/org/example/fake-jvm/1.0.0/fake-jvm-1.0.0.pom" to fakeJvmPom)
+    val klibSha =
+      mapOf(
+        "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "h-lib",
+        "/cache/com/example/other-linuxx64/2.0.0/other-linuxx64-2.0.0.klib" to "h-other",
+      )
+    val cachedFiles = mutableSetOf<String>()
+    cachedFiles.addAll(moduleContents.keys)
+
+    val jvmOnlyModulePath = "/cache/org/example/fake-jvm/1.0.0/fake-jvm-1.0.0.module"
+    val jvmOnlyPomPath = "/cache/org/example/fake-jvm/1.0.0/fake-jvm-1.0.0.pom"
+
+    val deps =
+      object : ResolverDeps {
+        override fun fileExists(path: String): Boolean = path in cachedFiles
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          if (destPath == jvmOnlyModulePath) {
+            return Err(DownloadError.HttpFailed(url, 404))
+          }
+          if (destPath == jvmOnlyPomPath) {
+            cachedFiles.add(destPath)
+            return Ok(Unit)
+          }
+          cachedFiles.add(destPath)
+          return Ok(Unit)
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> {
+          val hash = klibSha[filePath] ?: return Err(Sha256Error(filePath))
+          return Ok(hash)
+        }
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> {
+          moduleContents[path]?.let {
+            return Ok(it)
+          }
+          pomContents[path]?.let {
+            return Ok(it)
+          }
+          return Err(OpenFailed(path))
+        }
+      }
+
+    val sink = RecordingResolverProgressSink()
+    val result = resolveNative(config, "/cache", deps, progress = sink, noteSink = {})
+    assertNotNull(result.get())
+
+    val artifactStarts = sink.events.filterIsInstance<RecordedProgressEvent.ArtifactStart>()
+    assertEquals(
+      2,
+      artifactStarts.size,
+      "expected onArtifactStart for the 2 Klib nodes only, got ${artifactStarts.map { it.groupArtifact }}",
+    )
+    assertEquals(
+      setOf("com.example:lib", "com.example:other"),
+      artifactStarts.map { it.groupArtifact }.toSet(),
+      "JvmOnly transitive must not appear in onArtifactStart notifications",
+    )
+    artifactStarts.forEach {
+      assertEquals(
+        2,
+        it.total,
+        "total must exclude the JvmOnly transitive so M/N reads as [_/2], got [${it.index}/${it.total}] for ${it.groupArtifact}",
+      )
+    }
+    assertEquals(
+      listOf(1, 2),
+      artifactStarts.map { it.index }.sorted(),
+      "indices must be the contiguous 1..2 range, got ${artifactStarts.map { it.index }}",
+    )
+  }
+
+  private fun rootModuleJson(
+    redirectGroup: String,
+    redirectModule: String,
+    redirectVersion: String,
+  ): String =
+    """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../$redirectModule/$redirectVersion/$redirectModule-$redirectVersion.module",
+                "group": "$redirectGroup",
+                "module": "$redirectModule",
+                "version": "$redirectVersion"
+              }
+            }
+          ]
+        }
+    """
+      .trimIndent()
+}

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveNativeTransitiveJvmOnlyNoteTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveNativeTransitiveJvmOnlyNoteTest.kt
@@ -1,0 +1,157 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import kolt.infra.DownloadError
+import kolt.infra.MkdirFailed
+import kolt.infra.OpenFailed
+import kolt.infra.Sha256Error
+import kolt.testConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ResolveNativeTransitiveJvmOnlyNoteTest {
+
+  @Test
+  fun transitiveJvmOnlyNonStdlibEmitsNoteAndSkipsFromResolvedDeps() {
+    val config =
+      testConfig(target = "linuxX64").copy(dependencies = mapOf("com.example:lib" to "1.0.0"))
+
+    val libRoot =
+      """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "available-at": {
+                "url": "../../lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module",
+                "group": "com.example",
+                "module": "lib-linuxx64",
+                "version": "1.0.0"
+              }
+            }
+          ]
+        }
+        """
+        .trimIndent()
+
+    val libPlatform =
+      """
+        {
+          "formatVersion": "1.1",
+          "variants": [
+            {
+              "name": "linuxX64ApiElements-published",
+              "attributes": {
+                "org.gradle.category": "library",
+                "org.gradle.usage": "kotlin-api",
+                "org.jetbrains.kotlin.native.target": "linux_x64",
+                "org.jetbrains.kotlin.platform.type": "native"
+              },
+              "dependencies": [
+                {
+                  "group": "org.example",
+                  "module": "fake-jvm-only",
+                  "version": { "requires": "1.0.0" }
+                }
+              ],
+              "files": [
+                {
+                  "name": "inner.klib",
+                  "url": "lib-linuxx64-1.0.0.klib",
+                  "sha256": "h-lib"
+                }
+              ]
+            }
+          ]
+        }
+        """
+        .trimIndent()
+
+    val pomXml =
+      "<project><groupId>org.example</groupId><artifactId>fake-jvm-only</artifactId><version>1.0.0</version></project>"
+
+    val moduleContents =
+      mutableMapOf(
+        "/cache/com/example/lib/1.0.0/lib-1.0.0.module" to libRoot,
+        "/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.module" to libPlatform,
+      )
+    val pomContents =
+      mutableMapOf("/cache/org/example/fake-jvm-only/1.0.0/fake-jvm-only-1.0.0.pom" to pomXml)
+    val klibSha = mapOf("/cache/com/example/lib-linuxx64/1.0.0/lib-linuxx64-1.0.0.klib" to "h-lib")
+    val cachedFiles = mutableSetOf<String>()
+    cachedFiles.addAll(moduleContents.keys)
+
+    val jvmOnlyModulePath = "/cache/org/example/fake-jvm-only/1.0.0/fake-jvm-only-1.0.0.module"
+    val jvmOnlyPomPath = "/cache/org/example/fake-jvm-only/1.0.0/fake-jvm-only-1.0.0.pom"
+
+    val deps =
+      object : ResolverDeps {
+        override fun fileExists(path: String): Boolean = path in cachedFiles
+
+        override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
+
+        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+          if (destPath == jvmOnlyModulePath) {
+            return Err(DownloadError.HttpFailed(url, 404))
+          }
+          if (destPath == jvmOnlyPomPath) {
+            cachedFiles.add(destPath)
+            return Ok(Unit)
+          }
+          cachedFiles.add(destPath)
+          return Ok(Unit)
+        }
+
+        override fun computeSha256(filePath: String): Result<String, Sha256Error> {
+          val hash = klibSha[filePath] ?: return Err(Sha256Error(filePath))
+          return Ok(hash)
+        }
+
+        override fun readFileContent(path: String): Result<String, OpenFailed> {
+          moduleContents[path]?.let {
+            return Ok(it)
+          }
+          pomContents[path]?.let {
+            return Ok(it)
+          }
+          return Err(OpenFailed(path))
+        }
+      }
+
+    val capturedNotes = mutableListOf<String>()
+    val result = resolveNative(config, "/cache", deps, noteSink = { capturedNotes += it })
+
+    val resolved = assertNotNull(result.get())
+
+    assertFalse(
+      resolved.deps.any { it.groupArtifact == "org.example:fake-jvm-only" },
+      "JvmOnly transitive must not appear in resolvedDeps, got: ${resolved.deps.map { it.groupArtifact }}",
+    )
+
+    assertTrue(
+      resolved.deps.any { it.groupArtifact == "com.example:lib" },
+      "Klib direct dep must still be resolved, got: ${resolved.deps.map { it.groupArtifact }}",
+    )
+
+    val expectedNote =
+      "note: org.example:fake-jvm-only:1.0.0 has no Gradle Module Metadata; skipping for native target"
+    assertEquals(
+      listOf(expectedNote),
+      capturedNotes,
+      "expected exactly one stderr note for the transitive JvmOnly skip",
+    )
+  }
+}


### PR DESCRIPTION
Closes #426 (Layer 1 only).

`kolt add io.ktor:ktor-server-core` on a `target = "linuxX64"` project used to abort on `kotlin-reflect-<v>.module` 404 because JetBrains does not publish Gradle Module Metadata for JVM-only Kotlin artifacts. The native resolver now detects that case structurally (`.module` all-repos 404 + `.pom` 200) and treats the artifact as having no native variant — silent skip for `kotlin-stdlib` / `kotlin-stdlib-common`, single stderr note for any other JVM-only transitive, `NoNativeVariant` error if the artifact was declared directly.

This is Layer 1 of the layered fix discussed in #426. Layer 2 (auditing why a JVM-only artifact reaches a native transitive in the first place, i.e. fixing variant interpretation for mixed-platform libraries) is out of scope and will be filed separately.

### Where to look

- `src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt` — the whole production diff lives here. `NativeResolved` is now `internal sealed class { Klib, JvmOnly }`; `fetchNativeMetadata` adds the `.pom` fallback gated by `is404OnAllAttempts`; the materialization loop's `JvmOnly` arm routes direct → `NoNativeVariant`, transitive non-stdlib → stderr note + skip, transitive stdlib → silent skip.
- `.kiro/specs/426-native-resolver-pom-fallback/` — full spec (requirements, design, research, tasks). Worth skimming `design.md`'s Boundary Commitments section if you want to know exactly what was intentionally left to Layer 2.

### Judgment calls to double-check

- **Visibility promotion to `internal`**: four symbols (`NativeResolved`, `is404OnAllAttempts`, `fetchNativeMetadata`, `makeNativeChildLookup`) went from `private` to `internal` so the new unit tests can drive each piece directly. The promotion is documented in `design.md` and `research.md`; no other production file in `src/nativeMain/` consumes them.
- **`isKotlinStdlib` is preserved, not generalised away**: `kotlin-stdlib` itself publishes `.module` but causes a double-link with konanc's bundled stdlib (ADR 0011 §1), so the name-based skip stays. `kotlin-stdlib-common` is now structurally covered by the same path as `kotlin-reflect`, but the name predicate still keeps its silent-skip behaviour per ADR 0011 §4. ADR 0011 itself was not edited in this PR.
- **`.pom` body is not parsed** — only its existence is confirmed. If a future change wants to walk POM deps, the synthetic XML fixtures in the new tests will need real content.
- **Out-of-boundary verification is golden-tested**: `NativeResolverTargetModule404GoldenTest` pins the contract that target `.module` 404 (after redirect) keeps the existing `DownloadFailed` behaviour. If Layer 2 changes that, this test fails — that's the canary.

### Regression coverage

`NativeResolverJvmOnlyFallbackTest.ktorTransitiveKotlinReflectModule404FallsBackViaPom` reproduces the exact reported scenario: `io.ktor:ktor-server-core:3.4.3` parent klib declaring `kotlin-reflect:2.3.0` as a native-variant transitive dep, with `kotlin-reflect.module` 404 and `kotlin-reflect.pom` 200. The test exercises the structural fallback end-to-end through `resolveNative` and asserts the user-visible promise: resolve completes, kotlin-reflect is absent from resolvedDeps, exactly one stderr note. No name-based skip-list entry for kotlin-reflect is added in production (Req 3.3 / 6.2).

Root + both daemon subprojects: 1951 / 166 / 48 tests pass. JVM resolver path (`TransitiveResolver.kt`, `Resolver.kt`) untouched.