### PR TITLE
feat(local-toml-overlay): gitignore kolt.local.toml in kolt init / kolt new

### DIFF
--- a/.kiro/specs/local-toml-overlay/tasks.md
+++ b/.kiro/specs/local-toml-overlay/tasks.md
@@ -205,7 +205,7 @@ Each implementation sub-task pairs the failing test (RED) and its passing implem
 
 - [ ] 7. `kolt init` writes `kolt.local.toml` to `.gitignore`
 
-- [ ] 7.1 Append `kolt.local.toml` to the gitignore template
+- [x] 7.1 Append `kolt.local.toml` to the gitignore template
   - Update the kolt-init gitignore template to include `kolt.local.toml` in a deterministic position (alphabetical or alongside `workspace.json`); the template remains a hardcoded literal — no preset-merge step is introduced.
   - Add or extend `InitGitignoreTest.kt` to assert that `kolt init` (and `kolt new`) produces a `.gitignore` containing `kolt.local.toml` exactly once, regardless of project `kind` (`bin` / `lib`) and `target`.
   - **Observable done**: a fresh `kolt init` produces a `.gitignore` whose contents include `kolt.local.toml` on its own line.

--- a/src/nativeMain/kotlin/kolt/config/Init.kt
+++ b/src/nativeMain/kotlin/kolt/config/Init.kt
@@ -98,6 +98,7 @@ fun generateGitignore(): String =
   """
   build/
   workspace.json
+  kolt.local.toml
   .idea/
   *.iml
   .DS_Store

--- a/src/nativeTest/kotlin/kolt/config/InitGitignoreTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/InitGitignoreTest.kt
@@ -1,0 +1,31 @@
+package kolt.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class InitGitignoreTest {
+
+  @Test
+  fun generateGitignoreIncludesKoltLocalTomlExactlyOnce() {
+    val output = generateGitignore()
+    val occurrences = output.lineSequence().count { it == "kolt.local.toml" }
+    assertEquals(
+      1,
+      occurrences,
+      "expected `kolt.local.toml` on its own line exactly once; actual:\n$output",
+    )
+  }
+
+  @Test
+  fun generateGitignoreEntriesAreEachOnTheirOwnLine() {
+    // `kolt.local.toml` must appear as a standalone line, not as a fragment of
+    // a broader path glob, so .gitignore matches the file at the project root
+    // unambiguously.
+    val lines = generateGitignore().lineSequence().toList()
+    assertTrue(
+      "kolt.local.toml" in lines,
+      "expected a `kolt.local.toml` line; actual lines: $lines",
+    )
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/InitTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/InitTest.kt
@@ -82,6 +82,7 @@ class InitTest {
       """
       build/
       workspace.json
+      kolt.local.toml
       .idea/
       *.iml
       .DS_Store


### PR DESCRIPTION
Closes #417.

`generateGitignore()` now emits `kolt.local.toml` alongside `workspace.json`, so a fresh `kolt init` / `kolt new` excludes the overlay file from version control by default. This raises the cost ceiling on the #416 credential storage path — a user who follows the recommended `kolt.local.toml [repositories.<name>] token = "..."` pattern in a new project no longer has to remember the `.gitignore` step.

### Scope

Per the parent spec, this is intentionally a template-only change. Existing projects' `.gitignore` files are not touched; the `.gitignore` merge mechanism belongs to the preset-flow spec when it lands. The current scaffold already short-circuits `.gitignore` writes when the file exists, so behavior for that case is unchanged.

### Tests

- `InitTest.generateGitignoreCoversBuildAndCommonNoise` already pins the entire template literal; updated to include the new line.
- `InitGitignoreTest` (new) pins two properties separately: `kolt.local.toml` appears exactly once and on its own line — so a future regression to a fragment-form glob fails here rather than slipping past the literal pin.

Task 7.1 of `local-toml-overlay` spec.