### PR TITLE
repositories: private Maven repo auth (Bearer / Basic, literal in kolt.local.toml)

### DIFF
--- a/.kiro/specs/private-maven-repos/design.md
+++ b/.kiro/specs/private-maven-repos/design.md
@@ -1,0 +1,870 @@
+# Design Document: private-maven-repos
+
+## Overview
+
+**Purpose**: kolt が認証付き Maven リポジトリ (GitHub Packages, Nexus, Cloudsmith, GitLab Package Registry など) から依存関係を取得できるようにする。 認証情報は `kolt.local.toml` の `[repositories.<name>]` に literal で配置し、 HTTP リクエストごとに `Authorization: Bearer` / `Authorization: Basic` を付与する。
+
+**Users**: 企業内 Maven リポジトリや GitHub Packages を必要とする kolt 利用者。 v1.0 では single-machine の plaintext 配置のみをサポートし、 env-var indirection や OS keychain は v1.1+ に持ち越す。
+
+**Impact**: 既存の resolver chain (`TransitiveResolver` / `NativeResolver` / `PluginJarFetcher` / `BtaImplFetcher`) が `Repository` 型を伝播するように切り替わる。 `Downloader.downloadFile` は optional headers パラメータを取る。 401/403 は新しい `RepositoryDownloadFailure.AuthFailed` variant としてハードエラー化する。 lockfile 整合性 (SHA-256) は不変。
+
+### Goals
+
+- `[repositories.<name>]` に `token` / `user` / `password` 認証フィールドを追加し、 相互排他と空値拒否を施行する
+- 認証情報は `kolt.local.toml` 限定とし、 `kolt.toml` の literal は parse-time に拒否する
+- 全 11 CLI 入口 × 全 artifact 種別に均一に `Authorization` ヘッダを付与する
+- 401/403 をハードエラーとし、 専用診断フォーマットで `credentials: <state>` と state-specific hint を提示する
+- error / log / stderr / `kolt.lock` のいずれにも認証情報を漏らさない (redaction guarantee)
+- `{ env = "..." }` 形式は parse-time に認識して reject する (v1.1+ の additive な flip-to-accept を可能にするため)
+
+### Non-Goals
+
+- `{ env = "..." }` の実装 (v1.1+ 持ち越し、 ADR 0032 §2 / ADR 0034 §3)
+- credential helpers / `.netrc` / OAuth / device flow
+- HTTP proxy, mTLS, custom CA bundles, client certificates
+- per-repository retry / backoff / timeout overrides
+- `~/.kolt/credentials.toml` などの外部 credential store
+- Sonatype Portal publish-side auth
+- 404 fall-through 動作の変更 (既存通り保持)
+- 既存 aggregated multi-repo error フォーマット (404 のみを束ねる動作) の変更
+
+## Boundary Commitments
+
+### This Spec Owns
+
+- `[repositories.<name>]` に `token` / `user` / `password` フィールドを追加する schema
+- 認証フィールドの mutex / empty / userinfo / `{env="..."}` recognize-and-reject 検証
+- `kolt.toml` 上の literal credential 拒否 (配置ポリシー)
+- `Repository` typed の `auth: RepositoryAuth?` field と、 resolver chain への伝播
+- `Downloader.downloadFile` への optional `headers` parameter と libcurl `curl_slist_append` 接続
+- `downloadFromRepositories` における 401/403 ハードエラー分岐 (404 fall-through は不変)
+- `RepositoryDownloadFailure.AuthFailed` variant と専用診断レンダリング (`credentials: <state>` + hint)
+- URL userinfo の defensive scrub utility (`redactUrlUserinfo`) と、 全 URL 出力経路への適用
+- legacy flat-string-map `[repositories]` 拒否のテキストが新スキーマを案内すること
+
+### Out of Boundary
+
+- `kolt.local.toml` overlay merge の仕組み自体 (#415 で実装済み、 本 spec は新フィールドを `mergeRepositories` の field-level merge に乗せるだけ)
+- `kolt.local.toml` の gitignore 自動付与 (#417 で実装済み)
+- 認証以外の HTTP layer 設定 (timeout / connect / redirect — 不変)
+- lockfile schema (`Lockfile.kt` の `dependencies` map shape — 不変)
+- daemon 経由経路の HTTP — kolt の daemon は HTTP を発行しない (local socket + file I/O のみ)
+
+### Allowed Dependencies
+
+- `kolt.config` (RawRepository / Repository / SysPropValueSerializer pattern)
+- `kolt.config.LocalOverlay` (mergeRepositories field-merge contract from #415)
+- `kolt.infra.Downloader` (libcurl easy-handle API)
+- `kolt.resolve.*` (TransitiveResolver, NativeResolver, downloadFromRepositories の iteration loop)
+- `kolt.tool.PluginJarFetcher` / `kolt.build.daemon.BtaImplFetcher` (これらは resolver chain の consumer)
+- `libcurl` cinterop の `curl_slist_append` / `CURLOPT_HTTPHEADER` / `curl_slist_free_all`
+- ktoml の custom KSerializer (precedent: `SysPropValueSerializer`)
+- kotlin-result `Result<V, E>` (ADR 0001)
+
+### Revalidation Triggers
+
+以下が変更されたら依存先 spec / 利用者は再検証する:
+
+- `Repository` typed の field 構成変更 (現状 `name` / `url` / `auth`; 新フィールド追加は formatResolveError 出力に影響しうる)
+- `RepositoryDownloadFailure` sealed 階層の追加 / 削除 / リネーム (renderer 側で網羅 when を持つため)
+- `Downloader.downloadFile` のシグネチャ変更 (現状 `url, destPath, headers?`)
+- `RawCredentialField` の polymorphism shape (literal / env の disjoint) — v1.1+ で env 認容に flip する際に再検証
+- libcurl header attach の cleanup ordering (slist free と easy_cleanup の順序契約)
+
+## Architecture
+
+### Existing Architecture Analysis
+
+kolt の依存方向は `cli → build → resolve → infra` (structure.md)。 本 spec は以下を守る:
+
+- `kolt.infra.Downloader` は domain types (`Repository`, `RepositoryAuth`) を import しない — 文字列 URL + headers map のみを受け取る
+- `kolt.resolve` 層が auth attachment の境界 (header の組み立てと libcurl 呼び出しへの引き渡し) を所有
+- `kolt.config` は raw decode + lift + 配置ポリシー検証のみを担当
+- `kolt.config.LocalOverlay` の `mergeRepositories` (#415) は field-level merge を既に提供しており、 新フィールドは null-default で追加するだけで既存契約を満たす
+
+既存の error-handling 規律 (ADR 0001) と value-class kotlin-result の利用慣行 (`getOrElse` / `getError` / `isErr`) を踏襲する。
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+    subgraph cli[kolt.cli]
+        Commands[BuildCommands / DependencyCommands]
+    end
+    subgraph resolve[kolt.resolve]
+        TransResolver[TransitiveResolver]
+        NativeResolver[NativeResolver]
+        DownloadLoop[downloadFromRepositories]
+        Renderer[formatResolveError]
+        AuthFailure[RepositoryDownloadFailure.AuthFailed]
+    end
+    subgraph config[kolt.config]
+        Parser[parseConfig]
+        RawRepo[RawRepository]
+        LiftRepo[liftRepositoriesMap]
+        AuthADT[RepositoryAuth ADT]
+        CredField[RawCredentialField + serializer]
+        Overlay[mergeRepositories from issue 415]
+    end
+    subgraph infra[kolt.infra]
+        Downloader[Downloader.downloadFile]
+        UrlRedact[redactUrlUserinfo]
+    end
+    subgraph external[external]
+        Libcurl[libcurl curl_slist_append]
+    end
+
+    Commands --> TransResolver
+    Commands --> NativeResolver
+    TransResolver --> DownloadLoop
+    NativeResolver --> DownloadLoop
+    DownloadLoop --> Downloader
+    DownloadLoop --> AuthFailure
+    AuthFailure --> Renderer
+    Renderer --> UrlRedact
+    Downloader --> Libcurl
+    Downloader --> UrlRedact
+    Parser --> RawRepo
+    RawRepo --> CredField
+    Parser --> LiftRepo
+    LiftRepo --> AuthADT
+    Parser --> Overlay
+    Commands --> Parser
+```
+
+**Architecture Integration**:
+
+- **Selected pattern**: layered with strict downward dependency (cli → resolve → infra). `kolt.config` is a sibling of `kolt.resolve` consumed by cli and resolve. New types live in `kolt.config` (domain) and `kolt.infra` (URL utility).
+- **Existing patterns preserved**: ADT-based `Result<V, E>` flow (ADR 0001), custom KSerializer pattern for polymorphic TOML values (`SysPropValueSerializer`), per-key source attribution model (`sysPropSourceMap` from #436), field-level overlay merge (`mergeRepositories` from #415).
+- **New components rationale**: `RepositoryAuth` ADT (typed projection over Bearer/Basic, drives both header attach and diagnostic state); `RawCredentialField` (recognize-and-reject `{env="..."}` forward-compat); `redactUrlUserinfo` (defense-in-depth utility shared by Downloader and Renderer).
+- **Steering compliance**: language (English code/comments per tech.md §Language Policy), no exceptions (ADR 0001), libcurl over ktor (ADR 0006), kotlin-result idioms (`isErr` / `getOrElse`).
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Native HTTP | libcurl (system, already pinned) | `curl_slist_append` for `Authorization` header attach | First use of header-list API in kolt; cleanup via `curl_slist_free_all` in finally |
+| TOML parsing | ktoml-core (existing) | Custom KSerializer for `RawCredentialField` polymorphism | Same pattern as `SysPropValueSerializer`; ktoml's KSerializer surface cannot do string-OR-table polymorphism directly ([[reference_ktoml_decode_quirks]]) |
+| Encoding | platform `Base64` (already used in lockfile sha2-256 path) | `Authorization: Basic <base64(user:password)>` encoding | RFC 7617; ASCII-only credentials assumed for v1.0 |
+| Error type | kotlin-result 2.x (existing) | `Result<Repository, ConfigError>` / `Result<Unit, RepositoryDownloadFailure>` | value class; use `getError` / `isErr` |
+
+## File Structure Plan
+
+### New files
+
+```
+src/nativeMain/kotlin/kolt/config/
+├── RepositoryAuth.kt              # RepositoryAuth sealed class (Bearer/Basic data classes with overridden toString)
+└── RawCredentialField.kt          # Uniform-inline-table literal/env discriminator + KSerializer
+
+src/nativeMain/kotlin/kolt/resolve/
+└── AuthStateProjection.kt         # AuthStateProjection sealed class + toDisplayString() (renderer-facing, secret-free)
+
+src/nativeMain/kotlin/kolt/infra/
+└── UrlRedaction.kt                # redactUrlUserinfo() shared utility
+
+src/nativeTest/kotlin/kolt/config/
+├── RepositoryAuthConfigTest.kt    # Req 1 + Req 2 + Req 2.3 schema / mutex / empty / placement / env-reject (parametrized, kolt.toml + kolt.local.toml fixtures shared)
+└── RepositoryUrlUserinfoTest.kt   # Req 3: URL @-rejection + redaction in message
+
+src/nativeTest/kotlin/kolt/infra/
+├── DownloaderAuthHeaderTest.kt    # Req 5: header attach + redirect Authorization drop (loopback HTTP stub)
+└── UrlRedactionTest.kt            # Req 8.3: userinfo scrub
+
+src/nativeTest/kotlin/kolt/resolve/
+├── RepositoryAuthFailureTest.kt   # Req 6, 7: 401/403 hard-error + 4-row parametrized hint matrix
+└── RepositoryAuthRedactionTest.kt # Req 8.1-8.5: cross-cutting redaction matrix
+```
+
+### Modified files
+
+- `src/nativeMain/kotlin/kolt/config/Config.kt` — extend `RawRepository` with `token` / `user` / `password` fields of type `RawCredentialField?`; extend `Repository` (currently `@Serializable data class Repository(val url: String)` at `:108`) with `name: String` and `auth: RepositoryAuth?`; mark `auth` as `@Transient` so the existing `@Serializable` annotation continues to compile (`RepositoryAuth` is non-serializable; secrets must never reach the JSON wire); update the default value of `KoltConfig.repositories` at `:120` to `mapOf("central" to Repository(name = "central", url = MAVEN_CENTRAL_BASE, auth = null))`; extend `liftRepositoriesMap` with mutex / empty / userinfo / env-reject validators and the `Repository.name == map_key` invariant enforcement; add base-only literal-credential reject (Req 2.1) inside `parseConfig` before merge; add `repositorySourceMap` helper next to the existing `sysPropSourceMap`.
+- `src/nativeMain/kotlin/kolt/config/LocalOverlay.kt` — extend `mergeRepositories` to field-merge the new credential fields. The shape mirrors the existing `url` merge: `merged[name] = baseRepo.copy(url = overlayRepo.url ?: baseRepo.url, token = overlayRepo.token ?: baseRepo.token, user = overlayRepo.user ?: baseRepo.user, password = overlayRepo.password ?: baseRepo.password)`. Null overlay field → keep base; non-null overlay → override (last-write-wins, consistent with `mergeSysProps`). The overlay-only-name rejection (#415) is unchanged. Note: if base has a credential field (forbidden by `rejectBaseCredentialLiterals`), the merge would propagate it forward, but `rejectBaseCredentialLiterals` runs before merge so this case is unreachable in production.
+- `src/nativeMain/kotlin/kolt/infra/Downloader.kt` — add `headers: Map<String, String>? = null` to `downloadFile`; apply via `curl_slist_append` → `CURLOPT_HTTPHEADER`; free via `curl_slist_free_all` in finally; set `CURLOPT_UNRESTRICTED_AUTH = 0L` so `Authorization` is dropped on cross-origin redirects; scrub URL via `redactUrlUserinfo` when constructing `DownloadError.HttpFailed`.
+- `src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt` — switch the `repos` accumulator at `:20` from `List<String>` to `List<Repository>` (drop the `.map { it.url }.toList()` projection; pass `config.repositories.values.toList()` directly); bump `downloadFromRepositories` signature to take `List<Repository>` and the new 3-arg `download` lambda type `(String, String, Map<String, String>?) -> Result<Unit, DownloadError>`; at each of the 4 fetch sites (`:69`, `:128`, `:186`, `:252`) compute headers from `repo.auth.toHeaders()` inside the new `download` lambda and pass through; add the 401/403 branch in `downloadFromRepositories` (~line 99) that returns `AuthFailed` immediately and stops iteration.
+- `src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt` — switch the `repos` accumulator at `:67` to `List<Repository>` (same projection drop); update both `downloadFromRepositories` call sites (`:139`, `:395`) to pass `Repository`-typed `repos` and the new `download` lambda.
+- `src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt` — switch the `repos` accumulator at `:180` to `List<Repository>`; update both `downloadFromRepositories` call sites (`:124`, `:197`).
+- `src/nativeMain/kotlin/kolt/resolve/PluginJarFetcher.kt` — bypasses `downloadFromRepositories` (calls `deps.downloadFile` directly at `:147`). Update the call site to pass the new `headers` parameter as `null` (compiler plugin jars are fetched from Maven Central anonymously; no auth context). No `Repository`-typed propagation here.
+- `src/nativeMain/kotlin/kolt/build/daemon/BtaImplFetcher.kt` — update the synthetic `Repository(MAVEN_CENTRAL_BASE)` constructor call (`:54`) to `Repository(name = "central", url = MAVEN_CENTRAL_BASE, auth = null)` to match the extended `Repository` shape.
+- `src/nativeMain/kotlin/kolt/cli/OutdatedCommand.kt` — switch the `repos` accumulator at `:42` to `List<Repository>`; update the single `downloadFromRepositories` call site (`:82`).
+- `src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt` — switch four `config.repositories.values.map { it.url }.toList()` projection sites (`:57`, `:300`, `:392`, `:412`) to `List<Repository>`; update the single `downloadFromRepositories` call site (`:165`) to pass `Repository`-typed `repos`.
+- `src/nativeMain/kotlin/kolt/cli/ToolCommands.kt` — switch the `repos` accumulator at `:163` to `List<Repository>`. This file does not call `downloadFromRepositories` directly; the `List<Repository>` flows downstream into `ensureTool` (`src/nativeMain/kotlin/kolt/usertool/ToolResolution.kt:53`), whose `repos: List<String>` parameter is bumped to `List<Repository>` in the same change.
+- `src/nativeMain/kotlin/kolt/usertool/ToolResolution.kt` — bump `ensureTool`'s `repos` parameter type at `:53` from `List<String>` to `List<Repository>`. This function forwards `repos` into `resolveSingleArtifact` in `BundleResolver.kt`.
+- `src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt` — in addition to the projection-site switch at `:180` and the two `downloadFromRepositories` call sites (`:124`, `:197`), bump `resolveSingleArtifact`'s `repos: List<String>` parameter at `:106` to `List<Repository>`. This function is called from `ToolResolution.kt:125` (`ensureTool`) and `DependencyCommands.kt:297` (the update-command tool-resolution path); both call sites flow `List<Repository>` directly after the projection-site switch.
+- `src/nativeMain/kotlin/kolt/resolve/Resolver.kt` — add `repositoryName: String` to `RepositoryAttempt`; add `RepositoryDownloadFailure.AuthFailed(repositoryName, url, statusCode, authState)`; extend `formatResolveError` with the new diagnostic shape (multi-line context with `credentials: <state>` + hint); apply `redactUrlUserinfo` in `repositoryDownloadFailureContext`.
+- `src/nativeTest/kotlin/kolt/resolve/ResolveErrorFormatTest.kt` — extend with 401/403 diagnostic format pins (4-row parametrized matrix for state-specific hints).
+- `src/nativeTest/kotlin/kolt/config/RepositorySchemaMigrationTest.kt` — keep existing flat-form rejection assertions; add cross-check that the migration hint now references the credential-bearing sub-table form.
+
+> Each new file has a single clear responsibility. Existing files are extended along the field-level overlay pattern that already exists for `[*.sys_props]`.
+
+## System Flows
+
+### Authentication header attachment (per-request, all entry points)
+
+```mermaid
+sequenceDiagram
+    participant CLI as kolt cli
+    participant Resolver as TransitiveResolver
+    participant Loop as downloadFromRepositories
+    participant Downloader as Downloader.downloadFile
+    participant Curl as libcurl
+
+    CLI->>Resolver: resolveTransitive(config)
+    Resolver->>Loop: downloadFromRepositories(repos: List<Repository>, coord)
+    loop per repo
+        Loop->>Loop: headers = repo.auth?.toHeader()
+        Loop->>Downloader: downloadFile(repo.url + path, dest, headers)
+        Downloader->>Curl: curl_slist_append(Authorization)
+        Downloader->>Curl: CURLOPT_HTTPHEADER + perform
+        alt 2xx
+            Downloader-->>Loop: Ok
+        else 404
+            Downloader-->>Loop: HttpFailed(404)
+            Note over Loop: fall through to next repo
+        else 401 or 403
+            Downloader-->>Loop: HttpFailed(401 or 403)
+            Loop-->>Resolver: AuthFailed(name, url, code, authState)
+            Note over Loop: break — stop iteration immediately
+        end
+    end
+```
+
+**Key decisions** (not obvious from diagram):
+
+- `downloadFromRepositories` is the sole place that distinguishes 401/403 vs 404. The `Downloader` layer remains status-code-agnostic (flat `HttpFailed`).
+- `repo.auth?.toHeader()` returns `null` for anonymous; the `Downloader` receives `headers: null` and skips `curl_slist_append` entirely.
+- The 401/403 branch stops iteration immediately. No subsequent repository is contacted. This is observable in tests as: a sequence of `[private-401, central-would-have-200]` resolves to a hard 401 error, not a successful fetch from central.
+
+### Config validation chain
+
+```mermaid
+graph TB
+    TOML[kolt.toml + kolt.local.toml strings]
+    Parse[parseConfig]
+    BaseRaw[rawBase: RawKoltConfig]
+    OverlayRaw[rawOverlay nullable]
+    BasePolicy[reject base credential literals]
+    Merge[mergeOverlay + mergeRepositories]
+    MergedRaw[merged raw]
+    Lift[liftRepositoriesMap]
+    Validators[mutex / empty / userinfo / env-reject]
+    Final[Map name to Repository]
+
+    TOML --> Parse
+    Parse --> BaseRaw
+    Parse --> OverlayRaw
+    BaseRaw --> BasePolicy
+    BasePolicy --> Merge
+    OverlayRaw --> Merge
+    Merge --> MergedRaw
+    MergedRaw --> Lift
+    Lift --> Validators
+    Validators --> Final
+```
+
+**Key decisions**:
+
+- The "kolt.toml carries literal credential" check (Req 2.1) runs on `rawBase` **before** merge. The file path attached to the rejection is the known `path` parameter (no source map needed — base raw originated entirely from `kolt.toml`).
+- Mutex / empty / userinfo / env-reject (Req 1.2, 1.3, 1.4, 2.3, 3.x) run on the **merged** raw inside `liftRepositoriesMap`. For overlay-sourced violations, attribution uses a new `repositorySourceMap` (mirroring `sysPropSourceMap` from #436) that maps each credential field's contributing file.
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | Optional `token` / `user` / `password` schema | RawRepository, RawCredentialField | `RawRepository` decode | Config validation chain |
+| 1.2 | token vs user/password mutex | liftRepositoriesMap validators | `validateAuthMutex(name, raw)` | Config validation chain |
+| 1.3 | user-password pair completeness | liftRepositoriesMap validators | `validateAuthMutex(name, raw)` | Config validation chain |
+| 1.4 | Empty/whitespace `literal` value reject | liftRepositoriesMap validators | `validateAuthNonEmpty(name, raw)` | Config validation chain |
+| 1.5 | URL-only entry → anonymous, no header | TransitiveResolver loop, Downloader | `repo.auth?.toHeaders()` returns null | Authentication header attachment |
+| 1.6 | Auth inline-table with neither `literal` nor `env` rejected | RawCredentialFieldSerializer.deserialize | `setFields.size == 0` → SerializationException → ParseFailed | Config validation chain |
+| 1.7 | Auth inline-table with both `literal` and `env` rejected | RawCredentialFieldSerializer.deserialize | `setFields.size == 2` → SerializationException → ParseFailed | Config validation chain |
+| 1.8 | Pre-v0.20.0 sub-table (no auth fields) parses cleanly, treated as anonymous | `RawRepository` nullable default fields + `liftRepositoriesMap` | `token/user/password = RawCredentialField? = null` → `Repository.auth = null` | Config validation chain |
+| 2.1 | kolt.toml literal credential reject | parseConfig pre-merge | `rejectBaseCredentialLiterals(rawBase, path)` | Config validation chain |
+| 2.2 | kolt.local.toml accepts when name in kolt.toml | mergeRepositories (existing from #415) | `mergeRepositories(base, overlay, overlayPath)` | Config validation chain |
+| 2.3 | `{env="..."}` recognize-and-reject | RawCredentialField KSerializer | `RawCredentialField.kind == Env` → ParseFailed | Config validation chain |
+| 2.4 | Reject message scrubs credential value | rejectBaseCredentialLiterals + ParseFailed renderer | message constructed without value | Config validation chain |
+| 3.1 | URL userinfo `@` reject | liftRepositoriesMap validators | `validateUrlNoUserinfo(name, url)` | Config validation chain |
+| 3.2 | userinfo with or without password both rejected | validateUrlNoUserinfo | regex/parse on `@` before host | Config validation chain |
+| 3.3 | Reject message scrubs userinfo | validateUrlNoUserinfo + redactUrlUserinfo | message includes redacted URL only | Config validation chain |
+| 4.1 | Implicit central fallback unchanged | `RawKoltConfig.repositories` data-class field default (decoded by ktoml) | (no change) | n/a |
+| 4.2 | Explicit `[repositories.central]` treated as any other | (no change) | (no change) | n/a |
+| 4.3 | TOML declaration order preserved | LinkedHashMap iteration (no change) | `config.repositories.values` | n/a |
+| 5.1 | Bearer header attach when token set | TransitiveResolver loop, RepositoryAuth.Bearer | `auth.toHeader() == "Authorization: Bearer <token>"` | Authentication header attachment |
+| 5.2 | Basic header attach when user+password set | TransitiveResolver loop, RepositoryAuth.Basic | `auth.toHeader() == "Authorization: Basic <base64(user:password)>"` | Authentication header attachment |
+| 5.3 | Every repository HTTP request, all subcommands and all artifact classes | All resolver entry points funnel into the same `downloadFile` site; auth attaches at the loop boundary | Resolver chain shared | Authentication header attachment |
+| 6.1 | 401/403 hard error, no fall-through | downloadFromRepositories loop branch | `if statusCode in 401..403 → return AuthFailed` | Authentication header attachment |
+| 6.2 | Hard error regardless of auth configured | downloadFromRepositories branch (no auth check on hard-error gate) | branch is status-code only | Authentication header attachment |
+| 6.3 | 404 continues fall-through | downloadFromRepositories loop (unchanged) | (no change) | Authentication header attachment |
+| 6.4 | Aggregated multi-repo errors only group 404 | downloadFromRepositories branch returns AuthFailed before AllAttemptsFailed | sealed dispatch in formatResolveError | n/a |
+| 7.1 | Headline via existing `ResolveError`-variant phrasing (`failed to download <X>` / `could not fetch metadata for <X>`) | outer `formatResolveError` `ResolveError` branches (unchanged) | RenderedDiagnostic.headline | n/a |
+| 7.2 | Context lines in declaration order | formatResolveError AuthFailed branch | RenderedDiagnostic.context | n/a |
+| 7.3 | `<state>` enum projection | RepositoryAuth.toStateString() | string projection | n/a |
+| 7.4 | Four state-specific hint texts (status × configuration-state matrix) | formatAuthHint(statusCode, state) | hint table | n/a |
+| 8.1 | No Authorization in output | Renderer never receives `RepositoryAuth` body, only projection | (architectural invariant) | n/a |
+| 8.2 | No token/user/password values in output | Same as 8.1 | (architectural invariant) | n/a |
+| 8.3 | No userinfo in output (defensive) | redactUrlUserinfo applied at all URL emission sites | `redactUrlUserinfo(url): String` | n/a |
+| 8.4 | No credentials in kolt.lock | Lockfile schema unchanged (no credential field) | (no change) | n/a |
+| 8.5 | Invariant holds regardless of verbosity | Architectural: Renderer / Lockfile receive only projections, not raw auth | (design discipline) | n/a |
+| 9.1 | Legacy flat form reject | KtomlMessageParse existing path | (no change in logic) | n/a |
+| 9.2 | Migration hint to sub-table form | KtomlMessageParse hint text | hint text update | n/a |
+| 9.3 | Legacy flat with URL userinfo scrubs | rejection message uses redactUrlUserinfo | redactUrlUserinfo | n/a |
+| 10.1 | SHA-256 verify unchanged | Lockfile verification path unchanged | (no change) | n/a |
+| 10.2 | No weakening based on auth status | Lockfile verification unaware of auth | (architectural invariant) | n/a |
+
+## Components and Interfaces
+
+| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies | Contracts |
+|-----------|--------------|--------|--------------|------------------|-----------|
+| `RepositoryAuth` ADT | kolt.config | Typed Bearer / Basic projection used by both header attach and diagnostic state | 1.5, 5.1, 5.2, 7.3 | None (data only) | State |
+| `RawCredentialField` + serializer | kolt.config | Uniform inline-table literal-vs-env discriminator; shape validator | 1.1, 1.4, 1.6, 1.7, 2.3 | ktoml KSerializer (P0) | State |
+| `liftRepositoriesMap` (extended) | kolt.config | Schema validators: mutex, non-empty, URL userinfo, env-reject; populates Repository.name == map_key; pre-v0.20.0 sub-tables (no auth fields) lift to anonymous | 1.1, 1.2, 1.3, 1.4, 1.8, 2.3, 3.1, 3.2, 3.3 | None | Service |
+| `rejectBaseCredentialLiterals` | kolt.config | Reject literal credentials in kolt.toml base before merge | 2.1, 2.4 | parseConfig (P0) | Service |
+| `mergeRepositories` (extended, from #415) | kolt.config.LocalOverlay | Field-merge new credential fields; existing overlay-only-name rejection unchanged | 2.2 | RawRepository (P0) | Service |
+| `Repository` (extended) | kolt.config | Typed repository carrying name, url, auth across resolver chain | 4.1, 4.2, 4.3, 5.1, 5.2, 5.3, 7.2 | RepositoryAuth (P0) | State |
+| `Downloader.downloadFile` (extended) | kolt.infra | HTTP fetch with optional Authorization headers via libcurl slist | 5.1, 5.2, 8.3 | libcurl (P0), redactUrlUserinfo (P1) | Service |
+| `downloadFromRepositories` (extended) | kolt.resolve | Repository iteration with 401/403 hard-error branch | 6.1, 6.2, 6.3, 6.4 | Downloader (P0), Repository (P0) | Service |
+| `RepositoryDownloadFailure.AuthFailed` | kolt.resolve | Sealed-ADT variant carrying name, url, status, authState | 6.4, 7.1, 7.2, 7.3 | RepositoryAuth (P0) | State |
+| `formatResolveError` (extended) | kolt.resolve | New AuthFailed branch rendering credentials-state diagnostic | 7.1, 7.2, 7.3, 7.4, 8.3 | redactUrlUserinfo (P1) | Service |
+| `redactUrlUserinfo` | kolt.infra | URL userinfo scrub utility, used by Downloader and Renderer | 3.3, 8.3, 9.3 | None | Service |
+
+### kolt.config
+
+#### RepositoryAuth
+
+| Field | Detail |
+|-------|--------|
+| Intent | Typed projection over Bearer / Basic that drives both Authorization header construction and `credentials: <state>` diagnostic line |
+| Requirements | 1.5, 5.1, 5.2, 7.3 |
+
+**Responsibilities & Constraints**
+
+- Single source of truth for "is this auth Bearer / Basic / anonymous"
+- Absence (`null`) means anonymous; no `RepositoryAuth.None` variant (simplification)
+- Projects to header string (`toHeader()`) and to diagnostic state string (`toStateString()`)
+- Immutable value class semantics; carries `password` / `token` but is never `equals`-leaked through stringification (no `data class toString()` override needed; `Renderer` only ever calls `toStateString()`)
+
+**Contracts**: State [x]
+
+##### State
+
+```kotlin
+// Non-data sealed class with explicit toString so secret fields cannot
+// reach println / eprintln / stringtemplate-based logging by accident.
+// Bearer / Basic remain data classes for equals / hashCode / copy
+// convenience, BUT they override toString to redact secrets.
+sealed class RepositoryAuth {
+  data class Bearer(val token: String) : RepositoryAuth() {
+    override fun toString(): String = "RepositoryAuth.Bearer(token=<redacted>)"
+  }
+  data class Basic(val user: String, val password: String) : RepositoryAuth() {
+    override fun toString(): String =
+      "RepositoryAuth.Basic(user=$user, password=<redacted>)"
+  }
+}
+
+fun RepositoryAuth.toHeaders(): Map<String, String> =
+  when (this) {
+    is RepositoryAuth.Bearer -> mapOf("Authorization" to "Bearer $token")
+    is RepositoryAuth.Basic ->
+      mapOf("Authorization" to "Basic ${base64Encode("$user:$password")}")
+  }
+
+fun RepositoryAuth?.toStateProjection(): AuthStateProjection =
+  when (this) {
+    null -> AuthStateProjection.NotConfigured
+    is RepositoryAuth.Bearer -> AuthStateProjection.ConfiguredToken
+    is RepositoryAuth.Basic -> AuthStateProjection.ConfiguredBasic
+  }
+```
+
+The `toHeaders()` return type is `Map<String, String>` (matches `Downloader.downloadFile`'s `headers` parameter, splitting `Authorization` key from `Bearer <token>` / `Basic <...>` value). The state projection returns `AuthStateProjection` (defined in `kolt.resolve.AuthStateProjection.kt`, co-located with `RepositoryDownloadFailure`) rather than a string, so the renderer alone owns the display-string mapping (Req 7.3 fixed text lives in one place).
+
+- **Preconditions**: For `Basic`, `user` and `password` are both non-empty (validators upstream enforce this).
+- **Postconditions**: `toHeaders()` always returns a single-entry map keyed by `"Authorization"`.
+- **Invariants**: `RepositoryAuth` is never serialized (no `@Serializable`); only the parsed-and-validated form constructed by `liftRepositoriesMap` exists. `toString` on every variant is overridden to redact secret fields, so `eprintln("retrying $repo")` style stringification cannot leak credentials.
+
+**Implementation Notes**
+
+- Integration: Constructed only by `liftRepositoriesMap`; consumed by `TransitiveResolver` (header attach) and `formatResolveError` (state projection)
+- Validation: Mutex enforced at construction site (validator rejects before constructor reached)
+- Risks: `data class` `equals` / `hashCode` still compare secret fields, but this is desirable (two `Bearer("X")` values being equal is correct). The leak surface is `toString`, which is overridden above. Test `RepositoryAuthRedactionTest` asserts the literal `RepositoryAuth.Basic("u","p").toString()` output contains the `<redacted>` placeholder and not the password.
+
+#### RawCredentialField
+
+| Field | Detail |
+|-------|--------|
+| Intent | Uniform inline-table discriminated value for `token` / `user` / `password`, accepting `{ literal = "..." }` in v1.0 and recognizing `{ env = "..." }` for forward-compat rejection per Req 2.3 |
+| Requirements | 1.1, 1.6, 1.4, 2.3 |
+
+**Responsibilities & Constraints**
+
+- ktoml 0.7.1 cannot decode "bare string OR inline-table" on a single field through the standard `KSerializer` surface (`SysPropValue.kt:14-16` documents the same constraint for `SysPropValue`). v1.0 therefore commits to **uniform inline-table**: every credential field is always written as an inline-table.
+- v1.0 schema: `token = { literal = "abc123" }` (accepted) or `token = { env = "GITHUB_TOKEN" }` (recognized but rejected per Req 2.3).
+- v1.1+ flip: the env-reject validator removes its check; no schema change needed.
+- The all-nullable-fields trick from `RawSysPropValue` directly applies: `RawCredentialField` has two nullable fields and a validator requires exactly one to be set (Req 1.6).
+
+**Contracts**: State [x], Service [x]
+
+##### State + Service
+
+```kotlin
+@Serializable(with = RawCredentialFieldSerializer::class)
+internal sealed class RawCredentialField {
+  data class Literal(val value: String) : RawCredentialField()
+  data class Env(val varName: String) : RawCredentialField()
+
+  // toString is overridden to never expose Literal.value
+  override fun toString(): String = when (this) {
+    is Literal -> "RawCredentialField.Literal(<redacted>)"
+    is Env -> "RawCredentialField.Env(varName=$varName)"
+  }
+}
+
+@Serializable
+internal data class RawCredentialFieldShape(
+  val literal: String? = null,
+  val env: String? = null,
+)
+
+internal object RawCredentialFieldSerializer : KSerializer<RawCredentialField> {
+  override val descriptor: SerialDescriptor =
+    RawCredentialFieldShape.serializer().descriptor
+
+  override fun serialize(encoder: Encoder, value: RawCredentialField) {
+    val raw = when (value) {
+      is RawCredentialField.Literal -> RawCredentialFieldShape(literal = value.value)
+      is RawCredentialField.Env -> RawCredentialFieldShape(env = value.varName)
+    }
+    encoder.encodeSerializableValue(RawCredentialFieldShape.serializer(), raw)
+  }
+
+  override fun deserialize(decoder: Decoder): RawCredentialField {
+    val raw = decoder.decodeSerializableValue(RawCredentialFieldShape.serializer())
+    val setFields = listOfNotNull(
+      raw.literal?.let { "literal" },
+      raw.env?.let { "env" },
+    )
+    if (setFields.size != 1) {
+      throw SerializationException(
+        "credential field value must set exactly one of { literal, env }, " +
+          "but ${setFields.size} were set: $setFields"
+      )
+    }
+    return when (setFields.single()) {
+      "literal" -> RawCredentialField.Literal(raw.literal!!)
+      "env" -> RawCredentialField.Env(raw.env!!)
+      else -> error("unreachable")
+    }
+  }
+}
+```
+
+- **Preconditions**: Called only by ktoml at decode time on `RawRepository.{token,user,password}`.
+- **Postconditions**: Returns `Literal` or `Env`; never null (the parent uses `RawCredentialField? = null` for "absent").
+- **Invariants**: The custom `serialize` is a real implementation (not `error(...)`), mirroring `SysPropValueSerializer` (`SysPropValue.kt:36-44`). Decode failures throw `SerializationException` per the `KSerializer` contract; this is allowed (the contract requires it) and the existing `parseConfig` `catch (e: SerializationException)` at `Config.kt:651` and `LocalOverlay.kt:27-30` converts these into `ConfigError.ParseFailed`. ADR 0001 ("no exceptions") applies to kolt's own error model, not to framework-mandated throws on a serializer boundary.
+
+**Implementation Notes**
+
+- Integration: Mirrors `SysPropValueSerializer` (`config/SysPropValue.kt:33-67`). The all-nullable-fields trick + post-decode validator is the canonical kolt pattern for ktoml 0.7.1 inline-table discrimination.
+- Validation: Env-shape rejection text is fixed in `liftRepositoriesMap` so tests can pin the exact wording. Shape-error (`Req 1.6`) comes from this serializer's `setFields.size != 1` check and reaches the user via `Config.kt:651` catch.
+- Risks: ktoml 0.7.x version drift could change the decoder API; pin to current version and keep the serializer adjacent to its sibling `SysPropValueSerializer` for consistency. If a future ktoml version supports string-OR-table polymorphism, the schema can additively accept the short `token = "abc"` form without breaking the existing inline-table syntax.
+
+#### liftRepositoriesMap (extended)
+
+| Field | Detail |
+|-------|--------|
+| Intent | Validate the merged `Map<String, RawRepository>` and lift to `Map<String, Repository>` with authentication populated |
+| Requirements | 1.1, 1.2, 1.3, 1.4, 2.3, 3.1, 3.2, 3.3 |
+
+**Responsibilities & Constraints**
+
+- Validation order (fail fast, first failure wins):
+  1. URL non-null / non-empty (existing)
+  2. URL no userinfo (`@` before host) — Req 3.1 / 3.2; rejection message uses `redactUrlUserinfo(url)` (Req 3.3)
+  3. Auth-field mutex: `token` set together with `user` or `password` → reject (Req 1.2)
+  4. Auth-field completeness: `user` without `password` or vice versa → reject (Req 1.3)
+  5. Auth-field non-empty: any of `token` / `user` / `password` Literal with empty-or-whitespace → reject (Req 1.4)
+  6. Auth-field env-form: any `RawCredentialField.Env(_)` → reject (Req 2.3)
+- Resulting `Repository.auth` is `null`, `Bearer(token)`, or `Basic(user, password)`. Constructor enforces invariants implicitly (validators must have rejected impossible states before reaching it).
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+internal fun liftRepositoriesMap(
+  raw: Map<String, RawRepository>,
+  repositorySourceMap: Map<String, Map<String, String?>>,  // name → field → file
+): Result<Map<String, Repository>, ConfigError>
+```
+
+`repositorySourceMap` follows the `sysPropSourceMap` (`Config.kt:398-414`) shape and semantics exactly:
+- **Outer key** is the repository name (post quote-stripping).
+- **Inner key** is one of the fixed strings `"url" / "token" / "user" / "password"`. Any other key is a programmer error.
+- **Inner key absent** means that field is unset on this repository (no base nor overlay contribution).
+- **Inner value is a `String?`**: the contributing file path. Set to `basePath` when only base contributes, to `overlayPath` when overlay contributes (overlay wins on conflict — last-write-wins, matching `mergeRepositories` from #415). The value is `null` only when the contributing source provided no path (internal-test scenario where `parseConfig` was called without `path` / `overlayPath`).
+
+- **Preconditions**: `raw` has been through `mergeRepositories` (#415 contract); `repositorySourceMap` covers every name in `raw` and every set field on each.
+- **Postconditions**: Returns `Map<String, Repository>` in insertion order (TOML declaration order, Req 4.3) on success; or `ConfigError.ParseFailed` with `path` attribution (looked up via `repositorySourceMap[name][field]`) on first failure.
+- **Invariants**: Successful return implies every value of the map has valid auth (`null` or fully-populated Bearer / Basic); `Repository.name == outer map key` (see Data Models §Domain Model for the full invariant; enforced at construction here).
+
+**Implementation Notes**
+
+- Integration: Receives the source map from a new `repositorySourceMap(base, overlay, basePath, overlayPath)` helper inside `parseConfig`, mirroring `sysPropSourceMap` from #436
+- Validation: All validator subfunctions return `Result<Unit, ConfigError>` per ADR 0001
+- Risks: Validator order matters for error message clarity. Document the order in a `// validation order: ...` comment with no rationale spread — colocated and short
+
+#### rejectBaseCredentialLiterals
+
+| Field | Detail |
+|-------|--------|
+| Intent | Reject `kolt.toml` containing literal `token` / `user` / `password` before merge, so the error path stays on the base file |
+| Requirements | 2.1, 2.4 |
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+internal fun rejectBaseCredentialLiterals(
+  rawBase: RawKoltConfig,
+  basePath: String?,
+): Result<Unit, ConfigError.ParseFailed>
+```
+
+- **Preconditions**: Called from `parseConfig` after base decode and before overlay merge
+- **Postconditions**: Returns `Ok` if no credential literal appears in `rawBase.repositories`; otherwise `ParseFailed(path = basePath, message = ...)` naming the repository, the offending field, and the directive to move to `kolt.local.toml`. The message does not include the credential value (Req 2.4)
+- **Invariants**:
+  - Only inspects `rawBase.repositories[*].token / user / password`.
+  - The base-placement check is **shape-blind**: any non-null `token` / `user` / `password` on a `kolt.toml` repository is rejected, regardless of whether the inner shape is `Literal` or `Env`. The rationale is policy-first: `kolt.toml` must not host credential-related fields at all.
+  - The env-form-specific reject (Req 2.3) runs in `liftRepositoriesMap` after merge, so it only fires for `kolt.local.toml`-sourced env-forms (or, after v1.1+ flips the validator, additively accepts them).
+  - Order: base-placement check first, then merge, then `liftRepositoriesMap` validators. A user who tries `token = { env = "X" }` in `kolt.toml` sees the placement message; if they move it to `kolt.local.toml` (the directed action), they then see the env-not-supported message. This is a 2-hop in v1.0; v1.1+ collapses to 1-hop when env is accepted.
+
+**Implementation Notes**
+
+- Integration: New private function in `Config.kt`; one call site in `parseConfig` between base decode and `mergeOverlay`
+- Validation: Iterates `rawBase.repositories` in declaration order; first violation wins
+- Risks: If a user puts `token = { env = "X" }` in `kolt.toml`, we want them to see the placement-policy message first ("declare in kolt.local.toml"), then if they move it to `kolt.local.toml` they'll hit the env-not-supported-in-v1.0 message. This two-step is intentional — both messages teach the right rule
+
+### kolt.infra
+
+#### Downloader.downloadFile (extended)
+
+| Field | Detail |
+|-------|--------|
+| Intent | Single-point HTTP GET with optional `Authorization` header injection |
+| Requirements | 5.1, 5.2, 8.3 |
+
+**Responsibilities & Constraints**
+
+- Optional `headers: Map<String, String>?` parameter, defaulting to `null` (no header list set when null). The default is retained as a DI seam for test callers and for `PluginJarFetcher` (which fetches compiler plugin jars from Maven Central anonymously and passes `null` explicitly).
+- libcurl resource management: `curl_slist_append` in setup, `curl_slist_free_all` in `finally` block alongside existing `curl_easy_cleanup`
+- URL userinfo scrub: when constructing `DownloadError.HttpFailed(url, code)`, apply `redactUrlUserinfo(url)` so even URLs that slip past the config parser don't leak into the error path
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+fun downloadFile(
+  url: String,
+  destPath: String,
+  headers: Map<String, String>? = null,
+): Result<Unit, DownloadError>
+```
+
+- **Headers Map contract**: `headers: Map<String, String>?`. The Map key is the **bare header name** (no colon, no trailing whitespace; e.g., `"Authorization"`). The Map value is the **bare header value** (no leading name, no leading colon; e.g., `"Bearer abc123"`). The Downloader internally builds each libcurl slist line as `"$name: $value"`. Callers (currently only `RepositoryAuth.toHeaders()`) must respect this split.
+- **Preconditions**: `url` is a complete URL; if `headers` is non-null, every (name, value) pair is ASCII and contains no CR / LF (callers responsible — `RepositoryAuth.toHeaders()` only emits ASCII).
+- **Postconditions**: Same as today (`Ok(Unit)` on 2xx, `Err(HttpFailed)` for non-2xx, `Err(NetworkError)` for libcurl-level failures); `DownloadError.HttpFailed.url` is the redacted form.
+- **Invariants**: libcurl slist memory is always freed regardless of success / failure (finally block); no header value ever appears in the returned error type.
+
+**Implementation Notes**
+
+- Integration: Pattern follows existing libcurl cinterop setup (`CURLOPT_URL`, `CURLOPT_WRITEFUNCTION` etc.). `curl_slist_append` is new for the codebase but documented as the standard libcurl pattern. Add a comment naming this as the canonical kolt pattern for future libcurl option lists (cookies, etc.).
+- **Redirect Authorization policy** (Req 5.x for redirected requests): libcurl strips `Authorization` on cross-origin redirect when `CURLOPT_UNRESTRICTED_AUTH` is `0L` (the default), and forwards it when `1L`. kolt commits to **`CURLOPT_UNRESTRICTED_AUTH = 0L`** (the default, explicitly set for documentation purposes). Rationale: forwarding credentials to an unintended host (e.g. a typo in `url` that 302s elsewhere) is a worse failure mode than a 401 from a CDN-fronted mirror. Repository operators who need cross-origin auth (e.g. GitHub Packages → AWS CloudFront → 401) should declare the final host directly, not rely on redirect-forwarding. `DownloaderAuthHeaderTest` includes a cross-origin redirect test case asserting the `Authorization` header is NOT seen by the redirect target.
+- **slist cleanup order**: `curl_slist_free_all` and `curl_easy_cleanup` are mutually safe in either order per libcurl docs (the slist's string copies are internal to libcurl). kolt's convention is **slist first, then easy** in the `finally` block, which is the opposite of most upstream sample code (`easy_cleanup → slist_free_all`). The order is documented inline as an anchored gotcha so a reader does not "fix" it to match upstream samples.
+- Validation: `DownloaderAuthHeaderTest` uses a loopback HTTP listener to assert (a) the server saw the expected `Authorization` header for Bearer / Basic; (b) no header for anonymous; (c) cross-origin redirect drops the header; (d) libcurl slist freed on success and failure (no leak under repeated calls).
+- Risks: First use of `curl_slist_append` in kolt. Pattern reuse is documented above so future header / cookie / option lists follow the same finally-block discipline.
+- **Per-call locality**: each `downloadFile` invocation calls `curl_easy_init` + `curl_easy_cleanup` and (when headers are present) `curl_slist_append` + `curl_slist_free_all` within the same scope. There is no shared `curl_easy_handle` or `curl_slist` state across calls. Concurrent invocations (e.g., a future parallel POM fetch) are therefore safe with respect to libcurl handle lifetime; each call owns its handle from init through finally-cleanup.
+- **Status-code routing**: only HTTP 401 and HTTP 403 trigger the `AuthFailed` hard-error branch in the calling `downloadFromRepositories`. Other non-2xx codes (including HTTP 402 / 407 / 5xx) continue to flow through the existing `DownloadError.HttpFailed` path: 404 falls through to the next repository per Req 6.3, and the rest aggregate into `AllAttemptsFailed`. This preserves the existing multi-repo aggregation behavior for everything except auth failures, and Req 6.4 (aggregated multi-repo errors only group 404s) holds because 401/403 are intercepted upstream before they can join the attempts list.
+
+#### redactUrlUserinfo
+
+| Field | Detail |
+|-------|--------|
+| Intent | Single utility that strips the userinfo component from a URL string (`https://user:pass@host/x` → `https://host/x`) |
+| Requirements | 3.3, 8.3, 9.3 |
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+fun redactUrlUserinfo(url: String): String
+```
+
+- **Preconditions**: `url` is any string; non-URL inputs return the input unchanged
+- **Postconditions**: If `url` contains a userinfo component, the returned string omits everything between `scheme://` and the `@` (exclusive of `@`); otherwise `url` is returned unchanged
+- **Invariants**: The function is pure, depends on nothing, and is idempotent
+
+**Implementation Notes**
+
+- Integration: Called by `Downloader.downloadFile` when constructing `HttpFailed`, by `liftRepositoriesMap` when rejecting userinfo URLs, by `formatResolveError` defensively in `repositoryDownloadFailureContext`
+- Validation: Detection by simple substring scan: find `://`, then find the next `@` before `/`, `?`, `#`. If both present, slice
+- Risks: Edge case: URL containing `@` inside the path (e.g. `https://host/foo@bar/baz`). The detector must check that `@` appears before the first path separator. Test matrix covers: (a) `https://host/path` — unchanged; (b) `https://u:p@host/path` — userinfo removed; (c) `https://u@host/path` — userinfo removed; (d) `https://host/foo@bar` — unchanged; (e) `not-a-url-at-all` — unchanged
+
+### kolt.resolve
+
+#### RepositoryDownloadFailure.AuthFailed
+
+| Field | Detail |
+|-------|--------|
+| Intent | Sealed-ADT variant signalling 401/403 from a specific repository, carrying the typed state for diagnostic rendering |
+| Requirements | 6.4, 7.1, 7.2, 7.3 |
+
+**Contracts**: State [x]
+
+##### State
+
+```kotlin
+sealed class RepositoryDownloadFailure {
+  data object NoRepositoriesConfigured : RepositoryDownloadFailure()
+  data class AllAttemptsFailed(val attempts: List<RepositoryAttempt>) : RepositoryDownloadFailure()
+  data class AuthFailed(
+    val repositoryName: String,
+    val url: String,            // already-redacted form
+    val statusCode: Int,        // 401 or 403
+    val authState: AuthStateProjection,
+  ) : RepositoryDownloadFailure()
+}
+
+sealed class AuthStateProjection {
+  data object NotConfigured : AuthStateProjection()
+  data object ConfiguredToken : AuthStateProjection()
+  data object ConfiguredBasic : AuthStateProjection()
+
+  // Owned by AuthStateProjection so the renderer reads the canonical
+  // text without re-deriving it per call site. Req 7.3 fixes these
+  // exact strings; tests pin them. The "from kolt.local.toml" suffix
+  // is hardcoded because Req 2.1 rejects credential literals from
+  // kolt.toml at parse time, so any configured credential that reaches
+  // the resolver provably originated in kolt.local.toml.
+  fun toDisplayString(): String = when (this) {
+    NotConfigured -> "not configured"
+    ConfiguredToken -> "configured (token, from kolt.local.toml)"
+    ConfiguredBasic -> "configured (basic, from kolt.local.toml)"
+  }
+}
+```
+
+`AuthFailed` does **not** carry a `coordinate` field. The coordinate lives in the outer `ResolveError.DownloadFailed.groupArtifact` (or `MetadataDownloadFailed.groupArtifact` etc.), which is already what produces the headline today. The renderer reads coordinate from the outer error and context from `repositoryDownloadFailureContext` — same split as existing `AllAttemptsFailed`. See "Headline text reconciliation" below.
+
+- **Preconditions**: Constructed only in `downloadFromRepositories` after a 401/403 response. `url` is passed through `redactUrlUserinfo` before storage.
+- **Postconditions**: Carries enough state for `repositoryDownloadFailureContext` to produce the 5-line context list without re-fetching anything.
+- **Invariants**: `AuthStateProjection` is fully decoupled from `RepositoryAuth` (the secrets-carrying type). Renderer switches on `AuthStateProjection` exhaustively via `toDisplayString()`; secrets never reach the renderer.
+
+#### downloadFromRepositories (extended)
+
+| Field | Detail |
+|-------|--------|
+| Intent | Iterate `List<Repository>` and dispatch downloads with auth headers; branch on 401/403 to hard-stop |
+| Requirements | 5.1, 5.2, 5.3, 6.1, 6.2, 6.3, 6.4 |
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+internal fun downloadFromRepositories(
+  repos: List<Repository>,
+  destPath: String,
+  urlBuilder: (Repository) -> String,
+  download: (String, String, Map<String, String>?) -> Result<Unit, DownloadError>,
+  onRetry: (Repository) -> Unit = {},
+): Result<Unit, RepositoryDownloadFailure>
+```
+
+The signature mirrors the current 5-parameter shape (`TransitiveResolver.kt:84-90`) and changes only the parameter types: `String → Repository` in `repos` / `urlBuilder` / `onRetry`, and `(String, String) → (String, String, Map<String, String>?)` in `download` so the per-repository headers can flow through to the infra layer. The DI seam (the `download` lambda, used by `ResolverDeps` for test injection) is preserved.
+
+- **Preconditions**: `repos` non-empty (otherwise caller returns `NoRepositoriesConfigured` upstream); each `Repository` has valid url and (optional) auth.
+- **Postconditions**: Returns `Ok` on first successful 2xx; `AuthFailed` on first 401/403 (no further iteration); `AllAttemptsFailed` if all repositories return 404 or network errors.
+- **Invariants**: The order of iteration is the order of `repos` (TOML declaration order, Req 4.3). Auth header is computed per-repository (`repo.auth?.toHeaders()`), not shared across iterations.
+
+**Implementation Notes**
+
+- Integration: One change site at the existing branch (`TransitiveResolver.kt:99` today); add `else if (httpFailed.statusCode == 401 || httpFailed.statusCode == 403) → return AuthFailed(repositoryName = repo.name, ...)`.
+- Callers (10 sites): `TransitiveResolver.kt:69` (sources jar fallback), `:128` (POM), `:186` (module metadata), `:252` (binary artifact); `NativeResolver.kt:139, 395` (klib + secondary path); `BundleResolver.kt:124, 197` (classpath bundle fetch); `OutdatedCommand.kt:82` (HEAD probes for newer versions); `DependencyCommands.kt:165` (add-command probing). Every caller's `urlBuilder` migrates from `(String) -> String` to `(Repository) -> String`, and the `download` lambda swap goes through `ResolverDeps.downloadFile`.
+
+**`urlBuilder` lambda discipline**: every lambda body must extract the URL via `repo.url`, never `repo.toString()` or `"$repo"`. The `Repository.toString()` returned by the auto-generated data-class `toString` includes the `auth` field (which is itself redacted-safe, see §RepositoryAuth), but it is NOT a URL — using it in string concatenation produces a malformed download URL and a silent regression. Lambdas SHOULD be written as `{ "${it.url}/$groupPath/..." }` rather than `{ "$it/..." }`. The implementer is responsible for grepping every migrated lambda for `"$it/"` / `"$it."` substrings before merge.
+- Validation: Test matrix includes `[private-401, central-200]` to confirm iteration stops at the 401 and central is NOT contacted; `[mirror-404, central-200]` to confirm 404 fall-through unchanged. The 4-call-site fan-out in `TransitiveResolver` itself is covered by the existing `TransitiveResolverTest`; the off-`TransitiveResolver` callers (`BundleResolver`, `OutdatedCommand`, `DependencyCommands`) each need a smoke test confirming the `Repository` typed input does not break their existing behavior.
+- Risks: A 401 from a misconfigured central is now a hard error. This is intentional but reverses prior behavior where central effectively had no auth surface. Migration note in release notes documents the change.
+
+#### formatResolveError (extended)
+
+| Field | Detail |
+|-------|--------|
+| Intent | Render `RepositoryDownloadFailure.AuthFailed` into the 6-line diagnostic |
+| Requirements | 7.1, 7.2, 7.3, 7.4, 8.3, 9.3 |
+
+**Responsibilities & Constraints**
+
+- Sealed `when` over `RepositoryDownloadFailure`; the AuthFailed branch emits the headline plus the 5 context lines
+- State-and-status to hint table:
+
+| status \ state | NotConfigured | ConfiguredToken | ConfiguredBasic |
+|---|---|---|---|
+| 401 | repository requires authentication; add credentials to `kolt.local.toml` | credentials may be invalid or expired | credentials may be invalid or expired |
+| 403 | authentication required | credentials are valid but lack permission for this repository | credentials are valid but lack permission for this repository |
+
+- All `<url>` fields go through `redactUrlUserinfo` defensively even though they already are at construction time. The double-redaction is idempotent
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```kotlin
+internal fun formatResolveError(error: ResolveError): RenderedDiagnostic
+// extended branch inside repositoryDownloadFailureContext:
+internal fun repositoryDownloadFailureContext(failure: RepositoryDownloadFailure): List<String> =
+  when (failure) {
+    is NoRepositoriesConfigured -> listOf(/* existing hint, unchanged */)
+    is AllAttemptsFailed -> failure.attempts.map { "${it.url} -> ${formatAttemptStatus(it.error)}" }
+    is AuthFailed -> listOf(
+      "repository: ${failure.repositoryName}",
+      "url: ${redactUrlUserinfo(failure.url)}",
+      "status: ${failure.statusCode} ${reasonPhrase(failure.statusCode)}",
+      "credentials: ${failure.authState.toDisplayString()}",
+      "hint: ${formatAuthHint(failure.statusCode, failure.authState)}",
+    )
+  }
+```
+
+- **Preconditions**: `failure.statusCode` is 401 or 403 (constructor enforces); `failure.authState` is one of three discriminants.
+- **Postconditions**: Returns a 5-entry context list in the declared order. Headline is owned by the outer `ResolveError` variant ("failed to download X" for `DownloadFailed`, "could not fetch metadata for X" for `MetadataDownloadFailed`, etc.).
+- **Invariants**: No raw credential value (`token` / `user` / `password` / base64 encoded `user:password`) appears in any returned string.
+
+**Headline text reconciliation**: Req 7.1 specifies the headline via existing `ResolveError`-variant phrasing. The two relevant variants in v0.20.0 are `failed to download <coordinate>` (`ResolveError.DownloadFailed`, used by POM / artifact / sources / klib fetch) and `could not fetch metadata for <coordinate>` (`ResolveError.MetadataDownloadFailed`, used by Gradle module metadata fetch). The 401/403 diagnostic therefore appears under whichever outer headline naturally describes the operation that triggered the fetch. Test pins assert the full headline+context shape per scenario (POM 401 → "failed to download G:A" + 5 context lines; metadata 401 → "could not fetch metadata for G:A" + 5 context lines). This is consistent with the existing `AllAttemptsFailed` rendering split.
+
+The outer `ResolveError` `when` in `formatResolveError` (`Resolver.kt:75-138`) is **not** modified: `AuthFailed` is a new variant of `RepositoryDownloadFailure`, not of `ResolveError`, so the new branch is added to `repositoryDownloadFailureContext` (`Resolver.kt:151-159`) rather than the top-level renderer. The existing `AllAttemptsFailed` aggregation path is untouched, which is why Req 6.4 (aggregated multi-repo errors only group 404s) falls out for free.
+
+## Data Models
+
+### Domain Model
+
+```mermaid
+graph LR
+    KoltConfig --> Repositories[Map name to Repository]
+    Repositories --> Repository
+    Repository --> Url
+    Repository --> Auth[RepositoryAuth nullable]
+    Auth --> Bearer[Bearer token]
+    Auth --> Basic[Basic user password]
+```
+
+**Invariants**:
+
+- `Repository.auth` is `null` ⇔ the repository is anonymous; never an empty `Bearer("")` or `Basic("","")`
+- `Repository.name` matches the TOML map key (after quote-stripping per existing `liftRepositoriesMap` convention). This is a structural redundancy (the name lives both as map key and inside the value), enforced at construction in `liftRepositoriesMap`. Callers that hold a `Repository` outside its enclosing map can rely on `.name` directly; callers iterating the map must not construct a `Repository` with a name different from its key
+- The map preserves TOML declaration order (LinkedHashMap)
+- `Repository.toString()` is the Kotlin auto-generated data-class `toString` (we do not override it). It produces `"Repository(name=<n>, url=<u>, auth=null)"` for anonymous repositories and `"Repository(name=<n>, url=<u>, auth=RepositoryAuth.Basic(user=<u2>, password=<redacted>))"` (or `Bearer(token=<redacted>)`) for authenticated ones. Safety is delegated to `RepositoryAuth.Bearer.toString()` and `RepositoryAuth.Basic.toString()` (both explicitly override `toString` to redact secret fields, see §RepositoryAuth State). This chain is asserted by `RepositoryAuthRedactionTest`.
+
+### Logical Data Model
+
+The new fields on `RawRepository`:
+
+```kotlin
+@Serializable
+internal data class RawRepository(
+  val url: String? = null,
+  val token: RawCredentialField? = null,
+  val user: RawCredentialField? = null,
+  val password: RawCredentialField? = null,
+)
+```
+
+The lifted `Repository`:
+
+```kotlin
+data class Repository(
+  val name: String,
+  val url: String,
+  val auth: RepositoryAuth? = null,
+)
+```
+
+### Data Contracts & Integration
+
+- **kolt.toml schema**: `[repositories.<name>] url = "..."` plus optional `token` / `user` / `password` (always rejected at base placement validator if present in `kolt.toml`)
+- **kolt.local.toml schema**: same shape; literal credentials accepted only here
+- **No schema change to `kolt.lock`** (Req 8.4, Req 10.x) — verified by an explicit test pinning the lockfile JSON shape
+
+## Error Handling
+
+### Error Strategy
+
+All new error paths return `Result<V, E>` per ADR 0001. The two new error surfaces:
+
+- **Config-time**: `ConfigError.ParseFailed` (existing), with `path` set to the originating file (`kolt.toml` for base, `kolt.local.toml` for overlay-sourced via `repositorySourceMap`)
+- **Resolve-time**: `RepositoryDownloadFailure.AuthFailed` (new), routed through the existing `formatResolveError` renderer
+
+### Error Categories and Responses
+
+- **Schema validation errors** (config): mutex / empty / userinfo / env-reject / placement policy → `ParseFailed` with field-named message and (where relevant) source file attribution
+- **Network errors** (resolve): 401/403 → `AuthFailed` hard error with state-specific hint; 404 → unchanged fall-through; libcurl-level failures → existing `NetworkError` (no change)
+- **Credential leak prevention**: Architectural invariant rather than runtime check. The renderer never receives the secret-carrying `RepositoryAuth` type; it receives `AuthStateProjection` only. Tests assert this end-to-end
+
+### Monitoring
+
+No new logging is introduced. If future verbose-mode logging is added, the dev must call `redactUrlUserinfo` before emitting URLs. This contract is documented adjacent to `redactUrlUserinfo` in code.
+
+## Testing Strategy
+
+### Unit Tests (config layer)
+
+1. **`RepositoryAuthConfigTest`** — parametrized Req 1 + Req 2 + Req 2.3 fixture matrix:
+   - schema accept/reject: (a) `token = { literal = "abc" }` accepted as Bearer; (b) `user = { literal = "u" }` + `password = { literal = "p" }` accepted as Basic; (c) `token` + `user` mutex rejected; (d) `user` alone rejected; (e) empty / whitespace `literal` rejected; (f) inline-table with neither `literal` nor `env`, or both, rejected (Req 1.6).
+   - placement: (g) literal `token` in `kolt.toml` rejected, message names `kolt.toml`; (h) literal `token` in `kolt.local.toml` accepted; (i) overlay-sourced env-reject names `kolt.local.toml` via `repositorySourceMap`; (j) reject message contains no credential value.
+   - env-form recognize-and-reject: (k) `token = { env = "X" }` rejected with the canonical v1.0 message; (l) same for `user` / `password`.
+   - The 2-hop UX (kolt.toml `{env = "..."}` → placement message → move to kolt.local.toml → env-not-supported message) is not pinned with a separate test case. The message difference between (g) base-placement and (k) env-reject is sufficient to verify that the validator order produces the right teaching sequence ([[feedback_sdd_test_inflation]]).
+2. **`RepositoryUrlUserinfoTest`** — Req 3: (a) `https://u:p@host/x` rejected; (b) `https://u@host/x` rejected; (c) `https://host/foo@bar/baz` accepted (no userinfo); (d) rejection message contains no userinfo character.
+
+### Unit Tests (infra layer)
+
+3. **`UrlRedactionTest`** — Req 3.3, 8.3, 9.3: 5-case redaction matrix.
+4. **`DownloaderAuthHeaderTest`** — Req 5.1, 5.2, and the redirect policy: loopback HTTP fixture server confirms (a) Bearer header attached for `RepositoryAuth.Bearer`; (b) Basic header attached with correct base64 for `RepositoryAuth.Basic`; (c) no Authorization header in the loopback server access log when `headers == null` (no empty `"Authorization: "` line either); (d) cross-origin 302 redirect does NOT forward the Authorization header (`CURLOPT_UNRESTRICTED_AUTH = 0L`). The libcurl slist `free_all` discipline in the `finally` block is enforced by code review, not by a separate observable test (Kotlin/Native has no in-test heap accounting).
+
+### Integration Tests (resolve layer)
+
+5. **`RepositoryAuthFailureTest`** — Req 6, 7: (a) `[401-repo, central-200]` returns 401 hard error, central is NOT contacted; (b) `[404-repo, 401-repo, central-200]` returns 401 hard error from the second repo; (c) 4-row parametrized matrix (`(401, 403) × (not configured, configured)`) asserts the hint text exactly.
+6. **`RepositoryAuthRedactionTest`** — Req 8: (a) stderr from a 401 fetch contains no Bearer token; (b) stderr from a Basic-auth 401 contains no base64 / no user / no password; (c) `RepositoryAuth.Basic("u","p").toString()` returns the `<redacted>` placeholder; (d) `Repository(name="x", url="y", auth=RepositoryAuth.Basic("alice","s3cret")).toString()` contains the literal substring `"<redacted>"` and does NOT contain `"s3cret"` (Repository → RepositoryAuth toString chain); (e) `kolt.lock` after a successful authenticated fetch contains no credential field; (f) `kolt info` JSON contains no credential field.
+
+### Implementation invariants (additional pin tests)
+
+7. **`PlacementOrderTest`** (inside `RepositoryAuthConfigTest`'s fixture pool, parametrized) — Req 2.1 ordering: a `kolt.toml` carrying a literal `token` plus a `kolt.local.toml` that "overrides" the same field to `null` shall still fail with the placement-policy error (the base-validator runs before merge, so the overlay cannot "rescue" the violation).
+8. **`RepositoryNameInvariantTest`** (inside `RepositoryAuthConfigTest`) — Req 1.x post-lift: for every entry in the returned `Map<String, Repository>`, `entry.key == entry.value.name`.
+9. **`AllCallersTypedTest`** — compile-time smoke: every one of the 10 `downloadFromRepositories` call sites and every one of the 9 `config.repositories.values.toList()` sites compiles with `List<Repository>` and the `(Repository) -> String` urlBuilder lambda type. This is implicitly covered by `kolt build` succeeding after migration, but tasks must verify the compile gate explicitly before claiming completion. The anonymous-no-slist assertion lives inside `DownloaderAuthHeaderTest` (c), not as a separate entry here.
+
+### Cross-cutting Tests
+
+10. **`RepositorySchemaMigrationTest`** (existing, extended) — Req 9: flat-form rejection now suggests `[repositories.<name>] url = "..."` (the new sub-table form); flat with URL userinfo still scrubs.
+
+### Self-host smoke gate
+
+Independent of the unit / integration tests above, the implementation tasks must include a self-host bootstrap check: `kolt build` against kolt's own four `kolt.toml` files (`/kolt.toml`, `/kolt-jvm-compiler-daemon/kolt.toml`, `/kolt-native-compiler-daemon/kolt.toml`, `/spike/native-ktor-cinterop-smoke/kolt.toml`) must succeed after the new `liftRepositoriesMap` validators land. All four already use `[repositories.central]` sub-table form, but the new userinfo / mutex / shape checks enter the hot path for every kolt parse, and a regression here breaks kolt's bootstrap. CI's `self-host-post` job covers this; tasks must not be marked complete without it green. [[feedback_subagent_smoke_misses_ci]]
+
+### Test discipline
+
+- Tests are sized 1 per acceptance criterion family, not 1 per AC. Schema / placement / env-reject share fixtures inside `RepositoryAuthConfigTest` (parametrized) rather than three separate files. The 4-row hint matrix in `RepositoryAuthFailureTest` is parametrized similarly. [[feedback_sdd_test_inflation]]
+- Loopback HTTP fixture (`testfixture/LoopbackHttpServer.kt`) is the testbed for `DownloaderAuthHeaderTest` and `RepositoryAuthFailureTest`; pattern follows `UnixEchoServer` (structure.md §Test fixtures).
+
+## Security Considerations
+
+- **Credential plaintext on disk**: ADR 0034 §3 commits to plaintext in `kolt.local.toml`; this is gitignored by default (#417). Filesystem-level protection (mode 600, encrypted home, etc.) is out of scope and left to the user
+- **Credential-in-process memory**: `RepositoryAuth` is held in `Repository` while the resolver runs. No process-isolation step; this is consistent with v1.0 scope
+- **`data class` `toString()` leakage**: `RepositoryAuth.Basic("u","p").toString()` exposes the password. Mitigation: `AuthFailed` never contains `RepositoryAuth`; the renderer receives `AuthStateProjection`. Test `RepositoryAuthRedactionTest` asserts the password string is absent from any output even when the test deliberately constructs a `RepositoryAuth.Basic` and walks it through the full error path
+- **TLS / certificate validation**: libcurl defaults (system CA bundle) — unchanged. Custom CA support is out of scope (issue #416 non-goal)
+- **Lockfile integrity**: Unchanged. Credentials authenticate the fetch, not the artifact; SHA-256 in `kolt.lock` remains the artifact-trust mechanism (ADR 0034 §5)
+
+## Supporting References
+
+See `.kiro/specs/private-maven-repos/research.md` for the codebase survey and the key-decision rationale that informed each commitment in this design.

--- a/.kiro/specs/private-maven-repos/requirements.md
+++ b/.kiro/specs/private-maven-repos/requirements.md
@@ -1,0 +1,150 @@
+# Requirements Document
+
+## Project Description (Input)
+
+**Source**: issue #416 — Private Maven repository support (literal credentials, v1.0). Milestone v0.20.0. Replaces #33 (closed). Architectural baseline: `docs/adr/0034-private-maven-repos.md` (already written; treat as input to design.md, do not re-derive).
+
+**Problem owner**: kolt users who need to fetch dependencies from authenticated Maven repositories — GitHub Packages, corporate Nexus, Cloudsmith, GitLab Package Registry — and cannot today.
+
+**Current situation**: `[repositories.<name>]` sub-table is anonymous-only (`url` only; no auth fields). Any 401/403 response is unusable: no way to declare credentials, no way to attach `Authorization` headers, no specialized diagnostic for credential failures. The overlay merge mechanism (#415) is in place; kolt.local.toml is gitignored by default (#417).
+
+**What should change**: Add the minimum schema, runtime, and diagnostic surface to fetch from authenticated repos in v1.0, with env-var-based credentials intentionally deferred to v1.1+.
+
+### Prerequisites (landed)
+
+- #415 (kolt.local.toml overlay scope extended to `[repositories]`) — closed 2026-05-13.
+- #417 (`kolt init` `.gitignore` automation for `kolt.local.toml`) — closed 2026-05-13.
+
+### Out of scope (deferred)
+
+`{ env = "..." }` env-var indirection (v1.1+, additive); `${env.X}` interpolation inside string field values (v1.1+; v1.0 treats `${env.X}` as a literal string per ADR 0034 §3); credential helpers / `.netrc` / OAuth / device flow; HTTP proxy / mTLS / custom CA bundles / client certificates; per-repository retry / backoff / timeout overrides; credential storage outside `kolt.toml` / `kolt.local.toml`; Sonatype Portal publishing auth (publish-side).
+
+## Boundary Context
+
+- **In scope**: schema and field validation for `token` / `user` / `password` on `[repositories.<name>]` (uniform inline-table form, see Schema commitment below); per-request `Authorization` header attachment to repository HTTP traffic; 401/403 diagnostic shape and no-fall-through semantics; redaction of credential material from any kolt output; rejection of legacy flat-string-map `[repositories]` form with a migration directive.
+- **Out of scope**: any credential source other than literal values in `kolt.local.toml`; any auth scheme other than HTTP Bearer / HTTP Basic; any change to 404 fall-through behavior or aggregated-error formatting; any change to lockfile integrity (SHA-256 hash verification remains the sole artifact-trust mechanism per ADR 0034 §5).
+- **Schema commitment**: auth fields use a uniform inline-table form (`token = { literal = "..." }` / `{ env = "..." }`). The bare-string form (`token = "..."`) is rejected at parse time. ADR 0034 §4 leaves the field shape to #416; this spec commits to inline-table for the same reason kolt already uses inline-table polymorphism for `[*.sys_props]` values (the TOML parser surface in use cannot decode "bare-string OR inline-table" polymorphism on a single field). Detailed rationale lives in design.md.
+- **Adjacent expectations**:
+  - The `[repositories]` overlay merge from #415 is the only mechanism by which `kolt.local.toml` supplies credential fields against a repository named in `kolt.toml`. A repository name appearing only in `kolt.local.toml` is rejected by the existing overlay validator and is not re-litigated here.
+  - The `kolt.local.toml` `.gitignore` guarantee (#417) is assumed for the placement-policy rationale but is not enforced by this feature.
+  - Existing `[repositories.<name>]` sub-tables in `kolt.toml` and `kolt.local.toml` that pre-date this feature (no `token` / `user` / `password` fields) must continue to parse cleanly after upgrade. The new credential fields default to absent (`null` at the raw-decode level).
+
+## Requirements
+
+### Requirement 1: 認証フィールド付き `[repositories.<name>]` schema
+
+**Objective:** kolt 利用者として、 各リポジトリに対して Bearer または Basic 認証情報を宣言的に指定したい。 そうすれば認証付き Maven リポジトリから依存関係を取得できる。
+
+> Schema commitment lives in the Boundary Context section; this section's ACs describe testable behaviors only.
+
+#### Acceptance Criteria
+
+1. The kolt config parser shall accept `[repositories.<name>]` sub-tables with an optional `token` field, an optional `user` field, and an optional `password` field, in addition to the required `url` field, where each auth field is an inline-table (`{ literal = "<value>" }` or `{ env = "<env-var-name>" }`).
+2. If a `[repositories.<name>]` entry sets both `token` and at least one of `user` / `password`, the kolt config parser shall reject the configuration with a message naming the repository and explaining that `token` is mutually exclusive with `user` / `password`.
+3. If a `[repositories.<name>]` entry sets `user` without `password` or `password` without `user`, the kolt config parser shall reject the configuration with a message naming the repository and explaining that `user` and `password` must be declared together.
+4. If a `[repositories.<name>]` entry sets `token`, `user`, or `password` with a `literal` value that is empty or whose characters are all Unicode whitespace codepoints, the kolt config parser shall reject the configuration with a message naming the offending field and the repository.
+5. When a `[repositories.<name>]` entry sets only `url` (no auth fields), the kolt resolver shall treat the repository as anonymous and shall send no `Authorization` header to that repository.
+6. If a `[repositories.<name>]` auth field's inline-table sets neither `literal` nor `env`, the kolt config parser shall reject the configuration with a message naming the offending field and the repository.
+7. If a `[repositories.<name>]` auth field's inline-table sets both `literal` and `env`, the kolt config parser shall reject the configuration with a message naming the offending field and the repository.
+8. When `kolt.toml` or `kolt.local.toml` declares a `[repositories.<name>]` sub-table without any of `token` / `user` / `password` (the pre-v0.20.0 shape), the kolt config parser shall parse it without producing an error and the kolt resolver shall treat that repository as anonymous.
+
+### Requirement 2: 認証情報の配置ポリシー
+
+**Objective:** kolt 利用者として、 共有される `kolt.toml` には機密値を絶対に書かない仕組みを持ちたい。 そうすれば誤コミットを防げる。
+
+#### Acceptance Criteria
+
+1. If `kolt.toml` declares any of `token`, `user`, or `password` as a literal value under `[repositories.<name>]`, the kolt config parser shall reject the configuration with a message identifying `kolt.toml` as the source file, naming the repository and the offending field, and directing the user to declare the field in `kolt.local.toml` instead.
+2. The kolt config parser shall accept literal `token`, `user`, and `password` values when they appear under `[repositories.<name>]` in `kolt.local.toml` and the repository name also appears in `kolt.toml`.
+3. If a `[repositories.<name>]` entry in either file sets any auth field to the inline-table form `{ env = "<env-var-name>" }`, the kolt config parser shall reject the configuration with a message stating that env-reference is not supported in v1.0 and directing the user to use the `{ literal = "..." }` form in `kolt.local.toml`.
+4. When the placement-policy validator rejects a literal credential in `kolt.toml`, the error message shall not include the credential value itself.
+
+### Requirement 3: URL に埋め込まれた認証情報の拒否
+
+**Objective:** kolt 利用者として、 URL に user:password を埋め込む形を使えないようにし、 認証情報の管理を専用フィールドに集約したい。
+
+#### Acceptance Criteria
+
+1. If a `[repositories.<name>]` entry's `url` field contains a userinfo component (an `@` character before the host portion of the URL), the kolt config parser shall reject the configuration with a message naming the repository and directing the user to declare credentials in the `token` field or the `user` / `password` fields.
+2. The kolt config parser shall apply the userinfo check regardless of whether the userinfo component includes a password (`user@host` and `user:pass@host` are both rejected).
+3. When the URL-userinfo validator rejects a URL, the error message shall not include any character of the userinfo component (no `user`, no `password`, no `:`-separated combination).
+
+### Requirement 4: 暗黙 `central` フォールバックと宣言順序の保存
+
+**Objective:** kolt 既存利用者として、 認証機能の追加によって `central` の暗黙フォールバックと TOML 宣言順序のセマンティクスが変わらないことを保証したい。
+
+#### Acceptance Criteria
+
+1. When `kolt.toml` declares no `[repositories]` sub-tables at all, the kolt config parser shall populate the repository map with a single `central → https://repo1.maven.org/maven2` entry, so the kolt resolver iterates a single anonymous Maven Central entry as if it had been declared explicitly.
+2. When `kolt.toml` declares `[repositories.central]` explicitly, the kolt resolver shall treat it as any other repository entry (no special reservation of the `central` name, no merging with the implicit fallback).
+3. When `kolt.toml` declares two or more `[repositories.<name>]` sub-tables, the kolt resolver shall iterate them in TOML declaration order during dependency resolution.
+
+### Requirement 5: 全 resolver 入口・全 artifact 種別への認証適用
+
+**Objective:** kolt 利用者として、 どの kolt サブコマンドを使っても、 どの artifact を取得するときでも、 設定した認証情報が一貫して使われたい。
+
+#### Acceptance Criteria
+
+1. When the kolt resolver issues an HTTP request to a `[repositories.<name>]` whose `token` field is set, the kolt resolver shall attach the header `Authorization: Bearer <token>` to that request.
+2. When the kolt resolver issues an HTTP request to a `[repositories.<name>]` whose `user` and `password` fields are set, the kolt resolver shall attach the header `Authorization: Basic <base64(user:password)>` to that request.
+3. The kolt resolver shall apply the Authorization-attachment rules from acceptance criteria 1 and 2 to every HTTP request it issues to a repository, regardless of which CLI subcommand initiated the resolution (`build`, `run`, `test`, `check`, `fetch`, `update`, `tree`, `deps`, `add`, `remove`, `outdated`) and regardless of which artifact class is being fetched (declared dependencies, test dependencies, `[classpaths.<name>]` bundle entries, tools, compiler plugin jars, incremental-compilation support libraries).
+
+### Requirement 6: 401 / 403 のハードエラー化
+
+**Objective:** kolt 利用者として、 認証エラーが他のリポジトリへの fall-through で隠蔽されることなく、 即座に診断できるようにしたい。
+
+#### Acceptance Criteria
+
+1. If a repository responds with HTTP status 401 or 403 to any kolt-issued request, the kolt resolver shall stop iterating subsequent repositories for that coordinate and shall surface the failure as a hard error.
+2. The kolt resolver shall apply the 401 / 403 hard-error rule regardless of whether the repository had any auth fields configured.
+3. When a repository responds with HTTP status 404, the kolt resolver shall continue to fall through to the next repository in declaration order (existing behavior, unchanged).
+4. When the kolt resolver aggregates multi-repository failures into a single error (existing v0.18.1 format), the aggregation shall include only 404 attempts; 401 / 403 attempts shall surface as a stand-alone diagnostic per Requirement 7.
+
+### Requirement 7: 401 / 403 用の専用エラー診断
+
+**Objective:** kolt 利用者として、 認証失敗時に何が起きているか・どこに何を設定すべきかを最小限の出力で把握したい。
+
+#### Acceptance Criteria
+
+1. When the kolt resolver emits a 401 / 403 diagnostic, the headline shall identify the requested coordinate (`group:artifact[:version]`) using the existing `ResolveError`-variant phrasing for the operation that triggered the fetch. The enumerable variants for v0.20.0 are: `failed to download <coordinate>` (`ResolveError.DownloadFailed`, used by POM / artifact / sources / klib fetch) and `could not fetch metadata for <coordinate>` (`ResolveError.MetadataDownloadFailed`, used by Gradle module metadata fetch).
+2. The kolt resolver shall include the following context lines in declaration order: `repository: <name>`, `url: <url>`, `status: <code> <reason>`, `credentials: <state>`, `hint: <state-specific>`.
+3. The `<state>` value shall be exactly one of: `not configured`, `configured (token, from kolt.local.toml)`, `configured (basic, from kolt.local.toml)`.
+4. When the kolt resolver emits a 401 or 403 diagnostic, the `<state-specific>` hint line shall be the entry in the following table matching the `(status, credentials state)` pair:
+
+| status | credentials state | hint text |
+|--------|-------------------|-----------|
+| 401 | `not configured` | the repository requires authentication; add credentials to `kolt.local.toml` |
+| 401 | configured (token or basic) | the credentials may be invalid or expired |
+| 403 | `not configured` | authentication is required |
+| 403 | configured (token or basic) | the credentials are valid but lack permission for this repository |
+
+### Requirement 8: 認証情報の redaction 保証
+
+**Objective:** kolt 利用者として、 設定した認証情報が誤って出力経路に漏れることがないと保証されたい。 そうすれば CI ログやエラー出力を安心して共有できる。
+
+#### Acceptance Criteria
+
+1. The kolt resolver shall not include any `Authorization` header value (Bearer token, Basic credential, or any future scheme) in any error message, log line, or stderr output.
+2. The kolt config parser and resolver shall not include any value of the `token`, `user`, or `password` fields in any error message, log line, or stderr output.
+3. As a defense-in-depth measure (Requirement 3 catches userinfo URLs at parse time, but a credential value supplied via a different code path must not leak), the kolt resolver shall not include any userinfo component (text between `://` and `@` of a URL) in any error message, log line, or stderr output.
+4. The kolt resolver shall not write any value of `token`, `user`, `password`, `Authorization`, or any URL userinfo component to `kolt.lock`.
+5. The kolt resolver shall enforce the redaction guarantees in acceptance criteria 1 through 4 regardless of current or future verbosity flags or debug modes.
+
+### Requirement 9: 既存 flat-string-map 形式の拒否
+
+**Objective:** kolt 利用者として、 古い `[repositories]` flat-string-map 形式を残したまま 0.20.0 にアップグレードしたとき、 黙って壊れるのではなく明確なエラーと移行先を示してほしい。
+
+#### Acceptance Criteria
+
+1. If `kolt.toml` declares a flat-string-map `[repositories]` entry of the form `<name> = "<url>"`, the kolt config parser shall reject the configuration with a message identifying `kolt.toml` as the source file.
+2. The kolt config parser's rejection message for a flat-string-map entry shall include a directive to use the sub-table form `[repositories.<name>] url = "<url>"`.
+3. When the kolt config parser rejects a flat-string-map entry that contained credentials via URL userinfo (e.g. `central = "https://user:pass@..."`), the error message shall not include any character of the userinfo component.
+
+### Requirement 10: lockfile-hash による artifact 整合性は不変
+
+**Objective:** kolt 利用者として、 認証は fetch の認可手段にすぎず、 artifact 内容の改ざん検知は引き続き lockfile の SHA-256 が担うことを期待したい。
+
+#### Acceptance Criteria
+
+1. When the kolt resolver successfully fetches an artifact from any repository (authenticated or anonymous), the kolt resolver shall verify the artifact's SHA-256 hash against `kolt.lock` using the same mechanism as before this feature.
+2. The kolt resolver shall not weaken or skip lockfile hash verification based on whether the source repository was authenticated.

--- a/.kiro/specs/private-maven-repos/research.md
+++ b/.kiro/specs/private-maven-repos/research.md
@@ -1,0 +1,218 @@
+# Gap Analysis: private-maven-repos
+
+**Date**: 2026-05-13
+**Inputs**: requirements.md (10 件), ADR 0034, codebase survey (Downloader / TransitiveResolver / Config / LocalOverlay / Resolver)
+
+## 1. Current State Investigation
+
+### Domain assets relevant to this feature
+
+| Asset | File | Current shape |
+|---|---|---|
+| `RawRepository` (ktoml decode) | `src/nativeMain/kotlin/kolt/config/Config.kt:173` | `data class RawRepository(val url: String? = null)` — no auth fields. |
+| `Repository` (typed) | `Config.kt:108` | `data class Repository(val url: String)` — no auth fields. |
+| `liftRepositoriesMap` (validator) | `Config.kt:256-269` | Strips quotes, rejects null/empty URL, trims trailing slash. No userinfo check. |
+| `mergeRepositories` (overlay merge) | `LocalOverlay.kt:82-105` | Field-level merge (line 102: `baseRepo.copy(url = overlayRepo.url ?: baseRepo.url)`). Rejects overlay-only names. No source-attribution map yet. |
+| Implicit `central` fallback | `Config.kt:185-186` (raw) + `Config.kt:120` (typed) | Populated by ktoml decoding the `RawKoltConfig.repositories` data-class field default `mapOf("central" to RawRepository(MAVEN_CENTRAL_BASE))` when the TOML omits `[repositories]`. The lifted `KoltConfig.repositories` has the same default for callers that bypass `parseConfig`. The `Resolver.kt:153` `NoRepositoriesConfigured` branch is a defensive surface for internal callers that construct `KoltConfig` with an explicit empty map. |
+| `Downloader.downloadFile` (HTTP) | `infra/Downloader.kt:47-109` | `downloadFile(url, destPath): Result<Unit, DownloadError>`. libcurl easy-handle. No header parameter. No `curl_slist_append` use anywhere in codebase. |
+| `DownloadError` | `infra/Downloader.kt:37-41` | `HttpFailed(url, statusCode)`, `NetworkError(url, message)`. All non-2xx flatten to `HttpFailed`. |
+| `downloadFromRepositories` (iteration) | `resolve/TransitiveResolver.kt:84-107` | Iterates `repos: List<String>` (URL-only). Falls through on 404 (line 99); hard-stops on any other error. Returns `RepositoryDownloadFailure.AllAttemptsFailed`. |
+| `formatResolveError` (diagnostic) | `resolve/Resolver.kt:75-138` | Emits headline + per-attempt context lines (`url -> status`). `repositoryDownloadFailureContext` helper at lines 151-159 renders `NoRepositoriesConfigured` and `AllAttemptsFailed` variants. |
+| `RawSysPropValue` polymorphism (precedent) | `config/SysPropValue.kt:27-31` + `Config.kt:220-250` | All-nullable-fields trick: `literal / classpath / project_dir` decoded as nullable, validator requires exactly one. **Reference pattern for `{env = "..."}` recognition.** |
+| `sysPropSourceMap` (per-key source attribution) | `Config.kt:398-414` | Maps each sys_prop key to its contributing file (base / overlay). **Reference pattern for repository field-level source attribution.** |
+| `RepositoryAttempt` (error context) | `resolve/Resolver.kt:18` | `RepositoryAttempt(url, error)` — URL only, no repository name. |
+
+### HTTP traffic call sites (relevant to Req 5 universal auth attachment)
+
+All seven `downloadFile` entry points converge on the single `Downloader.downloadFile`. Note: this table counts direct `Downloader.downloadFile` callers (i.e., HTTP entry points). The propagation layer above is `downloadFromRepositories`, which is itself called from 10 sites; see design.md File Structure Plan for that enumeration. The two layers are different and should not be conflated.
+
+| Caller | File:line | Repository context passed |
+|---|---|---|
+| POM fetch | `TransitiveResolver.kt:128-134` | `repos: List<String>` |
+| Module metadata | `TransitiveResolver.kt:186-191` | `repos: List<String>` |
+| Binary / artifact materialization | `TransitiveResolver.kt` (materialization) | `repos: List<String>` |
+| Sources jar fallback | `TransitiveResolver.kt:69-75` | `repos: List<String>` |
+| klib (native) | `NativeResolver.kt:139-145` | `repos: List<String>` |
+| Plugin jar | `resolve/PluginJarFetcher.kt:147` | URL-only (hardcoded Maven Central) |
+| BTA impl jar | `build/daemon/BtaImplFetcher.kt:47-55` | Synthetic config, funnels through `resolveTransitive` |
+
+**Repository name is lost after `parseConfig`**: every resolver call passes `config.repositories.values.map { it.url }` (TransitiveResolver.kt:20, NativeResolver.kt:67). The map key (= repository name) is dropped. This matters for Req 7 (`repository: <name>` line in 401/403 diagnostic).
+
+### Redaction surface (relevant to Req 8)
+
+Confirmed by `grep -rn "Authorization\|userinfo\|@.*://\|://.*@" src/nativeMain/` — zero hits.
+
+| Output channel | Emits URL today? | Emits repo name? | Notes |
+|---|---|---|---|
+| `formatResolveError` stderr | Yes (per-attempt `url ->`) | No | The only current URL emission path. |
+| `kolt.lock` | No | No | `Lockfile.kt` stores `version`, `kotlin`, `jvmTarget`, `dependencies: Map<String, LockEntry>` (each entry: `version`, `sha256`, `transitive`, `test`, `redirectTarget`), and `classpathBundles: Map<String, Map<String, LockEntry>>`. No repository URL or auth field is persisted in any of these. |
+| `kolt info` JSON | No | No | `cli/InfoCommand.kt` `InfoSnapshot` data class (lines 72-84); `parseError` field at line 82 carries config error string but not URLs. |
+| Watch-mode marker | No | No | `cli/WatchChangeDispatch.kt:77` and `cli/InfoCommand.kt:382` are the two call sites that invoke `renderConfigErrorAsLine`. The line emits the rendered string (which contains no URL by construction); no separate URL path. |
+| libcurl request log | No | No | Verbose libcurl is not enabled in `Downloader.kt`. |
+
+URL inline credentials (`https://user:pass@host/...`) would currently flow verbatim into `DownloadError.HttpFailed(url, ...)` → `RepositoryAttempt.url` → stderr if the parser failed to reject them (Req 3 catches at parse, Req 8.3 catches defensively if a URL slips through).
+
+### kolt's own kolt.toml files (relevant to Req 9 migration)
+
+| Path | `[repositories]` form |
+|---|---|
+| `/kolt.toml:30` | `[repositories.central]` sub-table |
+| `/kolt-jvm-compiler-daemon/kolt.toml:28` | `[repositories.central]` sub-table |
+| `/kolt-native-compiler-daemon/kolt.toml:27` | `[repositories.central]` sub-table |
+| `/spike/native-ktor-cinterop-smoke/kolt.toml:14` | `[repositories.maven_central]` sub-table |
+
+All four are already on the new sub-table form. Issue #416 body's claim ("kolt's own three `kolt.toml` files do not declare `[repositories]`") is incorrect, but the conclusion (no internal migration needed) stands.
+
+## 2. Requirements Feasibility Analysis
+
+### Requirement-to-asset map
+
+| Req | Asset extension needed | Status |
+|---|---|---|
+| 1 (schema + mutex) | `RawRepository` += {token, user, password, env}; new `RepositoryAuth` sealed type on `Repository`; new validator in `liftRepositoriesMap` | **Missing** |
+| 2 (placement policy) | New base-validator (reject literals in `kolt.toml`); reuse `#436` source-attribution model (`repositorySourceMap`) for overlay attribution | **Missing** (model exists for sys_props, not for repositories) |
+| 3 (URL userinfo) | New URL-userinfo check inside `liftRepositoriesMap`; redaction in error message | **Missing** |
+| 4 (central fallback + iteration order) | Preserve `Config.kt:120` and `TransitiveResolver.kt:20` | **No change** |
+| 5 (universal auth attachment) | Extend `Downloader.downloadFile` signature with headers; carry per-repo auth context through 7 call sites | **Missing** (libcurl header attach not used anywhere yet) |
+| 6 (401/403 hard error) | Add 401/403 branch alongside the existing 404 fall-through in `downloadFromRepositories:99`; new `RepositoryDownloadFailure.AuthFailed` variant | **Missing** (status code flattens to HttpFailed today) |
+| 7 (401/403 diagnostic format) | New `formatResolveError` branch; needs `repository name` (currently dropped) and `credentials state` (new enum) | **Missing** |
+| 8 (redaction guarantee) | Defensive scrub of URL userinfo in `DownloadError.HttpFailed`; never log Authorization; lockfile / kolt.lock confirmed clean today | **Partial** (lockfile clean, but URL-userinfo defensive scrub is missing) |
+| 9 (legacy flat-form rejection) | Already in place via `KtomlMessageParse` + `ConfigParseMessageFormatTest` pinning. Verify migration hint text matches issue body. | **Partial** (rejection exists; message text needs check) |
+| 10 (lockfile hash unchanged) | `Lockfile.kt` write path unchanged | **No change** |
+
+### Complexity signals
+
+- **External integration**: libcurl header attachment (new for kolt — no prior `curl_slist_append` use).
+- **Type / schema polymorphism**: `token` / `user` / `password` must accept literal string OR inline-table `{ env = "..." }` (recognize-and-reject for v1.0). ktoml 0.7.1 cannot do string-OR-table polymorphism on a standard `KSerializer`; the precedent is the custom `SysPropValueSerializer` (`SysPropValue.kt:46-59`). [[reference_ktoml_decode_quirks]]
+- **Cross-cutting redaction**: Req 8 cuts across every code path that emits a URL or auth value. Mostly clean slate, but the URL-userinfo defensive scrub is the one ongoing obligation.
+- **Repository-name propagation**: Either thread `Repository` (name + url + auth) through the resolver chain or build a URL → auth side table at the resolver boundary. Affects 7 call sites either way.
+
+### Constraints from existing architecture
+
+- **ADR 0001** — All new error paths must return `Result<V, E>` (no exceptions). Applies to the custom serializer for credential fields: deserialize must not throw; if ktoml forces an exception, we wrap.
+- **ADR 0006** — libcurl is the chosen native HTTP path. No ktor-client introduction.
+- **ADR 0032 §2** — `${env.X}` indirection deferred. Req 2.3 recognizes the inline-table form but rejects it.
+- **#415 overlay contract** — A repository name in `kolt.local.toml` but not in `kolt.toml` is already rejected. We do not re-litigate this.
+- **kotlin-result 2.x is value class** — Use `getOrElse` / `getError` / `isErr`; never `is Ok` / `is Err`. [[feedback_kotlin_result_value_class]]
+
+## 3. Implementation Approach Options
+
+### Option A: URL-keyed side table at resolver boundary
+
+**Shape**: Keep `Downloader.downloadFile(url, destPath)` unchanged in surface but add an internal `headers: Map<String, String>? = null` parameter. The resolver builds a `Map<URL, RepositoryAuth>` from the config and looks it up per request. Repository name lookup for diagnostics uses a parallel `Map<URL, RepositoryName>`.
+
+**Files touched**:
+- `Downloader.kt` — header attachment via `curl_slist_append`.
+- `TransitiveResolver.kt`, `NativeResolver.kt`, `PluginJarFetcher.kt`, `BtaImplFetcher.kt` — construct the side table and pass headers per call.
+- `Config.kt` — extend `RawRepository` + `Repository` with auth fields.
+- `LocalOverlay.kt` — extend `mergeRepositories` to merge auth fields.
+
+**Trade-offs**:
+- ✅ Smallest signature churn at resolver layer (`List<String>` stays).
+- ✅ Single-point libcurl change.
+- ❌ URL-keyed lookup is brittle if URLs normalize differently between config and request (trailing-slash, port, etc.).
+- ❌ Reverse-mapping URL → repository name for diagnostics is fragile if two repositories share a URL (rare but possible).
+
+### Option B: `Repository`-typed propagation
+
+**Shape**: Resolver functions take `repos: List<Repository>` instead of `repos: List<String>`. `Repository` becomes `data class Repository(val name: String, val url: String, val auth: RepositoryAuth?)`. Auth is a sealed type (`Bearer(token)` / `Basic(user, password)`). Each call site passes the repository, not the URL.
+
+**Files touched**:
+- `Downloader.kt` — accept optional `headers` parameter (same as Option A).
+- `TransitiveResolver.kt`, `NativeResolver.kt`, `downloadFromRepositories`, all 7 call sites — switch from `String` to `Repository`.
+- `Config.kt` — extend `Repository` typed class.
+- `Resolver.kt` (`RepositoryAttempt`, `formatResolveError`) — capture repository name in attempt records.
+
+**Trade-offs**:
+- ✅ Type-safe: repository name and auth always travel together.
+- ✅ Req 7 (`repository: <name>` line) falls out naturally.
+- ✅ Future credential schemes (mTLS, OAuth) extend `RepositoryAuth` cleanly.
+- ❌ Wider blast radius: every resolver-function signature shifts from `String` to `Repository`.
+- ❌ Lockfile and other downstream code that reads `repos: List<String>` (if any) needs adjustment.
+
+### Option C: Hybrid — typed propagation through resolve layer + Downloader signature change
+
+**Shape**: Resolver carries `List<Repository>`; at the boundary to `Downloader.downloadFile`, the resolver builds the headers and passes URL + headers. `Downloader` keeps a simple signature (`url, destPath, headers?`). The resolver also captures the repository name into `RepositoryAttempt`.
+
+**Files touched**: Same set as Option B, but `Downloader.kt` stays minimally extended (no `Repository` type at infra layer — keeps `kolt.infra` independent of `kolt.config`).
+
+**Trade-offs**:
+- ✅ Type-safe at the resolver layer where the information matters.
+- ✅ `kolt.infra` stays as a thin OS-primitive layer (no domain types leak in).
+- ✅ Diagnostic carries repository name without reverse-mapping.
+- ✅ Symmetric with the structure-md downward dependency rule (cli → build → resolve → infra).
+- ❌ Same blast radius as Option B at the resolver layer.
+- ⚠️ `Map<String, Repository>` with `Repository(name, url, auth)` introduces a `repository.name == map_key` redundancy. **Resolved in design.md §Domain Model: `liftRepositoriesMap` enforces the invariant at construction**, and a dedicated `RepositoryNameInvariantTest` pins it.
+- ❌ The `kolt.config` side grows (`RepositoryAuth` ADT, `RawCredentialField` + serializer, `repositorySourceMap`) while `kolt.infra` only gains a headers parameter. The asymmetry is intentional but worth naming so reviewers don't read it as "thin infra change".
+
+## 4. Effort and Risk
+
+- **Effort: M (3-7 days)**. Schema + parse validation (~1 day) + libcurl header attachment + Downloader extension (~1 day) + resolver propagation + new error variant (~1-2 days) + error format + redaction (~1 day) + comprehensive tests (~1-2 days).
+- **Risk: Medium**.
+  - libcurl `curl_slist_append` / `CURLOPT_HTTPHEADER` is new to kolt (no prior use). Need a small spike to confirm cleanup ordering with the existing finally-block pattern.
+  - Custom ktoml serializer for credential-field polymorphism (literal vs `{env = "..."}`) follows the `SysPropValueSerializer` precedent — known feasible but adds review surface.
+  - Redaction is a non-functional invariant; getting `Req 8.5` ("regardless of current or future verbosity flags") right needs explicit tests now and a documented contract for any future logger.
+
+## 5. Recommendations for Design Phase
+
+### Preferred approach: **Option C (hybrid: typed resolver + thin Downloader extension)**
+
+Rationale:
+- Cleanest fit with the `cli → build → resolve → infra` dependency direction (structure.md). `kolt.infra` does not learn about `Repository`; the resolver layer owns auth attachment.
+- Repository name flows for free through `RepositoryAttempt` — Req 7's `repository: <name>` line is direct, not a reverse lookup.
+- libcurl change is a single header-attachment call site, the same as Option A.
+- Future credential schemes (OAuth, mTLS) extend `RepositoryAuth` without touching infra.
+
+### Key decisions to commit in design.md
+
+1. **`RepositoryAuth` ADT shape** — `sealed class RepositoryAuth { object None; data class Bearer(token); data class Basic(user, password) }` vs a flat `(token?, user?, password?)`. Sealed ADT preferred (ADR 0001 idiom; lets `formatResolveError` switch exhaustively for `credentials: <state>`).
+2. **Credential-field polymorphism mechanism** — custom serializer (literal-vs-inline-table, mirrors `SysPropValueSerializer`) vs plain `String?` + ktoml-error remap. The custom serializer is forward-compat for v1.1+; the plain-string approach is simpler for v1.0 but adds remap fragility.
+3. **Placement-policy validator location** — pre-merge base-only validator (rejects literals in `kolt.toml` before merge) vs post-merge validator with `repositorySourceMap` (mirroring `sysPropSourceMap` from #436). Pre-merge is simpler; post-merge unifies with the source-attribution pattern.
+4. **Repository name in `RepositoryAttempt`** — extend the existing data class with `name: String` (breaks no contract; serialized only into stderr).
+5. **`DownloadError` extension vs new `RepositoryDownloadFailure.AuthFailed`** — extend `DownloadError` with `Unauthorized` / `Forbidden` variants and reuse the existing aggregation path, OR introduce `RepositoryDownloadFailure.AuthFailed` that bypasses aggregation (Req 6.4). Issue #416 implies the latter shape; design should commit.
+
+### Research items to carry forward
+
+- **libcurl spike**: Confirm `curl_slist_append` ownership and free-order with the existing `curl_easy_cleanup` pattern. ~30 minute spike.
+- **Custom serializer for credential fields**: Decide between the SysPropValue-style serializer and the plain-string remap; design.md should pick one with rationale.
+- **Multi-repo 401 + 404 interaction**: When repository A returns 401 (hard error) and repository B (declared later) would have returned 404 — what does the final aggregate error look like? Issue body says "401/403 hard error, no fall-through" so iteration stops at A. Design should explicitly state that subsequent repositories are not contacted.
+- **`token = { env = "..." }` recognition surface**: Should it also be recognized (and rejected in v1.0) for `url`, or only for credential fields? Issue body restricts it to `token` / `user` / `password`; design should confirm.
+- **Empty-credentials test matrix**: tabulate the rejection cases (Req 1.4) — `token = ""`, `token = "   "`, `user = ""` (with valid password), etc. Helps `/kiro-spec-tasks` size the test surface and avoid SDD test inflation. [[feedback_sdd_test_inflation]]
+
+---
+
+## 6. Design Synthesis Outcomes (2026-05-13)
+
+### Generalization decisions committed in design.md
+
+- **`RepositoryAuth` ADT is the source of truth for header attachment only.** It carries the secret material (token / user / password) and is consumed by the `kolt.resolve` loop to produce HTTP `Authorization` headers. It is NEVER passed to the renderer — Req 8.1 / 8.2 are upheld by type, not by runtime check.
+- **`AuthStateProjection`** is the renderer-facing secret-free counterpart (`kolt.resolve`, co-located with `RepositoryDownloadFailure`). `RepositoryDownloadFailure.AuthFailed` carries `AuthStateProjection`, not `RepositoryAuth`. Architectural redaction: the renderer cannot see secrets even if asked to. The display-string mapping (Req 7.3) is owned by `AuthStateProjection.toDisplayString()`, not the renderer.
+- **No `RepositoryAuth.None` variant** — `null` represents anonymous (simpler, fewer pattern-match branches).
+- **Source attribution via per-field map** generalizes the `sysPropSourceMap` pattern from #436 to repositories. New helper `repositorySourceMap(base, overlay, basePath, overlayPath): Map<repoName, Map<fieldName, file?>>`.
+
+### Build-vs-adopt decisions committed in design.md
+
+- **Adopt** libcurl `curl_slist_append` + `CURLOPT_HTTPHEADER` for header attachment. First use in kolt; cleanup via `curl_slist_free_all` in finally block (the order vs `curl_easy_cleanup` is mutually safe per libcurl docs — string copies are internal — but kolt's convention is slist-first followed by easy, opposite the common upstream example; documented as an anchored gotcha).
+- **Adopt** the `SysPropValueSerializer` pattern for `RawCredentialField`, but constrained to **uniform inline-table polymorphism**, not string-OR-table. The `SysPropValue.kt:14-16` comment documents that ktoml 0.7.1 rejects string-OR-table on a custom serializer (would require reaching into `TomlNode` internals). v1.0 auth fields therefore take the shape `token = { literal = "..." }` / `token = { env = "..." }`; v1.1+ flips the env-reject validator additively without schema change.
+- **Adopt** kotlin platform `Base64` for `Authorization: Basic` encoding. Same dependency already used for `kolt.lock` SHA-256 path (kotlincrypto.hash is sha2-only; base64 is platform stdlib).
+- **Adopt** `Map<String, String>` as the `Downloader.downloadFile` headers parameter type, with the boundary contract that the Map key is the bare header name (no colon) and the Map value is the bare header value. The Downloader assembles each libcurl slist line as `"$name: $value"` internally. This is the contract between `RepositoryAuth.toHeaders()` and the infra layer (`Downloader`).
+
+### Simplification decisions committed in design.md
+
+- **No `RepositoryAuth.None`** — `null` is sufficient and reduces pattern-match noise everywhere.
+- **No URL-keyed side table** (Option A from §3 rejected) — `Repository` is propagated as a typed value through the resolver chain (Option C).
+- **Req 2.1 (kolt.toml literal reject) uses `path` parameter directly**, not the source map. Base raw originates entirely from `kolt.toml`; no per-field attribution needed for this case. Source map is only invoked for overlay-attributed errors (Req 2.3 env-form, Req 1.x mutex / empty when the violating field came from overlay).
+- **`DownloadError` is not extended** with `Unauthorized` / `Forbidden`. 401/403 stay flat at `HttpFailed` in `kolt.infra`. The 401/403 → hard-error transformation happens at `downloadFromRepositories` in `kolt.resolve`. Keeps `kolt.infra` status-code-agnostic.
+- **No new diagnostic types for legacy flat-form rejection** (Req 9). Existing `KtomlMessageParse` path stays; only the hint text changes to reference the new sub-table-plus-credentials shape.
+
+### Carry-forward research items (resolved in design.md)
+
+| Item | Resolution |
+|---|---|
+| libcurl spike (slist cleanup order) | Resolved by reading libcurl docs: `curl_slist_*` strings are copied internally; either order is safe. kolt picks slist-first-then-easy, opposite the common upstream example; documented as anchored gotcha in `Downloader` Implementation Notes. |
+| libcurl redirect Authorization stripping | Cross-origin redirect strips `Authorization` by default (`CURLOPT_UNRESTRICTED_AUTH = 0L`). Critical for GitHub Packages / Cloudsmith / CDN-fronted repos. design.md commits to `CURLOPT_UNRESTRICTED_AUTH = 0L` (drop on cross-origin) with explicit test coverage. |
+| Custom serializer shape | Uniform inline-table only (`{ literal = "..." }` / `{ env = "..." }`), not string-OR-table. Driven by `SysPropValue.kt:14-16` ktoml-0.7.1 constraint. v1.1+ flip-to-accept-env stays additive. |
+| Multi-repo 401 + 404 interaction | `AuthFailed` returned before iteration continues. Subsequent repositories not contacted. Documented in `downloadFromRepositories` Implementation Notes and `System Flows` diagram. |
+| `{env="..."}` for `url` field too? | Restricted to `token` / `user` / `password` per issue body. `url` polymorphism out of scope; URL accepts only string. |
+| Empty-credentials test matrix | Sized as a single parametrized test (`RepositoryAuthConfigTest` with data table), not 1 file per case. |
+| `Repository.toString()` / `RepositoryAuth.toString()` leak | The `RepositoryAuth` parent is a non-data `sealed class`; its variants (`Bearer`, `Basic`) are `data class` with **explicit `toString()` overrides** that emit `<redacted>` for secret fields. `Repository` stays as a `data class` (no custom `toString`); its auto-generated `toString` delegates per-field, so the `auth` field surfaces through the overridden variant `toString` and the password / token never reach output. design.md §Domain Model invariants documents the chain explicitly. |

--- a/.kiro/specs/private-maven-repos/spec.json
+++ b/.kiro/specs/private-maven-repos/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "private-maven-repos",
+  "created_at": "2026-05-13T08:12:35Z",
+  "updated_at": "2026-05-13T14:45:00Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": false
+    }
+  },
+  "ready_for_implementation": false
+}

--- a/.kiro/specs/private-maven-repos/spec.json
+++ b/.kiro/specs/private-maven-repos/spec.json
@@ -1,9 +1,9 @@
 {
   "feature_name": "private-maven-repos",
   "created_at": "2026-05-13T08:12:35Z",
-  "updated_at": "2026-05-13T14:45:00Z",
+  "updated_at": "2026-05-14T00:00:00Z",
   "language": "ja",
-  "phase": "tasks-generated",
+  "phase": "tasks-approved",
   "approvals": {
     "requirements": {
       "generated": true,
@@ -15,8 +15,8 @@
     },
     "tasks": {
       "generated": true,
-      "approved": false
+      "approved": true
     }
   },
-  "ready_for_implementation": false
+  "ready_for_implementation": true
 }

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -1,0 +1,222 @@
+# Implementation Plan
+
+> **進め方**: TDD (Red→Green→Refactor) で各 sub-task を進める。 commit 列は読みやすさで切り、 Red/Green/Refactor の履歴を残す必要はない ([[feedback_tdd_commit_granularity]])。
+> **Self-host**: kolt の 4 つの `kolt.toml` (`/kolt.toml`, `/kolt-jvm-compiler-daemon/kolt.toml`, `/kolt-native-compiler-daemon/kolt.toml`, `/spike/native-ktor-cinterop-smoke/kolt.toml`) はすべて `[repositories.central]` sub-table 形で、 新 validator のホットパスを通る。 タスク完了の最終ゲートとして CI `self-host-post` job の green を要求する (7.3)。
+
+## 1. Foundation: new types and utilities
+
+- [ ] 1.1 (P) `RepositoryAuth` ADT と `AuthStateProjection` を追加
+  - `src/nativeMain/kotlin/kolt/config/RepositoryAuth.kt` を新規作成: sealed class `RepositoryAuth`、 `Bearer(token: String)` / `Basic(user: String, password: String)` を data class で持ち、 各 variant に `toString()` override を実装して secret を `<redacted>` に置換
+  - `RepositoryAuth.toHeaders(): Map<String, String>` を実装し、 Bearer は `mapOf("Authorization" to "Bearer $token")`、 Basic は `mapOf("Authorization" to "Basic ${base64Encode("$user:$password")}")` を返す
+  - `src/nativeMain/kotlin/kolt/resolve/AuthStateProjection.kt` を新規作成: sealed class + 3 data object (`NotConfigured` / `ConfiguredToken` / `ConfiguredBasic`)、 `toDisplayString()` で要件 7.3 の 3 文字列を所有 (`kolt.resolve` 配置で renderer 側からの import が自然に閉じる)
+  - `RepositoryAuth?.toStateProjection()` 拡張関数で nullable RepositoryAuth から AuthStateProjection への射影を行う (両ファイルのいずれかで定義)
+  - 観察可能な完了: `RepositoryAuth.Basic("alice","s3cret").toString()` が `"<redacted>"` を含み `"s3cret"` を含まないことを assert する単体 test が green
+  - _Requirements: 1.5, 5.1, 5.2, 7.3, 8.1, 8.2_
+  - _Boundary: kolt.config.RepositoryAuth, kolt.resolve.AuthStateProjection_
+
+- [ ] 1.2 (P) `RawCredentialField` と uniform inline-table custom serializer を追加
+  - `RawCredentialField` を sealed class + `Literal(value)` / `Env(varName)` 2 variants で導入
+  - `RawCredentialFieldShape(literal: String? = null, env: String? = null)` を all-nullable fields trick で構築、 `RawCredentialFieldSerializer` を `SysPropValueSerializer` と同型の custom KSerializer で実装し、 `setFields.size != 1` のとき `SerializationException` を throw
+  - `serialize` も `SysPropValueSerializer.kt:36-44` と同型の真面目な実装にする (error("...") にしない)
+  - 観察可能な完了: 単体 test で `token = { literal = "abc" }` が `Literal("abc")` に decode、 `token = { env = "X" }` が `Env("X")` に decode、 `token = { literal = "a", env = "X" }` と `token = {}` の双方で SerializationException が出る
+  - _Requirements: 1.1, 1.4, 1.6, 1.7, 2.3_
+  - _Boundary: kolt.config.RawCredentialField_
+
+- [ ] 1.3 (P) `redactUrlUserinfo` shared utility と `UrlRedactionTest` を追加
+  - `kolt.infra.redactUrlUserinfo(url: String): String` を実装、 `://` と `@` の位置関係 (`@` がパス区切り `/?#` より前にあること) で userinfo を検出して除去
+  - 5 ケース matrix test: (a) `https://host/path` 不変、 (b) `https://u:p@host/path` → userinfo 除去、 (c) `https://u@host/path` → userinfo 除去、 (d) `https://host/foo@bar` 不変 (path 内 `@`)、 (e) `not-a-url-at-all` 不変
+  - 観察可能な完了: `UrlRedactionTest` 5 ケース全 green
+  - _Requirements: 3.3, 8.3, 9.3_
+  - _Boundary: kolt.infra.UrlRedaction_
+
+## 2. Config layer
+
+- [ ] 2.1 `RawRepository` に credential field を追加
+  - `RawRepository` data class に `token: RawCredentialField? = null`, `user: RawCredentialField? = null`, `password: RawCredentialField? = null` を追加
+  - 既存の `RawRepository(url = MAVEN_CENTRAL_BASE)` 形 (`Config.kt:185-186` の default) との互換を維持
+  - 観察可能な完了: 既存の `RepositorySchemaMigrationTest` がそのまま緑のままで、 credential field 込みの `[repositories.x] url = "..."; token = { literal = "abc" }` が decode 成功する
+  - _Requirements: 1.1, 1.8_
+  - _Boundary: kolt.config.RawRepository_
+  - _Depends: 1.2_
+
+- [ ] 2.2 `Repository` (typed) を `name` + `auth` で拡張、 default と synthetic 構築サイトを更新
+  - `Repository` data class に `val name: String` (required) と `@Transient val auth: RepositoryAuth? = null` を追加 (`@Transient` で `RepositoryAuth` の非 `@Serializable` 性と整合させる)
+  - `KoltConfig.repositories` の default 値 (`Config.kt:120`) を `mapOf("central" to Repository(name = "central", url = MAVEN_CENTRAL_BASE, auth = null))` に更新
+  - `BtaImplFetcher.kt:54` の synthetic `Repository(MAVEN_CENTRAL_BASE)` 呼び出しを `Repository(name = "central", url = MAVEN_CENTRAL_BASE, auth = null)` に更新
+  - 観察可能な完了: `kolt build` が compile pass、 ktoml decode + 既存 lift の chain で `Repository` を組み立てる既存 test (例: `LiftRepositoriesMapTest`) が green
+  - _Requirements: 4.1, 4.2_
+  - _Boundary: kolt.config.Repository, kolt.build.daemon.BtaImplFetcher_
+  - _Depends: 1.1_
+
+- [ ] 2.3 `mergeRepositories` を credential field merge に拡張
+  - `LocalOverlay.kt:82-105` の `mergeRepositories` を更新し、 overlay の credential field (token / user / password) を base に対して last-write-wins で merge する: `baseRepo.copy(url = overlayRepo.url ?: baseRepo.url, token = overlayRepo.token ?: baseRepo.token, user = overlayRepo.user ?: baseRepo.user, password = overlayRepo.password ?: baseRepo.password)`
+  - 既存の overlay-only-name rejection 動作 (#415) は変更しない
+  - 観察可能な完了: 単体 test で `kolt.toml` の `[repositories.x] url = "..."` と `kolt.local.toml` の `[repositories.x] token = { literal = "abc" }` が merge 後に `RawRepository(url = "...", token = Literal("abc"))` を生成する
+  - _Requirements: 2.2_
+  - _Boundary: kolt.config.LocalOverlay_
+  - _Depends: 2.1_
+
+- [ ] 2.4 `rejectBaseCredentialLiterals` (新規) を実装し parseConfig pre-merge に挿入
+  - `parseConfig` 内の base raw decode 直後・overlay merge 前に呼び出される shape-blind validator を新規実装
+  - `rawBase.repositories` を走査し、 `token` / `user` / `password` のいずれかが non-null なら `ConfigError.ParseFailed(path = basePath, message = "kolt.toml [repositories.<name>]: literal <field> field. kolt.toml is intended to be committed; declare <field> in kolt.local.toml instead.")` を返す。 message には credential 値そのものは含めない
+  - `env` form / `literal` form を区別せず両方 reject (placement-policy first)
+  - 観察可能な完了: 単体 test で `kolt.toml` 内 `[repositories.x] token = { literal = "abc" }` が `kolt.toml` を名指す ParseFailed で reject される、 message に `"abc"` が含まれない
+  - _Requirements: 2.1, 2.4_
+  - _Boundary: kolt.config.Config (parseConfig)_
+  - _Depends: 2.1_
+
+- [ ] 2.5 `repositorySourceMap` helper を追加
+  - `sysPropSourceMap` (`Config.kt:398-414`) と同型の helper を新規実装、 戻り値型 `Map<repoName, Map<fieldName, String?>>`
+  - inner key 集合は `"url" / "token" / "user" / "password"` の 4 種固定、 base 由来 = `basePath`、 overlay 由来 = `overlayPath` (overlay last-write-wins)、 未設定 fields は inner map に key absent
+  - 観察可能な完了: 単体 test で base に `url`、 overlay に `token` がある repo について `map["repo"]["url"] == basePath`, `map["repo"]["token"] == overlayPath`, `map["repo"]["user"]` は absent
+  - _Requirements: 2.2_
+  - _Boundary: kolt.config.Config (repositorySourceMap)_
+  - _Depends: 2.1_
+
+- [ ] 2.6 `liftRepositoriesMap` を auth 検証で拡張
+  - 検証順 (fail-fast): URL 非空 (既存) → URL userinfo (`@` before path) → auth mutex (`token` ∧ (`user` ∨ `password`)) → auth pair 完全性 (`user` ⟺ `password`) → auth field 非空 (`literal` 値が empty / Unicode whitespace のみ → reject)
+  - validator が field-level rejection を出すとき `repositorySourceMap` から該当 field の contributing file を引いて `ParseFailed.path` にセット
+  - `Repository.name == map_key` invariant を構築時に enforce (`raw` の map key を `Repository.name` に代入)
+  - 観察可能な完了: 単体 test で各 validator branch が想定された ParseFailed message を返し、 lifted map の `entry.value.name == entry.key` が全 entry で成立
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.8, 2.3, 3.1, 3.2, 3.3_
+  - _Boundary: kolt.config.Config (liftRepositoriesMap)_
+  - _Depends: 1.2, 2.1, 2.5_
+
+- [ ] 2.7 `RepositoryAuthConfigTest` (parametric Req 1 + Req 2 + Req 2.3 + name invariant) を追加
+  - 単一 test ファイル内で fixture (kolt.toml + kolt.local.toml string) を共有、 data-table parametric で網羅
+  - 検証マトリクス: schema accept/reject (Req 1.1-1.7、 空・whitespace `literal` reject 含む) / placement (Req 2.1 base reject、 2.2 overlay accept、 source attribution) / env-form recognize-and-reject (Req 2.3 token/user/password 各 1 ケース、 message が `kolt.local.toml` を指す) / pre-v0.20.0 backward-compat (Req 1.8: base side の `kolt.toml` `[repositories.central]` auth field なし、 overlay side の `kolt.local.toml` `[repositories.central]` auth field なしの双方で parse 成功し anonymous 扱い) / `Repository.name == map_key` invariant
+  - 2-hop UX シナリオは個別 case として組まず: placement message と env-not-supported message は (g) base-placement / (k) env-reject の 2 ケースの message 差で間接的に検証される ([[feedback_sdd_test_inflation]])
+  - 観察可能な完了: 上記マトリクス全 case green、 各 fixture が 1 line で記述された data-table 配列に組み込まれる
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 2.1, 2.2, 2.3, 2.4_
+  - _Boundary: kolt.config (test)_
+  - _Depends: 2.4, 2.6_
+
+- [ ] 2.8 `RepositoryUrlUserinfoTest` を追加
+  - 4 ケース: (a) `https://u:p@host/x` reject、 (b) `https://u@host/x` reject、 (c) `https://host/foo@bar/baz` accept (path 内 `@`)、 (d) rejection message が userinfo character (`u`, `p`, `:`, `@`) を含まない
+  - 観察可能な完了: 4 ケース全 green
+  - _Requirements: 3.1, 3.2, 3.3_
+  - _Boundary: kolt.config (test)_
+  - _Depends: 2.6_
+
+## 3. Infra layer
+
+- [ ] 3.1 `Downloader.downloadFile` を `headers` parameter + libcurl slist + redirect policy で拡張
+  - signature を `downloadFile(url: String, destPath: String, headers: Map<String, String>? = null): Result<Unit, DownloadError>` に変更
+  - `headers` が non-null のとき `curl_slist_append` で `"$name: $value"` 形式のヘッダを追加し `CURLOPT_HTTPHEADER` にセット
+  - `CURLOPT_UNRESTRICTED_AUTH = 0L` を明示的に設定し、 cross-origin redirect で `Authorization` ヘッダが forward されない動作を確定させる
+  - `finally` block で `curl_slist_free_all` を `curl_easy_cleanup` より前に呼ぶ (anchored gotcha: upstream sample と逆の順序、 コメントで明示)
+  - `DownloadError.HttpFailed(url, code)` 構築時に `redactUrlUserinfo(url)` を適用する defensive 経路
+  - 観察可能な完了: `kolt build` compile pass、 既存の `DownloaderTest` 緑、 新たに `DownloaderAuthHeaderTest` が次タスクで作成可能な状態
+  - _Requirements: 5.1, 5.2, 8.3_
+  - _Boundary: kolt.infra.Downloader_
+  - _Depends: 1.3_
+
+- [ ] 3.2 `DownloaderAuthHeaderTest` (loopback HTTP fixture server + redirect policy) を追加
+  - `testfixture/LoopbackHttpServer.kt` を `UnixEchoServer` パターンで実装 (再利用可能、 anonymous + Bearer / Basic + 302 redirect target を提供する 2 ポート server)
+  - 4 サブテスト: (a) `RepositoryAuth.Bearer` で `Authorization: Bearer <token>` が server に到達、 (b) `RepositoryAuth.Basic` で正しい base64 `Authorization: Basic ...` が server に到達、 (c) `headers == null` で server の access log に Authorization ヘッダの行が出現しない (空 `Authorization:` も無い、 slist 自体組まれない)、 (d) cross-origin 302 で redirect target の access log に Authorization ヘッダなし
+  - libcurl resource leak の単体検査は Kotlin/Native ランタイムにヒープ計測手段がないため、 観察可能な test として組まない。 `finally` block で `curl_slist_free_all` が呼ばれる規律はコードレビューで担保 ([[feedback_sdd_test_inflation]])
+  - 観察可能な完了: 4 サブテスト全 green、 loopback server access log の文字列照合で Authorization ヘッダの有無が確定する
+  - _Requirements: 5.1, 5.2, 8.1, 8.3_
+  - _Boundary: kolt.infra (test) + testfixture.LoopbackHttpServer_
+  - _Depends: 1.1, 3.1_
+
+## 4. Resolver layer (signature bump + Authorization propagation)
+
+- [ ] 4.1 `downloadFromRepositories` の signature 変更 + `AuthFailed` variant 追加 + 401/403 hard-error 分岐
+  - signature を `(repos: List<Repository>, destPath: String, urlBuilder: (Repository) -> String, download: (String, String, Map<String, String>?) -> Result<Unit, DownloadError>, onRetry: (Repository) -> Unit = {})` に変更 (既存 5-arg shape を String → Repository に置換)
+  - loop body で `repo.auth?.toHeaders()` を計算し `download(url, dest, headers)` に渡す
+  - `RepositoryDownloadFailure` に `AuthFailed(repositoryName: String, url: String, statusCode: Int, authState: AuthStateProjection)` variant を追加。 `RepositoryAttempt` には `repositoryName: String` を追加 (既存 url-only から拡張)
+  - `TransitiveResolver.kt:99` の既存 branch (`error.statusCode != 404`) を分岐拡張: `else if (httpFailed.statusCode == 401 || httpFailed.statusCode == 403) -> return Err(AuthFailed(repo.name, redactUrlUserinfo(httpFailed.url), httpFailed.statusCode, repo.auth.toStateProjection()))`
+  - 404 fall-through と aggregated `AllAttemptsFailed` の既存動作は維持 (Req 6.3, 6.4)
+  - 観察可能な完了: `kolt build` compile pass、 `downloadFromRepositories` 単体 test (loopback server fixture) で `[401-repo, 200-repo]` から 401 hard-error を返し iteration が 200-repo まで進まないことを assert
+  - _Requirements: 5.1, 5.2, 5.3, 6.1, 6.2, 6.3, 6.4, 7.2, 7.3_
+  - _Boundary: kolt.resolve.TransitiveResolver (downloadFromRepositories), kolt.resolve.Resolver (RepositoryDownloadFailure, RepositoryAttempt)_
+  - _Depends: 1.1, 2.2, 3.1_
+
+- [ ] 4.2 `TransitiveResolver` の caller migration
+  - `:20` の `repos = config.repositories.values.map { it.url }.toList()` を `config.repositories.values.toList()` に書き換え (型は `List<Repository>` になる)
+  - 4 つの `downloadFromRepositories` 呼び出し (`:69` sources jar fallback, `:128` POM, `:186` module metadata, `:252` binary artifact) で `urlBuilder` lambda を `(Repository) -> String` に書き換え、 lambda body は `repo.url` を使う (`"$repo/"` 禁止規律)
+  - 観察可能な完了: `kolt build` compile pass、 既存の `TransitiveResolverTest` が anonymous central 経路で green を維持
+  - _Requirements: 5.3_
+  - _Boundary: kolt.resolve.TransitiveResolver_
+  - _Depends: 4.1_
+
+- [ ] 4.3 `NativeResolver` の caller migration
+  - `:67` の projection と `:139` / `:395` の 2 caller を `Repository` typed に switch
+  - `urlBuilder` lambda 内は `repo.url` のみを URL 構築に使う
+  - 観察可能な完了: `kolt build` compile pass、 既存の `NativeResolverTest` が klib 経路で green を維持
+  - _Requirements: 5.3_
+  - _Boundary: kolt.resolve.NativeResolver_
+  - _Depends: 4.1_
+
+- [ ] 4.4 `BundleResolver` の caller migration + `resolveSingleArtifact` signature bump
+  - `:180` の projection と `:124` / `:197` の 2 caller を `Repository` typed に switch
+  - `resolveSingleArtifact` (`:106`) の `repos: List<String>` parameter を `List<Repository>` に変更
+  - `urlBuilder` lambda 内は `repo.url` のみを URL 構築に使う
+  - 観察可能な完了: `kolt build` compile pass、 `BundleResolver` の既存 test が classpath bundle 経路で green を維持
+  - _Requirements: 5.3_
+  - _Boundary: kolt.resolve.BundleResolver_
+  - _Depends: 4.1_
+
+- [ ] 4.5 CLI commands + ToolResolution + PluginJarFetcher の migration
+  - `OutdatedCommand.kt:42` projection + `:82` caller、 `DependencyCommands.kt` の 4 projection (`:57`, `:300`, `:392`, `:412`) + `:165` の caller + `:297` の `resolveSingleArtifact` caller、 `ToolCommands.kt:163` projection、 `ToolResolution.kt:53` の `ensureTool` parameter `repos: List<String>` → `List<Repository>`、 `PluginJarFetcher.kt:147` の `deps.downloadFile(url, jarPath)` 呼び出しを 3-arg 形 `deps.downloadFile(url, jarPath, headers = null)` に変更
+  - 観察可能な完了: `kolt build` exit 0、 `kolt test` で既存の `OutdatedCommandTest` / `DependencyCommandsTest` / `ToolResolutionTest` / `PluginJarFetcherTest` が green を維持。 後続 7.2 (`AllCallersTypedTest`) がこの task 完了で初めて compile 成功する
+  - _Requirements: 5.3_
+  - _Boundary: kolt.cli.{OutdatedCommand, DependencyCommands, ToolCommands}, kolt.usertool.ToolResolution, kolt.resolve.PluginJarFetcher_
+  - _Depends: 4.1, 4.4_
+
+## 5. Renderer layer
+
+- [ ] 5.1 `repositoryDownloadFailureContext` に `AuthFailed` 分岐 + hint matrix を追加
+  - `Resolver.kt:151-159` の helper を sealed `when` で `AuthFailed` 分岐を追加、 5 行の context list (`repository: <name>` / `url: <redacted>` / `status: <code> <reason>` / `credentials: <state>` / `hint: <state-specific>`) を生成
+  - outer `formatResolveError` の `ResolveError` 分岐 (`Resolver.kt:75-138`) には触れない — `AuthFailed` は `RepositoryDownloadFailure` の variant なので、 既存の `ResolveError.DownloadFailed.context = repositoryDownloadFailureContext(error.failure)` 経由で headline (`failed to download <coordinate>` / `could not fetch metadata for <coordinate>`) と組み合わさる
+  - hint 文言の 4 行 matrix を `formatAuthHint(statusCode, authState): String` で実装 (要件 7.4 のテーブル)
+  - `url` フィールドには `redactUrlUserinfo(url)` を defensively 再適用
+  - 観察可能な完了: `ResolveErrorFormatTest` を拡張、 POM 401 → `failed to download G:A` + 5-line context、 metadata 401 → `could not fetch metadata for G:A` + 5-line context を pin
+  - _Requirements: 7.1, 7.2, 7.3, 7.4, 8.3_
+  - _Boundary: kolt.resolve.Resolver (formatResolveError, repositoryDownloadFailureContext)_
+  - _Depends: 1.1, 4.1_
+
+- [ ] 5.2 `RepositoryAuthFailureTest` (4-row hint matrix + iteration stop) を追加
+  - loopback fixture を `[401-repo, 200-repo]` / `[404-repo, 401-repo, 200-repo]` / 4 hint variants の scenarios で構成
+  - 4 row parametric matrix で `(statusCode, AuthStateProjection)` × `(401/403, NotConfigured/ConfiguredToken/ConfiguredBasic)` の hint text を完全一致 assert
+  - iteration stop assertion: `[401-repo, 200-repo]` で central (200-repo) に request が **届かない** ことを loopback server access log で確認
+  - 観察可能な完了: 4 hint row 全 green、 200-repo に request が届かないことが access log で確認できる
+  - _Requirements: 6.1, 6.2, 6.4, 7.1, 7.2, 7.3, 7.4_
+  - _Boundary: kolt.resolve (test) + testfixture.LoopbackHttpServer_
+  - _Depends: 3.2, 5.1_
+
+## 6. Redaction cross-cutting tests
+
+- [ ] 6.1 `RepositoryAuthRedactionTest` を追加 (Req 8 完備マトリクス)
+  - 6 アサーション: (a) 401 fetch の stderr に Bearer token literal が含まれない、 (b) Basic auth 401 の stderr に base64 / user / password literal が含まれない、 (c) `RepositoryAuth.Basic("u","p").toString()` が `<redacted>` placeholder を返し `"p"` を含まない、 (d) `Repository(name="x", url="y", auth=RepositoryAuth.Basic("alice","s3cret")).toString()` が `<redacted>` を含み `"s3cret"` を含まない、 (e) 認証 fetch 成功後の `kolt.lock` に credential field が無い (`Lockfile.kt` の serialized JSON を grep)、 (f) `kolt info` JSON に credential field が無い
+  - 観察可能な完了: 6 アサーション全 green
+  - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5, 10.1, 10.2_
+  - _Boundary: cross-cutting (test)_
+  - _Depends: 5.2_
+
+## 7. Migration verification and self-host smoke
+
+- [ ] 7.1 `RepositorySchemaMigrationTest` を Req 9.x で拡張
+  - 既存の flat-string-map rejection をそのまま、 migration hint の text を新 schema (`[repositories.<name>] url = "..."`) に追従する形で pin
+  - 追加: `central = "https://u:p@host/x"` 形式の flat-form + URL userinfo が rejection されるとき message が userinfo character を含まないことを assert (Req 9.3)
+  - 観察可能な完了: `RepositorySchemaMigrationTest` の全ケース green
+  - _Requirements: 9.1, 9.2, 9.3_
+  - _Boundary: kolt.config (test)_
+  - _Depends: 2.6_
+
+- [ ] 7.2 `AllCallersTypedTest` (compile gate smoke) を追加
+  - 10 `downloadFromRepositories` call sites (`TransitiveResolver` 4 + `NativeResolver` 2 + `BundleResolver` 2 + `OutdatedCommand` 1 + `DependencyCommands` 1) と 9 projection sites (`TransitiveResolver:20`, `NativeResolver:67`, `BundleResolver:180`, `OutdatedCommand:42`, `ToolCommands:163`, `DependencyCommands:57/:300/:392/:412`) と `ensureTool` (`ToolResolution:53`) / `resolveSingleArtifact` (`BundleResolver:106`) の各 signature bump が `kolt build` のコンパイルを通ることを確認する
+  - test 自体は no-op assertion で、 `kolt build` succeed が観察可能な合格条件
+  - 観察可能な完了: `kolt build` exit 0 + this test file compiles & loads
+  - _Requirements: 5.1, 5.2, 5.3_
+  - _Boundary: cross-cutting (compile gate)_
+  - _Depends: 4.2, 4.3, 4.4, 4.5_
+
+- [ ] 7.3 Self-host smoke gate確認
+  - `kolt build` を kolt 自身の 4 つの `kolt.toml` (`/kolt.toml`, `/kolt-jvm-compiler-daemon/kolt.toml`, `/kolt-native-compiler-daemon/kolt.toml`, `/spike/native-ktor-cinterop-smoke/kolt.toml`) に対して実行し、 新しい `liftRepositoriesMap` validators (userinfo / mutex / env-reject / name invariant) がいずれもホットパスで pass することを確認
+  - CI `.github/workflows/self-host-smoke.yml` の `self-host-post` job が green であることを最終ゲートとする ([[feedback_subagent_smoke_misses_ci]])
+  - 観察可能な完了: 4 ファイルすべてでローカル `kolt build` exit 0、 CI `self-host-post` job green
+  - _Requirements: 1.8, 4.1, 4.2, 4.3_
+  - _Boundary: cross-cutting (smoke)_
+  - _Depends: 7.1, 7.2_

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -167,7 +167,7 @@
 
 ## 5. Renderer layer
 
-- [ ] 5.1 `repositoryDownloadFailureContext` に `AuthFailed` 分岐 + hint matrix を追加
+- [x] 5.1 `repositoryDownloadFailureContext` に `AuthFailed` 分岐 + hint matrix を追加
   - `Resolver.kt:151-159` の helper を sealed `when` で `AuthFailed` 分岐を追加、 5 行の context list (`repository: <name>` / `url: <redacted>` / `status: <code> <reason>` / `credentials: <state>` / `hint: <state-specific>`) を生成
   - outer `formatResolveError` の `ResolveError` 分岐 (`Resolver.kt:75-138`) には触れない — `AuthFailed` は `RepositoryDownloadFailure` の variant なので、 既存の `ResolveError.DownloadFailed.context = repositoryDownloadFailureContext(error.failure)` 経由で headline (`failed to download <coordinate>` / `could not fetch metadata for <coordinate>`) と組み合わさる
   - hint 文言の 4 行 matrix を `formatAuthHint(statusCode, authState): String` で実装 (要件 7.4 のテーブル)

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -91,7 +91,7 @@
   - _Boundary: kolt.config (test)_
   - _Depends: 2.4, 2.6_
 
-- [ ] 2.8 `RepositoryUrlUserinfoTest` を追加
+- [x] 2.8 `RepositoryUrlUserinfoTest` を追加
   - 4 ケース: (a) `https://u:p@host/x` reject、 (b) `https://u@host/x` reject、 (c) `https://host/foo@bar/baz` accept (path 内 `@`)、 (d) rejection message が userinfo character (`u`, `p`, `:`, `@`) を含まない
   - 観察可能な完了: 4 ケース全 green
   - _Requirements: 3.1, 3.2, 3.3_

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -14,7 +14,7 @@
   - _Requirements: 1.5, 5.1, 5.2, 7.3, 8.1, 8.2_
   - _Boundary: kolt.config.RepositoryAuth, kolt.resolve.AuthStateProjection_
 
-- [ ] 1.2 (P) `RawCredentialField` と uniform inline-table custom serializer を追加
+- [x] 1.2 (P) `RawCredentialField` と uniform inline-table custom serializer を追加
   - `RawCredentialField` を sealed class + `Literal(value)` / `Env(varName)` 2 variants で導入
   - `RawCredentialFieldShape(literal: String? = null, env: String? = null)` を all-nullable fields trick で構築、 `RawCredentialFieldSerializer` を `SysPropValueSerializer` と同型の custom KSerializer で実装し、 `setFields.size != 1` のとき `SerializationException` を throw
   - `serialize` も `SysPropValueSerializer.kt:36-44` と同型の真面目な実装にする (error("...") にしない)

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -100,7 +100,7 @@
 
 ## 3. Infra layer
 
-- [ ] 3.1 `Downloader.downloadFile` を `headers` parameter + libcurl slist + redirect policy で拡張
+- [x] 3.1 `Downloader.downloadFile` を `headers` parameter + libcurl slist + redirect policy で拡張
   - signature を `downloadFile(url: String, destPath: String, headers: Map<String, String>? = null): Result<Unit, DownloadError>` に変更
   - `headers` が non-null のとき `curl_slist_append` で `"$name: $value"` 形式のヘッダを追加し `CURLOPT_HTTPHEADER` にセット
   - `CURLOPT_UNRESTRICTED_AUTH = 0L` を明示的に設定し、 cross-origin redirect で `Authorization` ヘッダが forward されない動作を確定させる

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -122,7 +122,7 @@
 
 ## 4. Resolver layer (signature bump + Authorization propagation)
 
-- [ ] 4.1 `downloadFromRepositories` の signature 変更 + `AuthFailed` variant 追加 + 401/403 hard-error 分岐
+- [x] 4.1 `downloadFromRepositories` の signature 変更 + `AuthFailed` variant 追加 + 401/403 hard-error 分岐
   - signature を `(repos: List<Repository>, destPath: String, urlBuilder: (Repository) -> String, download: (String, String, Map<String, String>?) -> Result<Unit, DownloadError>, onRetry: (Repository) -> Unit = {})` に変更 (既存 5-arg shape を String → Repository に置換)
   - loop body で `repo.auth?.toHeaders()` を計算し `download(url, dest, headers)` に渡す
   - `RepositoryDownloadFailure` に `AuthFailed(repositoryName: String, url: String, statusCode: Int, authState: AuthStateProjection)` variant を追加。 `RepositoryAttempt` には `repositoryName: String` を追加 (既存 url-only から拡張)
@@ -133,7 +133,7 @@
   - _Boundary: kolt.resolve.TransitiveResolver (downloadFromRepositories), kolt.resolve.Resolver (RepositoryDownloadFailure, RepositoryAttempt)_
   - _Depends: 1.1, 2.2, 3.1_
 
-- [ ] 4.2 `TransitiveResolver` の caller migration
+- [x] 4.2 `TransitiveResolver` の caller migration
   - `:20` の `repos = config.repositories.values.map { it.url }.toList()` を `config.repositories.values.toList()` に書き換え (型は `List<Repository>` になる)
   - 4 つの `downloadFromRepositories` 呼び出し (`:69` sources jar fallback, `:128` POM, `:186` module metadata, `:252` binary artifact) で `urlBuilder` lambda を `(Repository) -> String` に書き換え、 lambda body は `repo.url` を使う (`"$repo/"` 禁止規律)
   - 観察可能な完了: `kolt build` compile pass、 既存の `TransitiveResolverTest` が anonymous central 経路で green を維持
@@ -141,7 +141,7 @@
   - _Boundary: kolt.resolve.TransitiveResolver_
   - _Depends: 4.1_
 
-- [ ] 4.3 `NativeResolver` の caller migration
+- [x] 4.3 `NativeResolver` の caller migration
   - `:67` の projection と `:139` / `:395` の 2 caller を `Repository` typed に switch
   - `urlBuilder` lambda 内は `repo.url` のみを URL 構築に使う
   - 観察可能な完了: `kolt build` compile pass、 既存の `NativeResolverTest` が klib 経路で green を維持
@@ -149,7 +149,7 @@
   - _Boundary: kolt.resolve.NativeResolver_
   - _Depends: 4.1_
 
-- [ ] 4.4 `BundleResolver` の caller migration + `resolveSingleArtifact` signature bump
+- [x] 4.4 `BundleResolver` の caller migration + `resolveSingleArtifact` signature bump
   - `:180` の projection と `:124` / `:197` の 2 caller を `Repository` typed に switch
   - `resolveSingleArtifact` (`:106`) の `repos: List<String>` parameter を `List<Repository>` に変更
   - `urlBuilder` lambda 内は `repo.url` のみを URL 構築に使う
@@ -158,7 +158,7 @@
   - _Boundary: kolt.resolve.BundleResolver_
   - _Depends: 4.1_
 
-- [ ] 4.5 CLI commands + ToolResolution + PluginJarFetcher の migration
+- [x] 4.5 CLI commands + ToolResolution + PluginJarFetcher の migration
   - `OutdatedCommand.kt:42` projection + `:82` caller、 `DependencyCommands.kt` の 4 projection (`:57`, `:300`, `:392`, `:412`) + `:165` の caller + `:297` の `resolveSingleArtifact` caller、 `ToolCommands.kt:163` projection、 `ToolResolution.kt:53` の `ensureTool` parameter `repos: List<String>` → `List<Repository>`、 `PluginJarFetcher.kt:147` の `deps.downloadFile(url, jarPath)` 呼び出しを 3-arg 形 `deps.downloadFile(url, jarPath, headers = null)` に変更
   - 観察可能な完了: `kolt build` exit 0、 `kolt test` で既存の `OutdatedCommandTest` / `DependencyCommandsTest` / `ToolResolutionTest` / `PluginJarFetcherTest` が green を維持。 後続 7.2 (`AllCallersTypedTest`) がこの task 完了で初めて compile 成功する
   - _Requirements: 5.3_

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -65,7 +65,7 @@
   - _Boundary: kolt.config.Config (parseConfig)_
   - _Depends: 2.1_
 
-- [ ] 2.5 `repositorySourceMap` helper を追加
+- [x] 2.5 `repositorySourceMap` helper を追加
   - `sysPropSourceMap` (`Config.kt:398-414`) と同型の helper を新規実装、 戻り値型 `Map<repoName, Map<fieldName, String?>>`
   - inner key 集合は `"url" / "token" / "user" / "password"` の 4 種固定、 base 由来 = `basePath`、 overlay 由来 = `overlayPath` (overlay last-write-wins)、 未設定 fields は inner map に key absent
   - 観察可能な完了: 単体 test で base に `url`、 overlay に `token` がある repo について `map["repo"]["url"] == basePath`, `map["repo"]["token"] == overlayPath`, `map["repo"]["user"]` は absent

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -213,7 +213,7 @@
   - _Boundary: cross-cutting (compile gate)_
   - _Depends: 4.2, 4.3, 4.4, 4.5_
 
-- [ ] 7.3 Self-host smoke gate確認
+- [x] 7.3 Self-host smoke gate確認
   - `kolt build` を kolt 自身の 4 つの `kolt.toml` (`/kolt.toml`, `/kolt-jvm-compiler-daemon/kolt.toml`, `/kolt-native-compiler-daemon/kolt.toml`, `/spike/native-ktor-cinterop-smoke/kolt.toml`) に対して実行し、 新しい `liftRepositoriesMap` validators (userinfo / mutex / env-reject / name invariant) がいずれもホットパスで pass することを確認
   - CI `.github/workflows/self-host-smoke.yml` の `self-host-post` job が green であることを最終ゲートとする ([[feedback_subagent_smoke_misses_ci]])
   - 観察可能な完了: 4 ファイルすべてでローカル `kolt build` exit 0、 CI `self-host-post` job green

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -39,7 +39,7 @@
   - _Boundary: kolt.config.RawRepository_
   - _Depends: 1.2_
 
-- [ ] 2.2 `Repository` (typed) を `name` + `auth` で拡張、 default と synthetic 構築サイトを更新
+- [x] 2.2 `Repository` (typed) を `name` + `auth` で拡張、 default と synthetic 構築サイトを更新
   - `Repository` data class に `val name: String` (required) と `@Transient val auth: RepositoryAuth? = null` を追加 (`@Transient` で `RepositoryAuth` の非 `@Serializable` 性と整合させる)
   - `KoltConfig.repositories` の default 値 (`Config.kt:120`) を `mapOf("central" to Repository(name = "central", url = MAVEN_CENTRAL_BASE, auth = null))` に更新
   - `BtaImplFetcher.kt:54` の synthetic `Repository(MAVEN_CENTRAL_BASE)` 呼び出しを `Repository(name = "central", url = MAVEN_CENTRAL_BASE, auth = null)` に更新

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -31,7 +31,7 @@
 
 ## 2. Config layer
 
-- [ ] 2.1 `RawRepository` に credential field を追加
+- [x] 2.1 `RawRepository` に credential field を追加
   - `RawRepository` data class に `token: RawCredentialField? = null`, `user: RawCredentialField? = null`, `password: RawCredentialField? = null` を追加
   - 既存の `RawRepository(url = MAVEN_CENTRAL_BASE)` 形 (`Config.kt:185-186` の default) との互換を維持
   - 観察可能な完了: 既存の `RepositorySchemaMigrationTest` がそのまま緑のままで、 credential field 込みの `[repositories.x] url = "..."; token = { literal = "abc" }` が decode 成功する

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -197,7 +197,7 @@
 
 ## 7. Migration verification and self-host smoke
 
-- [ ] 7.1 `RepositorySchemaMigrationTest` を Req 9.x で拡張
+- [x] 7.1 `RepositorySchemaMigrationTest` を Req 9.x で拡張
   - 既存の flat-string-map rejection をそのまま、 migration hint の text を新 schema (`[repositories.<name>] url = "..."`) に追従する形で pin
   - 追加: `central = "https://u:p@host/x"` 形式の flat-form + URL userinfo が rejection されるとき message が userinfo character を含まないことを assert (Req 9.3)
   - 観察可能な完了: `RepositorySchemaMigrationTest` の全ケース green

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -111,7 +111,7 @@
   - _Boundary: kolt.infra.Downloader_
   - _Depends: 1.3_
 
-- [ ] 3.2 `DownloaderAuthHeaderTest` (loopback HTTP fixture server + redirect policy) を追加
+- [x] 3.2 `DownloaderAuthHeaderTest` (loopback HTTP fixture server + redirect policy) を追加
   - `testfixture/LoopbackHttpServer.kt` を `UnixEchoServer` パターンで実装 (再利用可能、 anonymous + Bearer / Basic + 302 redirect target を提供する 2 ポート server)
   - 4 サブテスト: (a) `RepositoryAuth.Bearer` で `Authorization: Bearer <token>` が server に到達、 (b) `RepositoryAuth.Basic` で正しい base64 `Authorization: Basic ...` が server に到達、 (c) `headers == null` で server の access log に Authorization ヘッダの行が出現しない (空 `Authorization:` も無い、 slist 自体組まれない)、 (d) cross-origin 302 で redirect target の access log に Authorization ヘッダなし
   - libcurl resource leak の単体検査は Kotlin/Native ランタイムにヒープ計測手段がないため、 観察可能な test として組まない。 `finally` block で `curl_slist_free_all` が呼ばれる規律はコードレビューで担保 ([[feedback_sdd_test_inflation]])

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -5,7 +5,7 @@
 
 ## 1. Foundation: new types and utilities
 
-- [ ] 1.1 (P) `RepositoryAuth` ADT と `AuthStateProjection` を追加
+- [x] 1.1 (P) `RepositoryAuth` ADT と `AuthStateProjection` を追加
   - `src/nativeMain/kotlin/kolt/config/RepositoryAuth.kt` を新規作成: sealed class `RepositoryAuth`、 `Bearer(token: String)` / `Basic(user: String, password: String)` を data class で持ち、 各 variant に `toString()` override を実装して secret を `<redacted>` に置換
   - `RepositoryAuth.toHeaders(): Map<String, String>` を実装し、 Bearer は `mapOf("Authorization" to "Bearer $token")`、 Basic は `mapOf("Authorization" to "Basic ${base64Encode("$user:$password")}")` を返す
   - `src/nativeMain/kotlin/kolt/resolve/AuthStateProjection.kt` を新規作成: sealed class + 3 data object (`NotConfigured` / `ConfiguredToken` / `ConfiguredBasic`)、 `toDisplayString()` で要件 7.3 の 3 文字列を所有 (`kolt.resolve` 配置で renderer 側からの import が自然に閉じる)

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -188,7 +188,7 @@
 
 ## 6. Redaction cross-cutting tests
 
-- [ ] 6.1 `RepositoryAuthRedactionTest` を追加 (Req 8 完備マトリクス)
+- [x] 6.1 `RepositoryAuthRedactionTest` を追加 (Req 8 完備マトリクス)
   - 6 アサーション: (a) 401 fetch の stderr に Bearer token literal が含まれない、 (b) Basic auth 401 の stderr に base64 / user / password literal が含まれない、 (c) `RepositoryAuth.Basic("u","p").toString()` が `<redacted>` placeholder を返し `"p"` を含まない、 (d) `Repository(name="x", url="y", auth=RepositoryAuth.Basic("alice","s3cret")).toString()` が `<redacted>` を含み `"s3cret"` を含まない、 (e) 認証 fetch 成功後の `kolt.lock` に credential field が無い (`Lockfile.kt` の serialized JSON を grep)、 (f) `kolt info` JSON に credential field が無い
   - 観察可能な完了: 6 アサーション全 green
   - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5, 10.1, 10.2_

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -205,7 +205,7 @@
   - _Boundary: kolt.config (test)_
   - _Depends: 2.6_
 
-- [ ] 7.2 `AllCallersTypedTest` (compile gate smoke) を追加
+- [x] 7.2 `AllCallersTypedTest` (compile gate smoke) を追加
   - 10 `downloadFromRepositories` call sites (`TransitiveResolver` 4 + `NativeResolver` 2 + `BundleResolver` 2 + `OutdatedCommand` 1 + `DependencyCommands` 1) と 9 projection sites (`TransitiveResolver:20`, `NativeResolver:67`, `BundleResolver:180`, `OutdatedCommand:42`, `ToolCommands:163`, `DependencyCommands:57/:300/:392/:412`) と `ensureTool` (`ToolResolution:53`) / `resolveSingleArtifact` (`BundleResolver:106`) の各 signature bump が `kolt build` のコンパイルを通ることを確認する
   - test 自体は no-op assertion で、 `kolt build` succeed が観察可能な合格条件
   - 観察可能な完了: `kolt build` exit 0 + this test file compiles & loads

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -82,7 +82,7 @@
   - _Boundary: kolt.config.Config (liftRepositoriesMap)_
   - _Depends: 1.2, 2.1, 2.5_
 
-- [ ] 2.7 `RepositoryAuthConfigTest` (parametric Req 1 + Req 2 + Req 2.3 + name invariant) を追加
+- [x] 2.7 `RepositoryAuthConfigTest` (parametric Req 1 + Req 2 + Req 2.3 + name invariant) を追加
   - 単一 test ファイル内で fixture (kolt.toml + kolt.local.toml string) を共有、 data-table parametric で網羅
   - 検証マトリクス: schema accept/reject (Req 1.1-1.7、 空・whitespace `literal` reject 含む) / placement (Req 2.1 base reject、 2.2 overlay accept、 source attribution) / env-form recognize-and-reject (Req 2.3 token/user/password 各 1 ケース、 message が `kolt.local.toml` を指す) / pre-v0.20.0 backward-compat (Req 1.8: base side の `kolt.toml` `[repositories.central]` auth field なし、 overlay side の `kolt.local.toml` `[repositories.central]` auth field なしの双方で parse 成功し anonymous 扱い) / `Repository.name == map_key` invariant
   - 2-hop UX シナリオは個別 case として組まず: placement message と env-not-supported message は (g) base-placement / (k) env-reject の 2 ケースの message 差で間接的に検証される ([[feedback_sdd_test_inflation]])

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -73,7 +73,7 @@
   - _Boundary: kolt.config.Config (repositorySourceMap)_
   - _Depends: 2.1_
 
-- [ ] 2.6 `liftRepositoriesMap` を auth 検証で拡張
+- [x] 2.6 `liftRepositoriesMap` を auth 検証で拡張
   - 検証順 (fail-fast): URL 非空 (既存) → URL userinfo (`@` before path) → auth mutex (`token` ∧ (`user` ∨ `password`)) → auth pair 完全性 (`user` ⟺ `password`) → auth field 非空 (`literal` 値が empty / Unicode whitespace のみ → reject)
   - validator が field-level rejection を出すとき `repositorySourceMap` から該当 field の contributing file を引いて `ParseFailed.path` にセット
   - `Repository.name == map_key` invariant を構築時に enforce (`raw` の map key を `Repository.name` に代入)

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -22,7 +22,7 @@
   - _Requirements: 1.1, 1.4, 1.6, 1.7, 2.3_
   - _Boundary: kolt.config.RawCredentialField_
 
-- [ ] 1.3 (P) `redactUrlUserinfo` shared utility と `UrlRedactionTest` を追加
+- [x] 1.3 (P) `redactUrlUserinfo` shared utility と `UrlRedactionTest` を追加
   - `kolt.infra.redactUrlUserinfo(url: String): String` を実装、 `://` と `@` の位置関係 (`@` がパス区切り `/?#` より前にあること) で userinfo を検出して除去
   - 5 ケース matrix test: (a) `https://host/path` 不変、 (b) `https://u:p@host/path` → userinfo 除去、 (c) `https://u@host/path` → userinfo 除去、 (d) `https://host/foo@bar` 不変 (path 内 `@`)、 (e) `not-a-url-at-all` 不変
   - 観察可能な完了: `UrlRedactionTest` 5 ケース全 green

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -56,7 +56,7 @@
   - _Boundary: kolt.config.LocalOverlay_
   - _Depends: 2.1_
 
-- [ ] 2.4 `rejectBaseCredentialLiterals` (新規) を実装し parseConfig pre-merge に挿入
+- [x] 2.4 `rejectBaseCredentialLiterals` (新規) を実装し parseConfig pre-merge に挿入
   - `parseConfig` 内の base raw decode 直後・overlay merge 前に呼び出される shape-blind validator を新規実装
   - `rawBase.repositories` を走査し、 `token` / `user` / `password` のいずれかが non-null なら `ConfigError.ParseFailed(path = basePath, message = "kolt.toml [repositories.<name>]: literal <field> field. kolt.toml is intended to be committed; declare <field> in kolt.local.toml instead.")` を返す。 message には credential 値そのものは含めない
   - `env` form / `literal` form を区別せず両方 reject (placement-policy first)

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -177,7 +177,7 @@
   - _Boundary: kolt.resolve.Resolver (formatResolveError, repositoryDownloadFailureContext)_
   - _Depends: 1.1, 4.1_
 
-- [ ] 5.2 `RepositoryAuthFailureTest` (4-row hint matrix + iteration stop) を追加
+- [x] 5.2 `RepositoryAuthFailureTest` (4-row hint matrix + iteration stop) を追加
   - loopback fixture を `[401-repo, 200-repo]` / `[404-repo, 401-repo, 200-repo]` / 4 hint variants の scenarios で構成
   - 4 row parametric matrix で `(statusCode, AuthStateProjection)` × `(401/403, NotConfigured/ConfiguredToken/ConfiguredBasic)` の hint text を完全一致 assert
   - iteration stop assertion: `[401-repo, 200-repo]` で central (200-repo) に request が **届かない** ことを loopback server access log で確認

--- a/.kiro/specs/private-maven-repos/tasks.md
+++ b/.kiro/specs/private-maven-repos/tasks.md
@@ -48,7 +48,7 @@
   - _Boundary: kolt.config.Repository, kolt.build.daemon.BtaImplFetcher_
   - _Depends: 1.1_
 
-- [ ] 2.3 `mergeRepositories` を credential field merge に拡張
+- [x] 2.3 `mergeRepositories` を credential field merge に拡張
   - `LocalOverlay.kt:82-105` の `mergeRepositories` を更新し、 overlay の credential field (token / user / password) を base に対して last-write-wins で merge する: `baseRepo.copy(url = overlayRepo.url ?: baseRepo.url, token = overlayRepo.token ?: baseRepo.token, user = overlayRepo.user ?: baseRepo.user, password = overlayRepo.password ?: baseRepo.password)`
   - 既存の overlay-only-name rejection 動作 (#415) は変更しない
   - 観察可能な完了: 単体 test で `kolt.toml` の `[repositories.x] url = "..."` と `kolt.local.toml` の `[repositories.x] token = { literal = "abc" }` が merge 後に `RawRepository(url = "...", token = Literal("abc"))` を生成する

--- a/src/nativeMain/kotlin/kolt/build/daemon/BtaImplFetcher.kt
+++ b/src/nativeMain/kotlin/kolt/build/daemon/BtaImplFetcher.kt
@@ -51,7 +51,8 @@ internal fun ensureBtaImplJars(
       kotlin = KotlinSection(version = version),
       build = BuildSection(target = "jvm", main = "unused.Main", sources = emptyList()),
       dependencies = mapOf(BTA_IMPL_GROUP_ARTIFACT to version),
-      repositories = mapOf("central" to Repository(MAVEN_CENTRAL_BASE)),
+      repositories =
+        mapOf("central" to Repository(name = "central", url = MAVEN_CENTRAL_BASE, auth = null)),
     )
   val result =
     resolver(syntheticConfig, null, cacheBase, deps).getOrElse {

--- a/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/DependencyCommands.kt
@@ -51,11 +51,7 @@ private fun doAddInner(args: List<String>): Result<Unit, Int> {
     if (addArgs.version != null) {
       addArgs.version
     } else {
-      fetchLatestVersion(
-          addArgs.group,
-          addArgs.artifact,
-          config.repositories.values.map { it.url }.toList(),
-        )
+      fetchLatestVersion(addArgs.group, addArgs.artifact, config.repositories.values.toList())
         .getOrElse {
           return Err(it)
         }
@@ -145,7 +141,7 @@ private fun doRemoveInner(args: List<String>): Result<Unit, Int> {
 private fun fetchLatestVersion(
   group: String,
   artifact: String,
-  repos: List<String>,
+  repos: List<Repository>,
 ): Result<String, Int> {
   val paths =
     resolveKoltPaths().getOrElse {
@@ -165,7 +161,7 @@ private fun fetchLatestVersion(
     downloadFromRepositories(
         repos,
         metadataPath,
-        { repo -> buildMetadataDownloadUrl(group, artifact, repo) },
+        { repo -> buildMetadataDownloadUrl(group, artifact, repo.url) },
         ::downloadFile,
       )
       .getError()
@@ -297,7 +293,7 @@ private fun doUpdateInner(): Result<Unit, Int> {
           resolveSingleArtifact(
             coord = coord,
             classifier = classifier,
-            repos = config.repositories.values.map { it.url }.toList(),
+            repos = config.repositories.values.toList(),
             cacheBase = paths.cacheBase,
             deps = resolverDeps,
           )
@@ -389,7 +385,7 @@ internal fun doTree(): Result<Unit, Int> {
   if (config.build.target in NATIVE_TARGETS) {
     val nativeLookup =
       createNativeLookup(
-        config.repositories.values.map { it.url }.toList(),
+        config.repositories.values.toList(),
         paths.cacheBase,
         createResolverDeps(),
         nativeTarget = konanTargetGradleName(config.build.target),
@@ -408,11 +404,7 @@ internal fun doTree(): Result<Unit, Int> {
   }
 
   val pomLookup =
-    createPomLookup(
-      config.repositories.values.map { it.url }.toList(),
-      paths.cacheBase,
-      createResolverDeps(),
-    )
+    createPomLookup(config.repositories.values.toList(), paths.cacheBase, createResolverDeps())
   if (seeds.mainSeeds.isNotEmpty()) {
     val tree = buildDependencyTree(seeds.mainSeeds, pomLookup)
     println(formatDependencyTree(tree))

--- a/src/nativeMain/kotlin/kolt/cli/OutdatedCommand.kt
+++ b/src/nativeMain/kotlin/kolt/cli/OutdatedCommand.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
+import kolt.config.Repository
 import kolt.config.resolveKoltPaths
 import kolt.infra.downloadFile
 import kolt.infra.ensureDirectoryRecursive
@@ -39,7 +40,7 @@ private fun doOutdatedInner(opts: OutdatedOptions): Result<Unit, Int> {
       return Err(EXIT_DEPENDENCY_ERROR)
     }
 
-  val repos = config.repositories.values.map { it.url }.toList()
+  val repos = config.repositories.values.toList()
   val report =
     computeOutdated(
       mainDeps = config.dependencies,
@@ -68,7 +69,7 @@ private fun doOutdatedInner(opts: OutdatedOptions): Result<Unit, Int> {
 private fun fetchLatestVersionString(
   group: String,
   artifact: String,
-  repos: List<String>,
+  repos: List<Repository>,
   cacheBase: String,
 ): Result<String, String> {
   val groupPath = group.replace('.', '/')
@@ -82,7 +83,7 @@ private fun fetchLatestVersionString(
     downloadFromRepositories(
         repos,
         metadataPath,
-        { repo -> buildMetadataDownloadUrl(group, artifact, repo) },
+        { repo -> buildMetadataDownloadUrl(group, artifact, repo.url) },
         ::downloadFile,
       )
       .getError()
@@ -121,6 +122,8 @@ private fun shortMetadataFailure(failure: RepositoryDownloadFailure): String =
       val statuses = failure.attempts.joinToString(", ") { formatAttemptStatus(it.error) }
       "metadata fetch failed ($statuses)"
     }
+    is RepositoryDownloadFailure.AuthFailed ->
+      "metadata fetch failed (${failure.repositoryName}: ${failure.statusCode})"
   }
 
 private fun reportArgsError(error: OutdatedArgsError) {

--- a/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
+++ b/src/nativeMain/kotlin/kolt/cli/PluginSupport.kt
@@ -24,8 +24,11 @@ private fun defaultPluginFetcherDeps(): PluginFetcherDeps =
     override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> =
       kolt.infra.ensureDirectoryRecursive(path)
 
-    override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> =
-      kolt.infra.downloadFile(url, destPath)
+    override fun downloadFile(
+      url: String,
+      destPath: String,
+      headers: Map<String, String>?,
+    ): Result<Unit, DownloadError> = kolt.infra.downloadFile(url, destPath, headers)
 
     override fun computeSha256(filePath: String): Result<String, Sha256Error> =
       kolt.infra.computeSha256(filePath)

--- a/src/nativeMain/kotlin/kolt/cli/ToolCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/ToolCommands.kt
@@ -160,7 +160,7 @@ internal fun runToolWithDeps(
         paths = paths,
         lockfile = lockfile,
         netDeps = deps,
-        repos = config.repositories.values.map { it.url }.toList(),
+        repos = config.repositories.values.toList(),
       )
       .getOrElse { resolutionError ->
         return surfaceToolError(ToolError.Resolve(resolutionError))
@@ -270,7 +270,8 @@ private fun createToolDeps(): ToolDeps {
 
     override fun ensureDirectoryRecursive(path: String) = resolver.ensureDirectoryRecursive(path)
 
-    override fun downloadFile(url: String, destPath: String) = resolver.downloadFile(url, destPath)
+    override fun downloadFile(url: String, destPath: String, headers: Map<String, String>?) =
+      resolver.downloadFile(url, destPath, headers)
 
     override fun computeSha256(filePath: String) = resolver.computeSha256(filePath)
 

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -105,7 +105,12 @@ data class RunSection(
   @SerialName("sys_props") val sysProps: Map<String, SysPropValue> = emptyMap()
 )
 
-@Serializable data class Repository(val url: String)
+@Serializable
+data class Repository(
+  val name: String,
+  val url: String,
+  @Transient val auth: RepositoryAuth? = null,
+)
 
 @Serializable
 data class KoltConfig(
@@ -117,7 +122,8 @@ data class KoltConfig(
   val fmt: FmtSection = FmtSection(),
   val dependencies: Map<String, String> = emptyMap(),
   @SerialName("test-dependencies") val testDependencies: Map<String, String> = emptyMap(),
-  val repositories: Map<String, Repository> = mapOf("central" to Repository(MAVEN_CENTRAL_BASE)),
+  val repositories: Map<String, Repository> =
+    mapOf("central" to Repository(name = "central", url = MAVEN_CENTRAL_BASE, auth = null)),
   val cinterop: List<CinteropConfig> = emptyList(),
   // [classpaths.<name>] declares a named, resolvable jar bundle independent
   // of [dependencies]. Bundles feed sysprop values via SysPropValue.ClasspathRef
@@ -269,7 +275,7 @@ internal fun liftRepositoriesMap(
     if (url.isNullOrEmpty()) {
       return Err(ConfigError.ParseFailed("repository '$name' has no url"))
     }
-    out[name] = Repository(url.trimEnd('/'))
+    out[name] = Repository(name = name, url = url.trimEnd('/'), auth = null)
   }
   return Ok(out)
 }

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -170,7 +170,13 @@ internal data class RawRunSection(
   @SerialName("sys_props") val sysProps: Map<String, RawSysPropValue> = emptyMap()
 )
 
-@Serializable internal data class RawRepository(val url: String? = null)
+@Serializable
+internal data class RawRepository(
+  val url: String? = null,
+  val token: RawCredentialField? = null,
+  val user: RawCredentialField? = null,
+  val password: RawCredentialField? = null,
+)
 
 @Serializable
 internal data class RawKoltConfig(

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -439,6 +439,45 @@ private fun validateBundleReferences(
   return Ok(Unit)
 }
 
+// Per-repository, per-field source attribution: maps the lifted repository
+// name (quotes stripped, matching liftRepositoriesMap) to a per-field map
+// from the field name (one of "url" / "token" / "user" / "password") to the
+// file path that contributed it. Overlay last-write-wins, matching
+// mergeRepositories. A field key is absent when neither base nor overlay
+// sets it on that repository. A null inner value means the contributing
+// file path is unknown (only happens when the caller did not pass `path`
+// to parseConfig, e.g. internal tests).
+internal fun repositorySourceMap(
+  baseRepositories: Map<String, RawRepository>,
+  overlayRepositories: Map<String, RawRepository>?,
+  basePath: String?,
+  overlayPath: String?,
+): Map<String, Map<String, String?>> {
+  val out =
+    LinkedHashMap<String, LinkedHashMap<String, String?>>(
+      baseRepositories.size + (overlayRepositories?.size ?: 0)
+    )
+  for ((rawName, repo) in baseRepositories) {
+    val name = rawName.removeSurrounding("\"")
+    val inner = out.getOrPut(name) { LinkedHashMap() }
+    if (repo.url != null) inner["url"] = basePath
+    if (repo.token != null) inner["token"] = basePath
+    if (repo.user != null) inner["user"] = basePath
+    if (repo.password != null) inner["password"] = basePath
+  }
+  if (overlayRepositories != null) {
+    for ((rawName, repo) in overlayRepositories) {
+      val name = rawName.removeSurrounding("\"")
+      val inner = out.getOrPut(name) { LinkedHashMap() }
+      if (repo.url != null) inner["url"] = overlayPath
+      if (repo.token != null) inner["token"] = overlayPath
+      if (repo.user != null) inner["user"] = overlayPath
+      if (repo.password != null) inner["password"] = overlayPath
+    }
+  }
+  return out
+}
+
 // Per-sysprop-key source attribution: maps the lifted key (quotes stripped,
 // matching liftSysPropsMap) to the file that contributed it. Overlay keys
 // override base keys, matching mergeSysProps' last-write-wins semantics. A

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -9,6 +9,7 @@ import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
 import kolt.infra.output.RenderedDiagnostic
 import kolt.infra.output.Severity
+import kolt.infra.redactUrlUserinfo
 import kolt.resolve.compareVersions
 import kolt.usertool.RawToolEntry
 import kolt.usertool.ToolEntry
@@ -299,20 +300,123 @@ internal fun rejectBaseCredentialLiterals(
 }
 
 // Lifts a Map<String, RawRepository> into Map<String, Repository>: strips
-// quotes around keys (consistent with cleanedDeps), rejects entries whose
-// url is null or empty, and preserves the trailing-slash normalization that
-// applied to the legacy flat-form string values.
+// quotes around keys (consistent with cleanedDeps), validates url and any
+// declared credential fields, and preserves trailing-slash normalization.
+//
+// `sourceMap` (Map<repoName, Map<field, contributingPath?>>) is consulted on
+// rejection to surface ParseFailed.path attributing the offending field to
+// kolt.toml or kolt.local.toml. See `repositorySourceMap` for shape.
+//
+// Validation order (fail-fast, first failure wins):
+//   1. url non-empty
+//   2. url has no userinfo (`@` before path) — message uses redactUrlUserinfo
+//   3. auth mutex: token must not coexist with user / password
+//   4. auth pair completeness: user iff password
+//   5. auth field non-empty: Literal value must not be empty / all whitespace
+//   6. env form unsupported in v1.0 — message directs to literal form
+//
+// Steps 3 / 4 sit ahead of 5 so a structurally-broken config (e.g. token + user
+// without password) gets the mutex / pair message rather than a non-empty error
+// on whatever happens to be empty. Step 6 sits last so a misplaced env form
+// has already passed the schema sanity checks above before its v1.0-specific
+// rejection fires.
 internal fun liftRepositoriesMap(
-  raw: Map<String, RawRepository>
+  raw: Map<String, RawRepository>,
+  sourceMap: Map<String, Map<String, String?>>,
 ): Result<Map<String, Repository>, ConfigError> {
   val out = LinkedHashMap<String, Repository>(raw.size)
   for ((rawKey, rawValue) in raw) {
     val name = rawKey.removeSurrounding("\"")
+    val urlSource = sourceMap[name]?.get("url")
+
+    // 1. url non-empty
     val url = rawValue.url
     if (url.isNullOrEmpty()) {
-      return Err(ConfigError.ParseFailed("repository '$name' has no url"))
+      return Err(
+        ConfigError.ParseFailed(message = "repository '$name' has no url", path = urlSource)
+      )
     }
-    out[name] = Repository(name = name, url = url.trimEnd('/'), auth = null)
+
+    // 2. url has no userinfo
+    val redacted = redactUrlUserinfo(url)
+    if (redacted != url) {
+      return Err(
+        ConfigError.ParseFailed(
+          message =
+            "[repositories.$name] url contains userinfo (redacted: '$redacted'); " +
+              "declare credentials in the token field or the user / password fields instead",
+          path = urlSource,
+        )
+      )
+    }
+
+    // 3. auth mutex
+    if (rawValue.token != null && (rawValue.user != null || rawValue.password != null)) {
+      val other = if (rawValue.user != null) "user" else "password"
+      return Err(
+        ConfigError.ParseFailed(
+          message =
+            "[repositories.$name] token is mutually exclusive with $other; " +
+              "use either token (Bearer) or user + password (Basic), not both",
+          path = sourceMap[name]?.get("token"),
+        )
+      )
+    }
+
+    // 4. pair completeness
+    if ((rawValue.user != null) != (rawValue.password != null)) {
+      val missing = if (rawValue.user == null) "user" else "password"
+      val presentField = if (rawValue.user == null) "password" else "user"
+      return Err(
+        ConfigError.ParseFailed(
+          message =
+            "[repositories.$name] $presentField is set without $missing; " +
+              "user and password must be declared together",
+          path = sourceMap[name]?.get(presentField),
+        )
+      )
+    }
+
+    // 5. non-empty literal check
+    for ((fieldName, field) in
+      listOf("token" to rawValue.token, "user" to rawValue.user, "password" to rawValue.password)) {
+      if (field is RawCredentialField.Literal) {
+        if (field.value.isEmpty() || field.value.all { it.isWhitespace() }) {
+          return Err(
+            ConfigError.ParseFailed(
+              message = "[repositories.$name] $fieldName literal value is empty or whitespace-only",
+              path = sourceMap[name]?.get(fieldName),
+            )
+          )
+        }
+      }
+    }
+
+    // 6. env-form not supported in v1.0
+    for ((fieldName, field) in
+      listOf("token" to rawValue.token, "user" to rawValue.user, "password" to rawValue.password)) {
+      if (field is RawCredentialField.Env) {
+        return Err(
+          ConfigError.ParseFailed(
+            message =
+              "[repositories.$name] $fieldName = { env = \"...\" } is not supported in v1.0; " +
+                "use { literal = \"...\" } in kolt.local.toml",
+            path = sourceMap[name]?.get(fieldName),
+          )
+        )
+      }
+    }
+
+    // All validators passed; construct typed RepositoryAuth.
+    val auth =
+      when {
+        rawValue.token is RawCredentialField.Literal -> RepositoryAuth.Bearer(rawValue.token.value)
+        rawValue.user is RawCredentialField.Literal &&
+          rawValue.password is RawCredentialField.Literal ->
+          RepositoryAuth.Basic(rawValue.user.value, rawValue.password.value)
+        else -> null
+      }
+    out[name] = Repository(name = name, url = url.trimEnd('/'), auth = auth)
   }
   return Ok(out)
 }
@@ -655,8 +759,15 @@ fun parseConfig(
     // ktoml preserves quotes in map keys; strip them.
     val cleanedDeps = raw.dependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }
     val cleanedTestDeps = raw.testDependencies.mapKeys { (key, _) -> key.removeSurrounding("\"") }
+    val repoSources =
+      repositorySourceMap(
+        baseRepositories = rawBase.repositories,
+        overlayRepositories = rawOverlay?.repositories,
+        basePath = path,
+        overlayPath = overlayPath,
+      )
     val cleanedRepos =
-      liftRepositoriesMap(raw.repositories).getOrElse {
+      liftRepositoriesMap(raw.repositories, repoSources).getOrElse {
         return Err(it)
       }
     val cleanedClasspaths =

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -273,7 +273,13 @@ private fun liftSysPropsMap(
 // Iteration is in declaration order; the first offending field on the
 // first offending repository wins. The error message names the repository
 // and the offending field but never the credential value (Req 2.4).
-internal fun rejectBaseCredentialLiterals(
+//
+// `AuthStateProjection.toDisplayString()`'s "from kolt.local.toml" suffix
+// depends on this validator: any credential that reaches the resolver
+// provably originated in kolt.local.toml because base-side credentials
+// are rejected here. Do not weaken this validator without revisiting
+// that display string.
+internal fun rejectBaseCredentialFields(
   rawBase: RawKoltConfig,
   basePath: String?,
 ): Result<Unit, ConfigError.ParseFailed> {
@@ -704,7 +710,7 @@ fun parseConfig(
     // Placement-policy gate: credentials in `kolt.toml` are rejected before
     // the overlay is merged, so the diagnostic path points at the base file
     // even when an overlay is supplied.
-    rejectBaseCredentialLiterals(rawBase, path).getError()?.let {
+    rejectBaseCredentialFields(rawBase, path).getError()?.let {
       return Err(it)
     }
     val rawOverlay: RawLocalOverlayConfig? =

--- a/src/nativeMain/kotlin/kolt/config/Config.kt
+++ b/src/nativeMain/kotlin/kolt/config/Config.kt
@@ -261,6 +261,43 @@ private fun liftSysPropsMap(
   return Ok(out)
 }
 
+// Rejects `kolt.toml` (the base file) carrying any credential-related field
+// on a repository entry. Shape-blind: both `{ literal = "..." }` and
+// `{ env = "..." }` forms trigger the placement-policy message. The
+// env-not-supported message (Req 2.3) is emitted later by `liftRepositoriesMap`
+// on the merged result, so a user who tries `{ env = ... }` in kolt.toml
+// sees the placement message first and, after moving to kolt.local.toml,
+// the env-not-supported message (intentional 2-hop in v1.0).
+//
+// Iteration is in declaration order; the first offending field on the
+// first offending repository wins. The error message names the repository
+// and the offending field but never the credential value (Req 2.4).
+internal fun rejectBaseCredentialLiterals(
+  rawBase: RawKoltConfig,
+  basePath: String?,
+): Result<Unit, ConfigError.ParseFailed> {
+  for ((rawName, repo) in rawBase.repositories) {
+    val name = rawName.removeSurrounding("\"")
+    val offendingField =
+      when {
+        repo.token != null -> "token"
+        repo.user != null -> "user"
+        repo.password != null -> "password"
+        else -> null
+      } ?: continue
+    return Err(
+      ConfigError.ParseFailed(
+        message =
+          "kolt.toml [repositories.$name]: literal $offendingField field. " +
+            "kolt.toml is intended to be committed; declare $offendingField in " +
+            "kolt.local.toml instead.",
+        path = basePath,
+      )
+    )
+  }
+  return Ok(Unit)
+}
+
 // Lifts a Map<String, RawRepository> into Map<String, Repository>: strips
 // quotes around keys (consistent with cleanedDeps), rejects entries whose
 // url is null or empty, and preserves the trailing-slash normalization that
@@ -521,6 +558,12 @@ fun parseConfig(
   }
   return try {
     val rawBase = toml.decodeFromString(RawKoltConfig.serializer(), tomlString)
+    // Placement-policy gate: credentials in `kolt.toml` are rejected before
+    // the overlay is merged, so the diagnostic path points at the base file
+    // even when an overlay is supplied.
+    rejectBaseCredentialLiterals(rawBase, path).getError()?.let {
+      return Err(it)
+    }
     val rawOverlay: RawLocalOverlayConfig? =
       if (overlayString != null && overlayPath != null) {
         parseLocalOverlay(overlayString, overlayPath).getOrElse {

--- a/src/nativeMain/kotlin/kolt/config/LocalOverlay.kt
+++ b/src/nativeMain/kotlin/kolt/config/LocalOverlay.kt
@@ -99,7 +99,13 @@ private fun mergeRepositories(
         )
       )
     }
-    merged[name] = baseRepo.copy(url = overlayRepo.url ?: baseRepo.url)
+    merged[name] =
+      baseRepo.copy(
+        url = overlayRepo.url ?: baseRepo.url,
+        token = overlayRepo.token ?: baseRepo.token,
+        user = overlayRepo.user ?: baseRepo.user,
+        password = overlayRepo.password ?: baseRepo.password,
+      )
   }
   return Ok(merged)
 }

--- a/src/nativeMain/kotlin/kolt/config/RawCredentialField.kt
+++ b/src/nativeMain/kotlin/kolt/config/RawCredentialField.kt
@@ -1,0 +1,51 @@
+package kolt.config
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(with = RawCredentialFieldSerializer::class)
+internal sealed class RawCredentialField {
+  data class Literal(val value: String) : RawCredentialField() {
+    override fun toString(): String = "RawCredentialField.Literal(<redacted>)"
+  }
+
+  data class Env(val varName: String) : RawCredentialField() {
+    override fun toString(): String = "RawCredentialField.Env(varName=$varName)"
+  }
+}
+
+@Serializable
+internal data class RawCredentialFieldShape(val literal: String? = null, val env: String? = null)
+
+internal object RawCredentialFieldSerializer : KSerializer<RawCredentialField> {
+  override val descriptor: SerialDescriptor = RawCredentialFieldShape.serializer().descriptor
+
+  override fun serialize(encoder: Encoder, value: RawCredentialField) {
+    val raw =
+      when (value) {
+        is RawCredentialField.Literal -> RawCredentialFieldShape(literal = value.value)
+        is RawCredentialField.Env -> RawCredentialFieldShape(env = value.varName)
+      }
+    encoder.encodeSerializableValue(RawCredentialFieldShape.serializer(), raw)
+  }
+
+  override fun deserialize(decoder: Decoder): RawCredentialField {
+    val raw = decoder.decodeSerializableValue(RawCredentialFieldShape.serializer())
+    val setFields = listOfNotNull(raw.literal?.let { "literal" }, raw.env?.let { "env" })
+    if (setFields.size != 1) {
+      throw SerializationException(
+        "credential field value must set exactly one of { literal, env }, " +
+          "but ${setFields.size} were set: $setFields"
+      )
+    }
+    return when (setFields.single()) {
+      "literal" -> RawCredentialField.Literal(raw.literal!!)
+      "env" -> RawCredentialField.Env(raw.env!!)
+      else -> error("unreachable")
+    }
+  }
+}

--- a/src/nativeMain/kotlin/kolt/config/RepositoryAuth.kt
+++ b/src/nativeMain/kotlin/kolt/config/RepositoryAuth.kt
@@ -1,0 +1,35 @@
+package kolt.config
+
+import kolt.resolve.AuthStateProjection
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+// Typed projection over Bearer / Basic credentials. `toString` is overridden
+// on every variant so that incidental stringification (eprintln, error
+// formatting, "$repo" interpolation) cannot leak secrets. `equals`/`hashCode`
+// remain data-class defaults intentionally — two `Bearer("X")` values are
+// equal, which is the right behavior; the leak surface is `toString` only.
+sealed class RepositoryAuth {
+  data class Bearer(val token: String) : RepositoryAuth() {
+    override fun toString(): String = "RepositoryAuth.Bearer(token=<redacted>)"
+  }
+
+  data class Basic(val user: String, val password: String) : RepositoryAuth() {
+    override fun toString(): String = "RepositoryAuth.Basic(user=$user, password=<redacted>)"
+  }
+}
+
+@OptIn(ExperimentalEncodingApi::class)
+fun RepositoryAuth.toHeaders(): Map<String, String> =
+  when (this) {
+    is RepositoryAuth.Bearer -> mapOf("Authorization" to "Bearer $token")
+    is RepositoryAuth.Basic ->
+      mapOf("Authorization" to "Basic ${Base64.encode("$user:$password".encodeToByteArray())}")
+  }
+
+fun RepositoryAuth?.toStateProjection(): AuthStateProjection =
+  when (this) {
+    null -> AuthStateProjection.NotConfigured
+    is RepositoryAuth.Bearer -> AuthStateProjection.ConfiguredToken
+    is RepositoryAuth.Basic -> AuthStateProjection.ConfiguredBasic
+  }

--- a/src/nativeMain/kotlin/kolt/infra/Downloader.kt
+++ b/src/nativeMain/kotlin/kolt/infra/Downloader.kt
@@ -8,8 +8,10 @@ import libcurl.CURLE_OK
 import libcurl.CURLINFO_RESPONSE_CODE
 import libcurl.CURLOPT_CONNECTTIMEOUT
 import libcurl.CURLOPT_FOLLOWLOCATION
+import libcurl.CURLOPT_HTTPHEADER
 import libcurl.CURLOPT_MAXREDIRS
 import libcurl.CURLOPT_TIMEOUT
+import libcurl.CURLOPT_UNRESTRICTED_AUTH
 import libcurl.CURLOPT_URL
 import libcurl.CURLOPT_WRITEDATA
 import libcurl.CURLOPT_WRITEFUNCTION
@@ -19,6 +21,9 @@ import libcurl.curl_easy_init
 import libcurl.curl_easy_perform
 import libcurl.curl_easy_setopt
 import libcurl.curl_easy_strerror
+import libcurl.curl_slist
+import libcurl.curl_slist_append
+import libcurl.curl_slist_free_all
 import platform.posix.FILE
 import platform.posix.closedir
 import platform.posix.fclose
@@ -44,7 +49,11 @@ sealed class DownloadError {
 private const val STALE_TEMP_AGE_SECONDS: Long = 86_400L
 
 @OptIn(ExperimentalForeignApi::class)
-fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+fun downloadFile(
+  url: String,
+  destPath: String,
+  headers: Map<String, String>? = null,
+): Result<Unit, DownloadError> {
   val parentDir = parentDirOf(destPath)
   if (parentDir != null) {
     cleanupStaleTemps(parentDir)
@@ -64,16 +73,43 @@ fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
     return Err(DownloadError.WriteFailed(tempPath))
   }
 
+  // Build the slist of "Name: Value" lines. curl_slist_append takes the
+  // running list pointer (null on the first call) and returns a new head;
+  // a null return signals allocation failure. The slist (and its string
+  // copies, which libcurl owns internally) is freed in the finally block.
+  var headerList: CPointer<curl_slist>? = null
+  if (headers != null) {
+    for ((name, value) in headers) {
+      val appended = curl_slist_append(headerList, "$name: $value")
+      if (appended == null) {
+        curl_slist_free_all(headerList)
+        fclose(fp)
+        curl_easy_cleanup(curl)
+        remove(tempPath)
+        return Err(DownloadError.NetworkError(url, "failed to allocate libcurl header list"))
+      }
+      headerList = appended
+    }
+  }
+
   var fileClosed = false
   var success = false
   try {
     curl_easy_setopt(curl, CURLOPT_URL, url)
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L)
     curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 10L)
+    // Explicit 0L: strip `Authorization` on cross-origin redirect. This is
+    // libcurl's default, set explicitly here as a documented commitment —
+    // forwarding credentials to an unintended host (e.g. a redirected typo
+    // URL) is a worse failure mode than a 401 from a CDN-fronted mirror.
+    curl_easy_setopt(curl, CURLOPT_UNRESTRICTED_AUTH, 0L)
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 30L)
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L)
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, staticCFunction(::curlWriteCallback))
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp)
+    if (headerList != null) {
+      curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerList)
+    }
 
     val res = curl_easy_perform(curl)
     if (res != CURLE_OK) {
@@ -86,7 +122,10 @@ fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
       curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, httpCode.ptr)
       val code = httpCode.value.toInt()
       if (code !in 200..299) {
-        return Err(DownloadError.HttpFailed(url, code))
+        // Defensive scrub: the config validator already rejects userinfo
+        // URLs (Req 3.x), but if one slips in via another path the
+        // credentials must not leak into the error payload.
+        return Err(DownloadError.HttpFailed(redactUrlUserinfo(url), code))
       }
     }
 
@@ -103,6 +142,14 @@ fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
     return Ok(Unit)
   } finally {
     if (!fileClosed) fclose(fp)
+    // ANCHORED GOTCHA: free the slist BEFORE curl_easy_cleanup. Most
+    // upstream libcurl samples show the reverse order (easy_cleanup first,
+    // then slist_free_all) — both orderings are documented-safe because
+    // the slist's string copies are internal to libcurl, but kolt's
+    // convention is slist-first across all future libcurl option lists
+    // (cookies, custom resolves, etc.). Do not "fix" this to match
+    // upstream samples.
+    curl_slist_free_all(headerList)
     curl_easy_cleanup(curl)
     if (!success) remove(tempPath)
   }

--- a/src/nativeMain/kotlin/kolt/infra/Downloader.kt
+++ b/src/nativeMain/kotlin/kolt/infra/Downloader.kt
@@ -65,7 +65,10 @@ fun downloadFile(
   val tempPath = "$destPath.tmp.${getpid()}"
 
   val curl =
-    curl_easy_init() ?: return Err(DownloadError.NetworkError(url, "failed to initialize libcurl"))
+    curl_easy_init()
+      ?: return Err(
+        DownloadError.NetworkError(redactUrlUserinfo(url), "failed to initialize libcurl")
+      )
 
   val fp = fopen(tempPath, "wb")
   if (fp == null) {
@@ -86,7 +89,12 @@ fun downloadFile(
         fclose(fp)
         curl_easy_cleanup(curl)
         remove(tempPath)
-        return Err(DownloadError.NetworkError(url, "failed to allocate libcurl header list"))
+        return Err(
+          DownloadError.NetworkError(
+            redactUrlUserinfo(url),
+            "failed to allocate libcurl header list",
+          )
+        )
       }
       headerList = appended
     }
@@ -114,7 +122,7 @@ fun downloadFile(
     val res = curl_easy_perform(curl)
     if (res != CURLE_OK) {
       val msg = curl_easy_strerror(res)?.toKString() ?: "unknown error"
-      return Err(DownloadError.NetworkError(url, msg))
+      return Err(DownloadError.NetworkError(redactUrlUserinfo(url), msg))
     }
 
     memScoped {

--- a/src/nativeMain/kotlin/kolt/infra/UrlRedaction.kt
+++ b/src/nativeMain/kotlin/kolt/infra/UrlRedaction.kt
@@ -1,0 +1,24 @@
+package kolt.infra
+
+private const val SCHEME_SEP = "://"
+
+internal fun redactUrlUserinfo(url: String): String {
+  val schemeEnd = url.indexOf(SCHEME_SEP)
+  if (schemeEnd < 0) return url
+  val authorityStart = schemeEnd + SCHEME_SEP.length
+
+  // `@` inside the path (e.g. `https://host/foo@bar`) is intentionally preserved:
+  // userinfo only exists between `://` and the first path/query/fragment separator.
+  var at = -1
+  for (i in authorityStart until url.length) {
+    val c = url[i]
+    if (c == '/' || c == '?' || c == '#') break
+    if (c == '@') {
+      at = i
+      break
+    }
+  }
+  if (at < 0) return url
+
+  return url.substring(0, authorityStart) + url.substring(at + 1)
+}

--- a/src/nativeMain/kotlin/kolt/resolve/AuthStateProjection.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/AuthStateProjection.kt
@@ -1,0 +1,22 @@
+package kolt.resolve
+
+// Display-time projection over `RepositoryAuth` that carries no secret state.
+// Lives in `kolt.resolve` so the renderer can import it without pulling in
+// the secret-carrying `RepositoryAuth` type from `kolt.config`. The
+// "from kolt.local.toml" suffix is hardcoded because Requirement 2.1 rejects
+// credential literals from kolt.toml at parse time, so any configured
+// credential that reaches the resolver provably originated in kolt.local.toml.
+sealed class AuthStateProjection {
+  data object NotConfigured : AuthStateProjection()
+
+  data object ConfiguredToken : AuthStateProjection()
+
+  data object ConfiguredBasic : AuthStateProjection()
+
+  fun toDisplayString(): String =
+    when (this) {
+      NotConfigured -> "not configured"
+      ConfiguredToken -> "configured (token, from kolt.local.toml)"
+      ConfiguredBasic -> "configured (basic, from kolt.local.toml)"
+    }
+}

--- a/src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/BundleResolver.kt
@@ -7,6 +7,7 @@ import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.map
 import kolt.build.ResolvedJar
 import kolt.config.KoltConfig
+import kolt.config.Repository
 
 // BundleResolver runs an independent fixpointResolve pass per bundle so that
 // transitive deps, strict pins, and rejects stay bundle-local (Req 4.5). The
@@ -106,7 +107,7 @@ internal fun resolveBundle(
 fun resolveSingleArtifact(
   coord: Coordinate,
   classifier: String?,
-  repos: List<String>,
+  repos: List<Repository>,
   cacheBase: String,
   deps: ResolverDeps,
   progress: ResolverProgressSink = ResolverProgressSink.NoOp,
@@ -124,9 +125,9 @@ fun resolveSingleArtifact(
     downloadFromRepositories(
         repos,
         cachePath,
-        { repo -> "$repo/$relativePath" },
+        { repo -> "${repo.url}/$relativePath" },
         deps::downloadFile,
-        onRetry = progress::onRetryAgainst,
+        onRetry = { repo -> progress.onRetryAgainst(repo.url) },
       )
       .getOrElse { failure ->
         return Err(ResolveError.DownloadFailed(groupArtifact, failure))
@@ -177,7 +178,7 @@ internal fun materialiseBundleJarsFromLock(
   progress: ResolverProgressSink = ResolverProgressSink.NoOp,
 ): Result<Unit, ResolveError> {
   val locked = existingLock.classpathBundles[bundleName] ?: return Ok(Unit)
-  val repos = config.repositories.values.map { it.url }.toList()
+  val repos = config.repositories.values.toList()
   val cachePrefix = "$cacheBase/"
   // Pre-count uncached locked jars so the total `M` is known before any
   // emission. Cache-warm jars do not advance the index and stay silent.
@@ -197,9 +198,9 @@ internal fun materialiseBundleJarsFromLock(
     downloadFromRepositories(
         repos,
         dep.cachePath,
-        { repo -> "$repo/$relativePath" },
+        { repo -> "${repo.url}/$relativePath" },
         deps::downloadFile,
-        onRetry = progress::onRetryAgainst,
+        onRetry = { repo -> progress.onRetryAgainst(repo.url) },
       )
       .getOrElse { failure ->
         return Err(ResolveError.DownloadFailed(dep.groupArtifact, failure))

--- a/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/NativeResolver.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltConfig
+import kolt.config.Repository
 import kolt.config.konanTargetGradleName
 import kolt.infra.DownloadError
 import kolt.infra.eprintln
@@ -64,7 +65,7 @@ fun resolveNative(
   noteSink: (String) -> Unit = ::eprintln,
 ): Result<ResolveResult, ResolveError> {
   val nativeTarget = konanTargetGradleName(config.build.target)
-  val repos = config.repositories.values.map { it.url }.toList()
+  val repos = config.repositories.values.toList()
 
   for ((groupArtifact, _) in config.dependencies) {
     if (isKotlinStdlib(groupArtifact)) continue
@@ -139,9 +140,9 @@ fun resolveNative(
             downloadFromRepositories(
                 repos,
                 klibCachePath,
-                { buildKlibDownloadUrl(targetCoord, it, klibFile.url) },
+                { buildKlibDownloadUrl(targetCoord, it.url, klibFile.url) },
                 deps::downloadFile,
-                onRetry = progress::onRetryAgainst,
+                onRetry = { repo -> progress.onRetryAgainst(repo.url) },
               )
               .getOrElse { failure ->
                 return Err(ResolveError.DownloadFailed(node.groupArtifact, failure))
@@ -202,7 +203,7 @@ internal fun makeNativeChildLookup(
   processed: MutableMap<String, NativeResolved>,
   nativeTarget: String,
   cacheBase: String,
-  repos: List<String>,
+  repos: List<Repository>,
   deps: ResolverDeps,
 ): (String, String) -> Result<List<Child>, ResolveError> = lookup@{ ga, v ->
   val cacheKey = "$ga:$v"
@@ -245,7 +246,7 @@ internal fun makeNativeChildLookup(
  * behaviour.
  */
 fun createNativeLookup(
-  repos: List<String>,
+  repos: List<Repository>,
   cacheBase: String,
   deps: ResolverDeps,
   nativeTarget: String,
@@ -305,7 +306,7 @@ internal fun fetchNativeMetadata(
   version: String,
   nativeTarget: String,
   cacheBase: String,
-  repos: List<String>,
+  repos: List<Repository>,
   deps: ResolverDeps,
 ): Result<NativeResolved, ResolveError> {
   val rootCoord =
@@ -317,7 +318,7 @@ internal fun fetchNativeMetadata(
     fetchAndRead(
         coord = rootCoord,
         relativePath = buildModuleCachePath(rootCoord),
-        urlBuilder = { buildModuleDownloadUrl(rootCoord, it) },
+        urlBuilder = { buildModuleDownloadUrl(rootCoord, it.url) },
         cacheBase = cacheBase,
         repos = repos,
         deps = deps,
@@ -328,7 +329,7 @@ internal fun fetchNativeMetadata(
             fetchAndRead(
               coord = rootCoord,
               relativePath = buildPomCachePath(rootCoord),
-              urlBuilder = { buildPomDownloadUrl(rootCoord, it) },
+              urlBuilder = { buildPomDownloadUrl(rootCoord, it.url) },
               cacheBase = cacheBase,
               repos = repos,
               deps = deps,
@@ -353,7 +354,7 @@ internal fun fetchNativeMetadata(
     fetchAndRead(
         coord = targetCoord,
         relativePath = buildModuleCachePath(targetCoord),
-        urlBuilder = { buildModuleDownloadUrl(targetCoord, it) },
+        urlBuilder = { buildModuleDownloadUrl(targetCoord, it.url) },
         cacheBase = cacheBase,
         repos = repos,
         deps = deps,
@@ -379,9 +380,9 @@ internal fun fetchNativeMetadata(
 private fun fetchAndRead(
   coord: Coordinate,
   relativePath: String,
-  urlBuilder: (String) -> String,
+  urlBuilder: (Repository) -> String,
   cacheBase: String,
-  repos: List<String>,
+  repos: List<Repository>,
   deps: ResolverDeps,
 ): Result<String, ResolveError> {
   val groupArtifact = "${coord.group}:${coord.artifact}"

--- a/src/nativeMain/kotlin/kolt/resolve/PluginJarFetcher.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/PluginJarFetcher.kt
@@ -47,7 +47,11 @@ interface PluginFetcherDeps {
 
   fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed>
 
-  fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError>
+  fun downloadFile(
+    url: String,
+    destPath: String,
+    headers: Map<String, String>? = null,
+  ): Result<Unit, DownloadError>
 
   fun computeSha256(filePath: String): Result<String, Sha256Error>
 
@@ -144,7 +148,11 @@ fun fetchPluginJar(
     return Err(PluginFetchError.CacheDirCreationFailed(artifactDir))
   }
 
-  deps.downloadFile(url, jarPath).getOrElse { cause ->
+  // Compiler plugin jars come from Maven Central only (the [repositories]
+  // config does not apply here; see module doc), so no Authorization
+  // header is ever set — the 3-arg call passes `null` explicitly to keep
+  // the seam uniform with `ResolverDeps.downloadFile`.
+  deps.downloadFile(url, jarPath, headers = null).getOrElse { cause ->
     return Err(PluginFetchError.DownloadFailed(alias, url, cause))
   }
 

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -11,19 +11,30 @@ import kolt.infra.output.RenderedDiagnostic
 import kolt.infra.output.Severity
 
 // Per-repository attempt captured by `downloadFromRepositories`. The
-// resolver keeps the URL it tried alongside the underlying error so
-// `formatResolveError` can render a per-repo dump (#355). For 404s we
-// continue to the next repo and append; any other error stops the loop
-// and surfaces with the singleton attempts list.
-data class RepositoryAttempt(val url: String, val error: DownloadError)
+// resolver keeps the repository name + URL it tried alongside the underlying
+// error so `formatResolveError` can render a per-repo dump (#355). For 404s
+// we continue to the next repo and append; any other non-auth error stops
+// the loop and surfaces with the singleton attempts list. 401/403 short-
+// circuits to AuthFailed and is never appended here.
+data class RepositoryAttempt(val repositoryName: String, val url: String, val error: DownloadError)
 
-// Splits "no repositories were tried" from "all attempts failed" — the
-// two have different remediations (config fix vs. network/auth) so the
-// formatter renders distinct hints.
+// Splits "no repositories were tried" from "all attempts failed" from
+// "auth blocked the first credentialed try" — each has a distinct
+// remediation (config fix vs. network/404 dump vs. token rotation) so the
+// formatter renders distinct hints. AuthFailed carries an AuthStateProjection
+// (no secrets) rather than the secret-bearing RepositoryAuth so credentials
+// never reach the renderer.
 sealed class RepositoryDownloadFailure {
   data object NoRepositoriesConfigured : RepositoryDownloadFailure()
 
   data class AllAttemptsFailed(val attempts: List<RepositoryAttempt>) : RepositoryDownloadFailure()
+
+  data class AuthFailed(
+    val repositoryName: String,
+    val url: String,
+    val statusCode: Int,
+    val authState: AuthStateProjection,
+  ) : RepositoryDownloadFailure()
 }
 
 sealed class ResolveError {
@@ -156,6 +167,14 @@ private fun repositoryDownloadFailureContext(failure: RepositoryDownloadFailure)
       )
     is RepositoryDownloadFailure.AllAttemptsFailed ->
       failure.attempts.map { "${it.url} -> ${formatAttemptStatus(it.error)}" }
+    // Task 5.1 expands this into the 5-line context (`repository / url /
+    // status / credentials / hint`). Until then, a single placeholder line
+    // keeps the sealed `when` exhaustive without leaking secrets.
+    is RepositoryDownloadFailure.AuthFailed ->
+      listOf(
+        "${failure.repositoryName} (${failure.url}) -> ${failure.statusCode} " +
+          "(${failure.authState.toDisplayString()})"
+      )
   }
 
 enum class Origin {
@@ -185,7 +204,11 @@ interface ResolverDeps {
 
   fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed>
 
-  fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError>
+  fun downloadFile(
+    url: String,
+    destPath: String,
+    headers: Map<String, String>? = null,
+  ): Result<Unit, DownloadError>
 
   fun computeSha256(filePath: String): Result<String, Sha256Error>
 
@@ -201,8 +224,8 @@ internal fun defaultResolverDeps(): ResolverDeps =
 
     override fun ensureDirectoryRecursive(path: String) = kolt.infra.ensureDirectoryRecursive(path)
 
-    override fun downloadFile(url: String, destPath: String) =
-      kolt.infra.downloadFile(url, destPath)
+    override fun downloadFile(url: String, destPath: String, headers: Map<String, String>?) =
+      kolt.infra.downloadFile(url, destPath, headers)
 
     override fun computeSha256(filePath: String) = kolt.infra.computeSha256(filePath)
 

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -9,6 +9,7 @@ import kolt.infra.OpenFailed
 import kolt.infra.Sha256Error
 import kolt.infra.output.RenderedDiagnostic
 import kolt.infra.output.Severity
+import kolt.infra.redactUrlUserinfo
 
 // Per-repository attempt captured by `downloadFromRepositories`. The
 // resolver keeps the repository name + URL it tried alongside the underlying
@@ -167,14 +168,42 @@ private fun repositoryDownloadFailureContext(failure: RepositoryDownloadFailure)
       )
     is RepositoryDownloadFailure.AllAttemptsFailed ->
       failure.attempts.map { "${it.url} -> ${formatAttemptStatus(it.error)}" }
-    // Task 5.1 expands this into the 5-line context (`repository / url /
-    // status / credentials / hint`). Until then, a single placeholder line
-    // keeps the sealed `when` exhaustive without leaking secrets.
+    // Defensive double-redaction: `failure.url` is already redacted at
+    // construction (TransitiveResolver passes it through redactUrlUserinfo),
+    // but we re-apply here so any future caller path cannot leak userinfo
+    // into the renderer. The operation is idempotent.
     is RepositoryDownloadFailure.AuthFailed ->
       listOf(
-        "${failure.repositoryName} (${failure.url}) -> ${failure.statusCode} " +
-          "(${failure.authState.toDisplayString()})"
+        "repository: ${failure.repositoryName}",
+        "url: ${redactUrlUserinfo(failure.url)}",
+        "status: ${failure.statusCode} ${reasonPhrase(failure.statusCode)}",
+        "credentials: ${failure.authState.toDisplayString()}",
+        "hint: ${formatAuthHint(failure.statusCode, failure.authState)}",
       )
+  }
+
+private fun reasonPhrase(statusCode: Int): String =
+  when (statusCode) {
+    401 -> "Unauthorized"
+    403 -> "Forbidden"
+    else -> ""
+  }
+
+private fun formatAuthHint(statusCode: Int, authState: AuthStateProjection): String =
+  when (authState) {
+    AuthStateProjection.NotConfigured ->
+      when (statusCode) {
+        401 -> "the repository requires authentication; add credentials to kolt.local.toml"
+        403 -> "authentication is required"
+        else -> ""
+      }
+    AuthStateProjection.ConfiguredToken,
+    AuthStateProjection.ConfiguredBasic ->
+      when (statusCode) {
+        401 -> "the credentials may be invalid or expired"
+        403 -> "the credentials are valid but lack permission for this repository"
+        else -> ""
+      }
   }
 
 enum class Origin {

--- a/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/Resolver.kt
@@ -172,14 +172,19 @@ private fun repositoryDownloadFailureContext(failure: RepositoryDownloadFailure)
     // construction (TransitiveResolver passes it through redactUrlUserinfo),
     // but we re-apply here so any future caller path cannot leak userinfo
     // into the renderer. The operation is idempotent.
-    is RepositoryDownloadFailure.AuthFailed ->
+    is RepositoryDownloadFailure.AuthFailed -> {
+      val phrase = reasonPhrase(failure.statusCode)
+      val statusLine =
+        if (phrase.isEmpty()) "status: ${failure.statusCode}"
+        else "status: ${failure.statusCode} $phrase"
       listOf(
         "repository: ${failure.repositoryName}",
         "url: ${redactUrlUserinfo(failure.url)}",
-        "status: ${failure.statusCode} ${reasonPhrase(failure.statusCode)}",
+        statusLine,
         "credentials: ${failure.authState.toDisplayString()}",
         "hint: ${formatAuthHint(failure.statusCode, failure.authState)}",
       )
+    }
   }
 
 private fun reasonPhrase(statusCode: Int): String =

--- a/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
+++ b/src/nativeMain/kotlin/kolt/resolve/TransitiveResolver.kt
@@ -6,7 +6,11 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltConfig
+import kolt.config.Repository
+import kolt.config.toHeaders
+import kolt.config.toStateProjection
 import kolt.infra.DownloadError
+import kolt.infra.redactUrlUserinfo
 
 fun resolveTransitive(
   config: KoltConfig,
@@ -17,7 +21,7 @@ fun resolveTransitive(
   testSeeds: Map<String, String> = emptyMap(),
   progress: ResolverProgressSink = ResolverProgressSink.NoOp,
 ): Result<ResolveResult, ResolveError> {
-  val repos = config.repositories.values.map { it.url }.toList()
+  val repos = config.repositories.values.toList()
 
   val basePomLookup = createPomLookup(repos, cacheBase, deps)
 
@@ -58,7 +62,7 @@ fun resolveTransitive(
 internal fun resolveSourcesPath(
   coord: Coordinate,
   cacheBase: String,
-  repos: List<String>,
+  repos: List<Repository>,
   deps: ResolverDeps,
   binaryWasCached: Boolean,
 ): String? {
@@ -69,45 +73,62 @@ internal fun resolveSourcesPath(
     downloadFromRepositories(
         repos,
         sourcesCachePath,
-        { buildSourcesDownloadUrl(coord, it) },
+        { buildSourcesDownloadUrl(coord, it.url) },
         deps::downloadFile,
       )
       .getError()
   return if (error == null) sourcesCachePath else null
 }
 
-// Falls back to next repo only on 404; any other error stops the loop
-// and surfaces with the attempts list. Each attempt records the URL we
+// Falls back to next repo only on 404; 401/403 short-circuits to AuthFailed
+// so a misconfigured private repo never falls through to a public mirror
+// (Req 6.1, 6.2, 6.4). Any other non-2xx stops the loop and surfaces with
+// the attempts list. Each attempt records the repository name + URL we
 // tried so the resolver can dump per-repo status (#355). Empty repos
 // surfaces as `NoRepositoriesConfigured` so the user gets a config-fix
 // hint instead of a "tried nothing" misread.
 internal fun downloadFromRepositories(
-  repos: List<String>,
+  repos: List<Repository>,
   destPath: String,
-  urlBuilder: (String) -> String,
-  download: (String, String) -> Result<Unit, DownloadError>,
-  onRetry: (String) -> Unit = {},
+  urlBuilder: (Repository) -> String,
+  download: (String, String, Map<String, String>?) -> Result<Unit, DownloadError>,
+  onRetry: (Repository) -> Unit = {},
 ): Result<Unit, RepositoryDownloadFailure> {
   if (repos.isEmpty()) return Err(RepositoryDownloadFailure.NoRepositoriesConfigured)
   val attempts = mutableListOf<RepositoryAttempt>()
   for (i in repos.indices) {
     val repo = repos[i]
     val url = urlBuilder(repo)
-    val error = download(url, destPath).getError()
+    val headers = repo.auth?.toHeaders()
+    val error = download(url, destPath, headers).getError()
     if (error == null) return Ok(Unit)
-    attempts.add(RepositoryAttempt(url, error))
-    if (error !is DownloadError.HttpFailed || error.statusCode != 404) {
-      return Err(RepositoryDownloadFailure.AllAttemptsFailed(attempts))
+    if (error is DownloadError.HttpFailed) {
+      if (error.statusCode == 401 || error.statusCode == 403) {
+        return Err(
+          RepositoryDownloadFailure.AuthFailed(
+            repositoryName = repo.name,
+            url = redactUrlUserinfo(error.url),
+            statusCode = error.statusCode,
+            authState = repo.auth.toStateProjection(),
+          )
+        )
+      }
+      if (error.statusCode == 404) {
+        attempts.add(RepositoryAttempt(repo.name, url, error))
+        if (i + 1 < repos.size) {
+          onRetry(repos[i + 1])
+        }
+        continue
+      }
     }
-    if (i + 1 < repos.size) {
-      onRetry(repos[i + 1])
-    }
+    attempts.add(RepositoryAttempt(repo.name, url, error))
+    return Err(RepositoryDownloadFailure.AllAttemptsFailed(attempts))
   }
   return Err(RepositoryDownloadFailure.AllAttemptsFailed(attempts))
 }
 
 internal fun createPomLookup(
-  repos: List<String>,
+  repos: List<Repository>,
   cacheBase: String,
   deps: ResolverDeps,
 ): (String, String) -> PomInfo? {
@@ -128,7 +149,7 @@ internal fun createPomLookup(
             downloadFromRepositories(
                 repos,
                 pomCachePath,
-                { buildPomDownloadUrl(coord, it) },
+                { buildPomDownloadUrl(coord, it.url) },
                 deps::downloadFile,
               )
               .getOrElse { null }
@@ -145,7 +166,7 @@ internal fun createPomLookup(
 }
 
 private fun createModuleLookup(
-  repos: List<String>,
+  repos: List<Repository>,
   cacheBase: String,
   deps: ResolverDeps,
 ): (String, String) -> JvmRedirect? {
@@ -169,7 +190,7 @@ private fun createModuleLookup(
 private fun checkModuleFile(
   groupArtifact: String,
   version: String,
-  repos: List<String>,
+  repos: List<Repository>,
   cacheBase: String,
   deps: ResolverDeps,
 ): JvmRedirect? {
@@ -186,7 +207,7 @@ private fun checkModuleFile(
     downloadFromRepositories(
         repos,
         moduleCachePath,
-        { buildModuleDownloadUrl(coord, it) },
+        { buildModuleDownloadUrl(coord, it.url) },
         deps::downloadFile,
       )
       .getOrElse {
@@ -209,7 +230,7 @@ private fun materialize(
   existingLock: Lockfile?,
   cacheBase: String,
   deps: ResolverDeps,
-  repos: List<String>,
+  repos: List<Repository>,
   progress: ResolverProgressSink = ResolverProgressSink.NoOp,
 ): Result<ResolveResult, ResolveError> {
   var lockChanged = false
@@ -252,9 +273,9 @@ private fun materialize(
       downloadFromRepositories(
           repos,
           fullCachePath,
-          { buildDownloadUrl(coord, it) },
+          { buildDownloadUrl(coord, it.url) },
           deps::downloadFile,
-          onRetry = progress::onRetryAgainst,
+          onRetry = { repo -> progress.onRetryAgainst(repo.url) },
         )
         .getOrElse { failure ->
           return Err(ResolveError.DownloadFailed(node.groupArtifact, failure))

--- a/src/nativeMain/kotlin/kolt/usertool/ToolResolution.kt
+++ b/src/nativeMain/kotlin/kolt/usertool/ToolResolution.kt
@@ -5,6 +5,8 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import kolt.config.KoltPaths
+import kolt.config.MAVEN_CENTRAL_BASE
+import kolt.config.Repository
 import kolt.infra.CopyFailed
 import kolt.resolve.Coordinate
 import kolt.resolve.Lockfile
@@ -56,7 +58,8 @@ internal fun <T> ensureTool(
   paths: KoltPaths,
   lockfile: Lockfile,
   netDeps: T,
-  repos: List<String> = listOf("https://repo.maven.apache.org/maven2"),
+  repos: List<Repository> =
+    listOf(Repository(name = "central", url = MAVEN_CENTRAL_BASE, auth = null)),
 ): Result<ToolJarHandle, ToolResolutionError> where T : ResolverDeps, T : ToolFsDeps {
   val coords = entry.coords
   val classifier = entry.classifier
@@ -185,6 +188,7 @@ private fun translateResolveError(
       val urls =
         when (val f = err.failure) {
           is RepositoryDownloadFailure.AllAttemptsFailed -> f.attempts.map { it.url }
+          is RepositoryDownloadFailure.AuthFailed -> listOf(f.url)
           RepositoryDownloadFailure.NoRepositoriesConfigured -> emptyList()
         }
       ToolResolutionError.ResolveFailed(alias = alias, coords = coords, attempts = urls)

--- a/src/nativeTest/kotlin/kolt/TestFixtures.kt
+++ b/src/nativeTest/kotlin/kolt/TestFixtures.kt
@@ -15,7 +15,8 @@ fun testConfig(
   testSources: List<String> = listOf("test"),
   testDependencies: Map<String, String> = emptyMap(),
   plugins: Map<String, Boolean> = emptyMap(),
-  repositories: Map<String, Repository> = mapOf("central" to Repository(MAVEN_CENTRAL_BASE)),
+  repositories: Map<String, Repository> =
+    mapOf("central" to Repository(name = "central", url = MAVEN_CENTRAL_BASE)),
   jdk: String? = null,
   target: String = "jvm",
   cinterop: List<CinteropConfig> = emptyList(),

--- a/src/nativeTest/kotlin/kolt/build/daemon/BtaImplFetcherTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/BtaImplFetcherTest.kt
@@ -31,7 +31,8 @@ class BtaImplFetcherTest {
 
       override fun ensureDirectoryRecursive(path: String) = error("must not be called")
 
-      override fun downloadFile(url: String, destPath: String) = error("must not be called")
+      override fun downloadFile(url: String, destPath: String, headers: Map<String, String>?) =
+        error("must not be called")
 
       override fun computeSha256(filePath: String) = error("must not be called")
 
@@ -112,7 +113,11 @@ class BtaImplFetcherTest {
         "org.jetbrains.kotlin:kotlin-build-tools-impl",
         RepositoryDownloadFailure.AllAttemptsFailed(
           listOf(
-            RepositoryAttempt("http://example/", DownloadError.HttpFailed("http://example/", 503))
+            RepositoryAttempt(
+              repositoryName = "central",
+              url = "http://example/",
+              error = DownloadError.HttpFailed("http://example/", 503),
+            )
           )
         ),
       )
@@ -181,7 +186,7 @@ class BtaImplFetcherTest {
 
       override fun ensureDirectoryRecursive(path: String) = Ok(Unit)
 
-      override fun downloadFile(url: String, destPath: String) =
+      override fun downloadFile(url: String, destPath: String, headers: Map<String, String>?) =
         Err(DownloadError.NetworkError(url, "stub"))
 
       override fun computeSha256(filePath: String) = Err(Sha256Error(filePath))

--- a/src/nativeTest/kotlin/kolt/build/daemon/BtaImplFetcherTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/BtaImplFetcherTest.kt
@@ -84,7 +84,10 @@ class BtaImplFetcherTest {
       config.dependencies,
     )
     assertEquals("jvm", config.build.target)
-    assertEquals(Repository(MAVEN_CENTRAL_BASE), config.repositories["central"])
+    assertEquals(
+      Repository(name = "central", url = MAVEN_CENTRAL_BASE),
+      config.repositories["central"],
+    )
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
+++ b/src/nativeTest/kotlin/kolt/build/daemon/DaemonPreconditionsTest.kt
@@ -226,7 +226,11 @@ class DaemonPreconditionsTest {
           "org.jetbrains.kotlin:kotlin-build-tools-impl",
           RepositoryDownloadFailure.AllAttemptsFailed(
             listOf(
-              RepositoryAttempt("http://example", DownloadError.HttpFailed("http://example", 503))
+              RepositoryAttempt(
+                repositoryName = "central",
+                url = "http://example",
+                error = DownloadError.HttpFailed("http://example", 503),
+              )
             )
           ),
         ),
@@ -451,8 +455,9 @@ class DaemonPreconditionsTest {
                 RepositoryDownloadFailure.AllAttemptsFailed(
                   listOf(
                     RepositoryAttempt(
-                      "http://example",
-                      DownloadError.HttpFailed("http://example", 503),
+                      repositoryName = "central",
+                      url = "http://example",
+                      error = DownloadError.HttpFailed("http://example", 503),
                     )
                   )
                 ),

--- a/src/nativeTest/kotlin/kolt/cli/BundleResolutionIntegrationTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BundleResolutionIntegrationTest.kt
@@ -417,7 +417,11 @@ class BundleResolutionIntegrationTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           downloadedUrls.add(url)
           cached.add(destPath)
           return Ok(Unit)
@@ -621,7 +625,11 @@ class BundleResolutionIntegrationTest {
 
     override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-    override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+    override fun downloadFile(
+      url: String,
+      destPath: String,
+      headers: Map<String, String>?,
+    ): Result<Unit, DownloadError> {
       downloadCount += 1
       cachedFiles.add(destPath)
       return Ok(Unit)

--- a/src/nativeTest/kotlin/kolt/cli/BundleResolutionIntegrationTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/BundleResolutionIntegrationTest.kt
@@ -398,7 +398,11 @@ class BundleResolutionIntegrationTest {
   @Test
   fun materialiseBundleJarsFromLockBuildsUrlFromCachePathNotGroupArtifact() {
     val config =
-      testConfig().copy(repositories = mapOf("central" to Repository("https://example.org/m2")))
+      testConfig()
+        .copy(
+          repositories =
+            mapOf("central" to Repository(name = "central", url = "https://example.org/m2"))
+        )
 
     val redirectedRelativePath = "org/example/lib-jvm/1.0.0/lib-jvm-1.0.0.jar"
     val redirectedCachePath = "/cache/$redirectedRelativePath"

--- a/src/nativeTest/kotlin/kolt/cli/ToolCommandsE2ETest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/ToolCommandsE2ETest.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
 import kolt.config.KoltPaths
+import kolt.config.Repository
 import kolt.infra.CopyFailed
 import kolt.infra.DownloadError
 import kolt.infra.MkdirFailed
@@ -113,7 +114,7 @@ class ToolCommandsE2ETest {
               paths = paths,
               lockfile = lockfile,
               netDeps = deps,
-              repos = listOf("https://central/"),
+              repos = listOf(Repository(name = "r", url = "https://central/")),
             )
             .get()
         )
@@ -185,7 +186,7 @@ class ToolCommandsE2ETest {
               paths = paths,
               lockfile = lockfile,
               netDeps = deps,
-              repos = listOf("https://central/"),
+              repos = listOf(Repository(name = "r", url = "https://central/")),
             )
             .get()
         )
@@ -271,7 +272,11 @@ class ToolCommandsE2ETest {
     override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> =
       kolt.infra.ensureDirectoryRecursive(path)
 
-    override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+    override fun downloadFile(
+      url: String,
+      destPath: String,
+      headers: Map<String, String>?,
+    ): Result<Unit, DownloadError> {
       downloads.add(url)
       return Ok(Unit)
     }

--- a/src/nativeTest/kotlin/kolt/config/ChangeMatrixTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ChangeMatrixTest.kt
@@ -212,7 +212,11 @@ class ChangeMatrixTest {
   @Test
   fun classifyChangeDetectsRepositoriesChange() {
     val old = testConfig()
-    val new = old.copy(repositories = mapOf("central" to Repository("https://repo.example/maven")))
+    val new =
+      old.copy(
+        repositories =
+          mapOf("central" to Repository(name = "central", url = "https://repo.example/maven"))
+      )
     val result = classifyChange(old, new)
     assertEquals(1, result.size)
     assertEquals("[repositories]", result[0].sectionName)

--- a/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/ConfigTest.kt
@@ -791,7 +791,10 @@ class ConfigTest {
     val config = assertNotNull(parseConfig(minimalToml).get())
 
     assertEquals(1, config.repositories.size)
-    assertEquals(Repository(MAVEN_CENTRAL_BASE), config.repositories["central"])
+    assertEquals(
+      Repository(name = "central", url = MAVEN_CENTRAL_BASE),
+      config.repositories["central"],
+    )
   }
 
   @Test
@@ -817,7 +820,7 @@ class ConfigTest {
     val config = assertNotNull(parseConfig(toml).get())
     assertEquals(1, config.repositories.size)
     assertEquals(
-      Repository("https://nexus.example.com/repository/maven-public"),
+      Repository(name = "myrepo", url = "https://nexus.example.com/repository/maven-public"),
       config.repositories["myrepo"],
     )
   }
@@ -849,9 +852,15 @@ class ConfigTest {
     assertEquals(2, config.repositories.size)
     val entries = config.repositories.entries.toList()
     assertEquals("internal", entries[0].key)
-    assertEquals(Repository("https://nexus.example.com/repository/internal"), entries[0].value)
+    assertEquals(
+      Repository(name = "internal", url = "https://nexus.example.com/repository/internal"),
+      entries[0].value,
+    )
     assertEquals("central", entries[1].key)
-    assertEquals(Repository("https://repo1.maven.org/maven2"), entries[1].value)
+    assertEquals(
+      Repository(name = "central", url = "https://repo1.maven.org/maven2"),
+      entries[1].value,
+    )
   }
 
   @Test
@@ -909,8 +918,14 @@ class ConfigTest {
         .trimIndent()
 
     val config = assertNotNull(parseConfig(toml).get())
-    assertEquals(Repository("https://jitpack.io"), config.repositories["jitpack"])
-    assertEquals(Repository(MAVEN_CENTRAL_BASE), config.repositories["central"])
+    assertEquals(
+      Repository(name = "jitpack", url = "https://jitpack.io"),
+      config.repositories["jitpack"],
+    )
+    assertEquals(
+      Repository(name = "central", url = MAVEN_CENTRAL_BASE),
+      config.repositories["central"],
+    )
   }
 
   @Test
@@ -1059,7 +1074,10 @@ class ConfigTest {
   fun mavenCentralBaseDefinedInConfigPackage() {
     assertEquals("https://repo1.maven.org/maven2", MAVEN_CENTRAL_BASE)
     val config = assertNotNull(parseConfig(minimalToml).get())
-    assertEquals(Repository(MAVEN_CENTRAL_BASE), config.repositories["central"])
+    assertEquals(
+      Repository(name = "central", url = MAVEN_CENTRAL_BASE),
+      config.repositories["central"],
+    )
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/config/LiftRepositoriesMapAuthValidatorTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/LiftRepositoriesMapAuthValidatorTest.kt
@@ -1,0 +1,366 @@
+package kolt.config
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+// Pins each `liftRepositoriesMap` validator branch with a minimal fixture.
+// The big parametric matrix lives in task 2.7 (RepositoryAuthConfigTest).
+class LiftRepositoriesMapAuthValidatorTest {
+
+  // Helper: source map indicating overlay-only credential contributions, base url.
+  private fun overlayCredSource(
+    name: String,
+    fields: List<String>,
+  ): Map<String, Map<String, String?>> {
+    val inner = LinkedHashMap<String, String?>()
+    inner["url"] = "kolt.toml"
+    for (f in fields) inner[f] = "kolt.local.toml"
+    return mapOf(name to inner)
+  }
+
+  @Test
+  fun rejectsEmptyUrl() {
+    // Existing behavior — first validator in fail-fast order.
+    val raw = mapOf("custom" to RawRepository(url = ""))
+    val src = mapOf("custom" to mapOf<String, String?>("url" to "kolt.toml"))
+    val err = liftRepositoriesMap(raw, src).getError()
+    val pf = assertIs<ConfigError.ParseFailed>(err)
+    assertTrue("custom" in pf.message, "message must name repository: ${pf.message}")
+    assertTrue("url" in pf.message, "message must mention url: ${pf.message}")
+    assertEquals("kolt.toml", pf.path)
+  }
+
+  @Test
+  fun rejectsUserinfoInUrlWithoutLeakingCredentials() {
+    val raw = mapOf("nexus" to RawRepository(url = "https://alice:s3cret@nexus.example.com/repo"))
+    val src = mapOf("nexus" to mapOf<String, String?>("url" to "kolt.toml"))
+    val err = liftRepositoriesMap(raw, src).getError()
+    val pf = assertIs<ConfigError.ParseFailed>(err)
+    assertTrue("nexus" in pf.message, "message must name repository: ${pf.message}")
+    // Redaction guarantee Req 3.3: no userinfo character leaks.
+    assertFalse("alice" in pf.message, "message must not leak user: ${pf.message}")
+    assertFalse("s3cret" in pf.message, "message must not leak password: ${pf.message}")
+    assertFalse("alice:s3cret" in pf.message, "message must not leak combo: ${pf.message}")
+    assertEquals("kolt.toml", pf.path)
+  }
+
+  @Test
+  fun acceptsAtSignInsidePath() {
+    // `https://host/foo@bar` has no userinfo (the `@` is past the path separator).
+    val raw = mapOf("ok" to RawRepository(url = "https://host.example.com/foo@bar"))
+    val src = mapOf("ok" to mapOf<String, String?>("url" to "kolt.toml"))
+    val result = liftRepositoriesMap(raw, src).get()
+    assertNotNull(result)
+    assertEquals("https://host.example.com/foo@bar", result["ok"]?.url)
+  }
+
+  @Test
+  fun rejectsTokenAndUserMutex() {
+    val raw =
+      mapOf(
+        "nexus" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            token = RawCredentialField.Literal("abc"),
+            user = RawCredentialField.Literal("alice"),
+            password = RawCredentialField.Literal("s3cret"),
+          )
+      )
+    val src = overlayCredSource("nexus", listOf("token", "user", "password"))
+    val err = liftRepositoriesMap(raw, src).getError()
+    val pf = assertIs<ConfigError.ParseFailed>(err)
+    assertTrue("nexus" in pf.message, "message must name repo: ${pf.message}")
+    assertTrue("token" in pf.message, "message must name token: ${pf.message}")
+    assertTrue(
+      "user" in pf.message || "password" in pf.message,
+      "message must mention basic field(s): ${pf.message}",
+    )
+    assertTrue(
+      "mutually exclusive" in pf.message || "exclusive" in pf.message,
+      "message must explain mutex: ${pf.message}",
+    )
+    // Mutex rejection attributes to the contributing file of the token field.
+    assertEquals("kolt.local.toml", pf.path)
+    // Defense: no credential value in the message.
+    assertFalse("abc" in pf.message, "message must not include token value: ${pf.message}")
+    assertFalse("s3cret" in pf.message, "message must not include password value: ${pf.message}")
+  }
+
+  @Test
+  fun rejectsUserWithoutPassword() {
+    val raw =
+      mapOf(
+        "nexus" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            user = RawCredentialField.Literal("alice"),
+          )
+      )
+    val src = overlayCredSource("nexus", listOf("user"))
+    val err = liftRepositoriesMap(raw, src).getError()
+    val pf = assertIs<ConfigError.ParseFailed>(err)
+    assertTrue("nexus" in pf.message, "message must name repo: ${pf.message}")
+    assertTrue("password" in pf.message, "message must name missing password: ${pf.message}")
+    assertEquals("kolt.local.toml", pf.path)
+  }
+
+  @Test
+  fun rejectsPasswordWithoutUser() {
+    val raw =
+      mapOf(
+        "nexus" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            password = RawCredentialField.Literal("s3cret"),
+          )
+      )
+    val src = overlayCredSource("nexus", listOf("password"))
+    val err = liftRepositoriesMap(raw, src).getError()
+    val pf = assertIs<ConfigError.ParseFailed>(err)
+    assertTrue("nexus" in pf.message, "message must name repo: ${pf.message}")
+    assertTrue("user" in pf.message, "message must name missing user: ${pf.message}")
+    assertFalse("s3cret" in pf.message, "message must not leak password value: ${pf.message}")
+    assertEquals("kolt.local.toml", pf.path)
+  }
+
+  @Test
+  fun rejectsEmptyLiteralToken() {
+    val raw =
+      mapOf(
+        "nexus" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            token = RawCredentialField.Literal(""),
+          )
+      )
+    val src = overlayCredSource("nexus", listOf("token"))
+    val err = liftRepositoriesMap(raw, src).getError()
+    val pf = assertIs<ConfigError.ParseFailed>(err)
+    assertTrue("nexus" in pf.message, "message must name repo: ${pf.message}")
+    assertTrue("token" in pf.message, "message must name token: ${pf.message}")
+    assertEquals("kolt.local.toml", pf.path)
+  }
+
+  @Test
+  fun rejectsWhitespaceOnlyLiteralToken() {
+    val raw =
+      mapOf(
+        "nexus" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            // Unicode whitespace + ASCII whitespace mix.
+            token = RawCredentialField.Literal(" \t \n"),
+          )
+      )
+    val src = overlayCredSource("nexus", listOf("token"))
+    val err = liftRepositoriesMap(raw, src).getError()
+    val pf = assertIs<ConfigError.ParseFailed>(err)
+    assertTrue("nexus" in pf.message, "message must name repo: ${pf.message}")
+    assertTrue("token" in pf.message, "message must name token: ${pf.message}")
+    assertEquals("kolt.local.toml", pf.path)
+  }
+
+  @Test
+  fun rejectsEmptyLiteralUser() {
+    val raw =
+      mapOf(
+        "nexus" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            user = RawCredentialField.Literal(""),
+            password = RawCredentialField.Literal("s3cret"),
+          )
+      )
+    val src = overlayCredSource("nexus", listOf("user", "password"))
+    val err = liftRepositoriesMap(raw, src).getError()
+    val pf = assertIs<ConfigError.ParseFailed>(err)
+    assertTrue("nexus" in pf.message, "message must name repo: ${pf.message}")
+    assertTrue("user" in pf.message, "message must name user: ${pf.message}")
+    assertEquals("kolt.local.toml", pf.path)
+  }
+
+  @Test
+  fun rejectsEnvFormToken() {
+    val raw =
+      mapOf(
+        "nexus" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            token = RawCredentialField.Env("NEXUS_TOKEN"),
+          )
+      )
+    val src = overlayCredSource("nexus", listOf("token"))
+    val err = liftRepositoriesMap(raw, src).getError()
+    val pf = assertIs<ConfigError.ParseFailed>(err)
+    assertTrue("nexus" in pf.message, "message must name repo: ${pf.message}")
+    assertTrue("token" in pf.message, "message must name token: ${pf.message}")
+    assertTrue(
+      "v1.0" in pf.message || "not supported" in pf.message,
+      "message must indicate env unsupported in v1.0: ${pf.message}",
+    )
+    assertTrue("kolt.local.toml" in pf.message, "message must direct to overlay: ${pf.message}")
+    // Defense (Req 8.2): env var name not echoed.
+    assertFalse("NEXUS_TOKEN" in pf.message, "message must not include env var name: ${pf.message}")
+    assertEquals("kolt.local.toml", pf.path)
+  }
+
+  @Test
+  fun rejectsEnvFormUser() {
+    val raw =
+      mapOf(
+        "nexus" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            user = RawCredentialField.Env("NEXUS_USER"),
+            password = RawCredentialField.Literal("s3cret"),
+          )
+      )
+    val src = overlayCredSource("nexus", listOf("user", "password"))
+    val err = liftRepositoriesMap(raw, src).getError()
+    val pf = assertIs<ConfigError.ParseFailed>(err)
+    assertTrue("nexus" in pf.message, "message must name repo: ${pf.message}")
+    assertTrue("user" in pf.message, "message must name user: ${pf.message}")
+    assertFalse("NEXUS_USER" in pf.message, "message must not include env var name: ${pf.message}")
+    assertFalse("s3cret" in pf.message, "message must not include password value: ${pf.message}")
+    assertEquals("kolt.local.toml", pf.path)
+  }
+
+  @Test
+  fun mutexFiresBeforeNonEmpty() {
+    // token + user + password all empty: order says mutex (#3) fires before
+    // pair-completeness (#4) and non-empty (#5). User sees mutex message.
+    val raw =
+      mapOf(
+        "nexus" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            token = RawCredentialField.Literal(""),
+            user = RawCredentialField.Literal(""),
+            password = RawCredentialField.Literal(""),
+          )
+      )
+    val src = overlayCredSource("nexus", listOf("token", "user", "password"))
+    val err = liftRepositoriesMap(raw, src).getError()
+    val pf = assertIs<ConfigError.ParseFailed>(err)
+    assertTrue(
+      "mutually exclusive" in pf.message || "exclusive" in pf.message,
+      "mutex message must win: ${pf.message}",
+    )
+  }
+
+  @Test
+  fun pairCompletenessFiresBeforeNonEmpty() {
+    // user without password — pair completeness wins over non-empty (the user
+    // field is empty too, but pair-completeness sits earlier in the order).
+    val raw =
+      mapOf(
+        "nexus" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            user = RawCredentialField.Literal(""),
+          )
+      )
+    val src = overlayCredSource("nexus", listOf("user"))
+    val err = liftRepositoriesMap(raw, src).getError()
+    val pf = assertIs<ConfigError.ParseFailed>(err)
+    assertTrue("password" in pf.message, "pair-completeness must win: ${pf.message}")
+  }
+
+  @Test
+  fun acceptsLiteralBearer() {
+    val raw =
+      mapOf(
+        "nexus" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            token = RawCredentialField.Literal("abc"),
+          )
+      )
+    val src = overlayCredSource("nexus", listOf("token"))
+    val lifted = assertNotNull(liftRepositoriesMap(raw, src).get())
+    val repo = assertNotNull(lifted["nexus"])
+    assertEquals("nexus", repo.name)
+    assertEquals("https://nexus.example.com/repo", repo.url)
+    assertEquals(RepositoryAuth.Bearer("abc"), repo.auth)
+  }
+
+  @Test
+  fun acceptsLiteralBasic() {
+    val raw =
+      mapOf(
+        "nexus" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            user = RawCredentialField.Literal("alice"),
+            password = RawCredentialField.Literal("s3cret"),
+          )
+      )
+    val src = overlayCredSource("nexus", listOf("user", "password"))
+    val lifted = assertNotNull(liftRepositoriesMap(raw, src).get())
+    val repo = assertNotNull(lifted["nexus"])
+    assertEquals("nexus", repo.name)
+    assertEquals(RepositoryAuth.Basic("alice", "s3cret"), repo.auth)
+  }
+
+  @Test
+  fun acceptsAnonymousRepository() {
+    val raw = mapOf("central" to RawRepository(url = "https://repo1.maven.org/maven2"))
+    val src = mapOf("central" to mapOf<String, String?>("url" to "kolt.toml"))
+    val lifted = assertNotNull(liftRepositoriesMap(raw, src).get())
+    val repo = assertNotNull(lifted["central"])
+    assertEquals("central", repo.name)
+    assertNull(repo.auth)
+  }
+
+  @Test
+  fun nameInvariantHoldsForAllEntries() {
+    // Multiple entries, including one whose key was quoted in the raw map.
+    val raw =
+      linkedMapOf(
+        "central" to RawRepository(url = "https://repo1.maven.org/maven2"),
+        "\"nexus\"" to
+          RawRepository(
+            url = "https://nexus.example.com/repo",
+            token = RawCredentialField.Literal("abc"),
+          ),
+        "ghcr" to RawRepository(url = "https://maven.pkg.github.com/owner/repo"),
+      )
+    val src =
+      mapOf(
+        "central" to mapOf<String, String?>("url" to "kolt.toml"),
+        "nexus" to mapOf<String, String?>("url" to "kolt.toml", "token" to "kolt.local.toml"),
+        "ghcr" to mapOf<String, String?>("url" to "kolt.toml"),
+      )
+    val lifted = assertNotNull(liftRepositoriesMap(raw, src).get())
+    for ((key, value) in lifted) {
+      assertEquals(key, value.name, "Repository.name must equal map key for entry $key")
+    }
+    // Quote-stripped key is the canonical name.
+    assertTrue("nexus" in lifted, "quoted key must be stripped: ${lifted.keys}")
+  }
+
+  @Test
+  fun preservesDeclarationOrder() {
+    val raw =
+      linkedMapOf(
+        "alpha" to RawRepository(url = "https://a.example.com"),
+        "beta" to RawRepository(url = "https://b.example.com"),
+        "gamma" to RawRepository(url = "https://c.example.com"),
+      )
+    val src =
+      mapOf(
+        "alpha" to mapOf<String, String?>("url" to "kolt.toml"),
+        "beta" to mapOf<String, String?>("url" to "kolt.toml"),
+        "gamma" to mapOf<String, String?>("url" to "kolt.toml"),
+      )
+    val lifted = assertNotNull(liftRepositoriesMap(raw, src).get())
+    assertEquals(listOf("alpha", "beta", "gamma"), lifted.keys.toList())
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/LocalTomlOverlayMergeTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/LocalTomlOverlayMergeTest.kt
@@ -508,6 +508,104 @@ class LocalTomlOverlayMergeTest {
   }
 
   @Test
+  fun mergeRepositoriesUnionsBaseUrlWithOverlayTokenLiteral() {
+    val base =
+      baseConfig()
+        .copy(
+          repositories = mapOf("internal" to RawRepository(url = "https://internal.example.com/m2"))
+        )
+    val overlay =
+      RawLocalOverlayConfig(
+        repositories = mapOf("internal" to RawRepository(token = RawCredentialField.Literal("abc")))
+      )
+
+    val merged =
+      assertNotNull(
+        mergeOverlay(base, overlay, overlayPath = "kolt.local.toml").get(),
+        "expected base url + overlay token to merge into a single RawRepository",
+      )
+
+    val repo = assertNotNull(merged.repositories["internal"])
+    assertEquals("https://internal.example.com/m2", repo.url)
+    assertEquals(RawCredentialField.Literal("abc"), repo.token)
+    assertEquals(null, repo.user)
+    assertEquals(null, repo.password)
+  }
+
+  @Test
+  fun mergeRepositoriesUnionsBaseUrlWithOverlayUserAndPassword() {
+    val base =
+      baseConfig()
+        .copy(
+          repositories = mapOf("internal" to RawRepository(url = "https://internal.example.com/m2"))
+        )
+    val overlay =
+      RawLocalOverlayConfig(
+        repositories =
+          mapOf(
+            "internal" to
+              RawRepository(
+                user = RawCredentialField.Literal("alice"),
+                password = RawCredentialField.Env("REPO_PASSWORD"),
+              )
+          )
+      )
+
+    val merged =
+      assertNotNull(
+        mergeOverlay(base, overlay, overlayPath = "kolt.local.toml").get(),
+        "expected base url + overlay user/password to merge into a single RawRepository",
+      )
+
+    val repo = assertNotNull(merged.repositories["internal"])
+    assertEquals("https://internal.example.com/m2", repo.url)
+    assertEquals(null, repo.token)
+    assertEquals(RawCredentialField.Literal("alice"), repo.user)
+    assertEquals(RawCredentialField.Env("REPO_PASSWORD"), repo.password)
+  }
+
+  @Test
+  fun mergeRepositoriesOverlayCredentialReplacesBaseCredentialLastWriteWins() {
+    val base =
+      baseConfig()
+        .copy(
+          repositories =
+            mapOf(
+              "internal" to
+                RawRepository(
+                  url = "https://internal.example.com/m2",
+                  token = RawCredentialField.Literal("base-token"),
+                  user = RawCredentialField.Literal("base-user"),
+                  password = RawCredentialField.Literal("base-password"),
+                )
+            )
+        )
+    val overlay =
+      RawLocalOverlayConfig(
+        repositories =
+          mapOf(
+            "internal" to
+              RawRepository(
+                token = RawCredentialField.Literal("overlay-token"),
+                password = RawCredentialField.Env("OVERLAY_PW"),
+              )
+          )
+      )
+
+    val merged =
+      assertNotNull(
+        mergeOverlay(base, overlay, overlayPath = "kolt.local.toml").get(),
+        "expected overlay credentials to override base credentials last-write-wins",
+      )
+
+    val repo = assertNotNull(merged.repositories["internal"])
+    assertEquals("https://internal.example.com/m2", repo.url)
+    assertEquals(RawCredentialField.Literal("overlay-token"), repo.token)
+    assertEquals(RawCredentialField.Literal("base-user"), repo.user)
+    assertEquals(RawCredentialField.Env("OVERLAY_PW"), repo.password)
+  }
+
+  @Test
   fun parseConfigOverlayMergesWhenBaseKeyIsQuotedButOverlayKeyIsBare() {
     val base =
       baseToml +

--- a/src/nativeTest/kotlin/kolt/config/LocalTomlOverlayMergeTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/LocalTomlOverlayMergeTest.kt
@@ -192,7 +192,12 @@ class LocalTomlOverlayMergeTest {
   fun parseConfigRejectsMergedRawWithEmptyRepositoryUrl() {
     val raw =
       mapOf("custom" to RawRepository(url = ""), "central" to RawRepository(url = "https://x"))
-    val err = liftRepositoriesMap(raw).getError()
+    val src =
+      mapOf(
+        "custom" to mapOf<String, String?>("url" to "kolt.toml"),
+        "central" to mapOf<String, String?>("url" to "kolt.toml"),
+      )
+    val err = liftRepositoriesMap(raw, src).getError()
     val parseFailed = assertNotNull(err) as ConfigError.ParseFailed
     assertTrue(
       "custom" in parseFailed.message && "url" in parseFailed.message,

--- a/src/nativeTest/kotlin/kolt/config/RawCredentialFieldTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RawCredentialFieldTest.kt
@@ -1,0 +1,68 @@
+package kolt.config
+
+import com.akuleshov7.ktoml.Toml
+import com.akuleshov7.ktoml.TomlInputConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.serialization.Serializable
+
+internal class RawCredentialFieldTest {
+
+  @Serializable private data class Wrapper(val token: RawCredentialField? = null)
+
+  private val toml = Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = true))
+
+  @Test
+  fun decodesLiteralVariant() {
+    val input = """token = { literal = "abc" }""".trimIndent()
+    val parsed = toml.decodeFromString(Wrapper.serializer(), input)
+    val value = parsed.token
+    assertIs<RawCredentialField.Literal>(value)
+    assertEquals("abc", value.value)
+  }
+
+  @Test
+  fun decodesEnvVariant() {
+    val input = """token = { env = "X" }""".trimIndent()
+    val parsed = toml.decodeFromString(Wrapper.serializer(), input)
+    val value = parsed.token
+    assertIs<RawCredentialField.Env>(value)
+    assertEquals("X", value.varName)
+  }
+
+  @Test
+  fun rejectsBothFieldsSet() {
+    val input = """token = { literal = "a", env = "X" }""".trimIndent()
+    val failure = assertFails { toml.decodeFromString(Wrapper.serializer(), input) }
+    assertTrue(
+      failure.message?.contains("exactly one") == true,
+      "expected exactly-one-of error, got: ${failure.message}",
+    )
+  }
+
+  @Test
+  fun rejectsZeroFieldsSet() {
+    val input = """token = {}""".trimIndent()
+    val failure = assertFails { toml.decodeFromString(Wrapper.serializer(), input) }
+    assertTrue(
+      failure.message?.contains("exactly one") == true,
+      "expected exactly-one-of error, got: ${failure.message}",
+    )
+  }
+
+  @Test
+  fun literalToStringRedactsValue() {
+    val rendered = RawCredentialField.Literal("abc").toString()
+    assertFalse(rendered.contains("abc"), "Literal.toString must not expose value, got: $rendered")
+  }
+
+  @Test
+  fun envToStringContainsVarName() {
+    val rendered = RawCredentialField.Env("X").toString()
+    assertTrue(rendered.contains("X"), "Env.toString must include varName, got: $rendered")
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/RawRepositoryDecodeTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RawRepositoryDecodeTest.kt
@@ -1,0 +1,74 @@
+package kolt.config
+
+import com.akuleshov7.ktoml.Toml
+import com.akuleshov7.ktoml.TomlInputConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.serialization.Serializable
+
+internal class RawRepositoryDecodeTest {
+
+  @Serializable
+  private data class Wrapper(val repositories: Map<String, RawRepository> = emptyMap())
+
+  private val toml = Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = false))
+
+  @Test
+  fun decodesUrlOnlySubTable() {
+    val input =
+      """
+        [repositories.central]
+        url = "https://repo1.maven.org/maven2"
+      """
+        .trimIndent()
+    val parsed = toml.decodeFromString(Wrapper.serializer(), input)
+    val repo = assertNotNull(parsed.repositories["central"])
+    assertEquals("https://repo1.maven.org/maven2", repo.url)
+    assertNull(repo.token)
+    assertNull(repo.user)
+    assertNull(repo.password)
+  }
+
+  @Test
+  fun decodesTokenCredentialAlongsideUrl() {
+    val input =
+      """
+        [repositories.x]
+        url = "https://nexus.example.com/repository/internal"
+        token = { literal = "abc" }
+      """
+        .trimIndent()
+    val parsed = toml.decodeFromString(Wrapper.serializer(), input)
+    val repo = assertNotNull(parsed.repositories["x"])
+    assertEquals("https://nexus.example.com/repository/internal", repo.url)
+    val token = repo.token
+    assertIs<RawCredentialField.Literal>(token)
+    assertEquals("abc", token.value)
+    assertNull(repo.user)
+    assertNull(repo.password)
+  }
+
+  @Test
+  fun decodesUserPasswordCredentialAlongsideUrl() {
+    val input =
+      """
+        [repositories.x]
+        url = "https://nexus.example.com/repository/internal"
+        user = { literal = "alice" }
+        password = { env = "NEXUS_PASS" }
+      """
+        .trimIndent()
+    val parsed = toml.decodeFromString(Wrapper.serializer(), input)
+    val repo = assertNotNull(parsed.repositories["x"])
+    val user = repo.user
+    val password = repo.password
+    assertIs<RawCredentialField.Literal>(user)
+    assertEquals("alice", user.value)
+    assertIs<RawCredentialField.Env>(password)
+    assertEquals("NEXUS_PASS", password.varName)
+    assertNull(repo.token)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/RejectBaseCredentialFieldsTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RejectBaseCredentialFieldsTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-class RejectBaseCredentialLiteralsTest {
+class RejectBaseCredentialFieldsTest {
 
   // Minimal valid base kolt.toml stem; tests append `[repositories.x]` blocks.
   private val baseStem =
@@ -119,7 +119,7 @@ class RejectBaseCredentialLiteralsTest {
   @Test
   fun acceptsOverlayOnlyCredential() {
     // Base declares the repository without credentials; overlay supplies
-    // the token. rejectBaseCredentialLiterals must not fire because it
+    // the token. rejectBaseCredentialFields must not fire because it
     // inspects rawBase only, not the merged result.
     val baseToml =
       baseStem +

--- a/src/nativeTest/kotlin/kolt/config/RejectBaseCredentialLiteralsTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RejectBaseCredentialLiteralsTest.kt
@@ -1,0 +1,163 @@
+package kolt.config
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class RejectBaseCredentialLiteralsTest {
+
+  // Minimal valid base kolt.toml stem; tests append `[repositories.x]` blocks.
+  private val baseStem =
+    """
+      name = "demo"
+      version = "0.0.0"
+
+      [kotlin]
+      version = "2.3.20"
+
+      [build]
+      target = "jvm"
+      main = "com.example.main"
+      sources = ["src"]
+
+    """
+      .trimIndent()
+
+  @Test
+  fun rejectsLiteralTokenInBaseKoltToml() {
+    val toml =
+      baseStem +
+        """
+
+        [repositories.x]
+        url = "https://nexus.example.com/repository/internal"
+        token = { literal = "abc" }
+      """
+          .trimIndent()
+    val error = assertIs<ConfigError.ParseFailed>(parseConfig(toml, path = "kolt.toml").getError())
+    assertEquals("kolt.toml", error.path)
+    val msg = error.message
+    assertTrue(msg.contains("kolt.toml"), "message must name kolt.toml: $msg")
+    assertTrue(msg.contains("[repositories.x]"), "message must name the repository: $msg")
+    assertTrue(msg.contains("literal token field"), "message must name the offending field: $msg")
+    assertTrue(msg.contains("kolt.local.toml"), "message must direct user to kolt.local.toml: $msg")
+    assertFalse(msg.contains("abc"), "message must not include credential value: $msg")
+  }
+
+  @Test
+  fun rejectsLiteralUserInBaseKoltToml() {
+    val toml =
+      baseStem +
+        """
+
+        [repositories.x]
+        url = "https://nexus.example.com/repository/internal"
+        user = { literal = "alice" }
+        password = { literal = "s3cret" }
+      """
+          .trimIndent()
+    val error = assertIs<ConfigError.ParseFailed>(parseConfig(toml, path = "kolt.toml").getError())
+    assertEquals("kolt.toml", error.path)
+    val msg = error.message
+    assertTrue(msg.contains("[repositories.x]"), "message must name the repository: $msg")
+    // user is declared before password in the entry; first violation wins on
+    // declaration order, so the message names `user`.
+    assertTrue(msg.contains("literal user field"), "message must name user: $msg")
+    assertTrue(msg.contains("kolt.local.toml"), "message must direct user to kolt.local.toml: $msg")
+    assertFalse(msg.contains("alice"), "message must not include user value: $msg")
+    assertFalse(msg.contains("s3cret"), "message must not include password value: $msg")
+  }
+
+  @Test
+  fun rejectsLiteralPasswordInBaseKoltToml() {
+    val toml =
+      baseStem +
+        """
+
+        [repositories.x]
+        url = "https://nexus.example.com/repository/internal"
+        password = { literal = "s3cret" }
+      """
+          .trimIndent()
+    val error = assertIs<ConfigError.ParseFailed>(parseConfig(toml, path = "kolt.toml").getError())
+    assertEquals("kolt.toml", error.path)
+    val msg = error.message
+    assertTrue(msg.contains("[repositories.x]"), "message must name the repository: $msg")
+    assertTrue(msg.contains("literal password field"), "message must name password: $msg")
+    assertTrue(msg.contains("kolt.local.toml"), "message must direct user to kolt.local.toml: $msg")
+    assertFalse(msg.contains("s3cret"), "message must not include password value: $msg")
+  }
+
+  @Test
+  fun rejectsEnvFormInBaseKoltTomlShapeBlind() {
+    // Placement-policy first: env form in kolt.toml is rejected by this
+    // validator before the env-not-supported message (which fires in
+    // liftRepositoriesMap, task 2.6) can run.
+    val toml =
+      baseStem +
+        """
+
+        [repositories.x]
+        url = "https://nexus.example.com/repository/internal"
+        token = { env = "NEXUS_TOKEN" }
+      """
+          .trimIndent()
+    val error = assertIs<ConfigError.ParseFailed>(parseConfig(toml, path = "kolt.toml").getError())
+    assertEquals("kolt.toml", error.path)
+    val msg = error.message
+    assertTrue(msg.contains("[repositories.x]"), "message must name the repository: $msg")
+    assertTrue(msg.contains("literal token field"), "message must name token: $msg")
+    assertTrue(msg.contains("kolt.local.toml"), "message must direct user to kolt.local.toml: $msg")
+    assertFalse(msg.contains("NEXUS_TOKEN"), "message must not include env var name: $msg")
+  }
+
+  @Test
+  fun acceptsOverlayOnlyCredential() {
+    // Base declares the repository without credentials; overlay supplies
+    // the token. rejectBaseCredentialLiterals must not fire because it
+    // inspects rawBase only, not the merged result.
+    val baseToml =
+      baseStem +
+        """
+
+        [repositories.x]
+        url = "https://nexus.example.com/repository/internal"
+      """
+          .trimIndent()
+    val overlayToml =
+      """
+        [repositories.x]
+        token = { literal = "abc" }
+      """
+        .trimIndent()
+    // Later validators (liftRepositoriesMap env-not-supported, mutex,
+    // userinfo, non-empty) are out of scope for task 2.4 — but a literal
+    // token in the overlay must not be rejected by THIS validator. The
+    // overall parseConfig may still fail downstream (e.g. once liftRepositoriesMap
+    // is wired in task 2.6), so we only assert the validator under test
+    // does not produce the placement-policy message.
+    val result =
+      parseConfig(
+        baseToml,
+        path = "kolt.toml",
+        overlayString = overlayToml,
+        overlayPath = "kolt.local.toml",
+      )
+    val error = result.getError()
+    if (error is ConfigError.ParseFailed) {
+      assertFalse(
+        error.message.contains("kolt.toml is intended to be committed"),
+        "placement-policy validator must not fire for overlay-only credential: ${error.message}",
+      )
+    } else {
+      // No error at all is fine — even better, it means downstream
+      // validators are not (yet) wired and the overlay-only path parses cleanly.
+      assertNotNull(result.get())
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/RepositoryAuthConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RepositoryAuthConfigTest.kt
@@ -1,0 +1,433 @@
+package kolt.config
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+// End-to-end parametric matrix driving parseConfig (with overlay) so that the
+// full chain — ktoml decode -> rejectBaseCredentialLiterals -> mergeOverlay ->
+// repositorySourceMap -> liftRepositoriesMap — composes with realistic
+// kolt.toml / kolt.local.toml fixtures. Per-validator unit branches live in
+// LiftRepositoriesMapAuthValidatorTest; this file pins source attribution
+// (ParseFailed.path) and surface-level message shape that only the chain can
+// expose.
+class RepositoryAuthConfigTest {
+
+  // Base stem: everything a kolt.toml needs to parse minus the `[repositories]`
+  // block, which each scenario appends inline.
+  private val baseStem =
+    """
+      name = "demo"
+      version = "0.0.0"
+
+      [kotlin]
+      version = "2.3.20"
+
+      [build]
+      target = "jvm"
+      main = "com.example.main"
+      sources = ["src"]
+
+    """
+      .trimIndent()
+
+  // Expected outcome encoded as a sealed class — each row in the matrix
+  // declares exactly one of these, and the runner switches on it.
+  private sealed class Expected {
+    // Successful parse. The lambda inspects the resulting repository map.
+    data class Ok(val assert: (Map<String, Repository>) -> Unit) : Expected()
+
+    // Parse failure. `path` is asserted on ParseFailed.path. Each substring
+    // in `messageContains` must appear in the message; each in `messageAbsent`
+    // must NOT appear (credential-value leak guard).
+    data class Err(
+      val path: String?,
+      val messageContains: List<String> = emptyList(),
+      val messageAbsent: List<String> = emptyList(),
+    ) : Expected()
+  }
+
+  private data class Scenario(
+    val label: String,
+    val baseRepos: String,
+    val overlayRepos: String? = null,
+    val expected: Expected,
+  )
+
+  private fun buildBase(reposBlock: String): String = baseStem + reposBlock.trimIndent()
+
+  // Single shared anonymous repo declaration that scenarios reuse as the
+  // base side of a kolt.toml + kolt.local.toml pair.
+  private val baseUrlOnly =
+    """
+
+      [repositories.x]
+      url = "https://nexus.example.com/repository/internal"
+    """
+
+  // Each scenario row is one line in the data table. Labels are descriptive
+  // so a failing row pinpoints the regression. Each row catches one unique
+  // regression and is annotated with the requirement it pins.
+  private val scenarios: List<Scenario> =
+    listOf(
+      // (a) Req 1.1 / 1.5: literal token in overlay -> Bearer.
+      Scenario(
+        label = "a/overlay-token-literal -> Bearer",
+        baseRepos = baseUrlOnly,
+        overlayRepos =
+          """
+            [repositories.x]
+            token = { literal = "abc" }
+          """,
+        expected =
+          Expected.Ok { repos ->
+            val r = assertNotNull(repos["x"])
+            assertEquals(RepositoryAuth.Bearer("abc"), r.auth)
+          },
+      ),
+      // (b) Req 1.1 / 1.5: literal user + password in overlay -> Basic.
+      Scenario(
+        label = "b/overlay-user-password-literal -> Basic",
+        baseRepos = baseUrlOnly,
+        overlayRepos =
+          """
+            [repositories.x]
+            user = { literal = "alice" }
+            password = { literal = "s3cret" }
+          """,
+        expected =
+          Expected.Ok { repos ->
+            val r = assertNotNull(repos["x"])
+            assertEquals(RepositoryAuth.Basic("alice", "s3cret"), r.auth)
+          },
+      ),
+      // (c) Req 1.2: token + user mutex; path attributes to overlay (token
+      // contributing file). Credential values must not leak.
+      Scenario(
+        label = "c/overlay-token-user-mutex",
+        baseRepos = baseUrlOnly,
+        overlayRepos =
+          """
+            [repositories.x]
+            token = { literal = "abc" }
+            user = { literal = "alice" }
+            password = { literal = "s3cret" }
+          """,
+        expected =
+          Expected.Err(
+            path = "kolt.local.toml",
+            messageContains = listOf("x", "token", "exclusive"),
+            messageAbsent = listOf("abc", "alice", "s3cret"),
+          ),
+      ),
+      // (d) Req 1.3: user alone -> pair-completeness reject.
+      Scenario(
+        label = "d/overlay-user-alone-pair-incomplete",
+        baseRepos = baseUrlOnly,
+        overlayRepos =
+          """
+            [repositories.x]
+            user = { literal = "alice" }
+          """,
+        expected =
+          Expected.Err(
+            path = "kolt.local.toml",
+            messageContains = listOf("x", "password"),
+            messageAbsent = listOf("alice"),
+          ),
+      ),
+      // (e) Req 1.4: empty literal -> non-empty reject; value `""` not echoed
+      // (covered tautologically; assert message names the field).
+      Scenario(
+        label = "e/overlay-token-empty-literal",
+        baseRepos = baseUrlOnly,
+        overlayRepos =
+          """
+            [repositories.x]
+            token = { literal = "" }
+          """,
+        expected = Expected.Err(path = "kolt.local.toml", messageContains = listOf("x", "token")),
+      ),
+      // (e') Req 1.4: Unicode/ASCII whitespace-only literal -> non-empty reject.
+      Scenario(
+        label = "e'/overlay-token-whitespace-literal",
+        baseRepos = baseUrlOnly,
+        overlayRepos =
+          """
+            [repositories.x]
+            token = { literal = "   " }
+          """,
+        expected = Expected.Err(path = "kolt.local.toml", messageContains = listOf("x", "token")),
+      ),
+      // (f) Req 1.6: inline-table with neither literal nor env -> ktoml
+      // SerializationException via RawCredentialFieldSerializer. Bubbled into
+      // ParseFailed via parseLocalOverlay's catch path.
+      Scenario(
+        label = "f/overlay-token-empty-inline-table",
+        baseRepos = baseUrlOnly,
+        overlayRepos =
+          """
+            [repositories.x]
+            token = {}
+          """,
+        expected =
+          Expected.Err(path = "kolt.local.toml", messageContains = listOf("literal", "env")),
+      ),
+      // (f') Req 1.7: inline-table with both literal AND env -> SerializationException.
+      Scenario(
+        label = "f'/overlay-token-literal-and-env",
+        baseRepos = baseUrlOnly,
+        overlayRepos =
+          """
+            [repositories.x]
+            token = { literal = "x", env = "Y" }
+          """,
+        expected =
+          Expected.Err(
+            path = "kolt.local.toml",
+            messageContains = listOf("literal", "env"),
+            // `x` is too short to safely assert-absent; assert env var name absent only.
+            messageAbsent = listOf("Y"),
+          ),
+      ),
+      // (g) Req 2.1 / 2.4: literal token in BASE kolt.toml -> placement reject
+      // attributed to kolt.toml. Credential value must NOT appear in message.
+      Scenario(
+        label = "g/base-token-literal-placement",
+        baseRepos =
+          """
+
+            [repositories.x]
+            url = "https://nexus.example.com/repository/internal"
+            token = { literal = "abc" }
+          """,
+        overlayRepos = null,
+        expected =
+          Expected.Err(
+            path = "kolt.toml",
+            messageContains = listOf("kolt.toml", "x", "token", "kolt.local.toml"),
+            messageAbsent = listOf("abc"),
+          ),
+      ),
+      // (h) Req 2.2: literal token in overlay accepted; placement validator
+      // does NOT fire because base side has no auth fields.
+      Scenario(
+        label = "h/overlay-token-literal-accepted",
+        baseRepos = baseUrlOnly,
+        overlayRepos =
+          """
+            [repositories.x]
+            token = { literal = "abc" }
+          """,
+        expected =
+          Expected.Ok { repos ->
+            val r = assertNotNull(repos["x"])
+            assertEquals(RepositoryAuth.Bearer("abc"), r.auth)
+          },
+      ),
+      // (i) Req 2.3: overlay-sourced env-form -> env-reject. Path attributes
+      // to kolt.local.toml; message names kolt.local.toml. Env var name absent.
+      Scenario(
+        label = "i/overlay-token-env-reject",
+        baseRepos = baseUrlOnly,
+        overlayRepos =
+          """
+            [repositories.x]
+            token = { env = "GITHUB_TOKEN" }
+          """,
+        expected =
+          Expected.Err(
+            path = "kolt.local.toml",
+            messageContains = listOf("x", "token", "kolt.local.toml"),
+            messageAbsent = listOf("GITHUB_TOKEN"),
+          ),
+      ),
+      // (k) Req 2.3 multi-field: env-form user/password also rejected.
+      // user is the first env-form field in the entry; we pin user here and
+      // password in a second row.
+      Scenario(
+        label = "k/overlay-user-env-reject",
+        baseRepos = baseUrlOnly,
+        overlayRepos =
+          """
+            [repositories.x]
+            user = { env = "NEXUS_USER" }
+            password = { literal = "s3cret" }
+          """,
+        expected =
+          Expected.Err(
+            path = "kolt.local.toml",
+            messageContains = listOf("x", "user", "kolt.local.toml"),
+            messageAbsent = listOf("NEXUS_USER", "s3cret"),
+          ),
+      ),
+      Scenario(
+        label = "k/overlay-password-env-reject",
+        baseRepos = baseUrlOnly,
+        overlayRepos =
+          """
+            [repositories.x]
+            user = { literal = "alice" }
+            password = { env = "NEXUS_PASSWORD" }
+          """,
+        expected =
+          Expected.Err(
+            path = "kolt.local.toml",
+            messageContains = listOf("x", "password", "kolt.local.toml"),
+            // env var name absent; "alice" is a valid literal user — it may
+            // be echoed in messages that name the user field but we are
+            // asserting on the password reject, so neither should leak.
+            messageAbsent = listOf("NEXUS_PASSWORD"),
+          ),
+      ),
+      // (k') Req 2.1 + Req 2.3 ordering: env-form in BASE produces the
+      // placement message, NOT the env-not-supported message. Confirms
+      // rejectBaseCredentialLiterals runs before liftRepositoriesMap env-reject.
+      Scenario(
+        label = "k'/base-token-env-form -> placement (not env-reject)",
+        baseRepos =
+          """
+
+            [repositories.x]
+            url = "https://nexus.example.com/repository/internal"
+            token = { env = "NEXUS_TOKEN" }
+          """,
+        overlayRepos = null,
+        expected =
+          Expected.Err(
+            path = "kolt.toml",
+            messageContains =
+              listOf(
+                "kolt.toml",
+                "x",
+                "token",
+                "kolt.local.toml",
+                // The placement validator says "literal <field> field"; this
+                // word distinguishes placement from env-not-supported text.
+                "literal",
+              ),
+            messageAbsent = listOf("NEXUS_TOKEN", "not supported", "v1.0"),
+          ),
+      ),
+      // (l) Req 1.8 backward compat: `[repositories.central] url = "..."` only
+      // in kolt.toml (no overlay, no auth fields) -> Ok, anonymous.
+      Scenario(
+        label = "l/base-anonymous-only -> anonymous",
+        baseRepos =
+          """
+
+            [repositories.central]
+            url = "https://repo1.maven.org/maven2"
+          """,
+        overlayRepos = null,
+        expected =
+          Expected.Ok { repos ->
+            val r = assertNotNull(repos["central"])
+            assertEquals("central", r.name)
+            assertNull(r.auth)
+          },
+      ),
+      // (m') Req 1.8 backward compat: same name in both files, no auth fields
+      // on either side -> Ok, anonymous. Pins that overlay decode of an
+      // auth-less `[repositories.<name>]` still parses and merges cleanly.
+      Scenario(
+        label = "m'/base-and-overlay-anonymous -> anonymous",
+        baseRepos =
+          """
+
+            [repositories.x]
+            url = "https://nexus.example.com/repository/internal"
+          """,
+        overlayRepos =
+          """
+            [repositories.x]
+            url = "https://nexus.example.com/repository/internal"
+          """,
+        expected =
+          Expected.Ok { repos ->
+            val r = assertNotNull(repos["x"])
+            assertNull(r.auth)
+          },
+      ),
+      // (n) Name invariant: quoted repo name + dotted key. After lift,
+      // map_key == Repository.name and quotes are stripped.
+      Scenario(
+        label = "n/quoted-name -> name == map_key",
+        baseRepos =
+          """
+
+            [repositories."my.repo"]
+            url = "https://nexus.example.com/repository/internal"
+          """,
+        overlayRepos =
+          """
+            [repositories."my.repo"]
+            token = { literal = "t" }
+          """,
+        expected =
+          Expected.Ok { repos ->
+            val r = assertNotNull(repos["my.repo"])
+            assertEquals("my.repo", r.name)
+            assertEquals(RepositoryAuth.Bearer("t"), r.auth)
+            for ((key, value) in repos) {
+              assertEquals(key, value.name, "Repository.name must equal map key for entry '$key'")
+            }
+          },
+      ),
+    )
+
+  @Test
+  fun parametricMatrix() {
+    for (s in scenarios) {
+      val baseToml = buildBase(s.baseRepos)
+      val overlay = s.overlayRepos?.trimIndent()
+      val result =
+        parseConfig(
+          tomlString = baseToml,
+          path = "kolt.toml",
+          overlayString = overlay,
+          overlayPath = if (overlay != null) "kolt.local.toml" else null,
+        )
+      when (val expected = s.expected) {
+        is Expected.Ok -> {
+          val config =
+            assertNotNull(
+              result.get(),
+              "[${s.label}] expected Ok but got Err: ${result.getError()}",
+            )
+          expected.assert(config.repositories)
+        }
+        is Expected.Err -> {
+          val error =
+            assertIs<ConfigError.ParseFailed>(
+              result.getError(),
+              "[${s.label}] expected Err(ParseFailed) but got: $result",
+            )
+          assertEquals(
+            expected.path,
+            error.path,
+            "[${s.label}] ParseFailed.path mismatch (message=${error.message})",
+          )
+          for (needle in expected.messageContains) {
+            assertTrue(
+              needle in error.message,
+              "[${s.label}] expected message to contain '$needle': ${error.message}",
+            )
+          }
+          for (forbidden in expected.messageAbsent) {
+            assertFalse(
+              forbidden in error.message,
+              "[${s.label}] expected message to NOT contain '$forbidden': ${error.message}",
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/RepositoryAuthConfigTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RepositoryAuthConfigTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 // End-to-end parametric matrix driving parseConfig (with overlay) so that the
-// full chain — ktoml decode -> rejectBaseCredentialLiterals -> mergeOverlay ->
+// full chain — ktoml decode -> rejectBaseCredentialFields -> mergeOverlay ->
 // repositorySourceMap -> liftRepositoriesMap — composes with realistic
 // kolt.toml / kolt.local.toml fixtures. Per-validator unit branches live in
 // LiftRepositoriesMapAuthValidatorTest; this file pins source attribution
@@ -288,7 +288,7 @@ class RepositoryAuthConfigTest {
       ),
       // (k') Req 2.1 + Req 2.3 ordering: env-form in BASE produces the
       // placement message, NOT the env-not-supported message. Confirms
-      // rejectBaseCredentialLiterals runs before liftRepositoriesMap env-reject.
+      // rejectBaseCredentialFields runs before liftRepositoriesMap env-reject.
       Scenario(
         label = "k'/base-token-env-form -> placement (not env-reject)",
         baseRepos =

--- a/src/nativeTest/kotlin/kolt/config/RepositoryAuthTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RepositoryAuthTest.kt
@@ -1,0 +1,70 @@
+package kolt.config
+
+import kolt.resolve.AuthStateProjection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RepositoryAuthTest {
+
+  @Test
+  fun basicToStringRedactsPasswordAndKeepsUser() {
+    val rendered = RepositoryAuth.Basic("alice", "s3cret").toString()
+    assertTrue("<redacted>" in rendered, "expected `<redacted>` in $rendered")
+    assertFalse("s3cret" in rendered, "expected `s3cret` to be absent from $rendered")
+    assertTrue("alice" in rendered, "expected user `alice` to be visible in $rendered")
+  }
+
+  @Test
+  fun bearerToStringRedactsToken() {
+    val rendered = RepositoryAuth.Bearer("ghp_xyz123").toString()
+    assertTrue("<redacted>" in rendered, "expected `<redacted>` in $rendered")
+    assertFalse("ghp_xyz123" in rendered, "expected token to be absent from $rendered")
+  }
+
+  @Test
+  fun bearerToHeadersProducesAuthorizationBearer() {
+    val headers = RepositoryAuth.Bearer("abc123").toHeaders()
+    assertEquals(mapOf("Authorization" to "Bearer abc123"), headers)
+  }
+
+  @Test
+  fun basicToHeadersProducesAuthorizationBasicBase64() {
+    val headers = RepositoryAuth.Basic("alice", "s3cret").toHeaders()
+    // RFC 7617 base64 of "alice:s3cret" — pinned literal so a swap to
+    // Base64.UrlSafe / Base64.Mime would be caught.
+    assertEquals(mapOf("Authorization" to "Basic YWxpY2U6czNjcmV0"), headers)
+  }
+
+  @Test
+  fun nullableProjectsToNotConfigured() {
+    val auth: RepositoryAuth? = null
+    assertEquals(AuthStateProjection.NotConfigured, auth.toStateProjection())
+  }
+
+  @Test
+  fun bearerProjectsToConfiguredToken() {
+    val auth: RepositoryAuth = RepositoryAuth.Bearer("t")
+    assertEquals(AuthStateProjection.ConfiguredToken, auth.toStateProjection())
+  }
+
+  @Test
+  fun basicProjectsToConfiguredBasic() {
+    val auth: RepositoryAuth = RepositoryAuth.Basic("u", "p")
+    assertEquals(AuthStateProjection.ConfiguredBasic, auth.toStateProjection())
+  }
+
+  @Test
+  fun authStateProjectionDisplayStringsMatchRequirement7_3() {
+    assertEquals("not configured", AuthStateProjection.NotConfigured.toDisplayString())
+    assertEquals(
+      "configured (token, from kolt.local.toml)",
+      AuthStateProjection.ConfiguredToken.toDisplayString(),
+    )
+    assertEquals(
+      "configured (basic, from kolt.local.toml)",
+      AuthStateProjection.ConfiguredBasic.toDisplayString(),
+    )
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/RepositorySchemaMigrationTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RepositorySchemaMigrationTest.kt
@@ -37,7 +37,10 @@ class RepositorySchemaMigrationTest {
 
     val config = assertNotNull(parseConfig(toml).get())
     assertEquals(1, config.repositories.size)
-    assertEquals(Repository("https://repo1.maven.org/maven2"), config.repositories["central"])
+    assertEquals(
+      Repository(name = "central", url = "https://repo1.maven.org/maven2"),
+      config.repositories["central"],
+    )
   }
 
   @Test

--- a/src/nativeTest/kotlin/kolt/config/RepositorySchemaMigrationTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RepositorySchemaMigrationTest.kt
@@ -79,12 +79,48 @@ class RepositorySchemaMigrationTest {
       "expected migration hint in error message; actual: $rendered",
     )
     assertTrue(
-      "[repositories.<name>]" in rendered || "repositories.<name>" in rendered,
-      "expected sub-table form mentioned in error message; actual: $rendered",
+      "[repositories.<name>] url = \"...\"" in rendered,
+      "expected new sub-table form `[repositories.<name>] url = \"...\"` mentioned in error message; actual: $rendered",
     )
     assertTrue(
       "kolt.toml" in rendered,
       "expected source file `kolt.toml` named in error message; actual: $rendered",
+    )
+  }
+
+  @Test
+  fun rejectLegacyFlatFormWithUrlUserinfoScrubsCredentials() {
+    // Req 9.3: a flat-form `[repositories]` entry whose URL embeds userinfo
+    // must still be rejected, and the rendered error message must not leak
+    // the userinfo component. The flat-form path bypasses the sub-table
+    // URL-userinfo validator, so this asserts the rejection text never
+    // attaches the original URL string verbatim.
+    val toml =
+      baseToml +
+        """
+            [repositories]
+            central = "https://u:p@host/x"
+        """
+          .trimIndent()
+
+    val err = parseConfig(toml, path = "kolt.toml").getError()
+    val parseFailed = assertNotNull(err) as ConfigError.ParseFailed
+    val rendered = renderConfigErrorAsLine(parseFailed)
+    assertTrue(
+      "repositories schema migrated" in rendered,
+      "expected migration hint in error message; actual: $rendered",
+    )
+    // Pragmatic substring approach (same as task 2.8): individual characters
+    // like `u`, `p`, `:`, `@` appear in unrelated context (e.g. `url`,
+    // `repositories`, the `:` of the headline). Pin the verbatim userinfo
+    // joined fragment instead.
+    assertTrue(
+      "u:p@host" !in rendered,
+      "expected userinfo `u:p@host` not to appear in error message; actual: $rendered",
+    )
+    assertTrue(
+      "u:p" !in rendered,
+      "expected userinfo `u:p` not to appear in error message; actual: $rendered",
     )
   }
 

--- a/src/nativeTest/kotlin/kolt/config/RepositorySourceMapTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RepositorySourceMapTest.kt
@@ -1,0 +1,129 @@
+package kolt.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RepositorySourceMapTest {
+
+  @Test
+  fun attributesBaseOnlyFieldsToBasePath() {
+    val base = mapOf("central" to RawRepository(url = "https://repo.maven.apache.org/maven2"))
+    val map =
+      repositorySourceMap(
+        baseRepositories = base,
+        overlayRepositories = null,
+        basePath = "kolt.toml",
+        overlayPath = null,
+      )
+    assertEquals("kolt.toml", map["central"]?.get("url"))
+    val inner = map["central"]!!
+    assertFalse("token" in inner, "token must be absent when unset: $inner")
+    assertFalse("user" in inner, "user must be absent when unset: $inner")
+    assertFalse("password" in inner, "password must be absent when unset: $inner")
+  }
+
+  @Test
+  fun overlayContributedFieldsResolveToOverlayPath() {
+    // Base supplies url; overlay supplies token. Per task 2.5 observable-completion:
+    // map["repo"]["url"] == basePath, map["repo"]["token"] == overlayPath,
+    // map["repo"]["user"] is absent.
+    val base = mapOf("repo" to RawRepository(url = "https://nexus.example.com/repository/internal"))
+    val overlay = mapOf("repo" to RawRepository(token = RawCredentialField.Literal("abc")))
+    val map =
+      repositorySourceMap(
+        baseRepositories = base,
+        overlayRepositories = overlay,
+        basePath = "kolt.toml",
+        overlayPath = "kolt.local.toml",
+      )
+    val inner = map["repo"]!!
+    assertEquals("kolt.toml", inner["url"])
+    assertEquals("kolt.local.toml", inner["token"])
+    assertFalse("user" in inner, "user must be absent: $inner")
+    assertFalse("password" in inner, "password must be absent: $inner")
+  }
+
+  @Test
+  fun overlayWinsOverBaseOnConflict() {
+    // Last-write-wins: overlay's url replaces base's url path attribution.
+    val base = mapOf("repo" to RawRepository(url = "https://old.example.com"))
+    val overlay = mapOf("repo" to RawRepository(url = "https://new.example.com"))
+    val map =
+      repositorySourceMap(
+        baseRepositories = base,
+        overlayRepositories = overlay,
+        basePath = "kolt.toml",
+        overlayPath = "kolt.local.toml",
+      )
+    assertEquals("kolt.local.toml", map["repo"]?.get("url"))
+  }
+
+  @Test
+  fun overlayUserPasswordAttributedToOverlay() {
+    val base = mapOf("repo" to RawRepository(url = "https://nexus.example.com/repository/internal"))
+    val overlay =
+      mapOf(
+        "repo" to
+          RawRepository(
+            user = RawCredentialField.Literal("alice"),
+            password = RawCredentialField.Literal("s3cret"),
+          )
+      )
+    val map =
+      repositorySourceMap(
+        baseRepositories = base,
+        overlayRepositories = overlay,
+        basePath = "kolt.toml",
+        overlayPath = "kolt.local.toml",
+      )
+    val inner = map["repo"]!!
+    assertEquals("kolt.toml", inner["url"])
+    assertEquals("kolt.local.toml", inner["user"])
+    assertEquals("kolt.local.toml", inner["password"])
+    assertFalse("token" in inner, "token must be absent: $inner")
+  }
+
+  @Test
+  fun nullPathsPassThrough() {
+    // Internal-test scenario: parseConfig called without `path`. The contributing
+    // file path is unknown, but the inner key must still be present to signal
+    // "this field is set on this repo".
+    val base = mapOf("repo" to RawRepository(url = "https://example.com"))
+    val overlay = mapOf("repo" to RawRepository(token = RawCredentialField.Literal("abc")))
+    val map =
+      repositorySourceMap(
+        baseRepositories = base,
+        overlayRepositories = overlay,
+        basePath = null,
+        overlayPath = null,
+      )
+    val inner = map["repo"]!!
+    assertTrue("url" in inner, "url key must be present even when path is null")
+    assertNull(inner["url"])
+    assertTrue("token" in inner, "token key must be present even when path is null")
+    assertNull(inner["token"])
+  }
+
+  @Test
+  fun preservesDeclarationOrder() {
+    // ktoml preserves declaration order; the source map iterates in the same
+    // order so downstream diagnostics can name the first offending field.
+    val base =
+      mapOf(
+        "alpha" to RawRepository(url = "https://a.example.com"),
+        "beta" to RawRepository(url = "https://b.example.com"),
+        "gamma" to RawRepository(url = "https://c.example.com"),
+      )
+    val map =
+      repositorySourceMap(
+        baseRepositories = base,
+        overlayRepositories = null,
+        basePath = "kolt.toml",
+        overlayPath = null,
+      )
+    assertEquals(listOf("alpha", "beta", "gamma"), map.keys.toList())
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/RepositoryUrlUserinfoTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RepositoryUrlUserinfoTest.kt
@@ -1,0 +1,122 @@
+package kolt.config
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+// End-to-end driver for Req 3.x (URL userinfo rejection). Exercises the real
+// parseConfig chain so the userinfo validator inside liftRepositoriesMap is
+// wired through ktoml decode + rejectBaseCredentialLiterals + sourceMap path
+// attribution. Per-validator branches live in LiftRepositoriesMapAuthValidatorTest;
+// this file pins (a) reject for user:password@ form, (b) reject for user@ form,
+// (c) accept for `@` inside path, and (d) the Req 3.3 leak guard: the userinfo
+// substring is never echoed back into the rejection message.
+class RepositoryUrlUserinfoTest {
+
+  private val baseStem =
+    """
+      name = "demo"
+      version = "0.0.0"
+
+      [kotlin]
+      version = "2.3.20"
+
+      [build]
+      target = "jvm"
+      main = "com.example.main"
+      sources = ["src"]
+
+    """
+      .trimIndent()
+
+  private fun buildConfig(reposBlock: String): String = baseStem + reposBlock.trimIndent()
+
+  @Test
+  fun rejectsUserPasswordUserinfo() {
+    val toml =
+      buildConfig(
+        """
+
+          [repositories.x]
+          url = "https://u:p@host/x"
+        """
+      )
+
+    val result = parseConfig(tomlString = toml, path = "kolt.toml")
+
+    val error = assertIs<ConfigError.ParseFailed>(result.getError())
+    assertEquals("kolt.toml", error.path)
+  }
+
+  @Test
+  fun rejectsUserOnlyUserinfo() {
+    val toml =
+      buildConfig(
+        """
+
+          [repositories.x]
+          url = "https://u@host/x"
+        """
+      )
+
+    val result = parseConfig(tomlString = toml, path = "kolt.toml")
+
+    val error = assertIs<ConfigError.ParseFailed>(result.getError())
+    assertEquals("kolt.toml", error.path)
+  }
+
+  @Test
+  fun acceptsAtSignInsidePath() {
+    val toml =
+      buildConfig(
+        """
+
+          [repositories.x]
+          url = "https://host/foo@bar/baz"
+        """
+      )
+
+    val result = parseConfig(tomlString = toml, path = "kolt.toml")
+
+    val config = assertNotNull(result.get(), "expected Ok but got: ${result.getError()}")
+    val repo = assertNotNull(config.repositories["x"])
+    assertEquals("https://host/foo@bar/baz", repo.url)
+  }
+
+  // Req 3.3 leak guard. The literal characters `u`, `p`, `:`, `@` each appear in
+  // unrelated tokens of the rejection message (e.g. "url", "password",
+  // "https://", "repositories"), so the spec phrasing "no character of the
+  // userinfo component" is asserted pragmatically: the verbatim userinfo
+  // substring `u:p@host` (and `u:p@`) must not appear anywhere in the message.
+  @Test
+  fun rejectionMessageDoesNotEchoUserinfo() {
+    val toml =
+      buildConfig(
+        """
+
+          [repositories.x]
+          url = "https://u:p@host/x"
+        """
+      )
+
+    val result = parseConfig(tomlString = toml, path = "kolt.toml")
+
+    val error = assertIs<ConfigError.ParseFailed>(result.getError())
+    assertFalse(
+      "u:p@host" in error.message,
+      "message must not echo the userinfo substring: ${error.message}",
+    )
+    assertFalse(
+      "u:p@" in error.message,
+      "message must not echo the user:password@ fragment: ${error.message}",
+    )
+    assertFalse(
+      "u@host" in error.message,
+      "message must not echo a user@host fragment: ${error.message}",
+    )
+  }
+}

--- a/src/nativeTest/kotlin/kolt/config/RepositoryUrlUserinfoTest.kt
+++ b/src/nativeTest/kotlin/kolt/config/RepositoryUrlUserinfoTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertNotNull
 
 // End-to-end driver for Req 3.x (URL userinfo rejection). Exercises the real
 // parseConfig chain so the userinfo validator inside liftRepositoriesMap is
-// wired through ktoml decode + rejectBaseCredentialLiterals + sourceMap path
+// wired through ktoml decode + rejectBaseCredentialFields + sourceMap path
 // attribution. Per-validator branches live in LiftRepositoriesMapAuthValidatorTest;
 // this file pins (a) reject for user:password@ form, (b) reject for user@ form,
 // (c) accept for `@` inside path, and (d) the Req 3.3 leak guard: the userinfo

--- a/src/nativeTest/kotlin/kolt/infra/DownloaderAuthHeaderTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/DownloaderAuthHeaderTest.kt
@@ -1,0 +1,132 @@
+package kolt.infra
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getOrElse
+import kolt.config.RepositoryAuth
+import kolt.config.toHeaders
+import kolt.infra.testfixture.LoopbackHttpServer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.fail
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.getpid
+import platform.posix.remove
+
+@OptIn(ExperimentalForeignApi::class)
+class DownloaderAuthHeaderTest {
+
+  // Req 5.1: a Bearer-configured repository must produce an
+  // "Authorization: Bearer <token>" header on the outbound HTTP request.
+  @Test
+  fun bearerAuthHeaderReachesServer() {
+    val destPath = "/tmp/kolt_dl_auth_bearer_${getpid()}.bin"
+    remove(destPath)
+    LoopbackHttpServer.startOk(LoopbackHttpServer.Response.ok("ok")).use { server ->
+      try {
+        val headers = RepositoryAuth.Bearer("tok").toHeaders()
+        val result = downloadFile("http://127.0.0.1:${server.port}/x", destPath, headers = headers)
+        assertNotNull(result.get(), "downloadFile failed: $result")
+        val log = server.awaitAccessLog()
+        assertEquals(
+          "Bearer tok",
+          log.authorization(),
+          "server access log must capture exact Bearer header value",
+        )
+      } finally {
+        remove(destPath)
+      }
+    }
+  }
+
+  // Req 5.2: a Basic-configured repository must produce an
+  // "Authorization: Basic <base64(user:password)>" header. The base64 of
+  // "alice:s3cret" is "YWxpY2U6czNjcmV0" — pin the exact wire value.
+  @Test
+  fun basicAuthHeaderReachesServerWithExpectedBase64() {
+    val destPath = "/tmp/kolt_dl_auth_basic_${getpid()}.bin"
+    remove(destPath)
+    LoopbackHttpServer.startOk(LoopbackHttpServer.Response.ok("ok")).use { server ->
+      try {
+        val headers = RepositoryAuth.Basic("alice", "s3cret").toHeaders()
+        val result = downloadFile("http://127.0.0.1:${server.port}/x", destPath, headers = headers)
+        assertNotNull(result.get(), "downloadFile failed: $result")
+        val log = server.awaitAccessLog()
+        assertEquals(
+          "Basic YWxpY2U6czNjcmV0",
+          log.authorization(),
+          "server access log must capture exact Basic header value",
+        )
+      } finally {
+        remove(destPath)
+      }
+    }
+  }
+
+  // Req 5 (anonymous baseline): when headers == null, the request must
+  // carry no Authorization header at all. Asserting "the string
+  // 'Authorization' does not appear anywhere in the access log" covers
+  // both an absent header and a stray "Authorization: " empty line, and
+  // implicitly verifies the slist itself was never built.
+  @Test
+  fun anonymousRequestEmitsNoAuthorizationHeader() {
+    val destPath = "/tmp/kolt_dl_auth_anon_${getpid()}.bin"
+    remove(destPath)
+    LoopbackHttpServer.startOk(LoopbackHttpServer.Response.ok("ok")).use { server ->
+      try {
+        val result = downloadFile("http://127.0.0.1:${server.port}/x", destPath, headers = null)
+        assertNotNull(result.get(), "downloadFile failed: $result")
+        val log = server.awaitAccessLog()
+        assertFalse(
+          log.rawHeaderBlock.contains("Authorization", ignoreCase = true),
+          "anonymous request must not carry any Authorization header; got:\n${log.rawHeaderBlock}",
+        )
+      } finally {
+        remove(destPath)
+      }
+    }
+  }
+
+  // Req 5 (redirect policy): with CURLOPT_UNRESTRICTED_AUTH = 0L, libcurl
+  // must NOT forward the Authorization header to a different-port redirect
+  // target (host:port mismatch counts as cross-origin). Test asserts:
+  //   - Server A receives Authorization
+  //   - Server B receives no Authorization
+  @Test
+  fun crossOriginRedirectDropsAuthorizationHeader() {
+    val destPath = "/tmp/kolt_dl_auth_redirect_${getpid()}.bin"
+    remove(destPath)
+    LoopbackHttpServer.startOk(LoopbackHttpServer.Response.ok("final")).use { serverB ->
+      LoopbackHttpServer.startOk(
+          LoopbackHttpServer.Response.redirect("http://127.0.0.1:${serverB.port}/final")
+        )
+        .use { serverA ->
+          try {
+            val headers = RepositoryAuth.Bearer("redirected-tok").toHeaders()
+            val result =
+              downloadFile("http://127.0.0.1:${serverA.port}/start", destPath, headers = headers)
+            assertNotNull(result.get(), "downloadFile failed: $result")
+
+            val logA = serverA.awaitAccessLog()
+            val logB = serverB.awaitAccessLog()
+            assertEquals(
+              "Bearer redirected-tok",
+              logA.authorization(),
+              "initial server A must receive Authorization",
+            )
+            assertFalse(
+              logB.rawHeaderBlock.contains("Authorization", ignoreCase = true),
+              "redirect target server B must not receive Authorization; got:\n${logB.rawHeaderBlock}",
+            )
+          } finally {
+            remove(destPath)
+          }
+        }
+    }
+  }
+}
+
+private fun LoopbackHttpServer.Companion.startOk(
+  response: LoopbackHttpServer.Response
+): LoopbackHttpServer = start(response).getOrElse { fail("LoopbackHttpServer.start failed: $it") }

--- a/src/nativeTest/kotlin/kolt/infra/UrlRedactionTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/UrlRedactionTest.kt
@@ -1,0 +1,32 @@
+package kolt.infra
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UrlRedactionTest {
+
+  @Test
+  fun plainUrlWithoutUserinfoIsUnchanged() {
+    assertEquals("https://host/path", redactUrlUserinfo("https://host/path"))
+  }
+
+  @Test
+  fun userinfoWithUserAndPasswordIsRemoved() {
+    assertEquals("https://host/path", redactUrlUserinfo("https://u:p@host/path"))
+  }
+
+  @Test
+  fun userinfoWithUserOnlyIsRemoved() {
+    assertEquals("https://host/path", redactUrlUserinfo("https://u@host/path"))
+  }
+
+  @Test
+  fun atSignInsidePathIsPreserved() {
+    assertEquals("https://host/foo@bar", redactUrlUserinfo("https://host/foo@bar"))
+  }
+
+  @Test
+  fun nonUrlInputIsUnchanged() {
+    assertEquals("not-a-url-at-all", redactUrlUserinfo("not-a-url-at-all"))
+  }
+}

--- a/src/nativeTest/kotlin/kolt/infra/testfixture/LoopbackHttpServer.kt
+++ b/src/nativeTest/kotlin/kolt/infra/testfixture/LoopbackHttpServer.kt
@@ -1,0 +1,457 @@
+package kolt.infra.testfixture
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import kotlin.concurrent.AtomicInt
+import kotlin.concurrent.AtomicReference
+import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.IntVar
+import kotlinx.cinterop.StableRef
+import kotlinx.cinterop.ULongVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.asStableRef
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.set
+import kotlinx.cinterop.sizeOf
+import kotlinx.cinterop.staticCFunction
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
+import platform.posix.AF_INET
+import platform.posix.ECONNABORTED
+import platform.posix.EINTR
+import platform.posix.INADDR_LOOPBACK
+import platform.posix.SOCK_STREAM
+import platform.posix.SOL_SOCKET
+import platform.posix.SO_REUSEADDR
+import platform.posix.accept
+import platform.posix.bind
+import platform.posix.errno
+import platform.posix.fputs
+import platform.posix.getsockname
+import platform.posix.htonl
+import platform.posix.htons
+import platform.posix.listen
+import platform.posix.memset
+import platform.posix.pthread_create
+import platform.posix.pthread_join
+import platform.posix.recv
+import platform.posix.send
+import platform.posix.setsockopt
+import platform.posix.sockaddr
+import platform.posix.sockaddr_in
+import platform.posix.socket
+import platform.posix.socklen_tVar
+import platform.posix.stderr
+import platform.posix.strerror
+
+// Loopback HTTP/1.1 stub server for downloader-layer tests. Mirrors
+// UnixEchoServer's pthread + StableRef + AtomicInt shutdown pattern but
+// binds AF_INET on 127.0.0.1:0 (kernel-assigned port) and speaks just
+// enough HTTP to drive a single libcurl GET: read request bytes until
+// the CRLFCRLF terminator, write a canned response, then exit.
+//
+// Single-shot: each instance accepts exactly one connection and then
+// stops; tests that need a redirect chain spin up two instances and
+// chain them via Response.Redirect.
+@OptIn(ExperimentalForeignApi::class)
+class LoopbackHttpServer
+private constructor(
+  val port: Int,
+  private val listenFd: Int,
+  private val workerThread: ULong,
+  private val workerRef: StableRef<WorkerState>,
+  private val state: WorkerState,
+) : AutoCloseable {
+  private var closed = false
+
+  override fun close() {
+    if (closed) return
+    closed = true
+    state.shutdown.value = 1
+    // Force any thread parked in accept() to return so the worker can
+    // observe `shutdown` and exit; close() alone does not reliably
+    // unblock accept() on Linux. A connect() to our own port wakes it.
+    selfConnectToWakeAccept(port)
+    pthread_join(workerThread, null)
+    workerRef.dispose()
+    platform.posix.close(listenFd)
+  }
+
+  // Returns the captured headers from the single served request, blocking
+  // until the worker thread has finished writing the access log. The
+  // pthread_join in close() guarantees memory visibility for tests that
+  // only inspect after `use {}` exits, but tests typically read the log
+  // while still inside use {} — busy-wait on the completion flag here.
+  fun awaitAccessLog(timeoutMillis: Long = 5_000): AccessLog {
+    val deadline = currentMonoMillis() + timeoutMillis
+    while (state.completed.value == 0) {
+      if (currentMonoMillis() > deadline) {
+        return AccessLog(rawHeaderBlock = "<timeout waiting for request>", headers = emptyMap())
+      }
+      sleepMillis(5)
+    }
+    return state.accessLog.value
+      ?: AccessLog(rawHeaderBlock = "<no request received>", headers = emptyMap())
+  }
+
+  // What the server should write back to the client. The test pins the
+  // exact shape (200 with a small body or 302 with a Location to another
+  // host:port). Each Response renders to a single ByteArray that the
+  // worker writes verbatim — keeps the wire format inspectable.
+  sealed class Response {
+    abstract fun render(): ByteArray
+
+    data class Ok(val body: String) : Response() {
+      override fun render(): ByteArray {
+        val bodyBytes = body.encodeToByteArray()
+        val head =
+          "HTTP/1.1 200 OK\r\n" +
+            "Content-Length: ${bodyBytes.size}\r\n" +
+            "Content-Type: application/octet-stream\r\n" +
+            "Connection: close\r\n" +
+            "\r\n"
+        return head.encodeToByteArray() + bodyBytes
+      }
+    }
+
+    data class Redirect(val location: String) : Response() {
+      override fun render(): ByteArray {
+        val head =
+          "HTTP/1.1 302 Found\r\n" +
+            "Location: $location\r\n" +
+            "Content-Length: 0\r\n" +
+            "Connection: close\r\n" +
+            "\r\n"
+        return head.encodeToByteArray()
+      }
+    }
+
+    companion object {
+      fun ok(body: String): Response = Ok(body)
+
+      fun redirect(location: String): Response = Redirect(location)
+    }
+  }
+
+  // Captured request preview. `rawHeaderBlock` is the verbatim request
+  // line plus headers as the wire delivered them, which lets tests
+  // assert on header presence/absence with simple `contains` checks.
+  // `headers` is a name -> value map (case-insensitive lookup helpers
+  // below) for tests that want the exact value of a single header.
+  data class AccessLog(val rawHeaderBlock: String, val headers: Map<String, String>) {
+    fun authorization(): String? =
+      headers.entries.firstOrNull { it.key.equals("Authorization", ignoreCase = true) }?.value
+  }
+
+  data class StartError(val step: String, val errno: Int, val message: String)
+
+  companion object {
+    private const val BACKLOG = 1
+
+    fun start(response: Response): Result<LoopbackHttpServer, StartError> {
+      val responseBytes = response.render()
+
+      val fd = socket(AF_INET, SOCK_STREAM, 0)
+      if (fd < 0) {
+        val e = errno
+        return Err(StartError("socket", e, strerrorMessage(e)))
+      }
+
+      // SO_REUSEADDR lets the kernel rebind ports left in TIME_WAIT from
+      // previous test runs without a 30-60s delay; the port itself is
+      // ephemeral so collisions are unlikely, but the option is cheap.
+      memScoped {
+        val one = alloc<IntVar>().apply { value = 1 }
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, one.ptr, sizeOf<IntVar>().convert())
+      }
+
+      val boundPort = bindEphemeralAndListen(fd)
+      if (boundPort is BindResult.Failed) {
+        platform.posix.close(fd)
+        return Err(boundPort.error)
+      }
+      val port = (boundPort as BindResult.Bound).port
+
+      val workerState =
+        WorkerState(
+          listenFd = fd,
+          response = responseBytes,
+          shutdown = AtomicInt(0),
+          completed = AtomicInt(0),
+          accessLog = AtomicReference<AccessLog?>(null),
+        )
+      val ref = StableRef.create(workerState)
+
+      var createdThread: ULong = 0uL
+      var createRc = 0
+      memScoped {
+        val threadVar = alloc<ULongVar>()
+        createRc =
+          pthread_create(
+            threadVar.ptr.reinterpret(),
+            null,
+            staticCFunction(::loopbackWorkerMain),
+            ref.asCPointer(),
+          )
+        if (createRc == 0) {
+          createdThread = threadVar.value
+        }
+      }
+      if (createRc != 0) {
+        ref.dispose()
+        platform.posix.close(fd)
+        return Err(
+          StartError(
+            step = "pthread_create",
+            errno = createRc,
+            message = "pthread_create failed with rc=$createRc",
+          )
+        )
+      }
+
+      return Ok(
+        LoopbackHttpServer(
+          port = port,
+          listenFd = fd,
+          workerThread = createdThread,
+          workerRef = ref,
+          state = workerState,
+        )
+      )
+    }
+
+    private sealed class BindResult {
+      data class Bound(val port: Int) : BindResult()
+
+      data class Failed(val error: StartError) : BindResult()
+    }
+
+    private fun bindEphemeralAndListen(fd: Int): BindResult = memScoped {
+      val addr = alloc<sockaddr_in>()
+      memset(addr.ptr, 0, sizeOf<sockaddr_in>().convert())
+      addr.sin_family = AF_INET.convert()
+      addr.sin_port = htons(0u)
+      addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK.convert())
+
+      if (bind(fd, addr.ptr.reinterpret<sockaddr>(), sizeOf<sockaddr_in>().convert()) != 0) {
+        val e = errno
+        return@memScoped BindResult.Failed(StartError("bind", e, strerrorMessage(e)))
+      }
+      if (listen(fd, BACKLOG) != 0) {
+        val e = errno
+        return@memScoped BindResult.Failed(StartError("listen", e, strerrorMessage(e)))
+      }
+
+      val boundAddr = alloc<sockaddr_in>()
+      val boundLen = alloc<socklen_tVar>().apply { value = sizeOf<sockaddr_in>().convert() }
+      if (getsockname(fd, boundAddr.ptr.reinterpret<sockaddr>(), boundLen.ptr) != 0) {
+        val e = errno
+        return@memScoped BindResult.Failed(StartError("getsockname", e, strerrorMessage(e)))
+      }
+      val port = ntohs(boundAddr.sin_port).toInt() and 0xFFFF
+      BindResult.Bound(port)
+    }
+
+    private fun selfConnectToWakeAccept(port: Int) {
+      val fd = socket(AF_INET, SOCK_STREAM, 0)
+      if (fd < 0) return
+      memScoped {
+        val addr = alloc<sockaddr_in>()
+        memset(addr.ptr, 0, sizeOf<sockaddr_in>().convert())
+        addr.sin_family = AF_INET.convert()
+        addr.sin_port = htons(port.toUShort())
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK.convert())
+        platform.posix.connect(
+          fd,
+          addr.ptr.reinterpret<sockaddr>(),
+          sizeOf<sockaddr_in>().convert(),
+        )
+      }
+      platform.posix.close(fd)
+    }
+
+    private fun strerrorMessage(e: Int): String = strerror(e)?.toKString() ?: "errno=$e"
+  }
+}
+
+// htons is exported by Kotlin/Native posix but ntohs is not in all
+// host platform klibs; on little-endian Linux both are identical byte
+// swaps so we use htons as the symmetric inverse.
+@OptIn(ExperimentalForeignApi::class) private fun ntohs(value: UShort): UShort = htons(value)
+
+internal class WorkerState(
+  val listenFd: Int,
+  val response: ByteArray,
+  val shutdown: AtomicInt,
+  val completed: AtomicInt,
+  val accessLog: AtomicReference<LoopbackHttpServer.AccessLog?>,
+)
+
+@OptIn(ExperimentalForeignApi::class)
+private fun loopbackWorkerMain(arg: COpaquePointer?): COpaquePointer? {
+  if (arg == null) return null
+  val state = arg.asStableRef<WorkerState>().get()
+  try {
+    runAcceptOnce(state)
+  } finally {
+    state.completed.value = 1
+  }
+  return null
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun runAcceptOnce(state: WorkerState) {
+  while (true) {
+    if (state.shutdown.value != 0) return
+    val clientFd = accept(state.listenFd, null, null)
+    if (clientFd < 0) {
+      val e = errno
+      if (e == EINTR || e == ECONNABORTED) continue
+      if (state.shutdown.value != 0) return
+      logStderr("LoopbackHttpServer: accept failed, errno=$e")
+      return
+    }
+    if (state.shutdown.value != 0) {
+      platform.posix.close(clientFd)
+      return
+    }
+    serveOne(clientFd, state)
+    platform.posix.close(clientFd)
+    return
+  }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun serveOne(clientFd: Int, state: WorkerState) {
+  val headBlock = readRequestHead(clientFd) ?: return
+  val headers = parseHeaders(headBlock)
+  state.accessLog.value =
+    LoopbackHttpServer.AccessLog(rawHeaderBlock = headBlock, headers = headers)
+  writeAll(clientFd, state.response)
+}
+
+// Reads bytes from clientFd until the CRLFCRLF terminator that ends the
+// HTTP request head. Returns the head as a String (decoded UTF-8) or
+// null if the client closed early / a recv error occurred. We don't
+// read the body: GET requests don't have one, and libcurl on the
+// client side won't send body bytes for a plain GET.
+@OptIn(ExperimentalForeignApi::class)
+private fun readRequestHead(fd: Int): String? {
+  val collected = mutableListOf<ByteArray>()
+  val buf = ByteArray(4096)
+  var totalLen = 0
+  while (totalLen < MAX_REQUEST_HEAD_BYTES) {
+    val n = buf.usePinned { pinned -> recv(fd, pinned.addressOf(0), buf.size.convert(), 0) }
+    if (n == 0L) break
+    if (n < 0L) {
+      val e = errno
+      if (e == EINTR) continue
+      logStderr("LoopbackHttpServer: recv failed, errno=$e")
+      return null
+    }
+    val chunk = buf.copyOf(n.toInt())
+    collected.add(chunk)
+    totalLen += chunk.size
+    // Check terminator across the assembled prefix. CRLFCRLF can
+    // straddle chunk boundaries, so concatenate before scanning.
+    val assembled = concatAll(collected)
+    val terminator = indexOfCRLFCRLF(assembled)
+    if (terminator >= 0) {
+      return assembled.decodeToString(0, terminator)
+    }
+  }
+  return null
+}
+
+private const val MAX_REQUEST_HEAD_BYTES = 64 * 1024
+
+private fun concatAll(parts: List<ByteArray>): ByteArray {
+  val total = parts.sumOf { it.size }
+  val out = ByteArray(total)
+  var pos = 0
+  for (p in parts) {
+    p.copyInto(out, pos)
+    pos += p.size
+  }
+  return out
+}
+
+private fun indexOfCRLFCRLF(data: ByteArray): Int {
+  val needle = byteArrayOf(0x0D, 0x0A, 0x0D, 0x0A)
+  outer@ for (i in 0..data.size - needle.size) {
+    for (j in needle.indices) {
+      if (data[i + j] != needle[j]) continue@outer
+    }
+    return i
+  }
+  return -1
+}
+
+private fun parseHeaders(headBlock: String): Map<String, String> {
+  val out = mutableMapOf<String, String>()
+  val lines = headBlock.split("\r\n")
+  // Skip request line (index 0); remaining are "Name: Value" pairs.
+  for (i in 1 until lines.size) {
+    val line = lines[i]
+    if (line.isEmpty()) continue
+    val colon = line.indexOf(':')
+    if (colon < 0) continue
+    val name = line.substring(0, colon).trim()
+    val value = line.substring(colon + 1).trim()
+    out[name] = value
+  }
+  return out
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun writeAll(fd: Int, data: ByteArray) {
+  var offset = 0
+  data.usePinned { pinned ->
+    while (offset < data.size) {
+      val n = send(fd, pinned.addressOf(offset), (data.size - offset).convert(), 0)
+      if (n < 0L) {
+        val e = errno
+        if (e == EINTR) continue
+        logStderr("LoopbackHttpServer: send failed at $offset/${data.size}, errno=$e")
+        return
+      }
+      if (n == 0L) {
+        logStderr("LoopbackHttpServer: send returned 0 at $offset/${data.size}")
+        return
+      }
+      offset += n.toInt()
+    }
+  }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun logStderr(message: String) {
+  fputs("$message\n", stderr)
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun currentMonoMillis(): Long {
+  memScoped {
+    val ts = alloc<platform.posix.timespec>()
+    platform.posix.clock_gettime(platform.posix.CLOCK_MONOTONIC.convert(), ts.ptr)
+    return ts.tv_sec * 1000L + ts.tv_nsec / 1_000_000L
+  }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun sleepMillis(ms: Long) {
+  memScoped {
+    val ts = alloc<platform.posix.timespec>()
+    ts.tv_sec = ms / 1000L
+    ts.tv_nsec = (ms % 1000L) * 1_000_000L
+    platform.posix.nanosleep(ts.ptr, null)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/infra/testfixture/LoopbackHttpServer.kt
+++ b/src/nativeTest/kotlin/kolt/infra/testfixture/LoopbackHttpServer.kt
@@ -134,10 +134,31 @@ private constructor(
       }
     }
 
+    // Arbitrary-status response, used by RepositoryAuthFailureTest to drive
+    // 401 / 403 / 404 paths through `downloadFromRepositories`. The `reason`
+    // is the HTTP/1.1 reason phrase ("Unauthorized" / "Forbidden" / etc.);
+    // it's wire-only — libcurl doesn't surface it back to callers, but it
+    // keeps the response line spec-conformant.
+    data class WithStatus(val code: Int, val reason: String, val body: String) : Response() {
+      override fun render(): ByteArray {
+        val bodyBytes = body.encodeToByteArray()
+        val head =
+          "HTTP/1.1 $code $reason\r\n" +
+            "Content-Length: ${bodyBytes.size}\r\n" +
+            "Content-Type: application/octet-stream\r\n" +
+            "Connection: close\r\n" +
+            "\r\n"
+        return head.encodeToByteArray() + bodyBytes
+      }
+    }
+
     companion object {
       fun ok(body: String): Response = Ok(body)
 
       fun redirect(location: String): Response = Redirect(location)
+
+      fun withStatus(code: Int, reason: String, body: String): Response =
+        WithStatus(code, reason, body)
     }
   }
 

--- a/src/nativeTest/kotlin/kolt/resolve/AllCallersTypedTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/AllCallersTypedTest.kt
@@ -1,0 +1,66 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Result
+import kolt.config.KoltConfig
+import kolt.config.Repository
+import kolt.infra.DownloadError
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+// Compile gate (no runtime value). Pins every public/internal touchpoint of
+// the private-Maven-repos type migration to `List<Repository>`. If any of
+// the 10 `downloadFromRepositories` call sites, the 9 projection sites that
+// materialise `config.repositories.values.toList()`, `ensureTool`'s
+// `repos` parameter, or `resolveSingleArtifact`'s `repos` parameter regresses
+// to `List<String>`, this file fails to compile and `kolt build` exits non-
+// zero. Runtime body is `assertTrue(true)` on purpose.
+class AllCallersTypedTest {
+
+  @Test
+  fun signaturesRemainTypedAsListOfRepository() {
+    // Projection-site shape: `KoltConfig.repositories` is a `Map<String, Repository>`,
+    // and every caller that hands repos to a downloader projects it via
+    // `.values.toList()` into `List<Repository>`. Hold a function reference
+    // that performs exactly that projection so a regression of the field type
+    // (e.g. `Map<String, String>`) breaks compilation here.
+    val projection: (KoltConfig) -> List<Repository> = { it.repositories.values.toList() }
+
+    // `downloadFromRepositories` signature pin. Bind it to a typed function
+    // reference; if any parameter loses the `List<Repository>` /
+    // `(Repository) -> String` / `(Repository) -> Unit` shape the assignment
+    // fails to type-check. This single binding transitively covers the 10
+    // call sites in TransitiveResolver (x4), NativeResolver (x2),
+    // BundleResolver (x2), OutdatedCommand (x1), DependencyCommands (x1).
+    val downloadRef:
+      (
+        List<Repository>,
+        String,
+        (Repository) -> String,
+        (String, String, Map<String, String>?) -> Result<Unit, DownloadError>,
+        (Repository) -> Unit,
+      ) -> Result<Unit, RepositoryDownloadFailure> =
+      ::downloadFromRepositories
+
+    // `resolveSingleArtifact` signature pin (BundleResolver:107). `repos`
+    // must remain `List<Repository>`.
+    val resolveSingleRef:
+      (Coordinate, String?, List<Repository>, String, ResolverDeps, ResolverProgressSink) -> Result<
+          SingleArtifact,
+          ResolveError,
+        > =
+      ::resolveSingleArtifact
+
+    // `ensureTool` (ToolResolution:55) is internal and generic. The function
+    // reference cannot be taken without supplying the type parameter, so pin
+    // its `repos: List<Repository>` parameter by referencing the typed shape
+    // through a lambda that would match its declaration. The lambda is never
+    // invoked; the type system checks the shape at compile time.
+    val ensureToolReposShape: (List<Repository>) -> Unit = { _: List<Repository> -> }
+
+    // Touch the references so the compiler cannot elide them as dead code.
+    // No runtime assertion is made about the bindings themselves; the value
+    // of this test is the type check above.
+    val touched = listOf(projection, downloadRef, resolveSingleRef, ensureToolReposShape)
+    assertTrue(touched.isNotEmpty())
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/BundleResolverIsolationTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/BundleResolverIsolationTest.kt
@@ -175,7 +175,11 @@ class BundleResolverIsolationTest {
 
       override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      override fun downloadFile(
+        url: String,
+        destPath: String,
+        headers: Map<String, String>?,
+      ): Result<Unit, DownloadError> {
         cachedFiles.add(destPath)
         return Ok(Unit)
       }

--- a/src/nativeTest/kotlin/kolt/resolve/BundleResolverProgressTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/BundleResolverProgressTest.kt
@@ -180,7 +180,11 @@ class BundleResolverProgressTest {
 
       override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      override fun downloadFile(
+        url: String,
+        destPath: String,
+        headers: Map<String, String>?,
+      ): Result<Unit, DownloadError> {
         cachedFiles.add(destPath)
         return Ok(Unit)
       }

--- a/src/nativeTest/kotlin/kolt/resolve/BundleResolverProgressTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/BundleResolverProgressTest.kt
@@ -97,7 +97,11 @@ class BundleResolverProgressTest {
   @Test
   fun lockReuseWithOneEvictedJarEmitsOneOfOne() {
     val config =
-      testConfig().copy(repositories = mapOf("primary" to Repository("https://repo.example.com")))
+      testConfig()
+        .copy(
+          repositories =
+            mapOf("primary" to Repository(name = "primary", url = "https://repo.example.com"))
+        )
 
     // Two bundle deps locked: one cached, one evicted.
     val cachedDep =

--- a/src/nativeTest/kotlin/kolt/resolve/BundleResolverSingleArtifactTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/BundleResolverSingleArtifactTest.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
+import kolt.config.Repository
 import kolt.infra.DownloadError
 import kolt.infra.MkdirFailed
 import kolt.infra.OpenFailed
@@ -31,7 +32,7 @@ class BundleResolverSingleArtifactTest {
       resolveSingleArtifact(
         coord = Coordinate("com.example", "tool", "1.0.0"),
         classifier = null,
-        repos = listOf("https://repo1/"),
+        repos = listOf(Repository(name = "r", url = "https://repo1/")),
         cacheBase = "/cache",
         deps = deps,
       )
@@ -56,7 +57,7 @@ class BundleResolverSingleArtifactTest {
         resolveSingleArtifact(
             coord = Coordinate("com.example", "tool", "1.0.0"),
             classifier = "all",
-            repos = listOf("https://repo1/"),
+            repos = listOf(Repository(name = "r", url = "https://repo1/")),
             cacheBase = "/cache",
             deps = deps,
           )
@@ -82,7 +83,7 @@ class BundleResolverSingleArtifactTest {
         resolveSingleArtifact(
             coord = Coordinate("com.example", "tool", "1.0.0"),
             classifier = null,
-            repos = listOf("https://repo1/"),
+            repos = listOf(Repository(name = "r", url = "https://repo1/")),
             cacheBase = "/cache",
             deps = deps,
           )
@@ -106,7 +107,11 @@ class BundleResolverSingleArtifactTest {
         resolveSingleArtifact(
             coord = Coordinate("com.example", "missing", "1.0.0"),
             classifier = null,
-            repos = listOf("https://repo1/", "https://repo2/"),
+            repos =
+              listOf(
+                Repository(name = "r1", url = "https://repo1/"),
+                Repository(name = "r2", url = "https://repo2/"),
+              ),
             cacheBase = "/cache",
             deps = deps,
           )
@@ -163,7 +168,11 @@ class BundleResolverSingleArtifactTest {
 
       override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      override fun downloadFile(
+        url: String,
+        destPath: String,
+        headers: Map<String, String>?,
+      ): Result<Unit, DownloadError> {
         recordDownloads?.add(url)
         if (downloadResult != null) return downloadResult.invoke(url, destPath)
         cachedFiles.add(destPath)

--- a/src/nativeTest/kotlin/kolt/resolve/BundleResolverVersionDivergenceTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/BundleResolverVersionDivergenceTest.kt
@@ -103,7 +103,11 @@ class BundleResolverVersionDivergenceTest {
 
       override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      override fun downloadFile(
+        url: String,
+        destPath: String,
+        headers: Map<String, String>?,
+      ): Result<Unit, DownloadError> {
         cachedFiles.add(destPath)
         return Ok(Unit)
       }

--- a/src/nativeTest/kotlin/kolt/resolve/CreateNativeLookupTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/CreateNativeLookupTest.kt
@@ -3,6 +3,7 @@ package kolt.resolve
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import kolt.config.Repository
 import kolt.infra.DownloadError
 import kolt.infra.MkdirFailed
 import kolt.infra.OpenFailed
@@ -39,7 +40,11 @@ class CreateNativeLookupTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           if (destPath.endsWith(".module")) {
             return Err(DownloadError.HttpFailed(url, 404))
           }
@@ -61,7 +66,7 @@ class CreateNativeLookupTest {
 
     val lookup =
       createNativeLookup(
-        repos = listOf("https://repo1.example/"),
+        repos = listOf(Repository(name = "r", url = "https://repo1.example/")),
         cacheBase = "/cache",
         deps = deps,
         nativeTarget = "linux_x64",
@@ -145,7 +150,11 @@ class CreateNativeLookupTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           if (destPath in contents) {
             cachedFiles.add(destPath)
             return Ok(Unit)
@@ -164,7 +173,7 @@ class CreateNativeLookupTest {
 
     val lookup =
       createNativeLookup(
-        repos = listOf("https://repo1.example/"),
+        repos = listOf(Repository(name = "r", url = "https://repo1.example/")),
         cacheBase = "/cache",
         deps = deps,
         nativeTarget = "linux_x64",
@@ -198,7 +207,11 @@ class CreateNativeLookupTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           if (destPath.endsWith(".module")) {
             moduleAttempts += 1
             return Err(DownloadError.HttpFailed(url, 404))
@@ -222,7 +235,7 @@ class CreateNativeLookupTest {
 
     val lookup =
       createNativeLookup(
-        repos = listOf("https://repo1.example/"),
+        repos = listOf(Repository(name = "r", url = "https://repo1.example/")),
         cacheBase = "/cache",
         deps = deps,
         nativeTarget = "linux_x64",
@@ -260,8 +273,11 @@ class CreateNativeLookupTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> =
-          Err(DownloadError.HttpFailed(url, 404))
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> = Err(DownloadError.HttpFailed(url, 404))
 
         override fun computeSha256(filePath: String): Result<String, Sha256Error> =
           Err(Sha256Error(filePath))
@@ -272,7 +288,7 @@ class CreateNativeLookupTest {
 
     val lookup =
       createNativeLookup(
-        repos = listOf("https://repo1.example/"),
+        repos = listOf(Repository(name = "r", url = "https://repo1.example/")),
         cacheBase = "/cache",
         deps = deps,
         nativeTarget = "linux_x64",

--- a/src/nativeTest/kotlin/kolt/resolve/DownloadFromRepositoriesAuthTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/DownloadFromRepositoriesAuthTest.kt
@@ -1,0 +1,139 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.getError
+import kolt.config.Repository
+import kolt.config.RepositoryAuth
+import kolt.infra.DownloadError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+// 401/403 hard-error branch (Req 6.1, 6.2, 6.4): a 401 or 403 from any
+// repository must short-circuit iteration with AuthFailed; the remaining
+// repos (including a hypothetical 200 successor) must never be contacted.
+// Uses lambda-mock download to match the rest of the downloadFromRepositories
+// unit suite in TransitiveResolverTest; the full loopback-server hint-matrix
+// lives in task 5.2 (RepositoryAuthFailureTest).
+class DownloadFromRepositoriesAuthTest {
+
+  @Test
+  fun returnsAuthFailedAndStopsIterationOn401() {
+    val private401 = Repository(name = "private", url = "https://private.example.com")
+    val central200 = Repository(name = "central", url = "https://central.example.com")
+    val touched = mutableListOf<String>()
+
+    val result =
+      downloadFromRepositories(
+        repos = listOf(private401, central200),
+        destPath = "/cache/lib.jar",
+        urlBuilder = { repo -> "${repo.url}/foo.jar" },
+        download = { url, _, _ ->
+          touched.add(url)
+          if (url.startsWith(private401.url)) Err(DownloadError.HttpFailed(url, 401)) else Ok(Unit)
+        },
+      )
+
+    val failure = assertIs<RepositoryDownloadFailure.AuthFailed>(result.getError())
+    assertEquals("private", failure.repositoryName)
+    assertEquals(401, failure.statusCode)
+    assertEquals(AuthStateProjection.NotConfigured, failure.authState)
+    assertEquals("https://private.example.com/foo.jar", failure.url)
+    assertEquals(
+      listOf("https://private.example.com/foo.jar"),
+      touched,
+      "iteration must stop at 401; central must not be contacted",
+    )
+  }
+
+  @Test
+  fun returnsAuthFailedAndStopsIterationOn403() {
+    val private403 = Repository(name = "private", url = "https://private.example.com")
+    val central200 = Repository(name = "central", url = "https://central.example.com")
+    val touched = mutableListOf<String>()
+
+    val result =
+      downloadFromRepositories(
+        repos = listOf(private403, central200),
+        destPath = "/cache/lib.jar",
+        urlBuilder = { repo -> "${repo.url}/foo.jar" },
+        download = { url, _, _ ->
+          touched.add(url)
+          if (url.startsWith(private403.url)) Err(DownloadError.HttpFailed(url, 403)) else Ok(Unit)
+        },
+      )
+
+    val failure = assertIs<RepositoryDownloadFailure.AuthFailed>(result.getError())
+    assertEquals("private", failure.repositoryName)
+    assertEquals(403, failure.statusCode)
+    assertEquals(1, touched.size)
+  }
+
+  @Test
+  fun authFailedCarriesConfiguredTokenStateWhenBearerSet() {
+    val private401 =
+      Repository(
+        name = "private",
+        url = "https://private.example.com",
+        auth = RepositoryAuth.Bearer("tok"),
+      )
+
+    val result =
+      downloadFromRepositories(
+        repos = listOf(private401),
+        destPath = "/cache/lib.jar",
+        urlBuilder = { repo -> "${repo.url}/foo.jar" },
+        download = { url, _, _ -> Err(DownloadError.HttpFailed(url, 401)) },
+      )
+
+    val failure = assertIs<RepositoryDownloadFailure.AuthFailed>(result.getError())
+    assertEquals(AuthStateProjection.ConfiguredToken, failure.authState)
+  }
+
+  @Test
+  fun authHeadersFromRepoAreForwardedToDownloadLambda() {
+    val privateRepo =
+      Repository(
+        name = "private",
+        url = "https://private.example.com",
+        auth = RepositoryAuth.Bearer("tok"),
+      )
+    val seen = mutableListOf<Map<String, String>?>()
+
+    downloadFromRepositories(
+      repos = listOf(privateRepo),
+      destPath = "/cache/lib.jar",
+      urlBuilder = { repo -> "${repo.url}/foo.jar" },
+      download = { _, _, headers ->
+        seen.add(headers)
+        Ok(Unit)
+      },
+    )
+
+    assertEquals(1, seen.size)
+    assertEquals(mapOf("Authorization" to "Bearer tok"), seen.single())
+  }
+
+  @Test
+  fun authFailedUrlIsRedactedWhenUpstreamUrlCarriedUserinfo() {
+    val privateRepo = Repository(name = "private", url = "https://private.example.com")
+
+    val result =
+      downloadFromRepositories(
+        repos = listOf(privateRepo),
+        destPath = "/cache/lib.jar",
+        urlBuilder = { repo -> "${repo.url}/foo.jar" },
+        download = { _, _, _ ->
+          // Simulate a defense-in-depth case where the download error reports
+          // a URL with userinfo embedded. Even though Downloader.downloadFile
+          // already redacts at the source, the resolver re-applies the
+          // redaction so an internal regression cannot leak credentials.
+          Err(DownloadError.HttpFailed("https://u:p@private.example.com/foo.jar", 401))
+        },
+      )
+
+    val failure = assertIs<RepositoryDownloadFailure.AuthFailed>(result.getError())
+    assertEquals("https://private.example.com/foo.jar", failure.url)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/resolve/FetchNativeMetadataJvmOnlyFallbackTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/FetchNativeMetadataJvmOnlyFallbackTest.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
+import kolt.config.Repository
 import kolt.infra.DownloadError
 import kolt.infra.MkdirFailed
 import kolt.infra.OpenFailed
@@ -34,7 +35,11 @@ class FetchNativeMetadataJvmOnlyFallbackTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           if (destPath.endsWith(".module")) {
             return Err(DownloadError.HttpFailed(url, 404))
           }
@@ -60,7 +65,11 @@ class FetchNativeMetadataJvmOnlyFallbackTest {
         version = "1.0.0",
         nativeTarget = "linux_x64",
         cacheBase = "/cache",
-        repos = listOf("https://repo1.example/", "https://repo2.example/"),
+        repos =
+          listOf(
+            Repository(name = "r1", url = "https://repo1.example/"),
+            Repository(name = "r2", url = "https://repo2.example/"),
+          ),
         deps = deps,
       )
 
@@ -83,8 +92,11 @@ class FetchNativeMetadataJvmOnlyFallbackTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> =
-          Err(DownloadError.HttpFailed(url, 404))
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> = Err(DownloadError.HttpFailed(url, 404))
 
         override fun computeSha256(filePath: String): Result<String, Sha256Error> =
           Err(Sha256Error(filePath))
@@ -99,7 +111,11 @@ class FetchNativeMetadataJvmOnlyFallbackTest {
         version = "1.0.0",
         nativeTarget = "linux_x64",
         cacheBase = "/cache",
-        repos = listOf("https://repo1.example/", "https://repo2.example/"),
+        repos =
+          listOf(
+            Repository(name = "r1", url = "https://repo1.example/"),
+            Repository(name = "r2", url = "https://repo2.example/"),
+          ),
         deps = deps,
       )
 
@@ -148,7 +164,11 @@ class FetchNativeMetadataJvmOnlyFallbackTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           recorded.add(url)
           if (destPath.endsWith(".module")) {
             return Err(moduleErrorFor(url))
@@ -171,7 +191,11 @@ class FetchNativeMetadataJvmOnlyFallbackTest {
         version = "1.0.0",
         nativeTarget = "linux_x64",
         cacheBase = "/cache",
-        repos = listOf("https://repo1.example/", "https://repo2.example/"),
+        repos =
+          listOf(
+            Repository(name = "r1", url = "https://repo1.example/"),
+            Repository(name = "r2", url = "https://repo2.example/"),
+          ),
         deps = deps,
       )
 

--- a/src/nativeTest/kotlin/kolt/resolve/Is404OnAllAttemptsTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/Is404OnAllAttemptsTest.kt
@@ -17,10 +17,12 @@ class Is404OnAllAttemptsTest {
             attempts =
               listOf(
                 RepositoryAttempt(
+                  repositoryName = "a",
                   url = "https://a.example/lib.module",
                   error = DownloadError.HttpFailed("https://a.example/lib.module", 404),
                 ),
                 RepositoryAttempt(
+                  repositoryName = "b",
                   url = "https://b.example/lib.module",
                   error = DownloadError.HttpFailed("https://b.example/lib.module", 404),
                 ),
@@ -41,10 +43,12 @@ class Is404OnAllAttemptsTest {
             attempts =
               listOf(
                 RepositoryAttempt(
+                  repositoryName = "a",
                   url = "https://a.example/lib.module",
                   error = DownloadError.HttpFailed("https://a.example/lib.module", 404),
                 ),
                 RepositoryAttempt(
+                  repositoryName = "b",
                   url = "https://b.example/lib.module",
                   error = DownloadError.HttpFailed("https://b.example/lib.module", 503),
                 ),
@@ -65,14 +69,17 @@ class Is404OnAllAttemptsTest {
             attempts =
               listOf(
                 RepositoryAttempt(
+                  repositoryName = "a",
                   url = "https://a.example/lib.module",
                   error = DownloadError.HttpFailed("https://a.example/lib.module", 404),
                 ),
                 RepositoryAttempt(
+                  repositoryName = "b",
                   url = "https://b.example/lib.module",
                   error = DownloadError.NetworkError("https://b.example/lib.module", "timeout"),
                 ),
                 RepositoryAttempt(
+                  repositoryName = "c",
                   url = "https://c.example/lib.module",
                   error = DownloadError.WriteFailed("/tmp/lib.module"),
                 ),

--- a/src/nativeTest/kotlin/kolt/resolve/MakeNativeChildLookupTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/MakeNativeChildLookupTest.kt
@@ -2,6 +2,7 @@ package kolt.resolve
 
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
+import kolt.config.Repository
 import kolt.infra.DownloadError
 import kolt.infra.MkdirFailed
 import kolt.infra.OpenFailed
@@ -34,7 +35,11 @@ class MakeNativeChildLookupTest {
         fail("unexpected ensureDirectoryRecursive call: $path")
       }
 
-      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      override fun downloadFile(
+        url: String,
+        destPath: String,
+        headers: Map<String, String>?,
+      ): Result<Unit, DownloadError> {
         fail("unexpected downloadFile call: $url -> $destPath")
       }
 
@@ -60,7 +65,7 @@ class MakeNativeChildLookupTest {
         processed = processed,
         nativeTarget = "linux_x64",
         cacheBase = "/cache",
-        repos = listOf("https://repo1.example/"),
+        repos = listOf(Repository(name = "r", url = "https://repo1.example/")),
         deps = noIoDeps,
       )
 
@@ -99,7 +104,7 @@ class MakeNativeChildLookupTest {
         processed = processed,
         nativeTarget = "linux_x64",
         cacheBase = "/cache",
-        repos = listOf("https://repo1.example/"),
+        repos = listOf(Repository(name = "r", url = "https://repo1.example/")),
         deps = noIoDeps,
       )
 
@@ -135,7 +140,7 @@ class MakeNativeChildLookupTest {
         processed = processed,
         nativeTarget = "linux_x64",
         cacheBase = "/cache",
-        repos = listOf("https://repo1.example/"),
+        repos = listOf(Repository(name = "r", url = "https://repo1.example/")),
         deps = noIoDeps,
       )
 

--- a/src/nativeTest/kotlin/kolt/resolve/MaterializeProgressTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/MaterializeProgressTest.kt
@@ -187,7 +187,11 @@ class MaterializeProgressTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           if (destPath.endsWith(".jar") && url.startsWith(repo1)) {
             return Err(DownloadError.HttpFailed(url, 404))
           }
@@ -256,7 +260,11 @@ class MaterializeProgressTest {
 
       override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      override fun downloadFile(
+        url: String,
+        destPath: String,
+        headers: Map<String, String>?,
+      ): Result<Unit, DownloadError> {
         val forcedError = downloadErrors[url]
         if (forcedError != null) return Err(forcedError)
         cachedFiles.add(destPath)

--- a/src/nativeTest/kotlin/kolt/resolve/MaterializeProgressTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/MaterializeProgressTest.kt
@@ -166,7 +166,11 @@ class MaterializeProgressTest {
     val config =
       testConfig(
         dependencies = mapOf("com.example:lib" to "1.0.0"),
-        repositories = mapOf("primary" to Repository(repo1), "fallback" to Repository(repo2)),
+        repositories =
+          mapOf(
+            "primary" to Repository(name = "primary", url = repo1),
+            "fallback" to Repository(name = "fallback", url = repo2),
+          ),
       )
     val pomXml =
       """

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverJvmOnlyFallbackTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverJvmOnlyFallbackTest.kt
@@ -129,7 +129,11 @@ class NativeResolverJvmOnlyFallbackTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           recordedDownloads.add(url)
           if (destPath == kotlinReflectModulePath) {
             return Err(DownloadError.HttpFailed(url, 404))

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverJvmOnlyFallbackTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverJvmOnlyFallbackTest.kt
@@ -37,7 +37,8 @@ class NativeResolverJvmOnlyFallbackTest {
       testConfig(target = "linuxX64")
         .copy(
           dependencies = mapOf("io.ktor:ktor-server-core" to "3.4.3"),
-          repositories = mapOf("central" to Repository("https://repo1.example/")),
+          repositories =
+            mapOf("central" to Repository(name = "central", url = "https://repo1.example/")),
         )
 
     val parentRoot =

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTargetModule404GoldenTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTargetModule404GoldenTest.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
+import kolt.config.Repository
 import kolt.infra.DownloadError
 import kolt.infra.MkdirFailed
 import kolt.infra.OpenFailed
@@ -62,7 +63,11 @@ class NativeResolverTargetModule404GoldenTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           recordedDownloadUrls.add(url)
           // Root `.module` succeeds on the first repo so the redirect is parseable.
           // Target `.module` (parent-linuxx64) 404s on every repo. `.pom` URLs
@@ -90,7 +95,11 @@ class NativeResolverTargetModule404GoldenTest {
         version = "1.0.0",
         nativeTarget = "linux_x64",
         cacheBase = "/cache",
-        repos = listOf("https://repo1.example/", "https://repo2.example/"),
+        repos =
+          listOf(
+            Repository(name = "r1", url = "https://repo1.example/"),
+            Repository(name = "r2", url = "https://repo2.example/"),
+          ),
         deps = deps,
       )
 

--- a/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/NativeResolverTest.kt
@@ -1265,7 +1265,11 @@ class NativeResolverTest {
 
       override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      override fun downloadFile(
+        url: String,
+        destPath: String,
+        headers: Map<String, String>?,
+      ): Result<Unit, DownloadError> {
         cachedFiles.add(destPath)
         return Ok(Unit)
       }

--- a/src/nativeTest/kotlin/kolt/resolve/PluginJarFetcherTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/PluginJarFetcherTest.kt
@@ -36,7 +36,11 @@ private class FakeFetcherDeps(
     return Ok(Unit)
   }
 
-  override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+  override fun downloadFile(
+    url: String,
+    destPath: String,
+    headers: Map<String, String>?,
+  ): Result<Unit, DownloadError> {
     downloadCalls += url to destPath
     val outcome = downloadResult(url, destPath)
     if (outcome.get() != null) {

--- a/src/nativeTest/kotlin/kolt/resolve/RepositoryAuthFailureTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/RepositoryAuthFailureTest.kt
@@ -1,0 +1,232 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.config.Repository
+import kolt.config.RepositoryAuth
+import kolt.infra.downloadFile
+import kolt.infra.testfixture.LoopbackHttpServer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.getpid
+import platform.posix.remove
+
+// End-to-end loopback-HTTP coverage for Req 6 (401/403 hard error + iteration
+// stop) and Req 7 (per-state hint matrix). Complements
+// `DownloadFromRepositoriesAuthTest` (task 4.1) which uses a lambda-mock
+// download: this test drives the real `downloadFile` against pthread-backed
+// loopback servers so the iteration-stop guarantee is observed at the socket
+// layer (a server's access log staying empty proves no request was sent), and
+// the hint matrix is pinned through the real `formatResolveError` renderer.
+@OptIn(ExperimentalForeignApi::class)
+class RepositoryAuthFailureTest {
+
+  // Iteration stop (Req 6.1, 6.2, 6.4): a 401 from the first repo must short-
+  // circuit; the second (200-ready) repo must never see a connection. The
+  // access-log timeout sentinel ("<timeout waiting for request>") is what
+  // proves no request arrived — the worker thread's `completed` flag only
+  // flips after serving exactly one request.
+  @Test
+  fun stopsIterationOn401AndDoesNotContactSubsequentRepo() {
+    val destPath = "/tmp/kolt_authfail_stop401_${getpid()}.bin"
+    remove(destPath)
+    LoopbackHttpServer.startOrFail(LoopbackHttpServer.Response.withStatus(401, "Unauthorized", ""))
+      .use { repo401 ->
+        LoopbackHttpServer.startOrFail(LoopbackHttpServer.Response.ok("payload")).use { repo200 ->
+          try {
+            val repos =
+              listOf(
+                Repository(name = "private", url = "http://127.0.0.1:${repo401.port}"),
+                Repository(name = "central", url = "http://127.0.0.1:${repo200.port}"),
+              )
+
+            val result =
+              downloadFromRepositories(
+                repos = repos,
+                destPath = destPath,
+                urlBuilder = { repo -> "${repo.url}/foo.jar" },
+                download = { url, dst, headers -> downloadFile(url, dst, headers) },
+              )
+
+            val failure = assertIs<RepositoryDownloadFailure.AuthFailed>(result.getError())
+            assertEquals("private", failure.repositoryName)
+            assertEquals(401, failure.statusCode)
+            assertEquals(AuthStateProjection.NotConfigured, failure.authState)
+
+            // The 200-repo's worker is parked in accept(); awaitAccessLog will
+            // hit its timeout sentinel because no client ever connected.
+            val centralLog = repo200.awaitAccessLog(timeoutMillis = 500)
+            assertTrue(
+              centralLog.rawHeaderBlock.startsWith("<timeout"),
+              "central must not receive a request when private returns 401; got:\n${centralLog.rawHeaderBlock}",
+            )
+          } finally {
+            remove(destPath)
+          }
+        }
+      }
+  }
+
+  // 404 → 401 fall-through then stop (Req 6.3 + 6.1): the loop must fall
+  // through 404 (declaration-order semantics, unchanged) and stop at the
+  // 401 from the middle repo. The third (200-ready) repo must not be
+  // contacted.
+  @Test
+  fun fallsThrough404ThenStopsAt401() {
+    val destPath = "/tmp/kolt_authfail_404then401_${getpid()}.bin"
+    remove(destPath)
+    LoopbackHttpServer.startOrFail(LoopbackHttpServer.Response.withStatus(404, "Not Found", ""))
+      .use { repo404 ->
+        LoopbackHttpServer.startOrFail(
+            LoopbackHttpServer.Response.withStatus(401, "Unauthorized", "")
+          )
+          .use { repo401 ->
+            LoopbackHttpServer.startOrFail(LoopbackHttpServer.Response.ok("payload")).use { repo200
+              ->
+              try {
+                val repos =
+                  listOf(
+                    Repository(name = "mirror", url = "http://127.0.0.1:${repo404.port}"),
+                    Repository(name = "private", url = "http://127.0.0.1:${repo401.port}"),
+                    Repository(name = "central", url = "http://127.0.0.1:${repo200.port}"),
+                  )
+
+                val result =
+                  downloadFromRepositories(
+                    repos = repos,
+                    destPath = destPath,
+                    urlBuilder = { repo -> "${repo.url}/foo.jar" },
+                    download = { url, dst, headers -> downloadFile(url, dst, headers) },
+                  )
+
+                val failure = assertIs<RepositoryDownloadFailure.AuthFailed>(result.getError())
+                assertEquals("private", failure.repositoryName)
+                assertEquals(401, failure.statusCode)
+                assertEquals(AuthStateProjection.NotConfigured, failure.authState)
+
+                val centralLog = repo200.awaitAccessLog(timeoutMillis = 500)
+                assertTrue(
+                  centralLog.rawHeaderBlock.startsWith("<timeout"),
+                  "central must not receive a request after private returns 401; got:\n${centralLog.rawHeaderBlock}",
+                )
+              } finally {
+                remove(destPath)
+              }
+            }
+          }
+      }
+  }
+
+  // Hint matrix row 1 of 4 (Req 7.4): anonymous repo + 401 →
+  // "the repository requires authentication; add credentials to kolt.local.toml".
+  // Drives the real `downloadFromRepositories` so the `AuthStateProjection`
+  // is computed from the live `Repository.auth = null`, then renders through
+  // the real `formatResolveError` so the hint text is pinned end-to-end.
+  @Test
+  fun hintRow401NotConfigured() {
+    val context = runAuthFailureAndRender(status = 401, auth = null, repoName = "private")
+    assertEquals(
+      "hint: the repository requires authentication; add credentials to kolt.local.toml",
+      context.last(),
+    )
+  }
+
+  // Hint matrix row 2 of 4: token-configured repo + 401 →
+  // "the credentials may be invalid or expired".
+  @Test
+  fun hintRow401ConfiguredToken() {
+    val context =
+      runAuthFailureAndRender(
+        status = 401,
+        auth = RepositoryAuth.Bearer("tok"),
+        repoName = "private",
+      )
+    assertEquals("hint: the credentials may be invalid or expired", context.last())
+  }
+
+  // Hint matrix row 2 of 4 (second `Configured` flavor): basic-configured
+  // repo + 401 → same wording per Req 7.4 (the table folds token and basic
+  // into a single hint row for each status).
+  @Test
+  fun hintRow401ConfiguredBasic() {
+    val context =
+      runAuthFailureAndRender(
+        status = 401,
+        auth = RepositoryAuth.Basic("alice", "s3cret"),
+        repoName = "private",
+      )
+    assertEquals("hint: the credentials may be invalid or expired", context.last())
+  }
+
+  // Hint matrix row 3 of 4: anonymous repo + 403 → "authentication is required".
+  @Test
+  fun hintRow403NotConfigured() {
+    val context = runAuthFailureAndRender(status = 403, auth = null, repoName = "private")
+    assertEquals("hint: authentication is required", context.last())
+  }
+
+  // Hint matrix row 4 of 4: token-configured repo + 403 →
+  // "the credentials are valid but lack permission for this repository".
+  @Test
+  fun hintRow403ConfiguredToken() {
+    val context =
+      runAuthFailureAndRender(
+        status = 403,
+        auth = RepositoryAuth.Bearer("tok"),
+        repoName = "private",
+      )
+    assertEquals(
+      "hint: the credentials are valid but lack permission for this repository",
+      context.last(),
+    )
+  }
+
+  // Shared driver for the hint-matrix rows. Builds a single-repo loopback
+  // server returning the requested status, calls `downloadFromRepositories`
+  // with the real `downloadFile`, wraps the resulting `AuthFailed` into
+  // `ResolveError.DownloadFailed`, and returns the rendered `context` lines
+  // so each row can assert the trailing `hint:` line.
+  private fun runAuthFailureAndRender(
+    status: Int,
+    auth: RepositoryAuth?,
+    repoName: String,
+  ): List<String> {
+    val destPath = "/tmp/kolt_authfail_hint_${status}_${getpid()}.bin"
+    remove(destPath)
+    val reason = if (status == 401) "Unauthorized" else "Forbidden"
+    return LoopbackHttpServer.startOrFail(
+        LoopbackHttpServer.Response.withStatus(status, reason, "")
+      )
+      .use { server ->
+        try {
+          val repo =
+            Repository(name = repoName, url = "http://127.0.0.1:${server.port}", auth = auth)
+
+          val result =
+            downloadFromRepositories(
+              repos = listOf(repo),
+              destPath = destPath,
+              urlBuilder = { r -> "${r.url}/foo.jar" },
+              download = { url, dst, headers -> downloadFile(url, dst, headers) },
+            )
+
+          val failure = assertIs<RepositoryDownloadFailure.AuthFailed>(result.getError())
+          assertEquals(status, failure.statusCode)
+          val diagnostic =
+            formatResolveError(ResolveError.DownloadFailed("com.example:lib", failure))
+          assertEquals("failed to download com.example:lib", diagnostic.headline)
+          diagnostic.context
+        } finally {
+          remove(destPath)
+        }
+      }
+  }
+}
+
+private fun LoopbackHttpServer.Companion.startOrFail(
+  response: LoopbackHttpServer.Response
+): LoopbackHttpServer = start(response).getOrElse { fail("LoopbackHttpServer.start failed: $it") }

--- a/src/nativeTest/kotlin/kolt/resolve/RepositoryAuthRedactionTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/RepositoryAuthRedactionTest.kt
@@ -1,0 +1,196 @@
+package kolt.resolve
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.cli.HomeBreakdown
+import kolt.cli.InfoSnapshot
+import kolt.cli.JdkInfo
+import kolt.cli.KotlinInfo
+import kolt.cli.ProjectInfo
+import kolt.cli.formatInfoJson
+import kolt.config.Repository
+import kolt.config.RepositoryAuth
+import kolt.infra.downloadFile
+import kolt.infra.testfixture.LoopbackHttpServer
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.getpid
+import platform.posix.remove
+
+// Cross-cutting redaction matrix (Req 8). Each assertion pins a distinct
+// leak surface so a single architectural regression cannot silently widen the
+// blast radius:
+//   (a) 401 fetch with Bearer auth → rendered diagnostic carries no token
+//   (b) 401 fetch with Basic auth → rendered diagnostic carries no user, no
+//       password, no base64(user:password)
+//   (c) `RepositoryAuth.Basic.toString()` redacts the password
+//   (d) `Repository.toString()` chains through `RepositoryAuth.toString` so
+//       even `"$repo"` interpolation leaves no credential trace
+//   (e) `Lockfile` serialized JSON has no credential-shaped field — pins the
+//       Req 10.x invariant that the lockfile schema is unchanged
+//   (f) `kolt info --format=json` payload has no credential-shaped field —
+//       pins that the InfoJson schema does not surface auth state
+//
+// All six are green on first run by design (tasks 1.1, 4.x, 5.x already
+// implement the redaction); this file's role is the regression pin.
+@OptIn(ExperimentalForeignApi::class, ExperimentalEncodingApi::class)
+class RepositoryAuthRedactionTest {
+
+  // (a) Bearer token must not leak through the 401 rendering path. Drives
+  // the real loopback server + real `downloadFile` + real `formatResolveError`
+  // so any leak introduced anywhere in that chain (header echo, error
+  // message reflection, hint text accidentally interpolating the auth value)
+  // would surface as a substring hit.
+  @Test
+  fun bearerTokenIsAbsentFromRendered401Diagnostic() {
+    val token = "super-secret-tok-12345"
+    val rendered = renderAuthFailure(status = 401, auth = RepositoryAuth.Bearer(token))
+    assertFalse(token in rendered, "Bearer token literal must not appear in:\n$rendered")
+  }
+
+  // (b) Basic user, password, and their base64(user:password) form must all
+  // be absent from the 401 rendering path. Three independent substring
+  // assertions because each one catches a different regression: leaking
+  // `user` would come from a misplaced `repo.toString()`; leaking `password`
+  // from a missing `RepositoryAuth.Basic.toString()` override; leaking the
+  // base64 from echoing the literal `Authorization: Basic <b64>` header.
+  @Test
+  fun basicCredentialsAreAbsentFromRendered401Diagnostic() {
+    val user = "alice-distinctive"
+    val password = "s3cret-password-87"
+    val base64 = Base64.encode("$user:$password".encodeToByteArray())
+    val rendered = renderAuthFailure(status = 401, auth = RepositoryAuth.Basic(user, password))
+    assertFalse(user in rendered, "Basic user literal must not appear in:\n$rendered")
+    assertFalse(password in rendered, "Basic password literal must not appear in:\n$rendered")
+    assertFalse(base64 in rendered, "Basic base64 literal must not appear in:\n$rendered")
+  }
+
+  // (c) `RepositoryAuth.Basic.toString()` is the load-bearing override. If
+  // the data-class default is restored, both `"$auth"` and any
+  // `Repository.toString()` chain leak. Distinctive password literal avoids
+  // false negatives from coincidental short substrings.
+  @Test
+  fun repositoryAuthBasicToStringRedactsPassword() {
+    val password = "super-secret-pw-c"
+    val rendered = RepositoryAuth.Basic("u", password).toString()
+    assertTrue("<redacted>" in rendered, "expected <redacted> placeholder in: $rendered")
+    assertFalse(password in rendered, "password literal must not appear in: $rendered")
+  }
+
+  // (d) `Repository.toString()` is the data-class default that delegates the
+  // auth-field rendering to `RepositoryAuth.Basic.toString()`. This pins the
+  // chain end-to-end so a future code change like overriding
+  // `Repository.toString()` to print fields manually cannot regress.
+  @Test
+  fun repositoryToStringRedactsBasicPassword() {
+    val password = "s3cret-d-distinctive"
+    val rendered =
+      Repository(name = "x", url = "y", auth = RepositoryAuth.Basic("alice", password)).toString()
+    assertTrue("<redacted>" in rendered, "expected <redacted> in: $rendered")
+    assertFalse(password in rendered, "password literal must not appear in: $rendered")
+  }
+
+  // (e) `kolt.lock` schema is unchanged by this feature (Req 8.4, Req 10.x).
+  // We construct a representative `Lockfile`, serialize it via the real
+  // writer, and assert that none of the credential-shaped field names
+  // surface. The hash-shaped placeholder values are chosen to NOT contain
+  // any of the forbidden substrings.
+  @Test
+  fun serializedLockfileHasNoCredentialField() {
+    val lockfile =
+      Lockfile(
+        version = LOCKFILE_VERSION,
+        kotlin = "2.1.0",
+        jvmTarget = "17",
+        dependencies = mapOf("com.example:lib" to LockEntry(version = "1.0", sha256 = "abc123")),
+      )
+    val serialized = serializeLockfile(lockfile)
+    assertFalse("token" in serialized, "lockfile must not carry 'token' field: $serialized")
+    assertFalse("password" in serialized, "lockfile must not carry 'password' field: $serialized")
+    assertFalse(
+      "Authorization" in serialized,
+      "lockfile must not carry 'Authorization' field: $serialized",
+    )
+    // `user` is too generic to be safe against false matches in other field
+    // names; assert the exact JSON shape would not nest it under a known
+    // credential context by checking that no `"user"` key appears.
+    assertFalse("\"user\"" in serialized, "lockfile must not carry a 'user' JSON key: $serialized")
+  }
+
+  // (f) `kolt info --format=json` is the diagnostic surface most likely to
+  // grow a "show me my repositories" verbose mode. The InfoJson schema must
+  // never surface credential-shaped fields; this test pins the schema.
+  // Building the snapshot with strings unrelated to credentials prevents
+  // false positives from the project name or path matching a literal.
+  @Test
+  fun koltInfoJsonHasNoCredentialField() {
+    val snap =
+      InfoSnapshot(
+        koltVersion = "0.20.0",
+        koltPath = "/usr/local/bin/kolt",
+        koltHomeDisplay = "~/.kolt",
+        koltHomeBytes = 0L,
+        kotlin = KotlinInfo(version = "2.1.0", mode = "daemon", path = "~/.kolt/k/2.1.0"),
+        jdk = JdkInfo(version = "21", path = "~/.kolt/jdk/21"),
+        host = "linux-x86_64",
+        project = ProjectInfo(name = "demo", version = "0.1.0", kind = "app", target = "jvm"),
+        koltHomeBreakdown =
+          HomeBreakdown(
+            cacheBytes = 0L,
+            toolchainsBytes = 0L,
+            daemonBytes = 0L,
+            toolsBytes = 0L,
+            cachePath = "~/.kolt/cache",
+            toolchainsPath = "~/.kolt/toolchains",
+            daemonPath = "~/.kolt/daemon",
+            toolsPath = "~/.kolt/tools",
+          ),
+      )
+    val json = formatInfoJson(snap)
+    assertFalse("token" in json, "info json must not carry 'token' field: $json")
+    assertFalse("password" in json, "info json must not carry 'password' field: $json")
+    assertFalse("Authorization" in json, "info json must not carry 'Authorization' field: $json")
+    assertFalse("\"user\"" in json, "info json must not carry a 'user' JSON key: $json")
+  }
+
+  private fun renderAuthFailure(status: Int, auth: RepositoryAuth): String {
+    val destPath = "/tmp/kolt_redaction_${status}_${getpid()}.bin"
+    remove(destPath)
+    val reason = if (status == 401) "Unauthorized" else "Forbidden"
+    return LoopbackHttpServer.startOrFailRedaction(
+        LoopbackHttpServer.Response.withStatus(status, reason, "")
+      )
+      .use { server ->
+        try {
+          val repo =
+            Repository(name = "private", url = "http://127.0.0.1:${server.port}", auth = auth)
+
+          val result =
+            downloadFromRepositories(
+              repos = listOf(repo),
+              destPath = destPath,
+              urlBuilder = { r -> "${r.url}/foo.jar" },
+              download = { url, dst, headers -> downloadFile(url, dst, headers) },
+            )
+
+          val failure = assertIs<RepositoryDownloadFailure.AuthFailed>(result.getError())
+          val diagnostic =
+            formatResolveError(ResolveError.DownloadFailed("com.example:lib", failure))
+          (listOf(diagnostic.headline) + diagnostic.context + listOfNotNull(diagnostic.hint))
+            .joinToString("\n")
+        } finally {
+          remove(destPath)
+        }
+      }
+  }
+}
+
+private fun LoopbackHttpServer.Companion.startOrFailRedaction(
+  response: LoopbackHttpServer.Response
+): LoopbackHttpServer = start(response).getOrElse { fail("LoopbackHttpServer.start failed: $it") }

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveErrorFormatTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveErrorFormatTest.kt
@@ -278,6 +278,138 @@ class ResolveErrorFormatTest {
     assertEquals("resolved com.example:lib:1.0 is rejected by constraint '<2.0'", diag.headline)
   }
 
+  // Task 5.1: AuthFailed 5-line context rendering under the
+  // DownloadFailed / MetadataDownloadFailed outer headlines.
+  @Test
+  fun authFailedPom401NotConfiguredRendersFiveLineContextWithConfigHint() {
+    val error =
+      ResolveError.DownloadFailed(
+        "com.example:lib",
+        RepositoryDownloadFailure.AuthFailed(
+          repositoryName = "private",
+          url = "https://private.example.com/com/example/lib/1.0.0/lib-1.0.0.pom",
+          statusCode = 401,
+          authState = AuthStateProjection.NotConfigured,
+        ),
+      )
+    val diag = formatResolveError(error)
+    assertEquals("failed to download com.example:lib", diag.headline)
+    assertEquals(
+      listOf(
+        "repository: private",
+        "url: https://private.example.com/com/example/lib/1.0.0/lib-1.0.0.pom",
+        "status: 401 Unauthorized",
+        "credentials: not configured",
+        "hint: the repository requires authentication; add credentials to kolt.local.toml",
+      ),
+      diag.context,
+    )
+  }
+
+  @Test
+  fun authFailedMetadata401ConfiguredTokenRendersInvalidOrExpiredHint() {
+    val error =
+      ResolveError.MetadataDownloadFailed(
+        "com.example:lib",
+        RepositoryDownloadFailure.AuthFailed(
+          repositoryName = "private",
+          url = "https://private.example.com/com/example/lib/maven-metadata.xml",
+          statusCode = 401,
+          authState = AuthStateProjection.ConfiguredToken,
+        ),
+      )
+    val diag = formatResolveError(error)
+    assertEquals("could not fetch metadata for com.example:lib", diag.headline)
+    assertEquals(
+      listOf(
+        "repository: private",
+        "url: https://private.example.com/com/example/lib/maven-metadata.xml",
+        "status: 401 Unauthorized",
+        "credentials: configured (token, from kolt.local.toml)",
+        "hint: the credentials may be invalid or expired",
+      ),
+      diag.context,
+    )
+  }
+
+  @Test
+  fun authFailed403NotConfiguredRendersAuthRequiredHint() {
+    val error =
+      ResolveError.DownloadFailed(
+        "com.example:lib",
+        RepositoryDownloadFailure.AuthFailed(
+          repositoryName = "private",
+          url = "https://private.example.com/com/example/lib/1.0.0/lib-1.0.0.jar",
+          statusCode = 403,
+          authState = AuthStateProjection.NotConfigured,
+        ),
+      )
+    val diag = formatResolveError(error)
+    assertEquals("failed to download com.example:lib", diag.headline)
+    assertEquals(
+      listOf(
+        "repository: private",
+        "url: https://private.example.com/com/example/lib/1.0.0/lib-1.0.0.jar",
+        "status: 403 Forbidden",
+        "credentials: not configured",
+        "hint: authentication is required",
+      ),
+      diag.context,
+    )
+  }
+
+  @Test
+  fun authFailedPom403ConfiguredBasicRendersLackPermissionHint() {
+    val error =
+      ResolveError.DownloadFailed(
+        "com.example:lib",
+        RepositoryDownloadFailure.AuthFailed(
+          repositoryName = "private",
+          url = "https://private.example.com/com/example/lib/1.0.0/lib-1.0.0.pom",
+          statusCode = 403,
+          authState = AuthStateProjection.ConfiguredBasic,
+        ),
+      )
+    val diag = formatResolveError(error)
+    assertEquals("failed to download com.example:lib", diag.headline)
+    assertEquals(
+      listOf(
+        "repository: private",
+        "url: https://private.example.com/com/example/lib/1.0.0/lib-1.0.0.pom",
+        "status: 403 Forbidden",
+        "credentials: configured (basic, from kolt.local.toml)",
+        "hint: the credentials are valid but lack permission for this repository",
+      ),
+      diag.context,
+    )
+  }
+
+  // Defensive: even if a userinfo-bearing URL leaks into AuthFailed.url at
+  // construction time, the formatter re-applies redactUrlUserinfo so the
+  // rendered context never carries `user:password@host` slugs.
+  @Test
+  fun authFailedReRedactsUserinfoInUrlField() {
+    val error =
+      ResolveError.DownloadFailed(
+        "com.example:lib",
+        RepositoryDownloadFailure.AuthFailed(
+          repositoryName = "private",
+          url = "https://alice:s3cret@private.example.com/lib-1.0.0.pom",
+          statusCode = 401,
+          authState = AuthStateProjection.ConfiguredBasic,
+        ),
+      )
+    val diag = formatResolveError(error)
+    val rendered = diag.context.joinToString("\n")
+    assertTrue(rendered.none { it == '@' } || !rendered.contains("alice"))
+    assertTrue(!rendered.contains("alice"), "userinfo username must not appear")
+    assertTrue(!rendered.contains("s3cret"), "userinfo password must not appear")
+    assertTrue(
+      diag.context.contains("url: https://private.example.com/lib-1.0.0.pom"),
+      "url line must be redacted: ${diag.context}",
+    )
+  }
+
   @Test
   fun severityIsAlwaysError() {
     val variants =

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveErrorFormatTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveErrorFormatTest.kt
@@ -41,11 +41,13 @@ class ResolveErrorFormatTest {
         RepositoryDownloadFailure.AllAttemptsFailed(
           listOf(
             RepositoryAttempt(
-              "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar",
-              DownloadError.HttpFailed(
-                "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar",
-                404,
-              ),
+              repositoryName = "central",
+              url = "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar",
+              error =
+                DownloadError.HttpFailed(
+                  "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar",
+                  404,
+                ),
             )
           )
         ),
@@ -66,12 +68,14 @@ class ResolveErrorFormatTest {
         RepositoryDownloadFailure.AllAttemptsFailed(
           listOf(
             RepositoryAttempt(
-              "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar",
-              DownloadError.HttpFailed("u1", 404),
+              repositoryName = "central",
+              url = "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar",
+              error = DownloadError.HttpFailed("u1", 404),
             ),
             RepositoryAttempt(
-              "https://jitpack.io/com/example/lib/1.0.0/lib-1.0.0.jar",
-              DownloadError.HttpFailed("u2", 404),
+              repositoryName = "jitpack",
+              url = "https://jitpack.io/com/example/lib/1.0.0/lib-1.0.0.jar",
+              error = DownloadError.HttpFailed("u2", 404),
             ),
           )
         ),
@@ -99,11 +103,13 @@ class ResolveErrorFormatTest {
         RepositoryDownloadFailure.AllAttemptsFailed(
           listOf(
             RepositoryAttempt(
-              "https://example.com/lib-1.0.0.jar",
-              DownloadError.NetworkError(
-                "https://example.com/lib-1.0.0.jar",
-                "Could not resolve host",
-              ),
+              repositoryName = "central",
+              url = "https://example.com/lib-1.0.0.jar",
+              error =
+                DownloadError.NetworkError(
+                  "https://example.com/lib-1.0.0.jar",
+                  "Could not resolve host",
+                ),
             )
           )
         ),
@@ -144,8 +150,9 @@ class ResolveErrorFormatTest {
         RepositoryDownloadFailure.AllAttemptsFailed(
           listOf(
             RepositoryAttempt(
-              "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar",
-              DownloadError.WriteFailed("/cache/lib-1.0.0.jar.tmp.42"),
+              repositoryName = "central",
+              url = "https://repo1.maven.org/maven2/com/example/lib/1.0.0/lib-1.0.0.jar",
+              error = DownloadError.WriteFailed("/cache/lib-1.0.0.jar.tmp.42"),
             )
           )
         ),
@@ -163,8 +170,9 @@ class ResolveErrorFormatTest {
         RepositoryDownloadFailure.AllAttemptsFailed(
           listOf(
             RepositoryAttempt(
-              "https://repo1.maven.org/maven2/com/example/lib/maven-metadata.xml",
-              DownloadError.HttpFailed("u", 404),
+              repositoryName = "central",
+              url = "https://repo1.maven.org/maven2/com/example/lib/maven-metadata.xml",
+              error = DownloadError.HttpFailed("u", 404),
             )
           )
         ),

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveNativeDirectJvmOnlyErrorTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveNativeDirectJvmOnlyErrorTest.kt
@@ -38,7 +38,11 @@ class ResolveNativeDirectJvmOnlyErrorTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           if (destPath == jvmOnlyModulePath) {
             return Err(DownloadError.HttpFailed(url, 404))
           }

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveNativeJvmOnlyProgressTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveNativeJvmOnlyProgressTest.kt
@@ -117,7 +117,11 @@ class ResolveNativeJvmOnlyProgressTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           if (destPath == jvmOnlyModulePath) {
             return Err(DownloadError.HttpFailed(url, 404))
           }

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveNativeProgressTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveNativeProgressTest.kt
@@ -119,7 +119,11 @@ class ResolveNativeProgressTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           if (destPath.endsWith(".klib") && url.startsWith(repo1)) {
             return Err(DownloadError.HttpFailed(url, 404))
           }
@@ -308,7 +312,11 @@ class ResolveNativeProgressTest {
 
       override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      override fun downloadFile(
+        url: String,
+        destPath: String,
+        headers: Map<String, String>?,
+      ): Result<Unit, DownloadError> {
         cachedFiles.add(destPath)
         return Ok(Unit)
       }

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveNativeProgressTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveNativeProgressTest.kt
@@ -87,7 +87,11 @@ class ResolveNativeProgressTest {
       testConfig(
         target = "linuxX64",
         dependencies = mapOf("com.example:lib" to "1.0.0"),
-        repositories = mapOf("primary" to Repository(repo1), "fallback" to Repository(repo2)),
+        repositories =
+          mapOf(
+            "primary" to Repository(name = "primary", url = repo1),
+            "fallback" to Repository(name = "fallback", url = repo2),
+          ),
       )
 
     val rootModule = rootModuleJson("com.example", "lib-linuxx64", "1.0.0")

--- a/src/nativeTest/kotlin/kolt/resolve/ResolveNativeTransitiveJvmOnlyNoteTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolveNativeTransitiveJvmOnlyNoteTest.kt
@@ -103,7 +103,11 @@ class ResolveNativeTransitiveJvmOnlyNoteTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           if (destPath == jvmOnlyModulePath) {
             return Err(DownloadError.HttpFailed(url, 404))
           }

--- a/src/nativeTest/kotlin/kolt/resolve/ResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/ResolverTest.kt
@@ -235,8 +235,11 @@ class ResolverTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> =
-          Err(DownloadError.HttpFailed(url, 404))
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> = Err(DownloadError.HttpFailed(url, 404))
 
         override fun computeSha256(filePath: String): Result<String, Sha256Error> =
           Err(Sha256Error(filePath))
@@ -336,7 +339,11 @@ class ResolverTest {
 
       override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      override fun downloadFile(
+        url: String,
+        destPath: String,
+        headers: Map<String, String>?,
+      ): Result<Unit, DownloadError> {
         downloadedFiles[destPath] = url
         cachedFiles.add(destPath)
         return Ok(Unit)

--- a/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
@@ -1001,7 +1001,11 @@ class TransitiveResolverTest {
 
       override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      override fun downloadFile(
+        url: String,
+        destPath: String,
+        headers: Map<String, String>?,
+      ): Result<Unit, DownloadError> {
         val forcedError = downloadErrors[url]
         if (forcedError != null) return Err(forcedError)
         cachedFiles.add(destPath)
@@ -1032,7 +1036,13 @@ class TransitiveResolverTest {
     val deps = fakeTransitiveDeps(cachedFiles = mutableSetOf(sourcesCachePath))
 
     val result =
-      resolveSourcesPath(coord, "/cache", listOf("https://r"), deps, binaryWasCached = true)
+      resolveSourcesPath(
+        coord,
+        "/cache",
+        listOf(Repository(name = "r", url = "https://r")),
+        deps,
+        binaryWasCached = true,
+      )
 
     assertEquals(sourcesCachePath, result)
   }
@@ -1047,7 +1057,11 @@ class TransitiveResolverTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           downloadedUrls.add(url)
           return Ok(Unit)
         }
@@ -1060,7 +1074,13 @@ class TransitiveResolverTest {
       }
 
     val result =
-      resolveSourcesPath(coord, "/cache", listOf("https://r"), deps, binaryWasCached = true)
+      resolveSourcesPath(
+        coord,
+        "/cache",
+        listOf(Repository(name = "r", url = "https://r")),
+        deps,
+        binaryWasCached = true,
+      )
 
     assertEquals(null, result)
     assertTrue(downloadedUrls.isEmpty(), "must not re-probe when binary was already cached")
@@ -1072,7 +1092,13 @@ class TransitiveResolverTest {
     val deps = fakeTransitiveDeps()
 
     val result =
-      resolveSourcesPath(coord, "/cache", listOf("https://r"), deps, binaryWasCached = false)
+      resolveSourcesPath(
+        coord,
+        "/cache",
+        listOf(Repository(name = "r", url = "https://r")),
+        deps,
+        binaryWasCached = false,
+      )
 
     assertEquals("/cache/com/example/lib/1.0.0/lib-1.0.0-sources.jar", result)
   }
@@ -1087,7 +1113,13 @@ class TransitiveResolverTest {
       )
 
     val result =
-      resolveSourcesPath(coord, "/cache", listOf("https://r"), deps, binaryWasCached = false)
+      resolveSourcesPath(
+        coord,
+        "/cache",
+        listOf(Repository(name = "r", url = "https://r")),
+        deps,
+        binaryWasCached = false,
+      )
 
     assertEquals(null, result)
   }
@@ -1102,7 +1134,13 @@ class TransitiveResolverTest {
       )
 
     val result =
-      resolveSourcesPath(coord, "/cache", listOf("https://r"), deps, binaryWasCached = false)
+      resolveSourcesPath(
+        coord,
+        "/cache",
+        listOf(Repository(name = "r", url = "https://r")),
+        deps,
+        binaryWasCached = false,
+      )
 
     assertEquals(null, result)
   }
@@ -1193,10 +1231,14 @@ class TransitiveResolverTest {
 
     val result =
       downloadFromRepositories(
-        repos = listOf("https://repo1.example.com", "https://repo2.example.com"),
+        repos =
+          listOf(
+            Repository(name = "r1", url = "https://repo1.example.com"),
+            Repository(name = "r2", url = "https://repo2.example.com"),
+          ),
         destPath = "/cache/lib.jar",
-        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
-        download = { url, _ ->
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo.url) },
+        download = { url, _, _ ->
           downloadedUrls.add(url)
           Ok(Unit)
         },
@@ -1216,10 +1258,14 @@ class TransitiveResolverTest {
 
     val result =
       downloadFromRepositories(
-        repos = listOf(repo1Base, repo2Base),
+        repos =
+          listOf(
+            Repository(name = "r1", url = repo1Base),
+            Repository(name = "r2", url = repo2Base),
+          ),
         destPath = "/cache/lib.jar",
-        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
-        download = { url, _ ->
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo.url) },
+        download = { url, _, _ ->
           downloadedUrls.add(url)
           if (url.startsWith(repo1Base)) Err(DownloadError.HttpFailed(url, 404)) else Ok(Unit)
         },
@@ -1237,10 +1283,14 @@ class TransitiveResolverTest {
 
     val result =
       downloadFromRepositories(
-        repos = listOf("https://repo1.example.com", "https://repo2.example.com"),
+        repos =
+          listOf(
+            Repository(name = "r1", url = "https://repo1.example.com"),
+            Repository(name = "r2", url = "https://repo2.example.com"),
+          ),
         destPath = "/cache/lib.jar",
-        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
-        download = { url, _ -> Err(DownloadError.HttpFailed(url, 404)) },
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo.url) },
+        download = { url, _, _ -> Err(DownloadError.HttpFailed(url, 404)) },
       )
 
     val failure = assertIs<RepositoryDownloadFailure.AllAttemptsFailed>(result.getError())
@@ -1264,10 +1314,14 @@ class TransitiveResolverTest {
 
     val result =
       downloadFromRepositories(
-        repos = listOf("https://repo1.example.com", "https://repo2.example.com"),
+        repos =
+          listOf(
+            Repository(name = "r1", url = "https://repo1.example.com"),
+            Repository(name = "r2", url = "https://repo2.example.com"),
+          ),
         destPath = "/cache/lib.jar",
-        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
-        download = { url, _ ->
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo.url) },
+        download = { url, _, _ ->
           downloadedUrls.add(url)
           Err(DownloadError.NetworkError(url, "connection refused"))
         },
@@ -1289,10 +1343,15 @@ class TransitiveResolverTest {
 
     val result =
       downloadFromRepositories(
-        repos = listOf(repo1, repo2, repo3),
+        repos =
+          listOf(
+            Repository(name = "r1", url = repo1),
+            Repository(name = "r2", url = repo2),
+            Repository(name = "r3", url = repo3),
+          ),
         destPath = "/cache/lib.jar",
-        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
-        download = { url, _ ->
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo.url) },
+        download = { url, _, _ ->
           touched.add(url)
           when {
             url.startsWith(repo1) -> Err(DownloadError.HttpFailed(url, 404))
@@ -1317,8 +1376,8 @@ class TransitiveResolverTest {
       downloadFromRepositories(
         repos = emptyList(),
         destPath = "/cache/lib.jar",
-        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
-        download = { _, _ -> fail("should not be invoked") },
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo.url) },
+        download = { _, _, _ -> fail("should not be invoked") },
       )
 
     assertEquals(RepositoryDownloadFailure.NoRepositoriesConfigured, result.getError())
@@ -1333,13 +1392,13 @@ class TransitiveResolverTest {
 
     val result =
       downloadFromRepositories(
-        repos = listOf(repo1, repo2),
+        repos = listOf(Repository(name = "r1", url = repo1), Repository(name = "r2", url = repo2)),
         destPath = "/cache/lib.jar",
-        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
-        download = { url, _ ->
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo.url) },
+        download = { url, _, _ ->
           if (url.startsWith(repo1)) Err(DownloadError.HttpFailed(url, 404)) else Ok(Unit)
         },
-        onRetry = { repo -> captured.add(repo) },
+        onRetry = { repo -> captured.add(repo.url) },
       )
 
     assertNotNull(result.get())
@@ -1355,11 +1414,11 @@ class TransitiveResolverTest {
 
     val result =
       downloadFromRepositories(
-        repos = listOf(repo1, repo2),
+        repos = listOf(Repository(name = "r1", url = repo1), Repository(name = "r2", url = repo2)),
         destPath = "/cache/lib.jar",
-        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
-        download = { url, _ -> Err(DownloadError.NetworkError(url, "connection refused")) },
-        onRetry = { repo -> captured.add(repo) },
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo.url) },
+        download = { url, _, _ -> Err(DownloadError.NetworkError(url, "connection refused")) },
+        onRetry = { repo -> captured.add(repo.url) },
       )
 
     assertIs<RepositoryDownloadFailure.AllAttemptsFailed>(result.getError())
@@ -1376,11 +1435,16 @@ class TransitiveResolverTest {
 
     val result =
       downloadFromRepositories(
-        repos = listOf(repo1, repo2, repo3),
+        repos =
+          listOf(
+            Repository(name = "r1", url = repo1),
+            Repository(name = "r2", url = repo2),
+            Repository(name = "r3", url = repo3),
+          ),
         destPath = "/cache/lib.jar",
-        urlBuilder = { repo -> buildDownloadUrl(coord, repo) },
-        download = { url, _ -> Err(DownloadError.HttpFailed(url, 404)) },
-        onRetry = { repo -> captured.add(repo) },
+        urlBuilder = { repo -> buildDownloadUrl(coord, repo.url) },
+        download = { url, _, _ -> Err(DownloadError.HttpFailed(url, 404)) },
+        onRetry = { repo -> captured.add(repo.url) },
       )
 
     assertIs<RepositoryDownloadFailure.AllAttemptsFailed>(result.getError())
@@ -1415,7 +1479,11 @@ class TransitiveResolverTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           downloadedUrls.add(url)
           cachedFiles.add(destPath)
           return Ok(Unit)
@@ -1468,7 +1536,11 @@ class TransitiveResolverTest {
 
         override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-        override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+        override fun downloadFile(
+          url: String,
+          destPath: String,
+          headers: Map<String, String>?,
+        ): Result<Unit, DownloadError> {
           return if (url.startsWith(repo1Base)) {
             Err(DownloadError.HttpFailed(url, 404))
           } else {
@@ -1503,7 +1575,11 @@ class TransitiveResolverTest {
 
       override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-      override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+      override fun downloadFile(
+        url: String,
+        destPath: String,
+        headers: Map<String, String>?,
+      ): Result<Unit, DownloadError> {
         cachedFiles.add(destPath)
         return Ok(Unit)
       }

--- a/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
+++ b/src/nativeTest/kotlin/kolt/resolve/TransitiveResolverTest.kt
@@ -1393,7 +1393,7 @@ class TransitiveResolverTest {
     val config =
       testConfig(
         dependencies = mapOf("com.example:lib" to "1.0.0"),
-        repositories = mapOf("myrepo" to Repository(customRepoBase)),
+        repositories = mapOf("myrepo" to Repository(name = "myrepo", url = customRepoBase)),
       )
     val pomXml =
       """
@@ -1444,7 +1444,10 @@ class TransitiveResolverTest {
       testConfig(
         dependencies = mapOf("com.example:lib" to "1.0.0"),
         repositories =
-          mapOf("primary" to Repository(repo1Base), "fallback" to Repository(repo2Base)),
+          mapOf(
+            "primary" to Repository(name = "primary", url = repo1Base),
+            "fallback" to Repository(name = "fallback", url = repo2Base),
+          ),
       )
     val pomXml =
       """

--- a/src/nativeTest/kotlin/kolt/usertool/ToolResolutionTest.kt
+++ b/src/nativeTest/kotlin/kolt/usertool/ToolResolutionTest.kt
@@ -6,6 +6,7 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import kolt.config.KoltPaths
+import kolt.config.Repository
 import kolt.infra.CopyFailed
 import kolt.infra.DownloadError
 import kolt.infra.MkdirFailed
@@ -25,7 +26,7 @@ import kotlin.test.assertTrue
 class ToolResolutionTest {
 
   private val paths = KoltPaths(home = "/home/u")
-  private val repos = listOf("https://central/")
+  private val repos = listOf(Repository(name = "central", url = "https://central/"))
 
   // The Maven-layout cacheBase that resolveSingleArtifact writes into.
   private val cacheBase = "/home/u/.kolt/cache"
@@ -316,7 +317,11 @@ class ToolResolutionTest {
   @Test
   fun allRepos404SurfaceAsResolveFailedWithAttemptedUrls() {
     val coords = Coordinate("com.example", "tool", "1.0.0")
-    val tried = listOf("https://repo1/", "https://repo2/")
+    val tried =
+      listOf(
+        Repository(name = "r1", url = "https://repo1/"),
+        Repository(name = "r2", url = "https://repo2/"),
+      )
     val deps = fakeDeps(downloadResult = { url, _ -> Err(DownloadError.HttpFailed(url, 404)) })
     val lockfile = emptyLockfile()
 
@@ -387,7 +392,11 @@ class ToolResolutionTest {
 
     override fun ensureDirectoryRecursive(path: String): Result<Unit, MkdirFailed> = Ok(Unit)
 
-    override fun downloadFile(url: String, destPath: String): Result<Unit, DownloadError> {
+    override fun downloadFile(
+      url: String,
+      destPath: String,
+      headers: Map<String, String>?,
+    ): Result<Unit, DownloadError> {
       downloads.add(url)
       if (downloadResult != null) return downloadResult.invoke(url, destPath)
       cachedFiles.add(destPath)


### PR DESCRIPTION
Closes #416. Implements the Kiro spec at `.kiro/specs/private-maven-repos/` (24 tasks, 20 commits).

`[repositories.<name>]` now accepts `token = { literal = "..." }` or paired `user` / `password` inline-tables. The literal value must live in `kolt.local.toml` — `kolt.toml` (the committed file) is rejected pre-merge if it carries any of `token` / `user` / `password`. `{ env = "X" }` is parsed and rejected with a v1.0-specific message so the validator can flip to accept additively in v1.1+. Authenticated repos get `Authorization: Bearer …` / `Authorization: Basic <base64>` attached to every HTTP fetch in the resolver chain. A 401 or 403 from any repo short-circuits the loop with a dedicated 5-line diagnostic (`repository / url / status / credentials / hint`) including a hint matrix per Req 7.4; 404 fall-through and aggregated `AllAttemptsFailed` are unchanged.

## Reviewer focus

- **Validator order in `liftRepositoriesMap`** (Config.kt ~328-430). Fail-fast chain is URL-non-empty → URL-userinfo → token/user-password mutex → pair-completeness → Literal non-empty → env-form reject. Order matters for teaching messages — `LiftRepositoriesMapAuthValidatorTest` pins the two non-trivial ordering boundaries (mutex/pair before non-empty).
- **`Downloader.downloadFile` slist cleanup order** (Downloader.kt). `curl_slist_free_all` runs BEFORE `curl_easy_cleanup` — reverse of every upstream libcurl sample. Anchored comment in source; don't "fix" it.
- **`CURLOPT_UNRESTRICTED_AUTH = 0L`** explicitly set (default behavior, documented commitment). `DownloaderAuthHeaderTest` (d) and `RepositoryAuthFailureTest` socket-level assertions both prove cross-origin redirect drops Authorization.
- **Redaction chain**. Secrets stay in `kolt.config.RepositoryAuth`; only `kolt.resolve.AuthStateProjection` reaches the renderer. `Repository.toString()` is the auto-generated data-class form but redaction delegates through `RepositoryAuth.Basic.toString()` / `Bearer.toString()`. `RepositoryAuthRedactionTest` pins six leak surfaces including `kolt.lock` and `kolt info` JSON schemas.
- **Caller migration scope** (commit `a49705c`, 37 files). `downloadFromRepositories` flipped to `List<Repository>` + 3-arg `download` lambda; every projection site dropped `.map { it.url }`. The `urlBuilder` lambda discipline (use `repo.url`, never `"$repo/…"`) is grep-clean — `Repository.toString()` includes the redacted auth field and is NOT a URL. `AllCallersTypedTest` is a no-op compile gate that wedges if anything regresses to `List<String>`.
- **`LoopbackHttpServer` fixture** (`src/nativeTest/kotlin/kolt/infra/testfixture/LoopbackHttpServer.kt`). First AF_INET HTTP fixture in the repo; mirrors the existing `UnixEchoServer` pattern (pthread worker, single-shot accept, ephemeral port). Reused by `DownloaderAuthHeaderTest` and `RepositoryAuthFailureTest`.

Self-host smoke: HEAD binary builds all four `kolt.toml` files (root, `kolt-jvm-compiler-daemon`, `kolt-native-compiler-daemon`, `spike/native-ktor-cinterop-smoke`) through the new validator chain. `kolt test` passes 2087/2087.