### PR TITLE
hotfix(release): apply kolt.toml bootstrap shim in Assemble step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,9 +169,26 @@ jobs:
       # emits both the tarball and .sha256. The KOLT env var points the
       # script at the prebuilt bootstrap kexe instead of its default
       # `build/release/kolt.kexe` lookup.
+      #
+      # Pre-v0.20.0 bootstrap shim: KOLT_BOOTSTRAP_TAG (v0.16.3) predates
+      # the `[repositories.<name>]` sub-table schema, so we stage the
+      # three kolt.toml files in the legacy flat-string-map form for the
+      # duration of the bootstrap build only; the trap restores them
+      # before the tarball is assembled into dist/ (assemble-dist.sh
+      # does not bundle kolt.toml into the release tarball, so the
+      # transient flat form never reaches users). Remove the shim and
+      # bump KOLT_BOOTSTRAP_TAG once v0.20.0+ is the bootstrap pin.
       - name: Assemble tarball + sha256
         run: |
           set -euo pipefail
+          ./scripts/ci-kolt-toml-bootstrap-shim.sh apply \
+            kolt.toml \
+            kolt-jvm-compiler-daemon/kolt.toml \
+            kolt-native-compiler-daemon/kolt.toml
+          trap './scripts/ci-kolt-toml-bootstrap-shim.sh restore \
+            kolt.toml \
+            kolt-jvm-compiler-daemon/kolt.toml \
+            kolt-native-compiler-daemon/kolt.toml || true' EXIT
           KOLT="$BOOTSTRAP_KOLT" \
             ./scripts/assemble-dist.sh
 


### PR DESCRIPTION
The v0.20.0 release workflow run [25894174401](https://github.com/snicmakino/kolt/actions/runs/25894174401) failed at the **Assemble tarball + sha256** step because the bootstrap kolt (`KOLT_BOOTSTRAP_TAG = v0.16.3`) cannot parse the new `[repositories.<name>]` sub-table schema landed in #320.

`unit-tests.yml` and `self-host-smoke.yml` already wrap their bootstrap kolt calls with `scripts/ci-kolt-toml-bootstrap-shim.sh`; `release.yml` was the missing one. This PR adds the same `apply` + `trap restore EXIT` pair around the `assemble-dist.sh` invocation.

`assemble-dist.sh` does **not** bundle `kolt.toml` into the release tarball (verified: line 271 packs only `dist/kolt-<version>-linux-x64/`), so the transient flat-form during the bootstrap build never reaches users.

After merge: delete the `v0.20.0` tag, re-push at the new main HEAD, and the workflow re-fires.

Follow-up tracked in the commit message: bump `KOLT_BOOTSTRAP_TAG` to v0.20.0+ and delete the shim across all three workflows + `scripts/` once the v0.20.0 release is published.