### PR TITLE
chore: bump bootstrap tag to v0.19.2

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 env:
-  KOLT_BOOTSTRAP_TAG: v0.19.1
+  KOLT_BOOTSTRAP_TAG: v0.19.2
   # Run the bootstrap kolt from inside the extracted release tree so
   # `DaemonJarResolver` can find `libexec/<daemon>/*.jar` siblings and
   # spawn the warm daemon. Copying the binary out (as the original

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 env:
-  KOLT_BOOTSTRAP_TAG: v0.19.1
+  KOLT_BOOTSTRAP_TAG: v0.19.2
   # Run the bootstrap kolt from inside the extracted release tree so
   # `DaemonJarResolver` can find `libexec/<daemon>/*.jar` siblings and
   # spawn the warm daemon. Copying the binary out (as the original


### PR DESCRIPTION
Trail HEAD (v0.19.3) by one published release per the bootstrap policy. Both `unit-tests.yml` and `self-host-smoke.yml` were still pinned at v0.19.1 — the v0.19.2 release didn't get its bootstrap bump landed, so this catches both up in one PR.

Trailing by exactly one (not staying at HEAD-2) keeps the self-host smoke close to what most users run, while preserving the circular-bootstrap guard that the policy is there for.