### PR TITLE
Add kolt self update / --check (#27)

### DIFF
--- a/.kiro/specs/27-self-update/design.md
+++ b/.kiro/specs/27-self-update/design.md
@@ -1,0 +1,483 @@
+# Technical Design — 27-self-update (圧縮版)
+
+## Overview
+
+`kolt self update` および `kolt self update --check` を追加し、 installer spec が確立した `~/.local/share/kolt/<ver>/bin/kolt` + `~/.local/bin/kolt` symlink のレイアウト上で kolt 単一バイナリを GitHub Releases の最新安定版に自己置換する。 本 spec は **install.sh が POSIX sh で持つのと同等のスコープ** を Kotlin/Native に実装する。 install.sh wrapper にしないのは macOS / linuxArm64 対応時に platform 分岐をネイティブ側で一元管理するため。 install.sh が持たない防衛機構 (並行 advisory lock / SIGINT 中断回復 / layout 網羅分類) は priority: nice の本機能には過剰として scope 外。
+
+Users: installer 経由で kolt を入れた個人開発者・小規模チーム。 Impact: kolt CLI に新規サブコマンド群 `kolt self` を導入し、 新規 package `kolt.selfupdate` を切る (5 ファイル)。 daemon thin jar は release tarball の `libexec/` に同梱されるため、 symlink 切替 1 回でバイナリと daemon が同期更新される。 daemon ↔ binary 版整合性は既存 socket fingerprint が自動隔離するため self-update 側に daemon 専用ロジックは持たない。
+
+### Goals
+- 1 コマンドで最新安定版を取得・検証・配置し `~/.local/bin/kolt` を切り替える。
+- `releases/latest` の prerelease 自動除外 + `vX.Y.Z` regex で「安定版のみ」を契約化。
+- 失敗を Requirement 7 の 3 カテゴリ + 包括 catch にマッピングし、 メッセージなしの非ゼロ終了をしない。
+
+### Non-Goals
+- macOS / linuxArm64 (runtime gate で「未対応」と判定し即抜ける。 `expect-actual` 差し替えは macOS port 時の別 spec)。
+- 任意バージョン指定 / ダウングレード / プレリリース追従。
+- 旧バージョン dir の自動削除 / rollback。
+- 並行 `kolt self update` の advisory lock。
+- SIGINT / kill 中断からの専用回復ロジック (中断で残った staging dir は、 その pid が生存していなければ次回実行が best-effort で掃除する。 中断検出機構そのものは持たない)。
+- layout 非一致の網羅的分類 (単一判定に留める)。
+- `XDG_DATA_HOME` honor (`$HOME` のみ、 installer 整合)。
+
+## Boundary Commitments
+
+### This Spec Owns
+- `kolt self update` / `kolt self update --check` の CLI surface (dispatch、 usage、 不明フラグ拒否、 終了コード規約)。
+- `releases/latest` の参照、 `tag_name` の `vX.Y.Z` 形式検証、 現バージョンとの semver 比較。
+- 対応リリース成果物 (`kolt-<ver>-linux-x64.tar.gz` + 同 `.sha256`) の取得・SHA-256 検証・展開。
+- 自プロセス専用の一時ディレクトリ `~/.local/share/kolt/.staging-<pid>/` の使用 (自 pid dir を作り直す → download → verify → extract → rename)。 生存 pid の `.staging-*` には触れず、 死んだ pid のものは best-effort 掃除。
+- `~/.local/bin/kolt` の symlink 切替 (`symlink(2)` で一時 symlink → `rename(2)` で上書き、 1 回)。
+- installer layout の単一判定 (`~/.local/bin/kolt` が `~/.local/share/kolt/<ver>/bin/kolt` 配下を指す symlink か) + 書き込み権限プローブ + 非対応の拒否。
+- 自己更新固有のエラーカテゴリ (`SelfUpdateError` sealed ADT、 粗粒度)。
+
+### Out of Boundary
+- installer spec が所有する disk layout / tarball 内部構造 / `~/.local/bin/kolt` 初期作成。
+- release workflow が所有する成果物 publish と prerelease マーキング。
+- 既存 `kolt.infra.Downloader` の HTTPS GET 機構そのもの。
+- daemon ↔ binary 版整合性 (既存 socket fingerprint が自動解決)。
+- 並行排他 / 中断回復 / 旧 dir cleanup / layout 細分類 / 進捗 % 表示。
+
+### Allowed Dependencies
+- `kolt.infra.Downloader.downloadFile(url, destPath, headers)` — テンポラリパスへの HTTPS ストリーミング書き込み。
+- `kolt.infra.Sha256.computeSha256(filePath)` — SHA-256 計算。
+- `kolt.infra.ArchiveExtraction.extractArchive(archivePath, destDir)` — `ARCHIVE_EXTRACT_PERM` 保持、 absolute path / `..` は libarchive が reject。
+- `kolt.infra.FileSystem` 既存操作 + 本 spec で追加する `canWrite(path): Boolean` (`access(path, W_OK)`)。
+- `kolt.infra.SelfExe.readSelfExe()` — 実行中バイナリの解決パス。
+- 本 spec で追加する `kolt.infra.Symlink.replaceSymlinkAtomically(linkPath, newTarget): Result<Unit, SymlinkError>`。
+- `kolt.config.homeDirectory()` / `KOLT_VERSION` / `versionString()`。
+- `kolt.resolve.VersionCompare.compareVersions(a, b)` — semver 比較。
+- `kotlinx.serialization.json.Json` — `releases/latest` デコード (nativeMain では `GradleMetadata` / `Lockfile` が前例)。
+- `kolt.infra` の `readFileAsString` / `deleteRecursively` 相当 (staging の作り直しと `.sha256` 読み取り)。
+
+### Revalidation Triggers
+- installer spec が disk layout を変更 → `InstallerLayout` 判定と path 組み立てを再検証。
+- release workflow が成果物命名 / `.sha256` 形式 / prerelease マーキングを変更 → `GithubReleasesClient` と検証ロジックを再検証。
+- `KOLT_VERSION` の出力形式が `kolt <semver>` から変化 → 比較対象抽出を再検証。
+- `Downloader` の API (特に `headers`) が変化 → User-Agent 送出経路を再検証。
+
+## Architecture
+
+### Existing Architecture Analysis
+- CLI dispatch は `Main.kt` の `when (filteredArgs[0])` + `KNOWN_SUBCOMMANDS_SORTED`。 ネストは `doTool` / `doToolchain` が `args.drop(1)` で再 dispatch する前例。
+- infra primitives (Downloader / Sha256 / ArchiveExtraction / SelfExe) はすべて既存。
+- package direction は `cli → build → resolve / infra`。 本 spec は `cli → selfupdate → infra` のノードを足す。
+- daemon は `daemonInputsFingerprint` でソケットを版隔離するため、 self-update が daemon を stop する必要なし。
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+    User[User shell] --> Main[kolt.cli.Main dispatch]
+    Main -->|self update or check| SelfCommands[kolt.cli.SelfCommands]
+    SelfCommands --> SelfUpdater[kolt.selfupdate.SelfUpdater]
+
+    subgraph selfupdate[kolt.selfupdate]
+      SelfUpdater --> GithubReleasesClient[GithubReleasesClient]
+      SelfUpdater --> SelfUpdateError[SelfUpdateError]
+    end
+
+    subgraph infra[kolt.infra additions]
+      Symlink[Symlink replaceSymlinkAtomically]
+      WriteProbe[FileSystem canWrite]
+    end
+
+    GithubReleasesClient --> Downloader[kolt.infra.Downloader]
+    SelfUpdater --> ArchiveExtract[kolt.infra.ArchiveExtraction]
+    SelfUpdater --> Sha256[kolt.infra.Sha256]
+    SelfUpdater --> Symlink
+    SelfUpdater --> SelfExe[kolt.infra.SelfExe]
+    SelfUpdater --> WriteProbe
+    SelfUpdater --> VersionCompare[kolt.resolve.VersionCompare]
+    SelfUpdater --> Version[kolt.config.Version]
+
+    GitHub[github API and releases] -.->|HTTPS| Downloader
+    Disk[local share kolt and local bin kolt] -.->|read and write| SelfUpdater
+```
+
+**Key decisions**:
+- 新規 package `kolt.selfupdate` は `SelfUpdater` / `SelfUpdateError` / `GithubReleasesClient` の 3 ファイルのみ。 platform gate・layout 検出・staging lifecycle は `SelfUpdater` 内の `internal` 関数に内包し、 専用クラスにしない (圧縮判断)。 `SelfUpdateError` を `kolt.cli` に置かない package direction 整合のため package は分離する。
+- HTTPS API 取得は既存 `Downloader.downloadFile` を temp path に対して呼び、 `readFileAsString` で読み直す。 GET-to-memory variant は追加しない。
+- **Gating order**: `--check` は `ensureLinuxX64() → fetchLatest() → compare → 表示` (layout 判定なし・書き込みゼロ)。 `update` は `ensureLinuxX64() → detectLayout() → verifyWritable() → fetchLatest() → compare → (necessaryなら) download/verify/extract/swap`。 platform を最初に置くのは Requirement 6.2 の制約。 layout gate は書き込みを伴う `update` 経路のみ (Requirement 5.1、 `--check` は layout 非依存で version だけ答える)。 advisory lock は持たないため lock 起因の順序制約はない。
+- staging は `SelfUpdater` 内で「自 pid の `~/.local/share/kolt/.staging-<pid>/` を `deleteRecursively` してから `mkdir` → download → verify → extract → `rename` で確定」。 lock も cleanup 専用クラスも持たないが、 (1) pid 別ディレクトリで並行プロセスの相互破壊を防ぎ、 (2) 起動時に死んだ pid の `.staging-*` を `kill(pid, 0)` 判定で best-effort 削除して残骸累積を防ぐ (Requirement 4.5)。
+- platform gate は現状 linuxX64 単系統ビルドのため `uname(2)` の `sysname == "Linux"` && `machine in {x86_64, amd64}` の wide assertion。 macOS port 時に `expect-actual` へ差し替える seam としてのみ存在。
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| CLI | `kolt.cli.Main` + 新規 `kolt.cli.SelfCommands` | `kolt self ...` の dispatch + usage | `KNOWN_SUBCOMMANDS_SORTED` に `"self"` 追加。 `doTool` パターン踏襲。 |
+| Domain | 新規 `kolt.selfupdate` (3 ファイル) | self-update オーケストレーション | `SelfUpdater` / `SelfUpdateError` / `GithubReleasesClient` |
+| HTTP | 既存 `kolt.infra.Downloader` (libcurl) | HTTPS GET (API + asset + .sha256) | `headers` に `User-Agent: kolt/<KOLT_VERSION>` を載せる。 UA 未指定だと GitHub API は 403。 |
+| JSON | `kotlinx-serialization-json` 1.7.3 | `releases/latest` デコード | `Json { ignoreUnknownKeys = true }`。 `GradleMetadata` / `Lockfile` が nativeMain 前例。 |
+| Hash | 既存 `kolt.infra.Sha256` (`kotlincrypto.hash.sha2-256` 0.2.7) | tarball SHA-256 | `.sha256` パースは 1 行目を whitespace split (`ToolchainManager` パターン)。 |
+| Archive | 既存 `kolt.infra.ArchiveExtraction` (libarchive) | tarball 展開 | `ARCHIVE_EXTRACT_PERM` で +x 保持、 SECURE フラグで逸脱パス reject。 |
+| Symlink swap | 新規 `kolt.infra.Symlink.replaceSymlinkAtomically` | symlink 原子置換 | `symlink(newTarget, tmp)` + `rename(tmp, link)`。 `rename(2)` は newpath が既存 symlink でも atomic 置換 (Linux man-page)。 |
+| FS probe | 新規 `kolt.infra.FileSystem.canWrite(path)` | 書き込み権限プローブ | `access(path, W_OK) == 0`。 |
+| Path | 既存 `kolt.infra.FileSystem.homeDirectory()` | `$HOME` 解決 | `~/.local/share/kolt/`、 `~/.local/bin/` を組み立てる。 XDG は honor しない。 |
+
+## File Structure Plan
+
+### Directory Structure
+```
+src/nativeMain/kotlin/kolt/
+├── cli/
+│   ├── Main.kt                  # MODIFIED: "self" dispatch + KNOWN_SUBCOMMANDS_SORTED entry + usage line
+│   └── SelfCommands.kt          # NEW: doSelf(args) - parse subcommand/flags, route to SelfUpdater, format出力
+├── selfupdate/                  # NEW package (3 files)
+│   ├── SelfUpdater.kt           # check() / update() orchestration + internal: ensureLinuxX64 / detectLayout / verifyWritable / runStaged
+│   ├── SelfUpdateError.kt       # sealed ADT (粗粒度: Network / Metadata / Asset / Extract / Layout / Platform / Home)
+│   └── GithubReleasesClient.kt  # API GET + @Serializable LatestRelease / ReleaseAsset
+└── infra/
+    ├── Symlink.kt               # NEW: replaceSymlinkAtomically(linkPath, newTarget): Result<Unit, SymlinkError>
+    └── FileSystem.kt            # MODIFIED: add canWrite(path: String): Boolean
+
+src/nativeTest/kotlin/kolt/
+├── selfupdate/
+│   ├── SelfUpdaterCheckTest.kt          # --check: update available / already latest / older / platform (layout は見ない)
+│   ├── SelfUpdaterUpdateTest.kt         # update happy path + checksum mismatch + staging recreate (LoopbackHttpServer + tmp HOME)
+│   ├── GithubReleasesClientTest.kt      # JSON decode + tag regex + UA header
+│   └── testfixture/GithubReleasesFixture.kt   # canned JSON + tarball builder
+└── infra/SymlinkTest.kt                 # replace over existing/absent/regular file
+```
+
+### Modified Files
+- `src/nativeMain/kotlin/kolt/cli/Main.kt` — `when` に `"self" -> doSelf(args.drop(1))` を追加 (アルファベット順で `run` の前)、 `KNOWN_SUBCOMMANDS_SORTED` に `"self"` 挿入、 `usageLines()` に `kolt self update` 行を追加。
+- `src/nativeMain/kotlin/kolt/infra/FileSystem.kt` — `fun canWrite(path: String): Boolean = access(path, W_OK) == 0` を `fileExists` の隣に追加 (`@OptIn(ExperimentalForeignApi::class)`)。
+
+## System Flows
+
+### Flow: `kolt self update` (`--check` は download 以降を省略した部分集合)
+
+```mermaid
+sequenceDiagram
+    participant U as User shell
+    participant SC as SelfCommands
+    participant SU as SelfUpdater
+    participant GH as GithubReleasesClient
+    participant FS as local share kolt
+
+    U->>SC: kolt self update
+    SC->>SU: update()
+    SU->>SU: ensureLinuxX64()
+    SU->>SU: detectLayout() then verifyWritable()
+    SU->>U: "fetching release metadata"
+    SU->>GH: fetchLatest()
+    GH-->>SU: LatestRelease tag v0.21.0
+    SU->>SU: compareVersions(0.20.0, 0.21.0)
+    alt latest <= current
+        SU->>U: "Already at latest version (0.20.0)" exit 0
+    else latest > current
+        SU->>FS: recreate staging dir
+        SU->>U: "downloading tarball"
+        SU->>GH: download tarball and sha256 into staging
+        SU->>U: "verifying checksum"
+        SU->>SU: computeSha256 vs parsed .sha256
+        SU->>U: "extracting"
+        SU->>SU: extractArchive into staging
+        SU->>U: "switching to new version"
+        SU->>FS: rename staging extracted dir into local share kolt 0.21.0
+        SU->>SU: replaceSymlinkAtomically over local bin kolt
+        SU->>U: "0.20.0 -> 0.21.0" exit 0
+    end
+```
+
+update の Gate 順序は `ensureLinuxX64 → detectLayout → verifyWritable → fetchLatest` で固定 (Requirement 6.2)。 自 pid の staging dir は処理開始時に `deleteRecursively` で作り直すが生存 pid の `.staging-*` には触れないため、 並行プロセスと相互干渉せず、 死んだ pid の残骸は起動時 best-effort 掃除で累積しない (Requirement 4.5)。 `replaceSymlinkAtomically` は `rename(2)` 1 回なので中断は「旧か新か」の二値以外取らない (Requirement 3.6)。 `--check` は `ensureLinuxX64 → fetchLatest → compare → 表示` で終わり、 layout 判定も staging も symlink も触らない (Requirement 2.5; 5.1 は update 限定)。
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces |
+|-------------|---------|------------|------------|
+| 1.1 | `kolt self update` 開始 | SelfCommands, SelfUpdater | `doSelf` / `update()` |
+| 1.2 | `--check` モード | SelfCommands, SelfUpdater | `check()` |
+| 1.3 | `kolt self` 引数なし → usage + 0 | SelfCommands | `doSelf([])` |
+| 1.4 | `--help` で usage + 0 | SelfCommands | `doSelf` |
+| 1.5 | 未知フラグ拒否 | SelfCommands | `doSelf` arg parser |
+| 2.1 | tag `vX.Y.Z` 検証 | GithubReleasesClient | `validateTag(tag): Result<String, SelfUpdateError>` |
+| 2.2 | semver 比較 | SelfUpdater | `compareVersions` |
+| 2.3 | update available + 0 | SelfCommands, SelfUpdater | `CheckOutcome.UpdateAvailable` |
+| 2.4 | already latest + 0 | SelfCommands, SelfUpdater | `CheckOutcome.AlreadyLatest` |
+| 2.5 | `--check` 書き込みなし | SelfUpdater | `check()` read-only path |
+| 2.6 | `--check` 常に exit 0 | SelfCommands | exit code mapping |
+| 3.1 | update の段階順 | SelfUpdater | `update()` state machine |
+| 3.2 | latest <= current で no-op + 0 | SelfUpdater | `update()` compare branch |
+| 3.3 | 成功時 `<old> -> <new>` | SelfCommands | exit message formatter |
+| 3.4 | 5 ステージ進捗行 | SelfUpdater | `onStage` callback |
+| 3.5 | 既存 dir 削除しない | SelfUpdater | staging は自 pid `.staging-<pid>/` のみ触る |
+| 3.6 | symlink を rename 1 回で切替 | Symlink.replaceSymlinkAtomically | `rename(2)` atomic |
+| 4.1 | tarball + .sha256 取得 | SelfUpdater, GithubReleasesClient | `download(...)` |
+| 4.2 | SHA-256 比較 | SelfUpdater, Sha256 | `verifyChecksum(...)` |
+| 4.3 | 不一致で install せず非ゼロ | SelfUpdateError.Asset | error envelope |
+| 4.4 | アセット欠落の名前付きエラー | SelfUpdateError.Asset | error envelope |
+| 4.5 | 一時 dir 経由 + 無条件再作成 | SelfUpdater | `runStaged()` |
+| 5.1 | layout 単一判定 (update のみ) | SelfUpdater | `detectLayout()` (update 経路のみ呼ぶ) |
+| 5.2 | 非一致 → 案内付き拒否 (update のみ) | SelfUpdater, SelfUpdateError.Layout | `detectLayout()` |
+| 5.3 | 書き込み権限なし拒否 (update のみ) | SelfUpdater, FileSystem.canWrite | `verifyWritable()` |
+| 6.1 | 非対応プラットフォーム拒否 | SelfUpdater | `ensureLinuxX64()` |
+| 6.2 | platform 判定が最初、 update では layout より前 | SelfUpdater | gating order |
+| 7.1 | network/metadata 失敗の識別 | SelfUpdateError.Network / .Metadata | error envelope |
+| 7.2 | asset 失敗の識別 | SelfUpdateError.Asset | error envelope |
+| 7.3 | extract 失敗の識別 | SelfUpdateError.Extract | error envelope (symlink 不変) |
+| 7.4 | 全失敗経路で人間可読メッセージ | SelfCommands | exit error formatter |
+
+## Components and Interfaces
+
+| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies | Contracts |
+|-----------|--------------|--------|--------------|------------------|-----------|
+| `SelfCommands` | cli | parse + dispatch + 出力整形 | 1.1–1.5, 2.3, 2.4, 2.6, 3.3, 3.4, 7.4 | SelfUpdater (P0) | Service |
+| `SelfUpdater` | selfupdate | check / update orchestration + gate 順序 + staging | 2.*, 3.*, 4.5, 5.*, 6.* | GithubReleasesClient (P0), infra primitives (P0) | Service |
+| `GithubReleasesClient` | selfupdate | API GET + JSON decode + asset URL 解決 | 2.1, 4.1, 4.4, 7.1 | Downloader (P0), kotlinx.serialization (P0) | API |
+| `SelfUpdateError` | selfupdate | 粗粒度 sealed ADT | 4.3, 4.4, 5.2, 5.3, 6.1, 7.* | — | State |
+| `Symlink.replaceSymlinkAtomically` | infra | symlink 原子置換 | 3.6 | platform.posix.symlink/rename (P0) | Service |
+| `FileSystem.canWrite` | infra | 書き込み権限プローブ | 5.3 | platform.posix.access (P0) | Service |
+
+### selfupdate
+
+#### SelfUpdater
+
+| Field | Detail |
+|-------|--------|
+| Intent | check / update のオーケストレーション。 gate 順序・staging lifecycle を内包 |
+| Requirements | 2.*, 3.*, 4.5, 5.*, 6.* |
+
+**Responsibilities & Constraints**
+- `update()` は `ensureLinuxX64()` → `detectLayout()` → `verifyWritable()` の順に gate。 `check()` は `ensureLinuxX64()` のみで `detectLayout()` / `verifyWritable()` を省略 (書き込みゼロ + layout 非依存; Requirement 2.5 / 5.1 は update 限定)。
+- 進捗 5 ステージ (Requirement 3.4) は `out` lambda 経由で直接 println。
+- staging (`~/.local/share/kolt/.staging-<pid>/`) は `runStaged()` 内で 自 pid dir を `deleteRecursively` → `mkdir` → download → verify → extract → `rename` 確定。 専用クラス・lock なし。 起動時に死んだ pid の `.staging-*` を `kill(pid, 0)` で best-effort 掃除 (生存 pid のものには触れない)。
+- `detectLayout()` / `ensureLinuxX64()` は副作用なしの `internal` 関数として export し、 unit test から直接叩く。
+
+**Contracts**: Service [x]
+
+##### Service Interface
+```kotlin
+class SelfUpdater(
+    private val releases: GithubReleasesClient,
+    private val home: String,
+    private val currentVersion: String = KOLT_VERSION,
+    private val readSelfExe: () -> Result<String, SelfExeError> = ::readSelfExe,
+    private val canWrite: (String) -> Boolean = FileSystem::canWrite,
+    private val replaceSymlink: (String, String) -> Result<Unit, SymlinkError> =
+        ::replaceSymlinkAtomically,
+    private val out: (String) -> Unit = ::println,
+) {
+    fun check(): Result<CheckOutcome, SelfUpdateError>
+    fun update(): Result<UpdateOutcome, SelfUpdateError>
+
+    internal fun ensureLinuxX64(): Result<Unit, SelfUpdateError>
+    internal fun detectLayout(): Result<Layout, SelfUpdateError>
+    internal fun verifyWritable(layout: Layout): Result<Unit, SelfUpdateError>
+
+    data class Layout(
+        val binSymlink: String,        // ~/.local/bin/kolt
+        val currentInstallDir: String, // ~/.local/share/kolt/<ver>/
+        val shareRoot: String,         // ~/.local/share/kolt/
+    )
+}
+
+sealed interface CheckOutcome {
+    val current: String
+    data class UpdateAvailable(override val current: String, val latest: String) : CheckOutcome
+    data class AlreadyLatest(override val current: String) : CheckOutcome
+}
+
+sealed interface UpdateOutcome {
+    data class Switched(val from: String, val to: String) : UpdateOutcome
+    data class NoOp(val current: String) : UpdateOutcome
+}
+```
+
+**Implementation Notes**
+- Integration: `home` / `currentVersion` / `out` / 各 syscall 系を DI して unit test で観測可能化。
+- Validation: gate 順序は hard-code。 `detectLayout()` は `lstat` → `readlink` → target が `<shareRoot><X.Y.Z>/bin/kolt` の文字列 prefix にマッチ、 の単一判定 (Requirement 5.1)。 非一致はすべて `SelfUpdateError.Layout` 1 種に丸め、 メッセージに実体パスと「install.sh で入れ直してください」を載せる (Requirement 5.2)。
+- Risks: progress 5 行は test でスナップショット assert する。
+
+#### GithubReleasesClient
+
+| Field | Detail |
+|-------|--------|
+| Intent | `releases/latest` GET + JSON decode + asset/sha256 URL 抽出 + tag 検証 |
+| Requirements | 2.1, 4.1, 4.4, 7.1 |
+
+**Responsibilities & Constraints**
+- `User-Agent: kolt/<currentVersion>` を `Downloader.headers` で必ず送出。
+- `downloadFile` を kolt の既存 temp ディレクトリ規約に従った一時パス (例 `~/.local/share/kolt/.staging-<pid>/releases.json`、 staging dir を流用すれば `/tmp` 非依存) に呼び、 `readFileAsString` → `Json.decodeFromString<LatestRelease>`。 `--check` は staging を作らないので、 その場合のみ `homeDirectory()` 配下の一時パスを使う。
+- `validateTag(tag)`: `^v(\d+)\.(\d+)\.(\d+)$` にマッチしなければ `SelfUpdateError.Metadata`。 マッチ時は先頭 `v` を除いた `X.Y.Z` を返す。
+- アセット名で `kolt-<ver>-linux-x64.tar.gz` と `.sha256` を look up、 欠落は `SelfUpdateError.Asset` (名前付き)。
+- 通信失敗 (timeout / connect / 5xx) は `SelfUpdateError.Network`、 4xx/decode 失敗は `SelfUpdateError.Metadata`。
+
+**Contracts**: API [x]
+
+##### Service Interface
+```kotlin
+class GithubReleasesClient(
+    private val downloader: Downloader,
+    private val userAgent: String,
+    private val tempPathFactory: () -> String,
+) {
+    fun fetchLatest(): Result<LatestRelease, SelfUpdateError>
+    fun validateTag(tagName: String): Result<String, SelfUpdateError>
+}
+
+@Serializable
+data class LatestRelease(
+    @SerialName("tag_name") val tagName: String,
+    val assets: List<ReleaseAsset>,
+) {
+    fun assetByName(name: String): ReleaseAsset? = assets.firstOrNull { it.name == name }
+}
+
+@Serializable
+data class ReleaseAsset(
+    val name: String,
+    @SerialName("browser_download_url") val browserDownloadUrl: String,
+)
+```
+
+##### API Contract
+| Method | Endpoint | Request | Response | Errors |
+|--------|----------|---------|----------|--------|
+| GET | `https://api.github.com/repos/snicmakino/kolt/releases/latest` | `User-Agent: kolt/<ver>` | `200 LatestRelease` | 403 (UA欠落), 404 (release不在), 5xx, timeout |
+
+**Implementation Notes**
+- Integration: `tempPathFactory` DI でテスト予測可能化。
+- Validation: `Json { ignoreUnknownKeys = true }`。 `tag_name` 不在の decode 例外は `SelfUpdateError.Metadata` に変換。
+- Risks: 非認証レート制限 (60/hr/IP) は MVP では untouched。 CI で `--check` 連打する運用は呼び出し側で間引く。
+
+### infra
+
+#### Symlink.replaceSymlinkAtomically
+
+##### Service Interface
+```kotlin
+fun replaceSymlinkAtomically(
+    linkPath: String,
+    newTarget: String,
+): Result<Unit, SymlinkError>
+
+sealed interface SymlinkError {
+    data class CreateFailed(val tmp: String, val errno: Int) : SymlinkError
+    data class RenameFailed(val link: String, val errno: Int) : SymlinkError
+}
+```
+**Implementation Notes**
+- (a) `tmp = "${linkPath}.tmp.<pid>"`、 (b) `symlink(newTarget, tmp)`、 (c) `rename(tmp, link)`。 (c) 失敗時は (a) を `unlink` してから error。
+- `rename(2)` は newpath が既存 symlink でも atomic 置換 (Linux man-page)。 ext4 / 9p (WSL2) の挙動差は実装時に 1 度実機確認。
+
+#### FileSystem.canWrite
+
+##### Service Interface
+```kotlin
+fun canWrite(path: String): Boolean = access(path, W_OK) == 0
+```
+- 既存 `fileExists` の隣、 `@OptIn(ExperimentalForeignApi::class)`。 TOCTOU は許容 (rename 時の EACCES と二重 gate)。
+
+### cli
+
+#### SelfCommands
+
+| Field | Detail |
+|-------|--------|
+| Intent | `kolt self ...` の引数 parse + SelfUpdater 呼び出し + 出力フォーマット + exit code |
+| Requirements | 1.1–1.5, 2.3, 2.4, 2.6, 3.3, 3.4, 7.4 |
+
+##### Service Interface
+```kotlin
+fun doSelf(args: List<String>): ExitCode
+
+sealed interface SelfInvocation {
+    data object EmptyHelp : SelfInvocation       // `kolt self` 引数なし → usage, exit 0
+    data object Help : SelfInvocation            // --help → usage, exit 0
+    data class Update(val checkOnly: Boolean) : SelfInvocation
+    data class UnknownFlag(val flag: String) : SelfInvocation
+    data class UnknownSubcommand(val sub: String) : SelfInvocation
+}
+```
+**Implementation Notes**
+- `Main.kt` の `when` から `"self" -> doSelf(args.drop(1))`。
+- `args.isEmpty()` → `EmptyHelp` (exit 0)。 `args[0] != "update"` → `UnknownSubcommand` (非ゼロ)。
+- `SelfUpdateError` の各トップ variant を 1 行人間可読メッセージにマップ (Requirement 7.4)。
+
+## Data Models
+
+```mermaid
+classDiagram
+    class LatestRelease {
+        +String tagName
+        +List~ReleaseAsset~ assets
+        +assetByName(String) ReleaseAsset?
+    }
+    class ReleaseAsset {
+        +String name
+        +String browserDownloadUrl
+    }
+    LatestRelease "1" o-- "*" ReleaseAsset
+```
+
+タグ検証は `GithubReleasesClient.validateTag` の regex (`^v(\d+)\.(\d+)\.(\d+)$`) で完結。 `compareVersions` は String を取るため独立した `SemVer` 型は持たない。
+
+**`.sha256` format**: `<64-hex>  <filename>`。 1 行目を whitespace split して先頭採用。
+**GitHub API**: `Json { ignoreUnknownKeys = true }`、 `tag_name` + `assets[].name` + `assets[].browser_download_url` のみ使用。
+
+## Error Handling
+
+```kotlin
+sealed interface SelfUpdateError {
+    data class Network(val url: String, val detail: String) : SelfUpdateError
+    data class Metadata(val detail: String) : SelfUpdateError
+    data class Asset(val name: String, val detail: String) : SelfUpdateError
+    data class Extract(val detail: String) : SelfUpdateError
+    data class Layout(val detectedPath: String, val detail: String) : SelfUpdateError
+    data class Platform(val sysname: String, val machine: String) : SelfUpdateError
+    data class Home(val detail: String) : SelfUpdateError
+}
+```
+
+| ADT | Requirement | User-visible message (例) | Exit |
+|-----|-------------|---------------------------|------|
+| `Network` | 7.1 | `error: failed to reach api.github.com: <detail>` | 非ゼロ |
+| `Metadata` | 7.1 | `error: GitHub releases/latest response was invalid: <detail>` | 非ゼロ |
+| `Asset` | 4.3, 4.4, 7.2 | `error: release asset '<name>': <detail>` | 非ゼロ |
+| `Extract` | 7.3 | `error: failed to extract update package: <detail>` (symlink 未変更) | 非ゼロ |
+| `Layout` | 5.2 | `error: kolt at <detectedPath> is not an installer-managed symlink; reinstall with install.sh` | 非ゼロ |
+| `Layout` (writable) | 5.3 | `error: missing write permission on <path>` | 非ゼロ |
+| `Platform` | 6.1 | `error: kolt self update supports linuxX64 only (detected <sysname>/<machine>)` | 非ゼロ |
+| `Home` | 7.4 | `error: $HOME is not set` | 非ゼロ |
+
+`SelfCommands` がすべての variant を空でない人間可読文字列にマップする (Requirement 7.4)。 書き込み権限不足は `Layout` に `detail` で畳む (粗粒度方針)。
+
+### Monitoring
+CLI 単発実行のため runtime monitoring 対象外。 失敗時 stderr メッセージ + 進捗ステージの last-printed line が唯一の観測経路。
+
+## Testing Strategy
+
+steering tech.md の慣行 (`nativeTest/kotlin/`、 `*Test.kt`)。 subprocess CLI test の前例がないため導入しない (`doSelf` を直接呼ぶ unit test で覆う)。
+
+### Unit Tests
+- `SelfUpdaterCheckTest`: GithubReleasesClient を mock し `check()` の (a) update available、 (b) already latest (equal)、 (c) already latest (current > latest)、 (d) Platform 不一致を最初に返し fetch しない、 (e) layout 不一致でも check は version を返す (layout gate なし; Requirement 5.1 は update 限定)、 (f) 進捗・書き込み 0 (Requirement 2.5) を assert。
+- `GithubReleasesClientTest`: LoopbackHttpServer で (a) 正常 decode、 (b) `tag_name` 不在 → Metadata、 (c) tag が `vX.Y.Z` 違反 → Metadata、 (d) UA が `kolt/<ver>` で送出 (`awaitAccessLog`)、 (e) アセット欠落 → Asset(name)。
+- `SymlinkTest`: tmp dir で (a) linkPath 不在 → 新規、 (b) 既存 symlink → atomic 置換 (前後を `lstat`+`readlink` 観測)、 (c) newTarget 不在でも `symlink(2)` 成功、 (d) linkPath が regular file → `rename(2)` 上書き挙動を pin。
+- `SelfCommandsTest`: `doSelf` の `["update"]` / `["update","--check"]` / `[]` / `["--help"]` / `["update","--x"]` / `["foo"]` を ExitCode + 出力で観測 (Requirement 1.*)。
+- `SelfUpdaterLayoutTest`: tmp HOME で `update()` 経由の layout gate を検証。 (a) installer 通り → 通過、 (b) regular file / (c) dangling / (d) 外部 target は単一 `Layout`、 (e) `~/.local/share/kolt/` が `canWrite=false` は writable 系 `Layout` に落ちる (Requirement 5.1–5.3)。
+
+### Integration Tests
+- `SelfUpdaterUpdateTest`: tmp HOME + LoopbackHttpServer で end-to-end。 既存 `~/.local/share/kolt/0.20.0/bin/kolt` を fake バイナリ、 `~/.local/bin/kolt` を symlink で揃え、 `update()` 実行。 (a) 5 ステージ進捗行が順に出る、 (b) `0.21.0/bin/kolt` 作成、 (c) symlink 新 target、 (d) `0.20.0/` 残存、 (e) 自 pid `.staging-<pid>/` が成功後に削除 (Requirement 3.*, 4.*, 5.*)。
+- `SelfUpdaterUpdateChecksumMismatchTest`: `.sha256` を不正値に。 `Asset` で `0.21.0/` 未作成 + symlink 未変更 (Requirement 4.3, 7.3)。
+- `SelfUpdaterStagingIsolationTest`: 事前に他 pid を模した `~/.local/share/kolt/.staging-99999/` (生存しない pid) と、 別途生存 pid を模した dir を置く。 `update()` 後、 死んだ pid 分は best-effort 掃除で消え、 生存 pid 分は残存、 自 pid dir は新規作成→成功後に削除 (Requirement 4.5、 並行隔離 + 残骸非累積)。
+
+### Performance / Load
+単発 CLI 実行のため scaling 制約なし。
+
+## Optional Sections
+
+### Security Considerations
+- SHA-256 で tarball 完全性を検証。 `.sha256` 自体の改竄 (同一 HTTPS 経路) は検出不能 — 署名検証 (TUF / Sigstore) は scope 外、 follow-up issue 候補。
+- TLS は既存 `Downloader` (libcurl + openssl) に依存。
+- `sudo` 自動昇格は scope 外 (Requirement 5.3 で不足を通知のみ)。
+- tarball 内 `..` / absolute path は libarchive SECURE フラグが reject (memory `reference_libarchive_cinterop`)。
+- 並行排他なし: 並行 `kolt self update` は install.sh を 2 つ手動実行したのと同等のベストエフォート (Out of Boundary に明記)。
+
+### Migration Strategy
+不要 (新規追加、 初回 `kolt self update` 実行時から有効)。
+
+## Supporting References
+詳細な調査経緯 (代替案、 effort 試算、 圧縮判断の rationale) は `research.md` を参照。

--- a/.kiro/specs/27-self-update/requirements.md
+++ b/.kiro/specs/27-self-update/requirements.md
@@ -1,0 +1,118 @@
+# Requirements Document
+
+## Project Description (Input)
+`kolt self update` (および `kolt self update --check`) を追加し、 kolt の単一バイナリが GitHub Releases から自分自身を最新版に置き換えられるようにする。 ユーザーがインストーラを再実行したりリリース成果物を手動で取得することなく、 新リリースに追従できる体験を提供する。
+
+Source issue: [snicmakino/kolt#27](https://github.com/snicmakino/kolt/issues/27) (milestone v0.21.0, size: M, priority: nice)
+
+### スコープの方針 (圧縮版)
+本 spec は **install.sh が POSIX sh で持つのと同等のスコープ** を Kotlin/Native 側に実装するものとする。 install.sh wrapper にしないのは、 macOS / linuxArm64 対応時に platform 分岐をネイティブ側で一元管理するため (memory `project_macos_selfhost_v1`)。 install.sh が持たない防衛機構 (並行排他 advisory lock、 SIGINT 中断回復、 installer layout の網羅的分類) は priority: nice の本機能には過剰であり、 意図的に scope 外とする。
+
+### Who has the problem
+- 既存 kolt ユーザーで、 インストーラ経由で `~/.local/bin/kolt` (installer spec のレイアウト) に kolt を入れている人。
+- 新リリースに追従する手段が今は「インストーラを再実行する」または「リリースページから tarball を手動で取得する」しかない。
+
+### Current situation
+- kolt は Kotlin/Native の単一バイナリ (linuxX64) として配布される。
+- installer spec (`.kiro/specs/installer/`) が `~/.local/share/kolt/<version>/bin/kolt` 実体と `~/.local/bin/kolt` → 実体への symlink という配置を所有している。 release tarball は `bin/` + `libexec/` 構造で daemon thin jar を同梱するため、 バイナリ更新と daemon 更新は tarball 取り直しで同期する。
+- リリース成果物の命名規則は `kolt-<version>-linux-x64.tar.gz` と隣接する `kolt-<version>-linux-x64.tar.gz.sha256` で、 後者は標準 `sha256sum` フォーマット。
+- `kolt --version` は `kolt <semver>` を出力する (例: `kolt 0.20.0`)。
+- kolt は HTTPS ダウンロードを既に実装済み (内部の HTTPS GET 基盤を再利用する)。
+- v1 まで backward compatibility は持たない方針 (memory `feedback_no_backcompat_pre_v1`)。
+
+### What should change
+- 新しい CLI subcommand 群 `kolt self` を導入し、 その下に `update` (および `--check`) を実装する。
+- `--check` は API 参照のみで書き込み副作用ゼロ、 `update` は最新版へ置換する。
+- linuxX64 以外と installer layout 非一致のケースは明示的にエラーで拒否する。
+- ネットワーク・チェックサム・展開のエラーは識別可能なカテゴリで報告される。
+
+## Boundary Context
+
+- **In scope**:
+  - `kolt self update` および `kolt self update --check` の追加。
+  - linuxX64 ターゲットの kolt が installer spec のレイアウトでインストールされているケース。
+  - 比較対象は GitHub Releases の `releases/latest` (安定版のみ、 prerelease は release workflow が除外)。
+  - SHA256 による完全性検証と、 symlink を `rename(2)` で切り替えることによる「途中状態を観測させない」最小限の atomic 性。
+  - Network / metadata / asset / extract / layout / platform のエラーをカテゴリ単位で報告。
+- **Out of scope**:
+  - macOS / linuxArm64 ターゲット (memory `project_macos_selfhost_v1` でロードマップ管理)。
+  - `kolt self update --version <ver>` のような任意バージョン指定、 ダウングレード、 プレリリース追従。
+  - `~/.local/share/kolt/<old>/` の自動削除や rollback コマンド。
+  - `/usr/local/bin/kolt` など installer layout 外への上書き、 root 権限昇格、 `sudo` 自動実行。
+  - `kolt self uninstall` などその他 `self` サブコマンド。
+  - **並行 `kolt self update` 実行の排他**: advisory lock は持たない。 staging は pid 別ディレクトリ (`.staging-<pid>/`) で隔離されるため並行プロセスが互いの展開作業を破壊することはないが、 最終的な symlink 切替は last writer wins。 通常ユーザーは並行実行しない前提。
+  - **SIGINT / kill 中断からの専用回復ロジック**: 中断時は一時展開ディレクトリが残るが、 次回 `kolt self update` 実行時に無条件で作り直されるため実害はない。 中断検出や復旧の専用機構は持たない。
+  - **installer layout 非一致の網羅的分類**: 「installer 配置の symlink か否か」 の単一判定に留め、 dangling / 外部 target / regular file 等の細分類はしない (どのケースも「install.sh で入れ直してください」 で十分)。
+- **Adjacent expectations**:
+  - **installer spec が所有するもの**: 配布 tarball の構造、 `~/.local/share/kolt/<ver>/bin/kolt` 配置、 `~/.local/bin/kolt` symlink の初期作成。 `kolt self update` はこのレイアウトを前提に動作するが、 レイアウトそのものを再定義しない。
+  - **release workflow が所有するもの**: GitHub Releases に `kolt-<ver>-linux-x64.tar.gz` と `.sha256` を同時公開し、 安定版以外を draft / prerelease として印付けることで `releases/latest` が安定版のみを返すこと。
+  - **既存の HTTPS ダウンロード機構が提供するもの**: HTTPS GET と一時ファイルへのストリーミング書き込みは kolt 内に既にある (再実装しない前提)。
+  - **既存 daemon の version 隔離**: daemon ↔ binary の版整合性は既存の socket fingerprint 機構が自動的に隔離する。 `kolt self update` は daemon を意識しない。
+
+## Requirements
+
+### Requirement 1: `kolt self update` サブコマンドの提供
+**Objective:** As a kolt ユーザー, I want `kolt self update` および `kolt self update --check` を直接呼び出せる, so that 別ツールやインストーラ再実行なしに kolt の自己更新を起動できる.
+
+#### Acceptance Criteria
+1. When ユーザーが `kolt self update` を引数なしで実行した場合, the kolt CLI shall 「最新版の取得 → 検証 → 置換」を一連の処理として開始する.
+2. When ユーザーが `kolt self update --check` を実行した場合, the kolt CLI shall 最新版の確認のみを行い、 ファイルシステムに書き込みを残さない.
+3. When ユーザーが `kolt self` を引数なしで実行した場合, the kolt CLI shall `update` を含む利用可能なサブコマンド一覧を usage 文として表示し、 exit code 0 で終了する.
+4. When ユーザーが `kolt self update --help` または `kolt self --help` を実行した場合, the kolt CLI shall `update` と `--check` の使い方を含む usage 文字列を表示し、 exit code 0 で終了する.
+5. If ユーザーが `kolt self update` に未知のフラグまたは引数を渡した場合, then the kolt CLI shall 未知のフラグ名を含むエラーメッセージを表示し、 exit code を 0 以外で終了する.
+
+### Requirement 2: 最新バージョンの取得と比較 (`--check`)
+**Objective:** As a kolt ユーザー, I want 自分の kolt が最新かどうかをファイルを書き換えずに確認したい, so that 任意のタイミングで「アップデート可能か」を安全に問い合わせできる.
+
+#### Acceptance Criteria
+1. When `kolt self update --check` が呼ばれた場合, the kolt CLI shall GitHub Releases の `releases/latest` のタグ名を取得し、 タグ名が `vX.Y.Z` 形式 (X, Y, Z は非負整数、 プレリリース修飾子なし) であることを確認する.
+2. When タグ名の取得・パースに成功した場合, the kolt CLI shall 現在実行中の kolt のセマンティックバージョン (`kolt --version` の出力から `kolt ` を除いた部分) と取得したバージョンを semver 順序で比較する.
+3. When 取得した最新バージョンが現在バージョンより新しい場合, the kolt CLI shall 「Update available: `<current>` → `<latest>`」を含むメッセージを標準出力に表示し、 exit code 0 で終了する.
+4. When 取得した最新バージョンが現在バージョン以下 (等しいか古い) の場合, the kolt CLI shall 「Already at latest version (`<current>`)」を含むメッセージを標準出力に表示し、 exit code 0 で終了する.
+5. While `--check` が動作している間, the kolt CLI shall インストールディレクトリ・symlink・実行バイナリのいずれにも書き込みを行わない.
+6. The kolt CLI shall `--check` の正常完了時、 アップデート可否によらず常に exit code 0 を返す.
+
+### Requirement 3: 最新バージョンへの実行更新 (`update`)
+**Objective:** As a kolt ユーザー, I want `kolt self update` 1 コマンドで kolt 本体を最新の安定リリースに置き換えたい, so that 手動ダウンロードや tar 展開、 symlink 操作を回避できる.
+
+#### Acceptance Criteria
+1. When `kolt self update` が呼ばれ、 最新バージョンが現在バージョンより新しい場合, the kolt CLI shall 取得 → 検証 → 展開 → 切替 → 完了表示の順に処理を進める.
+2. When `kolt self update` が呼ばれ、 最新バージョンが現在バージョン以下である場合, the kolt CLI shall ファイルシステムに変更を加えず、 「Already at latest version (`<current>`)」を表示し、 exit code 0 で終了する.
+3. When 更新が成功した場合, the kolt CLI shall `<old-version> → <new-version>` 形式で更新前後のバージョン文字列を最終行に表示し、 exit code 0 で終了する.
+4. While 更新処理が進行中である間, the kolt CLI shall 以下の進行ステージそれぞれの開始時に、 一行ずつ識別可能な進捗行を標準出力に表示する: `fetching release metadata`, `downloading tarball`, `verifying checksum`, `extracting`, `switching to new version`.
+5. The kolt CLI shall 既存の `~/.local/share/kolt/<old-version>/` および他の既存バージョンディレクトリを `kolt self update` の処理中に削除しない.
+6. When symlink の切替を行う場合, the kolt CLI shall `~/.local/bin/kolt` を `rename(2)` 1 回で差し替え、 並行または後続の `kolt` 呼び出しが更新前か更新後のいずれかを完全に観測する (途中状態を観測しない) ようにする.
+
+### Requirement 4: ダウンロードとチェックサム検証
+**Objective:** As a kolt ユーザー, I want 自己更新で取得されるバイナリの完全性が保証されたい, so that ネットワーク経路の改竄や破損したダウンロードによって壊れた kolt を握らされない.
+
+#### Acceptance Criteria
+1. When `kolt self update` が新バージョンの取得を開始した場合, the kolt CLI shall リリース成果物 `kolt-<new-version>-linux-x64.tar.gz` と隣接する `.sha256` ファイルの両方を取得する.
+2. When 両ファイルの取得に成功した場合, the kolt CLI shall ダウンロードした tarball の SHA-256 を計算し、 `.sha256` ファイル内のハッシュと一致するかを比較する.
+3. If 取得した SHA-256 値とダウンロード成果物のハッシュが一致しない場合, then the kolt CLI shall インストールに進まずエラーを報告し、 `~/.local/share/kolt/` 配下に新バージョンディレクトリを作成しないまま exit code を 0 以外で終了する.
+4. If `kolt-<new-version>-linux-x64.tar.gz` または `.sha256` のいずれかが該当リリースに公開されていない場合, then the kolt CLI shall どの成果物が欠落しているかを名前付きでエラーに含め、 exit code を 0 以外で終了する.
+5. The kolt CLI shall ダウンロードと展開を自プロセス専用の一時ディレクトリ (`~/.local/share/kolt/.staging-<pid>/`) で行い、 SHA-256 検証と展開が成功した後に初めて `~/.local/share/kolt/<new-version>/` へ配置する. 自 pid のディレクトリは処理開始時に作り直す. 生存しているプロセスの `.staging-*` ディレクトリには触れない (並行実行時の相互破壊を防ぐ) が、 生存していないプロセスが残した `.staging-*` は処理開始時に best-effort で削除してよい (中断残骸の累積防止).
+
+### Requirement 5: installer layout の検出と非対応構成の拒否
+**Objective:** As a kolt の運用者, I want 想定外の場所に置かれた kolt バイナリに対しては自己更新を実行しないでほしい, so that root 所有の `/usr/local/bin/kolt` などを暗黙に書き換えて環境を壊さない.
+
+#### Acceptance Criteria
+1. When `kolt self update` が呼ばれた場合 (書き込みを伴う update 経路のみ; `--check` は対象外), the kolt CLI shall `~/.local/bin/kolt` が `~/.local/share/kolt/<ver>/bin/kolt` 配下を指す symlink であるか (installer spec のレイアウト) を判定する.
+2. If `~/.local/bin/kolt` が installer spec のレイアウトと一致しない場合, then the kolt CLI shall 検出された実体パスと「install.sh で入れ直してください」の案内を含むエラーを表示し、 ネットワークアクセスもファイル書き込みも行わずに exit code を 0 以外で終了する.
+3. If 起動された kolt は installer layout 上に存在するが、 `~/.local/share/kolt/` または `~/.local/bin/kolt` への書き込み権限が現在のユーザーにない場合, then the kolt CLI shall 該当パスを含むエラーを表示し、 ダウンロードや展開を行わずに exit code を 0 以外で終了する.
+
+### Requirement 6: プラットフォーム対応範囲
+**Objective:** As a kolt メンテナ, I want 現状サポートしている linuxX64 以外のプラットフォームでは自己更新を明示拒否したい, so that macOS / linuxArm64 など対応中のターゲットで意図しない動作が起こらない.
+
+#### Acceptance Criteria
+1. When `kolt self update` または `kolt self update --check` が linuxX64 以外のプラットフォームで実行された場合, the kolt CLI shall 「該当プラットフォーム向けバイナリは未対応である」旨を検出されたプラットフォーム名と共に表示し、 exit code を 0 以外で終了する.
+2. The kolt CLI shall `--check` / `update` いずれの経路でもプラットフォーム判定を最初に実行する. update 経路では installer layout 判定 (Requirement 5) よりも前にプラットフォーム判定を行い、 非対応プラットフォーム上では GitHub Releases API への問い合わせも layout 検査も行わない.
+
+### Requirement 7: エラー報告の識別性
+**Objective:** As a kolt ユーザー, I want 自己更新が失敗した場面を「何で失敗したか」が一目で分かる形でメッセージを受け取りたい, so that ネットワーク・整合性・権限・サポート範囲のどの問題かを即座に切り分けられる.
+
+#### Acceptance Criteria
+1. If GitHub Releases API への通信が失敗した (タイムアウト・接続エラー・5xx) または応答したタグ情報が `vX.Y.Z` 形式に一致しない場合, then the kolt CLI shall ネットワーク由来かメタデータ由来かを区別したメッセージを表示し、 exit code を 0 以外で終了する.
+2. If リリースアセット (`kolt-<new-version>-linux-x64.tar.gz` または `.sha256`) のダウンロードまたは SHA-256 検証に失敗した場合, then the kolt CLI shall アセット由来の失敗である旨と対象アセット名を表示し、 exit code を 0 以外で終了する.
+3. If tarball の展開や中身の検証に失敗した場合, then the kolt CLI shall 展開フェーズでの失敗である旨を表示し、 `~/.local/bin/kolt` の symlink を変更しないまま exit code を 0 以外で終了する.
+4. The kolt CLI shall 自己更新が失敗するすべての終了経路で、 人間可読な空でないエラーメッセージを表示し、 メッセージなしで非ゼロ終了しない.

--- a/.kiro/specs/27-self-update/research.md
+++ b/.kiro/specs/27-self-update/research.md
@@ -1,0 +1,181 @@
+# Gap Analysis — 27-self-update
+
+`kolt self update` 実装に向けて既存コードベースと requirements のギャップを整理する。design 着手前の事実集約。
+
+## 1. 現状調査
+
+### 1.1 アーキテクチャの該当領域
+
+- **CLI dispatch**: `src/nativeMain/kotlin/kolt/cli/Main.kt:39–148`
+  - `when (filteredArgs[0])` による 1 階層の dispatch + `KNOWN_SUBCOMMANDS_SORTED` (lines 126–148) の二重管理。
+  - 2 階層のネスト例: `doTool` (`ToolCommands.kt:35–104`) / `doToolchain` (`ToolchainCommands.kt:16–29`)。どちらも `args.drop(1)` してから `args[0]` で再 dispatch。
+  - `self` namespace は **未存在**。
+  - usage 表示は `usageLines()` + `printUsage()` (`Main.kt:234–271`)。`--help` の routing は明示的にはない。
+- **HTTPS ダウンロード**: `src/nativeMain/kotlin/kolt/infra/Downloader.kt:41–164`
+  - `fun downloadFile(url, destPath, headers): Result<Unit, DownloadError>` がファイル書き込み専用。Followlocation / 30s connect / 300s total / cross-origin Authorization strip 済み。
+  - **`User-Agent` ヘッダは付かない** (Downloader 内では未送出)。GitHub API は UA 必須。
+  - **GET-to-memory 関数は存在しない**。JSON を取得するにはテンポラリファイルを書いて読み直すか、新規に in-memory 取得を実装する必要あり。
+- **SHA-256**: `src/nativeMain/kotlin/kolt/infra/Sha256.kt:19–36`
+  - `fun computeSha256(filePath): Result<String, Sha256Error>` 既存。
+  - `.sha256` ファイルの比較ロジックは `ToolchainManager.kt` に類似の前例あり (tarball + 隣接 `.sha256` を取得し parse して比較)。
+- **アーカイブ展開**: `src/nativeMain/kotlin/kolt/infra/ArchiveExtraction.kt:75–133`
+  - `internal fun extractArchive(archivePath, destDir): Result<Unit, ExtractError>` 既存。
+  - `ARCHIVE_EXTRACT_PERM` フラグで実行ビット保持。symlink escape 検査済み (`ArchiveExtraction.kt:161–169`、 memory `reference_libarchive_cinterop` 参照)。
+- **Version / SemVer**:
+  - `src/nativeMain/kotlin/kolt/config/Version.kt`: `KOLT_VERSION = "0.20.0"` / `versionString()`。
+  - `src/nativeMain/kotlin/kolt/resolve/VersionCompare.kt:27–39`: `compareVersions(a, b): Int` / `isStableVersion(version): Boolean` 既存。
+- **自己バイナリパス**: `src/nativeMain/kotlin/kolt/infra/SelfExe.kt:25–39`
+  - `fun readSelfExe(): Result<String, SelfExeError>`、`/proc/self/exe` 経由。Linux 専用。
+- **JSON シリアライズ**: `kotlinx-serialization-json 1.7.3` (`kolt.toml:17`)。 nativeMain 内には `Json.decodeFromString` の load-bearing な前例が複数存在: `kolt.resolve.GradleMetadata` (Maven 取得 JSON のデコード)、 `kolt.resolve.Lockfile` (lockfile デコード)、 `kolt.build.BuildCache` / `kolt.cli.OutdatedFormatter` / `kolt.cli.InfoCommand` 等。 GitHub Releases JSON モデルも同じパターンを踏襲できる。
+
+### 1.2 既存パターン
+
+- **Result chain**: `kotlin-result` 2.x value class、 `is Ok / is Err` 禁止 (memory `feedback_kotlin_result_value_class`)。
+- **sealed error ADT**: `DownloadError`、 `Sha256Error`、 `ExtractError` などのパターンを踏襲。
+- **テスト**: `nativeTest/kotlin/` 配下、 mirror 構造。 ネットワーク stub は `testfixture/LoopbackHttpServer.kt`、 単一回応答のループバック HTTP/1.1。`DownloaderAuthHeaderTest.kt` がレファレンス。
+- **subprocess CLI テスト**: `.kexe` を直接呼ぶ integration test は未確認。 内部 API を直接叩く unit test が中心。
+
+### 1.3 統合ポイント
+
+- 既存 release 成果物の命名: `kolt-<ver>-linux-x64.tar.gz` + `kolt-<ver>-linux-x64.tar.gz.sha256` (installer spec で確定)。
+- インストール先: `~/.local/share/kolt/<ver>/bin/kolt` + `~/.local/bin/kolt` symlink (installer spec 所有)。
+- 既存 `kolt update` (依存解決の lockfile 更新) と命令名空間は衝突しない (こちらは top-level、 `kolt self update` は nested)。
+
+## 2. Requirement → Asset Map
+
+| Req | 必要な能力 | 既存資産 | ギャップ |
+|---|---|---|---|
+| 1: `self` サブコマンド surface | dispatch / usage / 未知フラグ拒否 | `Main.kt` dispatcher, `doTool`/`doToolchain` ネスト前例 | **Missing**: `self` namespace ハンドラ + usage 文。`KNOWN_SUBCOMMANDS_SORTED` への追加 |
+| 2: `--check` 動作 | GitHub Releases API GET + semver 比較 + 副作用ゼロ | `compareVersions` / `isStableVersion` / `KOLT_VERSION` / `Downloader.headers` param 経由でのカスタムヘッダ送出 (UA は既存 API で対応可、 `DownloaderAuthHeaderTest` が前例) | **Missing**: GitHub API GET の JSON 取得経路 (Downloader が file-write 専用なので一時ファイル経由 OR in-memory variant 追加)、 `tag_name` の `@Serializable` モデル |
+| 3: `update` 実行 | 取得→検証→展開→symlink 切替→表示 | `downloadFile` / `computeSha256` / `extractArchive` | **Missing**: オーケストレーション ("SelfUpdater" 相当)。 atomic symlink 切替 |
+| 4: ダウンロード + checksum | tarball + `.sha256` 同時取得、 一時パス、 ハッシュ比較 | `Downloader`、 `ToolchainManager` の前例パターン | **Constraint**: `.sha256` パースは ad-hoc (共通ヘルパなし)。 流用可だが小さな抽出が必要かは判断 |
+| 5: Atomic symlink 切替 | tmp symlink 生成 → `rename(2)` で原子置換 | なし — `FileSystem.kt` に `symlinkat`/`readlink`/`renameat` のラッパーなし | **Missing**: `kolt.infra` に新規プリミティブ |
+| 6: installer layout 検出 | `readSelfExe()` の解決結果が `~/.local/share/kolt/<ver>/bin/kolt` 形か判定 + `~/.local/bin/kolt` が一致 symlink か照合 | `SelfExe.readSelfExe`、 `FileSystem.lstat` | **Missing**: layout マッチャ。 書き込み権限プローブ (`access(W_OK)`) も未存在 |
+| 7: Platform support | linuxX64 限定で API 接触前に早期 abort | Kotlin/Native の compile-time target 判定 (`Platform.osFamily` / `expect-actual`)、ただし root プロジェクトは nativeMain 単独で `linuxX64` 固定。 macOS 部分 (memory `project_macos_selfhost_v1`) は未着 | **Constraint**: 現状 linuxX64 ビルドのみ。 ランタイム platform 判定の仕組みを設けるかは要検討 (compile-time でも要件は満たせる) |
+| 8: エラー識別性 | 5 経路 (network / metadata / asset 不在 / 展開 / その他) 別の sealed ADT | `DownloadError`、 `Sha256Error`、 `ExtractError` を再利用しつつ self-update 専用 envelope ADT が必要 | **Missing**: `SelfUpdateError` 相当の sealed ADT と CLI 側のメッセージマッピング |
+
+## 3. 実装アプローチ案
+
+### Option A: 既存ファイルに直接追加 (MVP minimum)
+
+`Main.kt` に `"self" -> doSelf(...)` を追加、 `kolt.cli` に `SelfCommands.kt` を 1 ファイル増やしてその中に取得・検証・展開・切替まで詰める、 必要な infra ヘルパ (symlink 置換 / write probe) だけ `kolt.infra` に最小追加、 という配置。
+
+- ✅ 新規ファイル最小 (`SelfCommands.kt` + infra ヘルパ 1〜2 個)、 ローカルなパターン継承
+- ✅ v0.21.0 MVP の scope に対しては domain pollution が小さい (新規実装の中身はそもそもオーケストレーション 1 本)
+- ❌ `kolt self uninstall` 等の将来追加が来た時点で 1 ファイルが膨らみ、 後追いで Option C に refactor する負債になる
+- ❌ `SelfUpdateError` の sealed ADT を `kolt.cli` 配下に置くと package 構造の方向 (cli → build → resolve) と整合しない
+
+### Option B: 新規 package を切る (推奨ベース)
+
+`kolt.cli.self` (CLI ハンドラ) と `kolt.selfupdate` (オーケストレーション + `SelfUpdater` + `SelfUpdateError` + `GithubReleasesClient` + `InstallerLayout`) を新設。 infra 側には**最小限の汎用プリミティブ**だけ追加 (`Downloader` への User-Agent 受け渡しは既存 `headers` param で対応可能、 symlink swap と write probe は `kolt.infra.FileSystem` か新規 `kolt.infra.Symlink` に小ヘルパを増やす)。
+
+- ✅ self-update のドメインが 1 package で読める
+- ✅ `installerLayout` / `selfUpdater` などの将来サブコマンド (`kolt self uninstall` 等) を同 package で受けられる
+- ✅ infra 追加分は他コマンドからも再利用可能 (libarchive / Downloader が辿った経路と同じ)
+- ❌ 新規ファイルがそれなりに増える (~6 ファイル想定)
+
+### Option C: Hybrid (推奨)
+
+Option B を基本としつつ、以下は明示的に **既存パターン継承**:
+
+- HTTPS GET は `Downloader.downloadFile` をテンポラリパスに対して呼び、 `readFileAsString` で取り直す (JSON は小さい)。 新規 GET-to-memory API を作らない。
+- `.sha256` 解析は `ToolchainManager` のパターンを `SelfUpdater` 内で踏襲し、 共通ヘルパには切り出さない (load-bearing でない抽象は作らない、 memory `feedback_sdd_test_inflation` 参照)。
+- symlink swap は `kolt.infra` に薄いラッパ (`replaceSymlinkAtomically(linkPath, newTarget)`) を追加し、 内部で `symlink(2)` で一時 symlink を作って `rename(2)` で linkPath を上書きする (Linux man-page 上 `rename(2)` は newpath が既存 symlink でも atomic に置換、 `renameat2` や `*at` 系は不要)。
+- 書き込みプローブは `kolt.infra.FileSystem` に 1 関数だけ追加 (`canWrite(path): Boolean`)。
+- installer layout 検出は `kolt.selfupdate.InstallerLayout` (data class + companion validator)。
+
+Option C は Option B からファイル数を最小化しつつ、 ドメイン境界を 1 package に閉じる。
+
+| 観点 | A (MVP min) | B | C (推奨) |
+|---|---|---|---|
+| ドメイン凝集 | 低 | 高 | 高 |
+| 新規ファイル | 2–3 | 6+ | 4–5 |
+| 既存テスト前例の再利用 | 高 | 中 | 高 |
+| 将来 `self uninstall` 拡張 | 弱 | 強 | 強 |
+| MVP 着地までの距離 | 最短 | 中 | 中 |
+
+Option A も「`self uninstall` がロードマップ入りした時点で Option C へ refactor」 という evolution path として現実的で、 v0.21.0 MVP では legitimate な選択肢。 ただし `SelfUpdateError` 等のドメイン ADT が `kolt.cli` に居座る違和感は残るため、 design 着手時に Option C が最終ターゲットだと共有しておく。
+
+## 4. 複雑度・リスク
+
+- **Effort: S–M (2–4 日 baseline / 3–7 日 並行・中断耐性込み)**
+  - **2–4 日 (S–M 境界)** の根拠: 既存プリミティブ (`Downloader` / `Sha256` / `extractArchive` / `compareVersions` / `readSelfExe`) を再利用でき、 nativeMain での JSON デコード前例も既に複数あるため「ロジック量より配線量が支配的」。 新規記述は (1) GitHub Releases JSON モデル ~30 行、 (2) `SelfUpdater` orchestration ~150 行、 (3) symlink swap ラッパ ~40 行、 (4) layout 検出器 ~80 行、 (5) CLI 配線 + usage ~50 行、 (6) テスト (LoopbackHttpServer + on-disk テスト) ~300 行、 合計 ~700 行。
+  - **3–7 日 (M)** の根拠: Requirement 5 (並行実行 lock + ステージング dir + 中断回復) を真面目に実装すると lock primitive 設計と SIGINT-aware なクリーンアップが追加される。 既存に `flock` ベースの advisory lock 前例があれば短縮可能。
+- **Risk: Medium**
+  - **Medium 要因**: `rename(2)` over 既存 symlink の atomic 置換は Linux man-page で確認済みだが、 ファイルシステム実装 (ext4 / btrfs / 9p WSL) ごとの挙動差は実機で 1 度走らせて確認する価値がある。 9p (WSL2) は memory `feedback_bench_mtime_granularity` / `feedback_mtime_unittest_gotcha` の例があり想定外の挙動を持つことが既知。
+  - **Medium 要因**: GitHub API 非認証レート制限 (60/hr/IP)。 `--check` を CI で繰り返す使い方が出てくると詰まる可能性。
+  - **Medium 要因 (Requirement 5 関連)**: 2 つの `kolt self update` 並行実行で同一ステージング dir を半端に上書きするリスク。 advisory lock (`flock` 等) を `~/.local/share/kolt/.update.lock` 等に取るのが定石だが、 lock の取得経路を design で決める。
+  - **Medium 要因 (Requirement 5 関連)**: 展開・検証中の SIGINT / kill。 `extractArchive` は libarchive 経由で chdir を伴うため (memory `reference_libarchive_cinterop`)、 中断時の savedCwd 復帰が間に合わないと外部から見て kolt の cwd が壊れた状態が観測されうる。 ステージング → atomic rename への切替で殆ど吸収できるが、 abort path で savedCwd を `atexit` 的に restore する仕組みは design で確認。
+  - **Medium 要因**: 切替直前まで生きていた古い `kolt` が daemon JVM を spawn 中に symlink が差し替わると、 「親 kolt (新版) と既存 daemon プロセス (旧版 jar) が混在」する状態が発生しうる。 daemon 側の handshake (バージョン照合) で reject される想定だが、 design で観測経路を確認。
+  - **Low 要因**: その他 (semver 比較、 tarball 展開、 SHA256 検証、 UA ヘッダ送出) はすべて load-bearing な前例が存在。
+
+## 5. design に持ち越す Research Items
+
+1. **Atomic symlink replacement**: `symlink(2)` で一時 symlink を作って `rename(2)` で linkPath を上書きする経路 (Linux man-page 上は OK、 N-3 で確認済) を ext4 / 9p (WSL2) 両方で 1 度実機確認。
+2. **GitHub API on libcurl**: User-Agent ヘッダ未指定で `api.github.com` に GET したときの 403 挙動を確認 (実機 1 度)。 既存 `Downloader.headers` パラメータで `User-Agent: kolt/<ver>` を渡せば足りる。
+3. **macOS expectation hook**: linuxX64 以外を「明示エラー」で拒否する判定は、 現状 nativeMain が linuxX64 単独ビルドである以上、 compile-time でなく runtime に「常に linuxX64 でないと走らない」前提を assert する形になる。 macOS port 着手時に `expect-actual` で差し替えるルートを残すか、 design で判断。
+4. **`--check` の `releases/latest` 解釈**: GitHub API は draft / prerelease を `releases/latest` から自動除外する (GitHub REST docs 確認済)。 これに乗ると requirements の「安定版のみ」が API 仕様 + release workflow の prerelease マーキングだけで満たせる。 design で「`tag_name` をそのまま `compareVersions` に渡す」 + Requirement 2.1 の regex で `vX.Y.Z` 形式を assert するアプローチに収束させる。
+5. **テスト戦略の粒度**: subprocess CLI test (`kolt.kexe self update --check`) を追加するか、 `SelfUpdater` の unit test + `LoopbackHttpServer` 接続テストで十分か。 既存に subprocess CLI integration test の前例がないため、 後者を default にしたい。
+6. **並行実行 lock 戦略**: advisory `flock` を `~/.local/share/kolt/.update.lock` 相当に取って後発を refuse するか、 `~/.local/share/kolt/<new>/` の存在チェックで「別プロセス進行中」を検出するかを design で決定。 ステージング dir の path も含めて確定。
+7. **中断回復ポリシー**: ステージング dir が前回中断で残っているとき、 (a) 即破棄して再展開、 (b) 整合性を再検証して使い回す、 のどちらを既定にするか。 設計上は (a) の方が単純で safe restart を保証しやすい。
+8. **`~/.local/bin/kolt` が regular file のケース**: installer 経由でない手動配置 (`cp kolt.kexe ~/.local/bin/kolt`) ユーザーが現実にいる場合の挙動。 Requirement 6.2 で「拒否」確定済みだが、 メッセージ内に「installer 経由で再インストールしてください」等のリカバリ案内を入れるかは design で決める。
+9. **`XDG_DATA_HOME` 等の path override 対応**: `kolt.config.KoltPaths` (もしくは類似) が既に XDG_DATA_HOME / HOME 取得を抽象化しているか確認し、 self-update の path 解決もそれに乗せる。
+10. **ダウンロード進捗表示**: tarball が数 MiB 規模になる前提で、 Requirement 3.4 の「`downloading tarball`」 1 行 のみで足りるか、 % 進捗を出すかを design で判断。 libcurl progress callback を引き回すと既存 Downloader API に拡張が必要。
+11. **libarchive SECURE_NOABSOLUTEPATHS 整合性**: `extractArchive` は absolute path / `..` を含む symlink を弾く (memory `reference_libarchive_cinterop` 参照)。 self-update tarball が内部に absolute path や `..` を含むエントリを持たないことを release workflow が保証する旨を docs に明示し、 整合性を pin。
+12. **daemon との版整合性**: 切替直後の `kolt` invocation が古い daemon JVM プロセス (旧 jar) に接続した場合の挙動を design で確認。 既存の handshake (memory `feedback_daemon_canary_pattern` / `feedback_daemon_launch_field_fingerprint` 参照) が version mismatch を reject するならそのまま依拠、 さもなければ `kolt daemon stop` を self-update が呼ぶ必要があるかを判断。
+
+## 6. design phase への推奨
+
+- **Preferred approach**: Option C (Hybrid) を最終ターゲットとしつつ、 v0.21.0 MVP のサイズ次第で Option A を中継点として通る選択肢を design 段階で評価。 どちらも `kolt.infra` への追加 (`replaceSymlinkAtomically`、 `canWrite`) は共通で最小限。
+- **Key decisions to lock in design**:
+  - `SelfUpdateError` の sealed ADT 構成と Requirement 8 の 4 経路 (Network / Metadata / Asset / Extract) + 包括 catch のマッピング。
+  - GitHub Releases JSON モデルの最小フィールドセット (`tag_name`、 `assets[].name`、 `assets[].browser_download_url`)、 `@Serializable` で nativeMain にもう存在する `GradleMetadata.kt` / `Lockfile.kt` パターンを踏襲。
+  - Requirement 6 のレイアウト検出ロジック (`readSelfExe` 結果と `~/.local/bin/kolt` の `lstat` + `readlink` + path-prefix 比較)。
+  - Requirement 5 の lock 戦略 (`flock`-based vs 存在チェックベース)、 ステージング dir の path、 中断回復のデフォルト挙動。
+  - Platform 判定の置き場所 (Requirement 7.2 で「最初の gate」 と明示済み)。
+  - 出力文字列フォーマット (Requirement 2.3 / 2.4 / 3.3 / 3.4 を満たす最小書式、 i18n は対象外)。
+- **Carry-forward research**: §5 の 12 項目を design.md の Research セクションに転記し、 実機確認結果を追記する。
+
+---
+
+# スコープ圧縮の判断 (2026-05-16)
+
+design validation (GO 判定) 後、 ユーザーと「この機能を v0.21.0 でやるか / どこまでやるか」を再検討した結果、 **要件を圧縮した spec に書き直す (Option 1)** を選択。 install.sh wrapper 案 (Option 2) は、 macOS / linuxArm64 対応時に platform 分岐がネイティブ側で一元管理できなくなるため却下 (memory `project_macos_selfhost_v1` の方向と非整合)。
+
+## なぜ圧縮したか
+
+- #27 は priority: **nice**。 当初 Issue は「`rename(2)` で置換」程度のライトな想定だった。
+- adversarial review で Requirement 5 系 (並行 `flock` lock / SIGINT 中断回復 / `cleanupAbandoned` / dangling・外部 target・regular file の 4 分類 / `SelfUpdateError` 11 variant) が積み上がり、 effort が M (3–7 日) に膨張。 技術的指摘は正しいが priority: nice に対する投資 bar として過大と判断。
+- 基準は **install.sh が POSIX sh で持つスコープ**。 install.sh も並行排他しない / 中断回復専用機構を持たない / layout は単一判定。 self-update がそれを超える防衛機構を持つ必然性はない。
+- daemon 増加は self-update の複雑度に **影響しない**ことを確認済み (release tarball の `libexec/` 同梱 + socket fingerprint 自動隔離)。 ユーザーの「daemon で難易度が上がった」直観は事実とズレており、 複雑度増は専ら review 由来だった。
+
+## 何を切ったか
+
+| 削除/縮小した項目 | 旧 | 新 |
+|---|---|---|
+| 並行 advisory lock (`UpdateLock`) | Requirement 5.2 + 専用クラス | 削除 (Out of Boundary に明記) |
+| SIGINT/kill 中断回復 (`cleanupAbandoned`) | Requirement 5.4/5.5 + 専用機構 | 削除。 staging を処理開始時に無条件再作成するだけ (Requirement 4.5) |
+| layout 細分類 | Requirement 6.2–6.4 (NotASymlink/Dangling/外部) | 単一判定 1 件に集約 (Requirement 5.1/5.2) |
+| `SelfUpdateError` 粒度 | 11 variant (4 重 sealed) | 7 トップ variant (粗粒度、 detail は String) |
+| package 分割 | 7+ ファイル (`UpdateLock`/`StagingArea`/`PlatformGate`/`InstallerLayout` 個別) | 3 ファイル (`SelfUpdater` に internal 関数で内包) |
+| 新規ファイル総数 | 12 + 2 modified | 5 + 2 modified |
+| effort | M (3–7 日) | S (1–3 日) |
+
+## 何を残したか (core)
+
+- `kolt self update` / `--check` の CLI surface
+- `releases/latest` + `vX.Y.Z` regex 検証 + semver 比較
+- SHA-256 検証
+- linuxX64 以外の拒否 (gate 最前)
+- installer layout の単一判定 + 書き込み権限プローブ
+- `rename(2)` 1 回による symlink atomic 切替 (lock なしでも `rename` の atomic 性は無料で得られる — Requirement 3.6)
+- 一時 dir 経由の配置 (lock も pid も cleanup 専用機構も持たない最小形)
+
+## 圧縮後も残る Research Items (実装時に確認)
+
+1. `symlink(2)` + `rename(2)` の atomic 置換を ext4 / 9p (WSL2) で実機確認 (圧縮後も core)。
+2. User-Agent 未指定で `api.github.com` が 403 を返すことの実機確認 (`Downloader.headers` 経由送出で解決の想定)。
+3. `releases/latest` の prerelease 自動除外 + `vX.Y.Z` regex で「安定版のみ」契約が成立することの確認 (GitHub docs 確認済、 実 release で 1 度確認)。
+4. macOS port 時の `expect-actual` 差し替え seam (`ensureLinuxX64`) — 本 spec では runtime wide assertion のみ。
+
+§5 の旧 12 項目のうち lock 戦略 / 中断回復ポリシー / daemon 版整合性 / 進捗 % / XDG 対応は scope 圧縮により不要化、 または Out of Boundary に移送済み。

--- a/.kiro/specs/27-self-update/spec.json
+++ b/.kiro/specs/27-self-update/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "27-self-update",
+  "created_at": "2026-05-15T03:38:14Z",
+  "updated_at": "2026-05-16T03:00:00Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": false
+}

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -43,7 +43,7 @@
   - _Depends: 1.1, 1.3_
   - _Boundary: SelfUpdater_
 
-- [ ] 3.2 `check()` + `SelfUpdaterCheckTest`
+- [x] 3.2 `check()` + `SelfUpdaterCheckTest`
   - `ensureLinuxX64` → `fetchLatest` → `compareVersions` → CheckOutcome、`detectLayout`/`verifyWritable` は呼ばない、ファイル書き込みゼロ
   - 観察: SelfUpdaterCheckTest が green — update available / already latest(equal) / older / Platform 不一致で fetch しない / layout 不一致でも version を返す / 書き込み 0 行
   - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 6.2_

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -3,7 +3,7 @@
 > 圧縮版 spec (install.sh 同等スコープ)。kolt は TDD: 各実装サブタスクは対応する test を同一ユニットで green にする (reviewer の mechanical test-pass check が RED-only commit を拒否するため)。
 
 - [ ] 1. Foundation: 共有型・OS プリミティブ・test fixture
-- [ ] 1.1 (P) `SelfUpdateError` sealed ADT を定義
+- [x] 1.1 (P) `SelfUpdateError` sealed ADT を定義
   - Network / Metadata / Asset / Extract / Layout / Platform / Home の 7 トップ variant、各 variant は detail / path / name を String で保持 (粗粒度方針)
   - 観察: 全 variant がコンパイル可能で、design の Error Handling 表に対応する引数を持つ
   - _Requirements: 7.1, 7.2, 7.3_

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -50,7 +50,7 @@
   - _Depends: 2.1, 3.1_
   - _Boundary: SelfUpdater_
 
-- [ ] 3.3 `update()` + `runStaged` 本体 + `SelfUpdaterUpdateTest`
+- [x] 3.3 `update()` + `runStaged` 本体 + `SelfUpdaterUpdateTest`
   - `ensureLinuxX64`→`detectLayout`→`verifyWritable`→`fetchLatest`→compare、新しければ自 pid `~/.local/share/kolt/.staging-<pid>/` を作り直し→tarball+`.sha256` download→`computeSha256` 検証(一致で通過)→`extractArchive`→`rename` で `<new-ver>` 確定→`replaceSymlinkAtomically`→progress 5 段表示→旧バージョン dir 非削除。死 pid 掃除はここに含めない (3.4)
   - 観察: SelfUpdaterUpdateTest が green — 5 ステージ進捗が順に出る / `<new>/bin/kolt` 作成 / symlink が新 target / 旧 dir 残存 / 自 pid staging が成功後に削除 / checksum 一致で extract に進む / latest≤current は no-op exit 0
   - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 4.1, 4.2, 4.5_
@@ -88,3 +88,4 @@
 
 ## Implementation Notes
 - 実装後は必ず `kolt fmt` を実行すること。pre-commit の ktfmt フックが未整形ファイルの commit を拒否する (task 1.2 で発覚)。
+- production コメントに `Requirement N.N` / task / spec ID を書かない (WHY のみ)。直接 posix 呼び出し (`getpid`/`rename`/`access` 等) には function-level `@OptIn(ExperimentalForeignApi::class)` を付ける。task 3.3 で両方再発し reviewer reject → remediation 要した。test ファイルの `// Req N.N:` シナリオタグは許容 idiom。

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -72,7 +72,7 @@
   - _Depends: 1.1, 3.2, 3.3_
   - _Boundary: SelfCommands_
 
-- [ ] 4.2 `Main.kt` 配線
+- [x] 4.2 `Main.kt` 配線
   - `when` 句に `"self" -> doSelf(args.drop(1))` (アルファベット順で `run` の前)、`KNOWN_SUBCOMMANDS_SORTED` に `"self"` 挿入、`usageLines()` に `kolt self update` 行を追加
   - 観察: `kolt self update --check` が dispatch され、`kolt self` が未知コマンド扱いされず、usage 出力に self が含まれる (既存 Main の挙動/テストで確認)
   - _Requirements: 1.1, 1.3_

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -57,7 +57,7 @@
   - _Depends: 1.2, 2.1, 3.1_
   - _Boundary: SelfUpdater_
 
-- [ ] 3.4 死 pid staging 掃除実装 + `SelfUpdaterStagingIsolationTest` + `SelfUpdaterUpdateChecksumMismatchTest`
+- [x] 3.4 死 pid staging 掃除実装 + `SelfUpdaterStagingIsolationTest` + `SelfUpdaterUpdateChecksumMismatchTest`
   - 起動時に `.staging-*` を列挙し `kill(pid, 0)` で死 pid のみ best-effort 削除 (生存 pid 非干渉)。checksum mismatch 経路で `<new>` 未作成 + symlink 不変を保証
   - 観察: 両 test が green — 死 pid 分は掃除済 / 生存 pid 分は残存 / 自 pid は成功後削除、checksum mismatch で `<new>` 未作成 + symlink 不変
   - _Requirements: 4.3, 4.5, 7.2, 7.3_

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -80,7 +80,7 @@
   - _Boundary: cli Main_
 
 - [ ] 5. Validation
-- [ ] 5.1 全経路通し + self-host smoke 非影響 + workflows grep
+- [x] 5.1 全経路通し + self-host smoke 非影響 + workflows grep
   - `doSelf` 経由で check / update / 各 error 経路を通し確認、full `kolt test` を green に、`.github/workflows/` を grep して新 `self` subcommand と `KNOWN_SUBCOMMANDS_SORTED` 変更で破綻する path 仮定がないこと、`self-host-post` 経路に regression がないことを確認
   - 観察: full `kolt test` が green、`.github/workflows/` grep で新規 path 仮定の破綻なし、self-host smoke 経路に regression なし
   - _Requirements: 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1_

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -15,7 +15,7 @@
   - _Requirements: 3.6_
   - _Boundary: infra Symlink_
 
-- [ ] 1.3 (P) `FileSystem.canWrite(path)` を追加 + test
+- [x] 1.3 (P) `FileSystem.canWrite(path)` を追加 + test
   - `access(path, W_OK) == 0` の薄いラッパ、`@OptIn(ExperimentalForeignApi::class)` を function-level に、既存 `fileExists` の隣
   - 観察: 書き込み可能 dir で true、0500 dir で false を assert する test が green
   - _Requirements: 5.3_
@@ -85,3 +85,6 @@
   - 観察: full `kolt test` が green、`.github/workflows/` grep で新規 path 仮定の破綻なし、self-host smoke 経路に regression なし
   - _Requirements: 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1_
   - _Depends: 4.2_
+
+## Implementation Notes
+- 実装後は必ず `kolt fmt` を実行すること。pre-commit の ktfmt フックが未整形ファイルの commit を拒否する (task 1.2 で発覚)。

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -9,7 +9,7 @@
   - _Requirements: 7.1, 7.2, 7.3_
   - _Boundary: SelfUpdateError_
 
-- [ ] 1.2 (P) `replaceSymlinkAtomically` と `SymlinkError` を実装 + `SymlinkTest`
+- [x] 1.2 (P) `replaceSymlinkAtomically` と `SymlinkError` を実装 + `SymlinkTest`
   - `SymlinkError` sealed ADT (CreateFailed / RenameFailed)、`symlink(2)` で一時 symlink を作り `rename(2)` で linkPath を上書き、rename 失敗時は一時 symlink を unlink
   - 観察: SymlinkTest が green — (a) linkPath 不在で新規作成 (b) 既存 symlink を atomic 置換 (前後を lstat+readlink で観測) (c) newTarget 不在でも symlink(2) 成功 (d) regular file 上書き挙動を pin
   - _Requirements: 3.6_

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -89,3 +89,5 @@
 ## Implementation Notes
 - 実装後は必ず `kolt fmt` を実行すること。pre-commit の ktfmt フックが未整形ファイルの commit を拒否する (task 1.2 で発覚)。
 - production コメントに `Requirement N.N` / task / spec ID を書かない (WHY のみ)。直接 posix 呼び出し (`getpid`/`rename`/`access` 等) には function-level `@OptIn(ExperimentalForeignApi::class)` を付ける。task 3.3 で両方再発し reviewer reject → remediation 要した。test ファイルの `// Req N.N:` シナリオタグは許容 idiom。
+- nativeTest で実 libcurl (`::downloadFile`) + `LoopbackHttpServer` (pthread) を full `kolt test` に混ぜると、後続の `fork()` する test (`PromptTest`) を futex deadlock させ `kolt test` が完了しなくなる (~2h hang)。SelfUpdater↔SelfCommands の seam を lock する integration test は network transport を in-memory fake `Downloader` (`GithubReleasesClient(downloader=...)` seam) に差し替え、実 `SelfUpdater` + 実 `doSelf` を通す。feature-level validation の NoOp double-print remediation で発覚。
+- cross-task seam バグ (NoOp message を SelfUpdater と SelfCommands が二重 print) は per-task review が見逃した: 両 test が seam の片側を stub していたため。実コンポーネントを通す integration test を 1 本足して seam を lock する。

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -21,7 +21,7 @@
   - _Requirements: 5.3_
   - _Boundary: infra FileSystem_
 
-- [ ] 1.4 (P) `GithubReleasesFixture` test fixture を作成
+- [x] 1.4 (P) `GithubReleasesFixture` test fixture を作成
   - LoopbackHttpServer に載せる canned `releases/latest` JSON、および `kolt-<ver>-linux-x64.tar.gz` + 同 `.sha256` を生成する builder (3.3/3.4 の integration test が依存する test-infra)
   - 観察: fixture を使う最小 test が green — 生成 tarball が `extractArchive` で展開でき、生成 `.sha256` が `computeSha256` 結果と一致する
   - _Requirements: 4.1, 4.2_

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -36,7 +36,7 @@
   - _Boundary: GithubReleasesClient_
 
 - [ ] 3. Core: SelfUpdater 本体 (同一ファイル `SelfUpdater.kt`、順次)
-- [ ] 3.1 ゲート群 `ensureLinuxX64` / `detectLayout` / `verifyWritable` + `SelfUpdaterLayoutTest`
+- [x] 3.1 ゲート群 `ensureLinuxX64` / `detectLayout` / `verifyWritable` + `SelfUpdaterLayoutTest`
   - `ensureLinuxX64`: uname で sysname=Linux && machine ∈ {x86_64, amd64}、`detectLayout`: lstat→readlink→target が `<shareRoot><X.Y.Z>/bin/kolt` の文字列 prefix にマッチ、非一致は単一 `Layout`、`verifyWritable` は `canWrite`
   - 観察: SelfUpdaterLayoutTest が green — installer 通り通過 / regular file・dangling・外部 target は単一 `Layout` / `canWrite=false` は writable 系 `Layout` / 非 linuxX64→Platform
   - _Requirements: 5.1, 5.2, 5.3, 6.1_

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -28,7 +28,7 @@
   - _Boundary: testfixture_
 
 - [ ] 2. Core: GitHub Releases クライアント
-- [ ] 2.1 `GithubReleasesClient` を実装 + `GithubReleasesClientTest`
+- [x] 2.1 `GithubReleasesClient` を実装 + `GithubReleasesClientTest`
   - `downloadFile` を一時パスへ呼び `readFileAsString` → `Json.decodeFromString` (ignoreUnknownKeys)、`User-Agent: kolt/<ver>` を headers で送出、`validateTag` は `^v(\d+)\.(\d+)\.(\d+)$` で `X.Y.Z` を返す、asset 名 lookup で欠落は Asset(name)。既存 LoopbackHttpServer + awaitAccessLog を再利用し新規 server infra は作らない、fixture は 1.4 を使用
   - 観察: GithubReleasesClientTest が green — 正常 JSON decode / `tag_name` 不在→Metadata / tag 形式違反→Metadata / UA が `kolt/<ver>` で送出 (awaitAccessLog) / asset 欠落→Asset(name)
   - _Requirements: 2.1, 4.1, 4.4, 7.1, 7.2_

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -1,0 +1,87 @@
+# Implementation Plan
+
+> 圧縮版 spec (install.sh 同等スコープ)。kolt は TDD: 各実装サブタスクは対応する test を同一ユニットで green にする (reviewer の mechanical test-pass check が RED-only commit を拒否するため)。
+
+- [ ] 1. Foundation: 共有型・OS プリミティブ・test fixture
+- [ ] 1.1 (P) `SelfUpdateError` sealed ADT を定義
+  - Network / Metadata / Asset / Extract / Layout / Platform / Home の 7 トップ variant、各 variant は detail / path / name を String で保持 (粗粒度方針)
+  - 観察: 全 variant がコンパイル可能で、design の Error Handling 表に対応する引数を持つ
+  - _Requirements: 7.1, 7.2, 7.3_
+  - _Boundary: SelfUpdateError_
+
+- [ ] 1.2 (P) `replaceSymlinkAtomically` と `SymlinkError` を実装 + `SymlinkTest`
+  - `SymlinkError` sealed ADT (CreateFailed / RenameFailed)、`symlink(2)` で一時 symlink を作り `rename(2)` で linkPath を上書き、rename 失敗時は一時 symlink を unlink
+  - 観察: SymlinkTest が green — (a) linkPath 不在で新規作成 (b) 既存 symlink を atomic 置換 (前後を lstat+readlink で観測) (c) newTarget 不在でも symlink(2) 成功 (d) regular file 上書き挙動を pin
+  - _Requirements: 3.6_
+  - _Boundary: infra Symlink_
+
+- [ ] 1.3 (P) `FileSystem.canWrite(path)` を追加 + test
+  - `access(path, W_OK) == 0` の薄いラッパ、`@OptIn(ExperimentalForeignApi::class)` を function-level に、既存 `fileExists` の隣
+  - 観察: 書き込み可能 dir で true、0500 dir で false を assert する test が green
+  - _Requirements: 5.3_
+  - _Boundary: infra FileSystem_
+
+- [ ] 1.4 (P) `GithubReleasesFixture` test fixture を作成
+  - LoopbackHttpServer に載せる canned `releases/latest` JSON、および `kolt-<ver>-linux-x64.tar.gz` + 同 `.sha256` を生成する builder (3.3/3.4 の integration test が依存する test-infra)
+  - 観察: fixture を使う最小 test が green — 生成 tarball が `extractArchive` で展開でき、生成 `.sha256` が `computeSha256` 結果と一致する
+  - _Requirements: 4.1, 4.2_
+  - _Boundary: testfixture_
+
+- [ ] 2. Core: GitHub Releases クライアント
+- [ ] 2.1 `GithubReleasesClient` を実装 + `GithubReleasesClientTest`
+  - `downloadFile` を一時パスへ呼び `readFileAsString` → `Json.decodeFromString` (ignoreUnknownKeys)、`User-Agent: kolt/<ver>` を headers で送出、`validateTag` は `^v(\d+)\.(\d+)\.(\d+)$` で `X.Y.Z` を返す、asset 名 lookup で欠落は Asset(name)。既存 LoopbackHttpServer + awaitAccessLog を再利用し新規 server infra は作らない、fixture は 1.4 を使用
+  - 観察: GithubReleasesClientTest が green — 正常 JSON decode / `tag_name` 不在→Metadata / tag 形式違反→Metadata / UA が `kolt/<ver>` で送出 (awaitAccessLog) / asset 欠落→Asset(name)
+  - _Requirements: 2.1, 4.1, 4.4, 7.1, 7.2_
+  - _Depends: 1.1, 1.4_
+  - _Boundary: GithubReleasesClient_
+
+- [ ] 3. Core: SelfUpdater 本体 (同一ファイル `SelfUpdater.kt`、順次)
+- [ ] 3.1 ゲート群 `ensureLinuxX64` / `detectLayout` / `verifyWritable` + `SelfUpdaterLayoutTest`
+  - `ensureLinuxX64`: uname で sysname=Linux && machine ∈ {x86_64, amd64}、`detectLayout`: lstat→readlink→target が `<shareRoot><X.Y.Z>/bin/kolt` の文字列 prefix にマッチ、非一致は単一 `Layout`、`verifyWritable` は `canWrite`
+  - 観察: SelfUpdaterLayoutTest が green — installer 通り通過 / regular file・dangling・外部 target は単一 `Layout` / `canWrite=false` は writable 系 `Layout` / 非 linuxX64→Platform
+  - _Requirements: 5.1, 5.2, 5.3, 6.1_
+  - _Depends: 1.1, 1.3_
+  - _Boundary: SelfUpdater_
+
+- [ ] 3.2 `check()` + `SelfUpdaterCheckTest`
+  - `ensureLinuxX64` → `fetchLatest` → `compareVersions` → CheckOutcome、`detectLayout`/`verifyWritable` は呼ばない、ファイル書き込みゼロ
+  - 観察: SelfUpdaterCheckTest が green — update available / already latest(equal) / older / Platform 不一致で fetch しない / layout 不一致でも version を返す / 書き込み 0 行
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 6.2_
+  - _Depends: 2.1, 3.1_
+  - _Boundary: SelfUpdater_
+
+- [ ] 3.3 `update()` + `runStaged` 本体 + `SelfUpdaterUpdateTest`
+  - `ensureLinuxX64`→`detectLayout`→`verifyWritable`→`fetchLatest`→compare、新しければ自 pid `~/.local/share/kolt/.staging-<pid>/` を作り直し→tarball+`.sha256` download→`computeSha256` 検証(一致で通過)→`extractArchive`→`rename` で `<new-ver>` 確定→`replaceSymlinkAtomically`→progress 5 段表示→旧バージョン dir 非削除。死 pid 掃除はここに含めない (3.4)
+  - 観察: SelfUpdaterUpdateTest が green — 5 ステージ進捗が順に出る / `<new>/bin/kolt` 作成 / symlink が新 target / 旧 dir 残存 / 自 pid staging が成功後に削除 / checksum 一致で extract に進む / latest≤current は no-op exit 0
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 4.1, 4.2, 4.5_
+  - _Depends: 1.2, 2.1, 3.1_
+  - _Boundary: SelfUpdater_
+
+- [ ] 3.4 死 pid staging 掃除実装 + `SelfUpdaterStagingIsolationTest` + `SelfUpdaterUpdateChecksumMismatchTest`
+  - 起動時に `.staging-*` を列挙し `kill(pid, 0)` で死 pid のみ best-effort 削除 (生存 pid 非干渉)。checksum mismatch 経路で `<new>` 未作成 + symlink 不変を保証
+  - 観察: 両 test が green — 死 pid 分は掃除済 / 生存 pid 分は残存 / 自 pid は成功後削除、checksum mismatch で `<new>` 未作成 + symlink 不変
+  - _Requirements: 4.3, 4.5, 7.2, 7.3_
+  - _Depends: 3.3_
+  - _Boundary: SelfUpdater_
+
+- [ ] 4. Integration: CLI 配線
+- [ ] 4.1 `SelfCommands.doSelf` + `SelfCommandsTest`
+  - 引数 parse: `[]`→EmptyHelp exit0 / `--help`→Help exit0 / `update`→update / `update --check`→check / 未知フラグ→非ゼロ / 未知 subcommand→非ゼロ、全 `SelfUpdateError` variant を人間可読 1 行メッセージへマップ
+  - 観察: SelfCommandsTest が green — 6 引数パターンの ExitCode と出力、全 error variant が空でないメッセージを返す
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.3, 2.4, 2.6, 3.3, 7.4_
+  - _Depends: 1.1, 3.2, 3.3_
+  - _Boundary: SelfCommands_
+
+- [ ] 4.2 `Main.kt` 配線
+  - `when` 句に `"self" -> doSelf(args.drop(1))` (アルファベット順で `run` の前)、`KNOWN_SUBCOMMANDS_SORTED` に `"self"` 挿入、`usageLines()` に `kolt self update` 行を追加
+  - 観察: `kolt self update --check` が dispatch され、`kolt self` が未知コマンド扱いされず、usage 出力に self が含まれる (既存 Main の挙動/テストで確認)
+  - _Requirements: 1.1, 1.3_
+  - _Depends: 4.1_
+  - _Boundary: cli Main_
+
+- [ ] 5. Validation
+- [ ] 5.1 全経路通し + self-host smoke 非影響 + workflows grep
+  - `doSelf` 経由で check / update / 各 error 経路を通し確認、full `kolt test` を green に、`.github/workflows/` を grep して新 `self` subcommand と `KNOWN_SUBCOMMANDS_SORTED` 変更で破綻する path 仮定がないこと、`self-host-post` 経路に regression がないことを確認
+  - 観察: full `kolt test` が green、`.github/workflows/` grep で新規 path 仮定の破綻なし、self-host smoke 経路に regression なし
+  - _Requirements: 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1_
+  - _Depends: 4.2_

--- a/.kiro/specs/27-self-update/tasks.md
+++ b/.kiro/specs/27-self-update/tasks.md
@@ -65,7 +65,7 @@
   - _Boundary: SelfUpdater_
 
 - [ ] 4. Integration: CLI 配線
-- [ ] 4.1 `SelfCommands.doSelf` + `SelfCommandsTest`
+- [x] 4.1 `SelfCommands.doSelf` + `SelfCommandsTest`
   - 引数 parse: `[]`→EmptyHelp exit0 / `--help`→Help exit0 / `update`→update / `update --check`→check / 未知フラグ→非ゼロ / 未知 subcommand→非ゼロ、全 `SelfUpdateError` variant を人間可読 1 行メッセージへマップ
   - 観察: SelfCommandsTest が green — 6 引数パターンの ExitCode と出力、全 error variant が空でないメッセージを返す
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.3, 2.4, 2.6, 3.3, 7.4_

--- a/src/nativeMain/kotlin/kolt/cli/Main.kt
+++ b/src/nativeMain/kotlin/kolt/cli/Main.kt
@@ -104,6 +104,7 @@ fun main(args: Array<String>) {
       val exit = doTool(filteredArgs.drop(1)).fold(success = { it }, failure = { it })
       exitProcess(exit)
     }
+    "self" -> doSelf(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
     "toolchain" -> doToolchain(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
     "daemon" -> doDaemon(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
     "cache" -> doCache(filteredArgs.drop(1)).getOrElse { exitProcess(it) }
@@ -139,6 +140,7 @@ internal val KNOWN_SUBCOMMANDS_SORTED: List<String> =
       "outdated",
       "remove",
       "run",
+      "self",
       "test",
       "tool",
       "toolchain",
@@ -252,6 +254,7 @@ internal fun usageLines(): List<String> =
     "  tree       Show dependency tree",
     "  outdated   Show dependencies with newer versions on Maven Central",
     "  tool       Run a [tools] alias (kolt tool run <alias> [-- args...])",
+    "  self       Self-update kolt (kolt self update [--check])",
     "  toolchain  Manage toolchains (install, list, remove)",
     "  daemon     Manage compiler daemons (stop)",
     "  cache      Manage the global dependency cache (clean)",

--- a/src/nativeMain/kotlin/kolt/cli/SelfCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/SelfCommands.kt
@@ -146,9 +146,12 @@ private fun runUpdate(
       err(it.toMessage())
       return Err(EXIT_BUILD_ERROR)
     }
+  // SelfUpdater.update() already announces the already-latest state for the
+  // no-op branch via its own `out`; re-printing here would duplicate the
+  // line. Only the success arrow is this layer's to emit.
   when (outcome) {
     is UpdateOutcome.Switched -> out("${outcome.from} → ${outcome.to}")
-    is UpdateOutcome.NoOp -> out("Already at latest version (${outcome.current})")
+    is UpdateOutcome.NoOp -> Unit
   }
   return Ok(Unit)
 }

--- a/src/nativeMain/kotlin/kolt/cli/SelfCommands.kt
+++ b/src/nativeMain/kotlin/kolt/cli/SelfCommands.kt
@@ -1,0 +1,185 @@
+package kolt.cli
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import kolt.config.KOLT_VERSION
+import kolt.infra.downloadFile
+import kolt.infra.eprintln
+import kolt.infra.homeDirectory
+import kolt.selfupdate.CheckOutcome
+import kolt.selfupdate.Downloader
+import kolt.selfupdate.GithubReleasesClient
+import kolt.selfupdate.SelfUpdateError
+import kolt.selfupdate.SelfUpdater
+import kolt.selfupdate.UpdateOutcome
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.getpid
+
+// The slice of SelfUpdater that doSelf actually drives. Narrowing to this
+// interface lets the dispatch/format/exit-code logic be unit-tested with a
+// canned stub instead of a real network + filesystem round-trip; production
+// wires the concrete SelfUpdater via the defaulted runnerFactory below.
+interface SelfRunner {
+  fun check(): Result<CheckOutcome, SelfUpdateError>
+
+  fun update(): Result<UpdateOutcome, SelfUpdateError>
+}
+
+private class SelfUpdaterRunner(private val updater: SelfUpdater) : SelfRunner {
+  override fun check(): Result<CheckOutcome, SelfUpdateError> = updater.check()
+
+  override fun update(): Result<UpdateOutcome, SelfUpdateError> = updater.update()
+}
+
+internal sealed interface SelfInvocation {
+  data object EmptyHelp : SelfInvocation
+
+  data object Help : SelfInvocation
+
+  data class Update(val checkOnly: Boolean) : SelfInvocation
+
+  data class UnknownFlag(val flag: String) : SelfInvocation
+
+  data class UnknownSubcommand(val sub: String) : SelfInvocation
+}
+
+internal fun parseSelfArgs(args: List<String>): SelfInvocation {
+  if (args.isEmpty()) return SelfInvocation.EmptyHelp
+  if (args.any { it == "--help" || it == "-h" }) return SelfInvocation.Help
+  if (args[0] != "update") return SelfInvocation.UnknownSubcommand(args[0])
+
+  var checkOnly = false
+  for (arg in args.drop(1)) {
+    when (arg) {
+      "--check" -> checkOnly = true
+      else -> return SelfInvocation.UnknownFlag(arg)
+    }
+  }
+  return SelfInvocation.Update(checkOnly)
+}
+
+// Builds the production SelfUpdater. `$HOME` is resolved here (before the
+// updater exists) so a missing HOME is reported as a Home-domain failure
+// instead of crashing — every doSelf exit path keeps a message.
+@OptIn(ExperimentalForeignApi::class)
+private fun productionRunner(): Result<SelfRunner, SelfUpdateError> {
+  val home =
+    homeDirectory().getOrElse {
+      return Err(SelfUpdateError.Home(it.message))
+    }
+  val client =
+    GithubReleasesClient(
+      downloader = Downloader(::downloadFile),
+      userAgent = "kolt/$KOLT_VERSION",
+      // --check needs a temp path but no staging dir; a HOME-rooted dotfile
+      // keeps it off /tmp while staying predictable for the single fetch.
+      tempPathFactory = { "$home/.local/share/kolt/.self-update-meta-${getpid()}.json" },
+    )
+  return Ok(SelfUpdaterRunner(SelfUpdater(releases = client, home = home)))
+}
+
+internal fun doSelf(
+  args: List<String>,
+  out: (String) -> Unit = ::println,
+  err: (String) -> Unit = ::eprintln,
+  runnerFactory: () -> Result<SelfRunner, SelfUpdateError> = ::productionRunner,
+): Result<Unit, Int> {
+  when (val invocation = parseSelfArgs(args)) {
+    SelfInvocation.EmptyHelp,
+    SelfInvocation.Help -> {
+      for (line in selfUsageLines()) out(line)
+      return Ok(Unit)
+    }
+    is SelfInvocation.UnknownFlag -> {
+      err("error: unknown flag '${invocation.flag}'")
+      return Err(EXIT_CONFIG_ERROR)
+    }
+    is SelfInvocation.UnknownSubcommand -> {
+      err("error: unknown self subcommand '${invocation.sub}'")
+      for (line in selfUsageLines()) err(line)
+      return Err(EXIT_COMMAND_NOT_FOUND)
+    }
+    is SelfInvocation.Update -> {
+      val runner =
+        runnerFactory().getOrElse {
+          err(it.toMessage())
+          return Err(EXIT_BUILD_ERROR)
+        }
+      return if (invocation.checkOnly) {
+        runCheck(runner, out, err)
+      } else {
+        runUpdate(runner, out, err)
+      }
+    }
+  }
+}
+
+// --check always exits 0 on success regardless of whether an update is
+// available; only a fetch/metadata/platform failure is non-zero.
+private fun runCheck(
+  runner: SelfRunner,
+  out: (String) -> Unit,
+  err: (String) -> Unit,
+): Result<Unit, Int> {
+  val outcome =
+    runner.check().getOrElse {
+      err(it.toMessage())
+      return Err(EXIT_BUILD_ERROR)
+    }
+  when (outcome) {
+    is CheckOutcome.UpdateAvailable ->
+      out("Update available: ${outcome.current} → ${outcome.latest}")
+    is CheckOutcome.AlreadyLatest -> out("Already at latest version (${outcome.current})")
+  }
+  return Ok(Unit)
+}
+
+private fun runUpdate(
+  runner: SelfRunner,
+  out: (String) -> Unit,
+  err: (String) -> Unit,
+): Result<Unit, Int> {
+  val outcome =
+    runner.update().getOrElse {
+      err(it.toMessage())
+      return Err(EXIT_BUILD_ERROR)
+    }
+  when (outcome) {
+    is UpdateOutcome.Switched -> out("${outcome.from} → ${outcome.to}")
+    is UpdateOutcome.NoOp -> out("Already at latest version (${outcome.current})")
+  }
+  return Ok(Unit)
+}
+
+// Each top-level variant collapses to one human-readable line so the user can
+// tell network from metadata from asset from layout from platform at a glance.
+private fun SelfUpdateError.toMessage(): String =
+  when (this) {
+    is SelfUpdateError.Network -> "error: failed to reach ${hostOf(url)}: $detail"
+    is SelfUpdateError.Metadata -> "error: GitHub releases/latest response was invalid: $detail"
+    is SelfUpdateError.Asset -> "error: release asset '$name': $detail"
+    is SelfUpdateError.Extract -> "error: failed to extract update package: $detail"
+    is SelfUpdateError.Layout -> "error: $detail (detected $detectedPath)"
+    is SelfUpdateError.Platform ->
+      "error: kolt self update supports linuxX64 only (detected $sysname/$machine)"
+    is SelfUpdateError.Home -> "error: $detail"
+  }
+
+// Best-effort host extraction for the network message; falls back to the raw
+// URL so the message is never empty even on an unparseable value.
+private fun hostOf(url: String): String {
+  val afterScheme = url.substringAfter("://", url)
+  val host = afterScheme.substringBefore('/').substringBefore('?')
+  return host.ifEmpty { url }
+}
+
+private fun selfUsageLines(): List<String> =
+  listOf(
+    "usage: kolt self <subcommand>",
+    "",
+    "subcommands:",
+    "  update           Replace this kolt binary with the latest stable release",
+    "  update --check    Report whether a newer stable release is available (no writes)",
+  )

--- a/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
+++ b/src/nativeMain/kotlin/kolt/infra/FileSystem.kt
@@ -36,6 +36,11 @@ fun fileExists(path: String): Boolean {
 }
 
 @OptIn(ExperimentalForeignApi::class)
+fun canWrite(path: String): Boolean {
+  return access(path, W_OK) == 0
+}
+
+@OptIn(ExperimentalForeignApi::class)
 fun ensureDirectory(path: String): Result<Unit, MkdirFailed> {
   if (fileExists(path)) return Ok(Unit)
   return if (mkdir(path, 0b111111101u) == 0) { // 0755

--- a/src/nativeMain/kotlin/kolt/infra/Symlink.kt
+++ b/src/nativeMain/kotlin/kolt/infra/Symlink.kt
@@ -1,0 +1,36 @@
+package kolt.infra
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.errno
+import platform.posix.getpid
+import platform.posix.rename
+import platform.posix.symlink
+import platform.posix.unlink
+
+sealed interface SymlinkError {
+  data class CreateFailed(val tmp: String, val errno: Int) : SymlinkError
+
+  data class RenameFailed(val link: String, val errno: Int) : SymlinkError
+}
+
+// Stage the new link at a sibling tmp path, then `rename(2)` it over the
+// target. `rename(2)` is the only step that mutates `linkPath`, and the
+// kernel guarantees it atomically swaps an existing symlink — so a
+// concurrent or subsequent `kolt` invocation always observes either the
+// pre- or post-update binary, never a half-written link.
+@OptIn(ExperimentalForeignApi::class)
+fun replaceSymlinkAtomically(linkPath: String, newTarget: String): Result<Unit, SymlinkError> {
+  val tmp = "$linkPath.tmp.${getpid()}"
+  if (symlink(newTarget, tmp) != 0) {
+    return Err(SymlinkError.CreateFailed(tmp = tmp, errno = errno))
+  }
+  if (rename(tmp, linkPath) != 0) {
+    val e = errno
+    unlink(tmp)
+    return Err(SymlinkError.RenameFailed(link = linkPath, errno = e))
+  }
+  return Ok(Unit)
+}

--- a/src/nativeMain/kotlin/kolt/selfupdate/GithubReleasesClient.kt
+++ b/src/nativeMain/kotlin/kolt/selfupdate/GithubReleasesClient.kt
@@ -1,0 +1,113 @@
+package kolt.selfupdate
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.DownloadError
+import kolt.infra.readFileAsString
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+// GitHub's API replies 403 to requests without a User-Agent, so the UA is a
+// hard requirement of the contract rather than a courtesy header.
+const val GITHUB_RELEASES_LATEST_URL =
+  "https://api.github.com/repos/snicmakino/kolt/releases/latest"
+
+// `downloadFile` is a top-level libcurl function; this fun interface is the
+// kolt seam idiom (cf. ResolverDeps / PluginFetcherDeps) so tests pass the
+// real `::downloadFile` against a loopback server and production wires the
+// same function by default.
+fun interface Downloader {
+  fun downloadFile(
+    url: String,
+    destPath: String,
+    headers: Map<String, String>?,
+  ): Result<Unit, DownloadError>
+}
+
+class GithubReleasesClient(
+  private val downloader: Downloader,
+  private val userAgent: String,
+  private val tempPathFactory: () -> String,
+) {
+  // Endpoint defaults to the canonical GitHub URL (API Contract) but stays
+  // overridable so loopback-server tests can drive the same code path.
+  fun fetchLatest(
+    url: String = GITHUB_RELEASES_LATEST_URL
+  ): Result<LatestRelease, SelfUpdateError> {
+    val tempPath = tempPathFactory()
+    val downloaded = downloader.downloadFile(url, tempPath, mapOf("User-Agent" to userAgent))
+    downloaded.getError()?.let {
+      return Err(it.toSelfUpdateError())
+    }
+
+    val body =
+      readFileAsString(tempPath).getOrElse {
+        return Err(SelfUpdateError.Metadata("could not read downloaded releases metadata"))
+      }
+
+    return try {
+      Ok(lenientJson.decodeFromString<LatestRelease>(body))
+    } catch (e: Exception) {
+      Err(SelfUpdateError.Metadata("releases/latest body was not valid JSON: ${e.message}"))
+    }
+  }
+
+  fun validateTag(tagName: String): Result<String, SelfUpdateError> {
+    val match = SEMVER_TAG.matchEntire(tagName)
+    return if (match == null) {
+      Err(SelfUpdateError.Metadata("tag '$tagName' is not a vX.Y.Z stable release tag"))
+    } else {
+      val (major, minor, patch) = match.destructured
+      Ok("$major.$minor.$patch")
+    }
+  }
+
+  // Resolves a named release asset's download URL; a missing asset is a
+  // named SelfUpdateError.Asset so the caller can report which artifact is absent.
+  fun assetUrl(release: LatestRelease, name: String): Result<String, SelfUpdateError> {
+    val asset = release.assetByName(name)
+    return if (asset == null) {
+      Err(SelfUpdateError.Asset(name, "asset not published in releases/latest"))
+    } else {
+      Ok(asset.browserDownloadUrl)
+    }
+  }
+
+  private fun DownloadError.toSelfUpdateError(): SelfUpdateError =
+    when (this) {
+      // Connect/timeout/transport failures are network-domain.
+      is DownloadError.NetworkError -> SelfUpdateError.Network(url, message)
+      is DownloadError.WriteFailed -> SelfUpdateError.Metadata("could not write metadata to $path")
+      is DownloadError.HttpFailed ->
+        // 5xx (and transport-ish) are network; 4xx are server-side
+        // metadata problems (404 = no release, 403 = UA rejected).
+        if (statusCode >= 500) {
+          SelfUpdateError.Network(url, "HTTP $statusCode from $url")
+        } else {
+          SelfUpdateError.Metadata("releases/latest returned HTTP $statusCode")
+        }
+    }
+
+  private companion object {
+    val SEMVER_TAG = Regex("""^v(\d+)\.(\d+)\.(\d+)$""")
+    val lenientJson = Json { ignoreUnknownKeys = true }
+  }
+}
+
+@Serializable
+data class LatestRelease(
+  @SerialName("tag_name") val tagName: String,
+  val assets: List<ReleaseAsset>,
+) {
+  fun assetByName(name: String): ReleaseAsset? = assets.firstOrNull { it.name == name }
+}
+
+@Serializable
+data class ReleaseAsset(
+  val name: String,
+  @SerialName("browser_download_url") val browserDownloadUrl: String,
+)

--- a/src/nativeMain/kotlin/kolt/selfupdate/SelfUpdateError.kt
+++ b/src/nativeMain/kotlin/kolt/selfupdate/SelfUpdateError.kt
@@ -1,0 +1,17 @@
+package kolt.selfupdate
+
+sealed interface SelfUpdateError {
+  data class Network(val url: String, val detail: String) : SelfUpdateError
+
+  data class Metadata(val detail: String) : SelfUpdateError
+
+  data class Asset(val name: String, val detail: String) : SelfUpdateError
+
+  data class Extract(val detail: String) : SelfUpdateError
+
+  data class Layout(val detectedPath: String, val detail: String) : SelfUpdateError
+
+  data class Platform(val sysname: String, val machine: String) : SelfUpdateError
+
+  data class Home(val detail: String) : SelfUpdateError
+}

--- a/src/nativeMain/kotlin/kolt/selfupdate/SelfUpdater.kt
+++ b/src/nativeMain/kotlin/kolt/selfupdate/SelfUpdater.kt
@@ -14,6 +14,7 @@ import kolt.infra.downloadFile
 import kolt.infra.ensureDirectoryRecursive
 import kolt.infra.extractArchive
 import kolt.infra.fileExists
+import kolt.infra.listSubdirectories
 import kolt.infra.readFileAsString
 import kolt.infra.readSelfExe
 import kolt.infra.removeDirectoryRecursive
@@ -28,10 +29,13 @@ import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.set
 import kotlinx.cinterop.toKString
+import platform.posix.ESRCH
 import platform.posix.PATH_MAX
 import platform.posix.S_IFLNK
 import platform.posix.S_IFMT
+import platform.posix.errno
 import platform.posix.getpid
+import platform.posix.kill
 import platform.posix.lstat
 import platform.posix.readlink
 import platform.posix.rename
@@ -153,6 +157,8 @@ class SelfUpdater(
         return Err(it)
       }
 
+    sweepDeadStaging(layout.shareRoot)
+
     val staging = "${layout.shareRoot}/.staging-${getpid()}"
     removeDirectoryRecursive(staging)
     ensureDirectoryRecursive(staging).getError()?.let {
@@ -215,6 +221,39 @@ class SelfUpdater(
 
     removeDirectoryRecursive(staging)
     return Ok(UpdateOutcome.Switched(from = currentVersion, to = newVersion))
+  }
+
+  // A `.staging-<pid>/` whose owning process is no longer alive is debris
+  // from an interrupted run; with no advisory lock and no dedicated
+  // interrupt-recovery, sweeping these here is the only thing that keeps them
+  // from accumulating. The probe is `kill(pid, 0)`: a live or
+  // permission-shielded (EPERM) pid is left strictly untouched so a
+  // concurrent updater's payload is never destroyed; only an ESRCH (no such
+  // process) pid is reclaimed, best-effort. The own pid is skipped here — the
+  // caller recreates it deterministically right after.
+  @OptIn(ExperimentalForeignApi::class)
+  private fun sweepDeadStaging(shareRoot: String) {
+    val ownPid = getpid()
+    val names =
+      listSubdirectories(shareRoot).getOrElse {
+        return
+      }
+    for (name in names) {
+      val pid =
+        name.removePrefix(".staging-").takeIf { name.startsWith(".staging-") }?.toIntOrNull()
+      if (pid == null || pid == ownPid) continue
+      if (!isProcessDead(pid)) continue
+      removeDirectoryRecursive("$shareRoot/$name")
+    }
+  }
+
+  // ESRCH means no process bears this pid → safe to reclaim. A 0 return (alive)
+  // or EPERM (exists but signalling is denied) both mean "do not touch"; any
+  // other errno is treated conservatively as still-present.
+  @OptIn(ExperimentalForeignApi::class)
+  private fun isProcessDead(pid: Int): Boolean {
+    if (kill(pid, 0) == 0) return false
+    return errno == ESRCH
   }
 
   // Standard `sha256sum` format: `<64-hex>  <filename>`. Take the first

--- a/src/nativeMain/kotlin/kolt/selfupdate/SelfUpdater.kt
+++ b/src/nativeMain/kotlin/kolt/selfupdate/SelfUpdater.kt
@@ -9,8 +9,14 @@ import kolt.config.KOLT_VERSION
 import kolt.infra.SelfExeError
 import kolt.infra.SymlinkError
 import kolt.infra.canWrite as fsCanWrite
+import kolt.infra.computeSha256
+import kolt.infra.downloadFile
+import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.extractArchive
 import kolt.infra.fileExists
+import kolt.infra.readFileAsString
 import kolt.infra.readSelfExe
+import kolt.infra.removeDirectoryRecursive
 import kolt.infra.replaceSymlinkAtomically
 import kolt.resolve.compareVersions
 import kotlinx.cinterop.ByteVar
@@ -25,8 +31,10 @@ import kotlinx.cinterop.toKString
 import platform.posix.PATH_MAX
 import platform.posix.S_IFLNK
 import platform.posix.S_IFMT
+import platform.posix.getpid
 import platform.posix.lstat
 import platform.posix.readlink
+import platform.posix.rename
 import platform.posix.stat
 import platform.posix.uname
 import platform.posix.utsname
@@ -47,6 +55,10 @@ class SelfUpdater(
   private val currentVersion: String = KOLT_VERSION,
   private val readSelfExe: () -> Result<String, SelfExeError> = ::readSelfExe,
   private val canWrite: (String) -> Boolean = ::fsCanWrite,
+  // Asset transport seam: the staged tarball / .sha256 fetch goes through
+  // this so tests can serve the binary archive from disk without a real
+  // HTTPS round-trip. Production wires the same libcurl GET as everything else.
+  private val downloader: Downloader = Downloader(::downloadFile),
   private val replaceSymlink: (String, String) -> Result<Unit, SymlinkError> =
     ::replaceSymlinkAtomically,
   private val uname: () -> Pair<String, String> = ::hostUname,
@@ -78,6 +90,142 @@ class SelfUpdater(
     } else {
       Ok(CheckOutcome.AlreadyLatest(current = currentVersion))
     }
+  }
+
+  // The write-bearing path. The platform gate is first so an unsupported
+  // host is rejected before any network or disk work; the layout +
+  // writability gates run next so a non-installer layout is rejected
+  // without touching GitHub or disk. Only once a strictly newer stable
+  // release is confirmed does the staged download/verify/extract/swap run.
+  fun update(): Result<UpdateOutcome, SelfUpdateError> {
+    ensureLinuxX64().getError()?.let {
+      return Err(it)
+    }
+    val layout =
+      detectLayout().getOrElse {
+        return Err(it)
+      }
+    verifyWritable(layout).getError()?.let {
+      return Err(it)
+    }
+
+    out("fetching release metadata")
+    val release =
+      releases.fetchLatest(releasesUrl).getOrElse {
+        return Err(it)
+      }
+    val latest =
+      releases.validateTag(release.tagName).getOrElse {
+        return Err(it)
+      }
+
+    if (compareVersions(latest, currentVersion) <= 0) {
+      out("Already at latest version ($currentVersion)")
+      return Ok(UpdateOutcome.NoOp(current = currentVersion))
+    }
+
+    return runStaged(layout, release, latest)
+  }
+
+  // Download → verify → extract → place → swap, all inside this process's
+  // own `.staging-<pid>/`. The own-pid staging dir is recreated
+  // unconditionally so an interrupted prior run leaves no stale payload;
+  // sibling version dirs and other pids' staging dirs are never touched
+  // (dead-pid sweep handled separately). The new payload lands at
+  // `<shareRoot>/<new>/` only after the checksum matches and extraction
+  // succeeds; the swap is a single rename so a concurrent or interrupted
+  // run is observed as old-or-new, never partial.
+  @OptIn(ExperimentalForeignApi::class)
+  private fun runStaged(
+    layout: Layout,
+    release: LatestRelease,
+    newVersion: String,
+  ): Result<UpdateOutcome, SelfUpdateError> {
+    val tarballName = "kolt-$newVersion-linux-x64.tar.gz"
+    val sha256Name = "$tarballName.sha256"
+
+    val tarballUrl =
+      releases.assetUrl(release, tarballName).getOrElse {
+        return Err(it)
+      }
+    val sha256Url =
+      releases.assetUrl(release, sha256Name).getOrElse {
+        return Err(it)
+      }
+
+    val staging = "${layout.shareRoot}/.staging-${getpid()}"
+    removeDirectoryRecursive(staging)
+    ensureDirectoryRecursive(staging).getError()?.let {
+      return Err(SelfUpdateError.Extract("could not create staging dir $staging"))
+    }
+
+    out("downloading tarball")
+    val tarballPath = "$staging/$tarballName"
+    val sha256Path = "$staging/$sha256Name"
+    downloader.downloadFile(tarballUrl, tarballPath, null).getError()?.let {
+      return Err(SelfUpdateError.Asset(tarballName, "download failed"))
+    }
+    downloader.downloadFile(sha256Url, sha256Path, null).getError()?.let {
+      return Err(SelfUpdateError.Asset(sha256Name, "download failed"))
+    }
+
+    out("verifying checksum")
+    val computed =
+      computeSha256(tarballPath).getOrElse {
+        return Err(SelfUpdateError.Asset(tarballName, "could not hash downloaded tarball"))
+      }
+    val expected =
+      readSha256(sha256Path)
+        ?: return Err(SelfUpdateError.Asset(sha256Name, "could not read expected checksum"))
+    if (!computed.equals(expected, ignoreCase = true)) {
+      return Err(
+        SelfUpdateError.Asset(tarballName, "checksum mismatch: expected $expected, got $computed")
+      )
+    }
+
+    out("extracting")
+    val extractDir = "$staging/extract"
+    ensureDirectoryRecursive(extractDir).getError()?.let {
+      return Err(SelfUpdateError.Extract("could not create extract dir $extractDir"))
+    }
+    extractArchive(tarballPath, extractDir).getError()?.let {
+      return Err(SelfUpdateError.Extract(it.message))
+    }
+
+    // The release tarball wraps its content in a `kolt-<ver>-linux-x64/`
+    // directory (assemble-dist.sh / install.sh contract); when that wrapper
+    // is absent the extraction root itself is the payload.
+    val wrapper = "$extractDir/kolt-$newVersion-linux-x64"
+    val payloadDir = if (fileExists(wrapper)) wrapper else extractDir
+    val newInstallDir = "${layout.shareRoot}/$newVersion"
+    removeDirectoryRecursive(newInstallDir)
+    if (rename(payloadDir, newInstallDir) != 0) {
+      return Err(SelfUpdateError.Extract("could not place new version at $newInstallDir"))
+    }
+
+    out("switching to new version")
+    replaceSymlink(layout.binSymlink, "$newInstallDir/bin/kolt").getError()?.let {
+      return Err(
+        SelfUpdateError.Layout(
+          detectedPath = layout.binSymlink,
+          detail = "could not swap the bin symlink to the new version",
+        )
+      )
+    }
+
+    removeDirectoryRecursive(staging)
+    return Ok(UpdateOutcome.Switched(from = currentVersion, to = newVersion))
+  }
+
+  // Standard `sha256sum` format: `<64-hex>  <filename>`. Take the first
+  // whitespace-split field of the first non-blank line.
+  private fun readSha256(path: String): String? {
+    val body =
+      readFileAsString(path).getOrElse {
+        return null
+      }
+    val firstLine = body.lineSequence().firstOrNull { it.isNotBlank() } ?: return null
+    return firstLine.trim().split(Regex("\\s+")).firstOrNull()?.takeIf { it.isNotEmpty() }
   }
 
   // Wide assertion: linuxX64 is the only build target today. The `amd64`
@@ -192,4 +340,10 @@ sealed interface CheckOutcome {
   data class UpdateAvailable(override val current: String, val latest: String) : CheckOutcome
 
   data class AlreadyLatest(override val current: String) : CheckOutcome
+}
+
+sealed interface UpdateOutcome {
+  data class Switched(val from: String, val to: String) : UpdateOutcome
+
+  data class NoOp(val current: String) : UpdateOutcome
 }

--- a/src/nativeMain/kotlin/kolt/selfupdate/SelfUpdater.kt
+++ b/src/nativeMain/kotlin/kolt/selfupdate/SelfUpdater.kt
@@ -1,0 +1,156 @@
+package kolt.selfupdate
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import kolt.config.KOLT_VERSION
+import kolt.infra.SelfExeError
+import kolt.infra.SymlinkError
+import kolt.infra.canWrite as fsCanWrite
+import kolt.infra.fileExists
+import kolt.infra.readSelfExe
+import kolt.infra.replaceSymlinkAtomically
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.set
+import kotlinx.cinterop.toKString
+import platform.posix.PATH_MAX
+import platform.posix.S_IFLNK
+import platform.posix.S_IFMT
+import platform.posix.lstat
+import platform.posix.readlink
+import platform.posix.stat
+import platform.posix.uname
+import platform.posix.utsname
+
+// Single source of truth for the (sysname, machine) pair the platform gate
+// checks. Defaults to `uname(2)`; the seam exists so a macOS / linuxArm64
+// port can swap the assertion and tests can drive the non-Linux branch.
+@OptIn(ExperimentalForeignApi::class)
+private fun hostUname(): Pair<String, String> = memScoped {
+  val buf = alloc<utsname>()
+  if (uname(buf.ptr) != 0) return@memScoped "unknown" to "unknown"
+  buf.sysname.toKString() to buf.machine.toKString()
+}
+
+class SelfUpdater(
+  private val releases: GithubReleasesClient,
+  private val home: String,
+  private val currentVersion: String = KOLT_VERSION,
+  private val readSelfExe: () -> Result<String, SelfExeError> = ::readSelfExe,
+  private val canWrite: (String) -> Boolean = ::fsCanWrite,
+  private val replaceSymlink: (String, String) -> Result<Unit, SymlinkError> =
+    ::replaceSymlinkAtomically,
+  private val uname: () -> Pair<String, String> = ::hostUname,
+  private val out: (String) -> Unit = ::println,
+) {
+  // Wide assertion: linuxX64 is the only build target today. The `amd64`
+  // alias is accepted because some kernels report it instead of `x86_64`.
+  internal fun ensureLinuxX64(): Result<Unit, SelfUpdateError> {
+    val (sysname, machine) = uname()
+    val supported = sysname == "Linux" && (machine == "x86_64" || machine == "amd64")
+    return if (supported) {
+      Ok(Unit)
+    } else {
+      Err(SelfUpdateError.Platform(sysname = sysname, machine = machine))
+    }
+  }
+
+  // The installer owns `~/.local/bin/kolt` as a symlink into
+  // `~/.local/share/kolt/<X.Y.Z>/bin/kolt`. Every deviation — regular file,
+  // dangling link, target escaping the share root — collapses to one
+  // `Layout` error; the caller only needs "re-run install.sh", not a taxonomy.
+  internal fun detectLayout(): Result<Layout, SelfUpdateError> {
+    val shareRoot = "$home/.local/share/kolt"
+    val binSymlink = "$home/.local/bin/kolt"
+    val guidance = "install.sh で入れ直してください"
+
+    if (!isSymlink(binSymlink)) {
+      return Err(
+        SelfUpdateError.Layout(
+          detectedPath = binSymlink,
+          detail = "$binSymlink is not an installer-managed symlink; $guidance",
+        )
+      )
+    }
+
+    val target =
+      symlinkTarget(binSymlink)
+        ?: return Err(
+          SelfUpdateError.Layout(
+            detectedPath = binSymlink,
+            detail = "could not read the symlink target of $binSymlink; $guidance",
+          )
+        )
+
+    // The target must be the installer's real binary path and must still
+    // exist — a dangling link points nowhere installable.
+    val prefix = "$shareRoot/"
+    val suffix = "/bin/kolt"
+    val matchesLayout = target.startsWith(prefix) && target.endsWith(suffix) && fileExists(target)
+    if (!matchesLayout) {
+      return Err(
+        SelfUpdateError.Layout(
+          detectedPath = target,
+          detail = "$binSymlink does not point under $shareRoot/<version>/bin/kolt; $guidance",
+        )
+      )
+    }
+
+    val currentInstallDir = target.removeSuffix(suffix)
+    return Ok(
+      Layout(binSymlink = binSymlink, currentInstallDir = currentInstallDir, shareRoot = shareRoot)
+    )
+  }
+
+  // Refuse before any network or extraction work if the user cannot write
+  // the share root (where the new version dir lands) or the bin symlink
+  // (which `rename(2)` swaps).
+  internal fun verifyWritable(layout: Layout): Result<Unit, SelfUpdateError> {
+    if (!canWrite(layout.shareRoot)) {
+      return Err(
+        SelfUpdateError.Layout(
+          detectedPath = layout.shareRoot,
+          detail = "no write permission on ${layout.shareRoot}",
+        )
+      )
+    }
+    if (!canWrite(layout.binSymlink)) {
+      return Err(
+        SelfUpdateError.Layout(
+          detectedPath = layout.binSymlink,
+          detail = "no write permission on ${layout.binSymlink}",
+        )
+      )
+    }
+    return Ok(Unit)
+  }
+
+  @OptIn(ExperimentalForeignApi::class)
+  private fun isSymlink(path: String): Boolean = memScoped {
+    val st = alloc<stat>()
+    if (lstat(path, st.ptr) != 0) return@memScoped false
+    (st.st_mode.toInt() and S_IFMT) == S_IFLNK
+  }
+
+  // readlink does not NUL-terminate; reserve one byte and add it.
+  @OptIn(ExperimentalForeignApi::class)
+  private fun symlinkTarget(path: String): String? = memScoped {
+    val buf = allocArray<ByteVar>(PATH_MAX)
+    val n = readlink(path, buf, (PATH_MAX - 1).convert())
+    if (n < 0) return@memScoped null
+    buf[n] = 0
+    buf.toKString()
+  }
+
+  data class Layout(
+    val binSymlink: String, // ~/.local/bin/kolt
+    val currentInstallDir: String, // ~/.local/share/kolt/<ver>/
+    val shareRoot: String, // ~/.local/share/kolt/
+  )
+}

--- a/src/nativeMain/kotlin/kolt/selfupdate/SelfUpdater.kt
+++ b/src/nativeMain/kotlin/kolt/selfupdate/SelfUpdater.kt
@@ -3,6 +3,8 @@ package kolt.selfupdate
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
 import kolt.config.KOLT_VERSION
 import kolt.infra.SelfExeError
 import kolt.infra.SymlinkError
@@ -10,6 +12,7 @@ import kolt.infra.canWrite as fsCanWrite
 import kolt.infra.fileExists
 import kolt.infra.readSelfExe
 import kolt.infra.replaceSymlinkAtomically
+import kolt.resolve.compareVersions
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.alloc
@@ -48,7 +51,35 @@ class SelfUpdater(
     ::replaceSymlinkAtomically,
   private val uname: () -> Pair<String, String> = ::hostUname,
   private val out: (String) -> Unit = ::println,
+  // Seam mirroring GithubReleasesClient.fetchLatest's own `url` default so
+  // loopback-server tests can drive check() without a real GitHub round-trip.
+  private val releasesUrl: String = GITHUB_RELEASES_LATEST_URL,
 ) {
+  // --check answers "is a newer stable release out?" with zero filesystem
+  // side effects: platform gate first, then fetch + tag-validate + semver
+  // compare. No layout probe, no staging, no symlink — those belong to the
+  // write-bearing update() path only.
+  fun check(): Result<CheckOutcome, SelfUpdateError> {
+    ensureLinuxX64().getError()?.let {
+      return Err(it)
+    }
+
+    val release =
+      releases.fetchLatest(releasesUrl).getOrElse {
+        return Err(it)
+      }
+    val latest =
+      releases.validateTag(release.tagName).getOrElse {
+        return Err(it)
+      }
+
+    return if (compareVersions(latest, currentVersion) > 0) {
+      Ok(CheckOutcome.UpdateAvailable(current = currentVersion, latest = latest))
+    } else {
+      Ok(CheckOutcome.AlreadyLatest(current = currentVersion))
+    }
+  }
+
   // Wide assertion: linuxX64 is the only build target today. The `amd64`
   // alias is accepted because some kernels report it instead of `x86_64`.
   internal fun ensureLinuxX64(): Result<Unit, SelfUpdateError> {
@@ -153,4 +184,12 @@ class SelfUpdater(
     val currentInstallDir: String, // ~/.local/share/kolt/<ver>/
     val shareRoot: String, // ~/.local/share/kolt/
   )
+}
+
+sealed interface CheckOutcome {
+  val current: String
+
+  data class UpdateAvailable(override val current: String, val latest: String) : CheckOutcome
+
+  data class AlreadyLatest(override val current: String) : CheckOutcome
 }

--- a/src/nativeTest/kotlin/kolt/cli/MainTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/MainTest.kt
@@ -19,6 +19,22 @@ class MainTest {
   }
 
   @Test
+  fun selfIsARecognizedSubcommand() {
+    assertTrue(
+      "self" in KNOWN_SUBCOMMANDS_SORTED,
+      "expected 'self' to be a recognized subcommand, not treated as unknown",
+    )
+  }
+
+  @Test
+  fun usageMentionsSelfUpdate() {
+    val lines = usageLines()
+
+    val self = lines.firstOrNull { it.contains("self") && it.contains("update") }
+    assertNotNull(self, "expected a 'kolt self update' line in usage output")
+  }
+
+  @Test
   fun flagsBlockMentionsKoltLocalTomlOverlay() {
     val lines = usageLines()
 

--- a/src/nativeTest/kotlin/kolt/cli/SelfCommandsIntegrationTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/SelfCommandsIntegrationTest.kt
@@ -1,0 +1,138 @@
+package kolt.cli
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.DownloadError
+import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.writeFileAsString
+import kolt.selfupdate.CheckOutcome
+import kolt.selfupdate.Downloader
+import kolt.selfupdate.GithubReleasesClient
+import kolt.selfupdate.SelfUpdateError
+import kolt.selfupdate.SelfUpdater
+import kolt.selfupdate.UpdateOutcome
+import kolt.selfupdate.testfixture.GithubReleasesFixture
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.fail
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.getpid
+import platform.posix.remove
+import platform.posix.symlink
+
+// Per-task review missed the no-op double print because SelfCommandsTest stubs
+// SelfRunner and SelfUpdaterUpdateTest injects its own `out` and never goes
+// through doSelf. This integration test closes that seam: it drives the REAL
+// SelfUpdater through doSelf on the no-op path with SelfUpdater's `out` and
+// doSelf's `out` pointed at the same sink (faithful to production, where both
+// default to ::println / stdout), so a re-print across the
+// SelfUpdater <-> SelfCommands boundary is observable as a count > 1.
+//
+// Transport is an in-memory fake Downloader (NOT libcurl / LoopbackHttpServer):
+// the only seam under test is whether the no-op line crosses the
+// SelfUpdater -> SelfCommands boundary once or twice. Real network + a server
+// worker thread are incidental to that seam and would leak libcurl/pthread
+// state into a later forking test, so they are deliberately excluded.
+@OptIn(ExperimentalForeignApi::class)
+class SelfCommandsIntegrationTest {
+
+  private fun tempPath(): String = "/tmp/kolt_selfcmd_it_${getpid()}.json"
+
+  private fun tempHome(): String = "/tmp/kolt_selfcmd_it_home_${getpid()}"
+
+  private fun installInstallerLayout(home: String, version: String) {
+    ensureDirectoryRecursive("$home/.local/bin").getOrElse { fail("mkdir bin failed") }
+    ensureDirectoryRecursive("$home/.local/share/kolt/$version/bin").getOrElse {
+      fail("mkdir share failed")
+    }
+    val realBin = "$home/.local/share/kolt/$version/bin/kolt"
+    writeFileAsString(realBin, "#!/bin/sh\necho old kolt $version\n").getOrElse {
+      fail("write fake binary failed")
+    }
+    val link = "$home/.local/bin/kolt"
+    if (symlink(realBin, link) != 0) fail("setup symlink failed")
+  }
+
+  // In-memory metadata transport: writes the canned releases/latest JSON to the
+  // destination instead of doing an HTTP GET. tag_name == currentVersion, so
+  // SelfUpdater.update() takes the no-op branch before any asset download is
+  // attempted — this Downloader is therefore only ever asked for the metadata
+  // URL, and never touches the network or a server thread.
+  private fun metadataOnlyDownloader(json: String): Downloader = Downloader { _, destPath, _ ->
+    writeFileAsString(destPath, json).getOrElse {
+      return@Downloader Err(DownloadError.WriteFailed(destPath))
+    }
+    Ok(Unit)
+  }
+
+  // Drive doSelf(["update"]) against a REAL SelfUpdater whose GithubReleases
+  // client uses an in-memory fake Downloader serving canned JSON with
+  // tag_name == the current version, so update() takes the no-op branch.
+  // SelfUpdater's `out` and doSelf's `out` share one sink (production wires
+  // both to stdout). Before the SelfCommands fix the message appears twice
+  // (SelfUpdater emits it, SelfCommands.runUpdate re-emits it for NoOp);
+  // after the fix it appears exactly once.
+  @Test
+  fun noOpUpdateThroughDoSelfPrintsAlreadyLatestExactlyOnce() {
+    remove(tempPath())
+    val home = tempHome()
+    removeDirectoryRecursive(home)
+    val captured = mutableListOf<String>()
+    val errSink = mutableListOf<String>()
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.20.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    try {
+      installInstallerLayout(home, "0.20.0")
+
+      val client =
+        GithubReleasesClient(
+          downloader = metadataOnlyDownloader(json),
+          userAgent = "kolt/test",
+          tempPathFactory = ::tempPath,
+        )
+      val realUpdater =
+        SelfUpdater(
+          releases = client,
+          home = home,
+          currentVersion = "0.20.0",
+          uname = { "Linux" to "x86_64" },
+          out = { captured.add(it) },
+          releasesUrl = "https://example.test/releases/latest",
+        )
+      val realRunner: SelfRunner =
+        object : SelfRunner {
+          override fun check(): Result<CheckOutcome, SelfUpdateError> = realUpdater.check()
+
+          override fun update(): Result<UpdateOutcome, SelfUpdateError> = realUpdater.update()
+        }
+
+      val result =
+        doSelf(
+          listOf("update"),
+          out = { captured.add(it) },
+          err = { errSink.add(it) },
+          runnerFactory = { Ok(realRunner) },
+        )
+
+      assertNull(result.getError(), "a no-op update through doSelf must exit 0")
+      val occurrences = captured.count { it.contains("Already at latest version (0.20.0)") }
+      assertEquals(
+        1,
+        occurrences,
+        "the already-latest line must be printed exactly once across the " +
+          "SelfUpdater/SelfCommands seam, got $occurrences in: $captured",
+      )
+    } finally {
+      remove(tempPath())
+      removeDirectoryRecursive(home)
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/cli/SelfCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/SelfCommandsTest.kt
@@ -112,14 +112,19 @@ class SelfCommandsTest {
     assertEquals("0.20.0 → 0.21.0", out.last(), "final line must be the version arrow")
   }
 
-  // Req 3.2: update no-op prints the already-latest line, exit 0.
+  // Req 3.2 / 3.3: the no-op already-latest line is SelfUpdater.update()'s to
+  // emit (via its own `out`), not SelfCommands'. With a stubbed runner that
+  // returns NoOp without an upstream print, SelfCommands must exit 0 and add
+  // no line of its own — re-printing here is the seam spill that double-prints
+  // the message in production. SelfCommands owns only the Switched arrow (3.3);
+  // the end-to-end single-print is locked by SelfCommandsIntegrationTest.
   @Test
-  fun updateNoOpPrintsAlreadyLatestExitsZero() {
+  fun updateNoOpExitsZeroWithoutReprintingAlreadyLatest() {
     val result = run(listOf("update"), updateResult = Ok(UpdateOutcome.NoOp(current = "0.20.0")))
     assertNull(result.getError(), "a no-op update exits 0")
     assertTrue(
-      out.any { it.contains("Already at latest version (0.20.0)") },
-      "expected the already-latest line, got: $out",
+      out.none { it.contains("Already at latest version") },
+      "SelfCommands must not re-print the already-latest line for NoOp, got: $out",
     )
   }
 

--- a/src/nativeTest/kotlin/kolt/cli/SelfCommandsTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/SelfCommandsTest.kt
@@ -1,0 +1,215 @@
+package kolt.cli
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
+import kolt.selfupdate.CheckOutcome
+import kolt.selfupdate.SelfUpdateError
+import kolt.selfupdate.UpdateOutcome
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SelfCommandsTest {
+
+  private val out = mutableListOf<String>()
+  private val err = mutableListOf<String>()
+
+  // Canned updater: doSelf only ever calls check()/update(), so a tiny stub
+  // that returns a fixed Result is enough to drive every dispatch + formatting
+  // + exit-code branch without touching the network or filesystem.
+  private fun runner(
+    checkResult: Result<CheckOutcome, SelfUpdateError>? = null,
+    updateResult: Result<UpdateOutcome, SelfUpdateError>? = null,
+  ): SelfRunner =
+    object : SelfRunner {
+      override fun check(): Result<CheckOutcome, SelfUpdateError> =
+        checkResult ?: error("check() not expected in this scenario")
+
+      override fun update(): Result<UpdateOutcome, SelfUpdateError> =
+        updateResult ?: error("update() not expected in this scenario")
+    }
+
+  private fun run(
+    args: List<String>,
+    checkResult: Result<CheckOutcome, SelfUpdateError>? = null,
+    updateResult: Result<UpdateOutcome, SelfUpdateError>? = null,
+  ): Result<Unit, Int> =
+    doSelf(
+      args,
+      out = { out.add(it) },
+      err = { err.add(it) },
+      runnerFactory = { Ok(runner(checkResult, updateResult)) },
+    )
+
+  // Req 1.3: bare `kolt self` prints a usage string and exits 0.
+  @Test
+  fun emptyArgsPrintsUsageExitsZero() {
+    val result = run(emptyList())
+    assertNull(result.getError(), "bare `kolt self` must exit 0")
+    assertTrue(out.any { it.contains("kolt self") }, "usage should be printed")
+    assertTrue(out.any { it.contains("update") }, "usage must mention the update subcommand")
+  }
+
+  // Req 1.4: `--help` prints usage and exits 0.
+  @Test
+  fun helpFlagPrintsUsageExitsZero() {
+    val result = run(listOf("--help"))
+    assertNull(result.getError(), "--help must exit 0")
+    assertTrue(out.any { it.contains("kolt self") }, "usage should be printed for --help")
+  }
+
+  // Req 1.4: `-h` is the short alias for help.
+  @Test
+  fun shortHelpFlagPrintsUsageExitsZero() {
+    val result = run(listOf("-h"))
+    assertNull(result.getError(), "-h must exit 0")
+    assertTrue(out.any { it.contains("kolt self") }, "usage should be printed for -h")
+  }
+
+  // Req 2.3: `--check` with a newer release prints the available-update line.
+  @Test
+  fun checkUpdateAvailablePrintsArrowExitsZero() {
+    val result =
+      run(
+        listOf("update", "--check"),
+        checkResult = Ok(CheckOutcome.UpdateAvailable(current = "0.20.0", latest = "0.21.0")),
+      )
+    assertNull(result.getError(), "--check success is always exit 0")
+    assertTrue(
+      out.any { it.contains("Update available: 0.20.0 → 0.21.0") },
+      "expected the update-available line, got: $out",
+    )
+  }
+
+  // Req 2.4 / 2.6: `--check` when already current prints the latest line, exit 0.
+  @Test
+  fun checkAlreadyLatestExitsZero() {
+    val result =
+      run(
+        listOf("update", "--check"),
+        checkResult = Ok(CheckOutcome.AlreadyLatest(current = "0.20.0")),
+      )
+    assertNull(result.getError(), "--check success is always exit 0")
+    assertTrue(
+      out.any { it.contains("Already at latest version (0.20.0)") },
+      "expected the already-latest line, got: $out",
+    )
+  }
+
+  // Req 3.3: a successful update prints `<old> → <new>` as the final line, exit 0.
+  @Test
+  fun updateSwitchedPrintsArrowExitsZero() {
+    val result =
+      run(
+        listOf("update"),
+        updateResult = Ok(UpdateOutcome.Switched(from = "0.20.0", to = "0.21.0")),
+      )
+    assertNull(result.getError(), "a successful update exits 0")
+    assertEquals("0.20.0 → 0.21.0", out.last(), "final line must be the version arrow")
+  }
+
+  // Req 3.2: update no-op prints the already-latest line, exit 0.
+  @Test
+  fun updateNoOpPrintsAlreadyLatestExitsZero() {
+    val result = run(listOf("update"), updateResult = Ok(UpdateOutcome.NoOp(current = "0.20.0")))
+    assertNull(result.getError(), "a no-op update exits 0")
+    assertTrue(
+      out.any { it.contains("Already at latest version (0.20.0)") },
+      "expected the already-latest line, got: $out",
+    )
+  }
+
+  // Req 1.5: an unknown flag on `update` is rejected, the flag is named, exit != 0.
+  @Test
+  fun unknownFlagIsRejectedAndNamed() {
+    val result = run(listOf("update", "--bogus"))
+    val code = result.getError()
+    assertNotNull(code, "an unknown flag must exit non-zero")
+    assertTrue(code != 0, "exit code must be non-zero")
+    assertTrue(
+      err.any { it.contains("--bogus") },
+      "the error must name the offending flag, got: $err",
+    )
+  }
+
+  // Req 1.5: an unknown subcommand under `self` is rejected, exit != 0.
+  @Test
+  fun unknownSubcommandIsRejected() {
+    val result = run(listOf("frobnicate"))
+    val code = result.getError()
+    assertNotNull(code, "an unknown subcommand must exit non-zero")
+    assertTrue(code != 0, "exit code must be non-zero")
+    assertTrue(
+      err.any { it.contains("frobnicate") },
+      "the error must name the unknown subcommand, got: $err",
+    )
+  }
+
+  // Req 7.4: every SelfUpdateError variant maps to a non-empty human-readable
+  // stderr line and a non-zero exit; the messages are variant-distinct so the
+  // user can tell network from asset from layout from platform failures.
+  @Test
+  fun everyErrorVariantPrintsDistinctNonEmptyMessageAndNonZero() {
+    val variants: List<Pair<String, SelfUpdateError>> =
+      listOf(
+        "network" to SelfUpdateError.Network("https://api.github.com", "connection refused"),
+        "metadata" to SelfUpdateError.Metadata("tag 'foo' is not vX.Y.Z"),
+        "asset" to SelfUpdateError.Asset("kolt-0.21.0-linux-x64.tar.gz", "checksum mismatch"),
+        "extract" to SelfUpdateError.Extract("libarchive rejected entry"),
+        "layout" to SelfUpdateError.Layout("/usr/local/bin/kolt", "not an installer symlink"),
+        "platform" to SelfUpdateError.Platform("Darwin", "arm64"),
+        "home" to SelfUpdateError.Home("HOME is not set"),
+      )
+
+    val messages = mutableListOf<String>()
+    for ((label, variant) in variants) {
+      out.clear()
+      err.clear()
+      val result = run(listOf("update"), updateResult = Err(variant))
+      val code = result.getError()
+      assertNotNull(code, "$label must exit non-zero")
+      assertTrue(code != 0, "$label exit code must be non-zero")
+      val printed = err.joinToString("\n")
+      assertTrue(printed.isNotBlank(), "$label must print a non-empty error message")
+      messages.add(printed)
+    }
+
+    // At least Network / Asset / Layout / Platform must be mutually distinct
+    // so the failure category is readable from the message alone (Req 7.*).
+    val network = messages[0]
+    val asset = messages[2]
+    val layout = messages[4]
+    val platform = messages[5]
+    val distinct = setOf(network, asset, layout, platform)
+    assertEquals(
+      4,
+      distinct.size,
+      "network/asset/layout/platform messages must be variant-distinct",
+    )
+    assertTrue(network.contains("api.github.com"), "network message should name the host")
+    assertTrue(
+      asset.contains("kolt-0.21.0-linux-x64.tar.gz"),
+      "asset message should name the asset",
+    )
+    assertTrue(layout.contains("/usr/local/bin/kolt"), "layout message should show the path")
+    assertTrue(platform.contains("Darwin"), "platform message should name the detected platform")
+  }
+
+  // Req 1.5 / 7.4: `--check` failures also surface a non-empty message + non-zero.
+  @Test
+  fun checkErrorPrintsMessageAndNonZero() {
+    val result =
+      run(
+        listOf("update", "--check"),
+        checkResult = Err(SelfUpdateError.Network("https://api.github.com", "timeout")),
+      )
+    val code = result.getError()
+    assertNotNull(code, "a --check network failure must exit non-zero")
+    assertTrue(code != 0, "exit code must be non-zero")
+    assertTrue(err.joinToString("\n").isNotBlank(), "a failure must print a message")
+  }
+}

--- a/src/nativeTest/kotlin/kolt/cli/UnknownCommandSuggestionTest.kt
+++ b/src/nativeTest/kotlin/kolt/cli/UnknownCommandSuggestionTest.kt
@@ -33,6 +33,7 @@ class UnknownCommandSuggestionTest {
         "outdated",
         "remove",
         "run",
+        "self",
         "test",
         "tool",
         "toolchain",

--- a/src/nativeTest/kotlin/kolt/infra/FileSystemTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/FileSystemTest.kt
@@ -78,6 +78,34 @@ class FileSystemTest {
   }
 
   @Test
+  fun canWriteReturnsTrueForWritableDirectory() {
+    val dir = "/tmp/kolt_can_write_writable_${platform.posix.getpid()}"
+    platform.posix.mkdir(dir, 0b111111101u)
+    try {
+      assertTrue(canWrite(dir))
+    } finally {
+      platform.posix.rmdir(dir)
+    }
+  }
+
+  @Test
+  fun canWriteReturnsFalseForReadOnlyDirectory() {
+    val dir = "/tmp/kolt_can_write_readonly_${platform.posix.getpid()}"
+    platform.posix.mkdir(dir, 0b101000000u) // 0500: read+execute, no write
+    try {
+      assertFalse(canWrite(dir))
+    } finally {
+      platform.posix.chmod(dir, 0b111111101u)
+      platform.posix.rmdir(dir)
+    }
+  }
+
+  @Test
+  fun canWriteReturnsFalseForNonExistentPath() {
+    assertFalse(canWrite("/tmp/kolt_can_write_nonexistent_${platform.posix.getpid()}"))
+  }
+
+  @Test
   fun ensureDirectoryCreatesNewDirectory() {
     val path = "/tmp/kolt_test_ensure_dir"
     remove(path)

--- a/src/nativeTest/kotlin/kolt/infra/SymlinkTest.kt
+++ b/src/nativeTest/kotlin/kolt/infra/SymlinkTest.kt
@@ -1,0 +1,140 @@
+package kolt.infra
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.set
+import kotlinx.cinterop.toKString
+import platform.posix.PATH_MAX
+import platform.posix.S_IFLNK
+import platform.posix.S_IFMT
+import platform.posix.S_IFREG
+import platform.posix.getpid
+import platform.posix.lstat
+import platform.posix.readlink
+import platform.posix.stat
+import platform.posix.symlink
+
+@OptIn(ExperimentalForeignApi::class)
+private fun isSymlink(path: String): Boolean = memScoped {
+  val st = alloc<stat>()
+  if (lstat(path, st.ptr) != 0) return@memScoped false
+  (st.st_mode.toInt() and S_IFMT) == S_IFLNK
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun isRegular(path: String): Boolean = memScoped {
+  val st = alloc<stat>()
+  if (lstat(path, st.ptr) != 0) return@memScoped false
+  (st.st_mode.toInt() and S_IFMT) == S_IFREG
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun symlinkTarget(path: String): String = memScoped {
+  val buf = allocArray<ByteVar>(PATH_MAX)
+  val n = readlink(path, buf, (PATH_MAX - 1).convert())
+  if (n < 0) fail("readlink failed for $path")
+  buf[n] = 0
+  buf.toKString()
+}
+
+class SymlinkTest {
+
+  @Test
+  fun createsNewSymlinkWhenLinkPathAbsent() {
+    val dir = "/tmp/kolt_symlink_absent_${getpid()}"
+    ensureDirectoryRecursive(dir).getOrElse { fail("mkdir failed") }
+    try {
+      val link = "$dir/kolt"
+      val target = "$dir/share/v1/bin/kolt"
+
+      replaceSymlinkAtomically(link, target).getOrElse { fail("expected Ok, got $it") }
+
+      assertTrue(isSymlink(link), "expected $link to be a symlink")
+      assertEquals(target, symlinkTarget(link))
+    } finally {
+      removeDirectoryRecursive(dir)
+    }
+  }
+
+  @Test
+  fun atomicallyReplacesExistingSymlink() {
+    val dir = "/tmp/kolt_symlink_replace_${getpid()}"
+    ensureDirectoryRecursive(dir).getOrElse { fail("mkdir failed") }
+    try {
+      val link = "$dir/kolt"
+      val oldTarget = "$dir/share/v1/bin/kolt"
+      val newTarget = "$dir/share/v2/bin/kolt"
+      if (symlink(oldTarget, link) != 0) fail("setup symlink failed")
+      assertEquals(oldTarget, symlinkTarget(link))
+
+      replaceSymlinkAtomically(link, newTarget).getOrElse { fail("expected Ok, got $it") }
+
+      assertTrue(isSymlink(link), "expected $link to still be a symlink after replace")
+      assertEquals(newTarget, symlinkTarget(link))
+    } finally {
+      removeDirectoryRecursive(dir)
+    }
+  }
+
+  @Test
+  fun succeedsWhenNewTargetDoesNotExistOnDisk() {
+    val dir = "/tmp/kolt_symlink_dangling_${getpid()}"
+    ensureDirectoryRecursive(dir).getOrElse { fail("mkdir failed") }
+    try {
+      val link = "$dir/kolt"
+      val missingTarget = "$dir/does/not/exist/kolt"
+      assertTrue(!fileExists(missingTarget), "precondition: target must not exist")
+
+      replaceSymlinkAtomically(link, missingTarget).getOrElse {
+        fail("dangling symlink must be allowed, got $it")
+      }
+
+      assertTrue(isSymlink(link), "expected a (dangling) symlink at $link")
+      assertEquals(missingTarget, symlinkTarget(link))
+    } finally {
+      removeDirectoryRecursive(dir)
+    }
+  }
+
+  @Test
+  fun overwritesRegularFileAtLinkPath() {
+    // Not reached in production (installer layout always has a symlink at the
+    // link path), but rename(2) overwrites a regular file with the new symlink.
+    // Pinned so a future switch to a non-overwriting primitive is caught.
+    val dir = "/tmp/kolt_symlink_regfile_${getpid()}"
+    ensureDirectoryRecursive(dir).getOrElse { fail("mkdir failed") }
+    try {
+      val link = "$dir/kolt"
+      val target = "$dir/share/v1/bin/kolt"
+      writeFileAsString(link, "i am a regular file").getOrElse { fail("setup write failed") }
+      assertTrue(isRegular(link), "precondition: link path is a regular file")
+
+      replaceSymlinkAtomically(link, target).getOrElse { fail("expected Ok, got $it") }
+
+      assertTrue(isSymlink(link), "rename(2) should have replaced the regular file with a symlink")
+      assertEquals(target, symlinkTarget(link))
+    } finally {
+      removeDirectoryRecursive(dir)
+    }
+  }
+
+  @Test
+  fun reportsCreateFailedWhenTmpDirectoryAbsent() {
+    // Parent directory of linkPath does not exist, so symlink(2) for the tmp
+    // path fails — distinct regression from the rename-failure branch.
+    val link = "/tmp/kolt_symlink_nodir_${getpid()}/sub/kolt"
+    val err = replaceSymlinkAtomically(link, "/some/target").getError()
+    assertTrue(err is SymlinkError.CreateFailed, "expected CreateFailed, got $err")
+  }
+}

--- a/src/nativeTest/kotlin/kolt/selfupdate/GithubReleasesClientTest.kt
+++ b/src/nativeTest/kotlin/kolt/selfupdate/GithubReleasesClientTest.kt
@@ -1,0 +1,169 @@
+package kolt.selfupdate
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.downloadFile
+import kolt.infra.testfixture.LoopbackHttpServer
+import kolt.selfupdate.testfixture.GithubReleasesFixture
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.getpid
+import platform.posix.remove
+
+@OptIn(ExperimentalForeignApi::class)
+class GithubReleasesClientTest {
+
+  private fun tempPath(): String = "/tmp/kolt_gh_releases_test_${getpid()}.json"
+
+  private fun client(server: LoopbackHttpServer): GithubReleasesClient =
+    GithubReleasesClient(
+      downloader = ::downloadFile,
+      userAgent = "kolt/9.9.9",
+      tempPathFactory = ::tempPath,
+    )
+
+  private fun startOk(body: String): LoopbackHttpServer =
+    LoopbackHttpServer.start(LoopbackHttpServer.Response.ok(body)).getOrElse {
+      fail("LoopbackHttpServer.start failed: $it")
+    }
+
+  // Req 2.1 / 4.1: a well-formed releases/latest body decodes into the
+  // expected tag and both assets with their browser_download_url.
+  @Test
+  fun fetchLatestDecodesTagAndAssets() {
+    remove(tempPath())
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.21.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    startOk(json).use { server ->
+      try {
+        val release =
+          client(server).fetchLatest("http://127.0.0.1:${server.port}/releases/latest").get()
+            ?: fail("fetchLatest should succeed on valid JSON")
+        assertEquals("v0.21.0", release.tagName)
+        val tarball = release.assetByName("kolt-0.21.0-linux-x64.tar.gz")
+        assertEquals(
+          "https://example.test/dl/kolt-0.21.0-linux-x64.tar.gz",
+          tarball?.browserDownloadUrl,
+          "tarball asset URL must round-trip from the JSON",
+        )
+        assertTrue(
+          release.assets.any { it.name == "kolt-0.21.0-linux-x64.tar.gz.sha256" },
+          "the .sha256 asset must also be present",
+        )
+      } finally {
+        remove(tempPath())
+      }
+    }
+  }
+
+  // Req 7.1: a syntactically broken / tag_name-less body is a metadata
+  // failure, distinguishable from a network failure.
+  @Test
+  fun malformedBodyIsMetadataError() {
+    remove(tempPath())
+    startOk("""{ "not_a_release": true }""").use { server ->
+      try {
+        val error =
+          client(server).fetchLatest("http://127.0.0.1:${server.port}/releases/latest").getError()
+            ?: fail("fetchLatest must fail when tag_name is absent")
+        assertIs<SelfUpdateError.Metadata>(error)
+      } finally {
+        remove(tempPath())
+      }
+    }
+  }
+
+  // Req 2.1: tag validation accepts exactly vX.Y.Z and strips the leading v.
+  @Test
+  fun validateTagAcceptsSemverAndStripsV() {
+    val client =
+      GithubReleasesClient(
+        downloader = ::downloadFile,
+        userAgent = "kolt/9.9.9",
+        tempPathFactory = ::tempPath,
+      )
+    assertEquals("1.2.3", client.validateTag("v1.2.3").get())
+  }
+
+  // Req 2.1 / 7.1: non-vX.Y.Z tags (prerelease suffix, missing v, extra
+  // component) are metadata failures, not silently accepted.
+  @Test
+  fun validateTagRejectsNonSemver() {
+    val client =
+      GithubReleasesClient(
+        downloader = ::downloadFile,
+        userAgent = "kolt/9.9.9",
+        tempPathFactory = ::tempPath,
+      )
+    for (bad in listOf("1.2.3", "v1.2", "v1.2.3.4", "v1.2.3-rc1", "vX.Y.Z", "")) {
+      val error = client.validateTag(bad).getError() ?: fail("'$bad' must be rejected")
+      assertIs<SelfUpdateError.Metadata>(error)
+    }
+  }
+
+  // Req contract: GitHub API returns 403 without a User-Agent, so the
+  // configured "kolt/<ver>" UA must actually reach the wire.
+  @Test
+  fun userAgentHeaderReachesTheWire() {
+    remove(tempPath())
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.21.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    startOk(json).use { server ->
+      try {
+        client(server).fetchLatest("http://127.0.0.1:${server.port}/releases/latest").get()
+          ?: fail("fetchLatest should succeed")
+        val log = server.awaitAccessLog()
+        assertEquals(
+          "kolt/9.9.9",
+          log.headers.entries.firstOrNull { it.key.equals("User-Agent", ignoreCase = true) }?.value,
+          "server access log must capture the exact User-Agent kolt sent",
+        )
+      } finally {
+        remove(tempPath())
+      }
+    }
+  }
+
+  // Req 4.4 / 7.2: an asset that the release does not publish surfaces as
+  // SelfUpdateError.Asset carrying the missing asset's name.
+  @Test
+  fun missingAssetIsAssetErrorCarryingName() {
+    remove(tempPath())
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.21.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    startOk(json).use { server ->
+      try {
+        val release =
+          client(server).fetchLatest("http://127.0.0.1:${server.port}/releases/latest").get()
+            ?: fail("fetchLatest should succeed")
+        assertNull(
+          release.assetByName("kolt-9.9.9-linux-x64.tar.gz"),
+          "an absent asset must not be found by assetByName",
+        )
+        val client = client(server)
+        val error =
+          client.assetUrl(release, "kolt-9.9.9-linux-x64.tar.gz").getError()
+            ?: fail("resolving an absent asset must fail")
+        val asset = assertIs<SelfUpdateError.Asset>(error)
+        assertEquals("kolt-9.9.9-linux-x64.tar.gz", asset.name)
+      } finally {
+        remove(tempPath())
+      }
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/selfupdate/SelfUpdateErrorTest.kt
+++ b/src/nativeTest/kotlin/kolt/selfupdate/SelfUpdateErrorTest.kt
@@ -1,0 +1,64 @@
+package kolt.selfupdate
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class SelfUpdateErrorTest {
+
+  @Test
+  fun networkCarriesUrlAndDetail() {
+    val error: SelfUpdateError =
+      SelfUpdateError.Network("https://api.github.com/x", "connect timed out")
+    val network = assertIs<SelfUpdateError.Network>(error)
+    assertEquals("https://api.github.com/x", network.url)
+    assertEquals("connect timed out", network.detail)
+  }
+
+  @Test
+  fun metadataCarriesDetail() {
+    val error: SelfUpdateError = SelfUpdateError.Metadata("tag_name missing")
+    val metadata = assertIs<SelfUpdateError.Metadata>(error)
+    assertEquals("tag_name missing", metadata.detail)
+  }
+
+  @Test
+  fun assetCarriesNameAndDetail() {
+    val error: SelfUpdateError =
+      SelfUpdateError.Asset("kolt-0.21.0-linux-x64.tar.gz", "not published")
+    val asset = assertIs<SelfUpdateError.Asset>(error)
+    assertEquals("kolt-0.21.0-linux-x64.tar.gz", asset.name)
+    assertEquals("not published", asset.detail)
+  }
+
+  @Test
+  fun extractCarriesDetail() {
+    val error: SelfUpdateError = SelfUpdateError.Extract("libarchive rejected absolute path")
+    val extract = assertIs<SelfUpdateError.Extract>(error)
+    assertEquals("libarchive rejected absolute path", extract.detail)
+  }
+
+  @Test
+  fun layoutCarriesDetectedPathAndDetail() {
+    val error: SelfUpdateError =
+      SelfUpdateError.Layout("/usr/local/bin/kolt", "not an installer-managed symlink")
+    val layout = assertIs<SelfUpdateError.Layout>(error)
+    assertEquals("/usr/local/bin/kolt", layout.detectedPath)
+    assertEquals("not an installer-managed symlink", layout.detail)
+  }
+
+  @Test
+  fun platformCarriesSysnameAndMachine() {
+    val error: SelfUpdateError = SelfUpdateError.Platform("Darwin", "arm64")
+    val platform = assertIs<SelfUpdateError.Platform>(error)
+    assertEquals("Darwin", platform.sysname)
+    assertEquals("arm64", platform.machine)
+  }
+
+  @Test
+  fun homeCarriesDetail() {
+    val error: SelfUpdateError = SelfUpdateError.Home("\$HOME is not set")
+    val home = assertIs<SelfUpdateError.Home>(error)
+    assertEquals("\$HOME is not set", home.detail)
+  }
+}

--- a/src/nativeTest/kotlin/kolt/selfupdate/SelfUpdaterCheckTest.kt
+++ b/src/nativeTest/kotlin/kolt/selfupdate/SelfUpdaterCheckTest.kt
@@ -1,0 +1,227 @@
+package kolt.selfupdate
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.downloadFile
+import kolt.infra.fileExists
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.testfixture.LoopbackHttpServer
+import kolt.selfupdate.testfixture.GithubReleasesFixture
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.fail
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.getpid
+import platform.posix.remove
+
+@OptIn(ExperimentalForeignApi::class)
+class SelfUpdaterCheckTest {
+
+  private fun tempPath(): String = "/tmp/kolt_selfupdate_check_${getpid()}.json"
+
+  private fun tempHome(): String = "/tmp/kolt_selfupdate_check_home_${getpid()}"
+
+  private fun releasesClient(): GithubReleasesClient =
+    GithubReleasesClient(
+      downloader = ::downloadFile,
+      userAgent = "kolt/test",
+      tempPathFactory = ::tempPath,
+    )
+
+  private fun startOk(body: String): LoopbackHttpServer =
+    LoopbackHttpServer.start(LoopbackHttpServer.Response.ok(body)).getOrElse {
+      fail("LoopbackHttpServer.start failed: $it")
+    }
+
+  private fun updater(
+    server: LoopbackHttpServer?,
+    home: String = tempHome(),
+    currentVersion: String = "0.20.0",
+    uname: () -> Pair<String, String> = { "Linux" to "x86_64" },
+    out: (String) -> Unit = {},
+  ): SelfUpdater =
+    SelfUpdater(
+      releases = releasesClient(),
+      home = home,
+      currentVersion = currentVersion,
+      uname = uname,
+      out = out,
+      releasesUrl =
+        if (server != null) "http://127.0.0.1:${server.port}/releases/latest"
+        else GITHUB_RELEASES_LATEST_URL,
+    )
+
+  // Req 2.3: latest > current resolves to UpdateAvailable carrying both the
+  // running version and the newer release version.
+  @Test
+  fun latestNewerThanCurrentIsUpdateAvailable() {
+    remove(tempPath())
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.21.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    startOk(json).use { server ->
+      try {
+        val outcome =
+          updater(server, currentVersion = "0.20.0").check().get()
+            ?: fail("check should succeed when a newer release exists")
+        val available = assertIs<CheckOutcome.UpdateAvailable>(outcome)
+        assertEquals("0.20.0", available.current)
+        assertEquals("0.21.0", available.latest)
+      } finally {
+        remove(tempPath())
+      }
+    }
+  }
+
+  // Req 2.4: latest == current resolves to AlreadyLatest (no update offered
+  // for an exact version match).
+  @Test
+  fun latestEqualToCurrentIsAlreadyLatest() {
+    remove(tempPath())
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.20.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    startOk(json).use { server ->
+      try {
+        val outcome =
+          updater(server, currentVersion = "0.20.0").check().get()
+            ?: fail("check should succeed when current equals latest")
+        val latest = assertIs<CheckOutcome.AlreadyLatest>(outcome)
+        assertEquals("0.20.0", latest.current)
+      } finally {
+        remove(tempPath())
+      }
+    }
+  }
+
+  // Req 2.4: a current build that is newer than the published release (e.g. a
+  // dev build ahead of the latest tag) is still AlreadyLatest, not a downgrade
+  // offer.
+  @Test
+  fun currentNewerThanLatestIsAlreadyLatest() {
+    remove(tempPath())
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.20.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    startOk(json).use { server ->
+      try {
+        val outcome =
+          updater(server, currentVersion = "0.21.0").check().get()
+            ?: fail("check should succeed when current is ahead of latest")
+        val latest = assertIs<CheckOutcome.AlreadyLatest>(outcome)
+        assertEquals("0.21.0", latest.current)
+      } finally {
+        remove(tempPath())
+      }
+    }
+  }
+
+  // Req 6.1 / 6.2: a non-Linux platform short-circuits to Platform BEFORE any
+  // network access — the loopback server must observe zero requests.
+  @Test
+  fun nonLinuxPlatformShortCircuitsBeforeFetch() {
+    remove(tempPath())
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.21.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    startOk(json).use { server ->
+      try {
+        val error =
+          updater(server, uname = { "Darwin" to "arm64" }).check().getError()
+            ?: fail("check must fail on a non-Linux platform")
+        val platform = assertIs<SelfUpdateError.Platform>(error)
+        assertEquals("Darwin", platform.sysname)
+        assertEquals("arm64", platform.machine)
+
+        // The server never completes its single accept() because the platform
+        // gate rejected before any connection: a captured request would carry
+        // a real "GET ... HTTP/1.1" line, the sentinels never do.
+        val log = server.awaitAccessLog(timeoutMillis = 300)
+        assertFalse(
+          log.rawHeaderBlock.contains("HTTP/1.1") || log.headers.isNotEmpty(),
+          "platform gate must reject before fetchLatest touches the network, " +
+            "but the loopback server captured: ${log.rawHeaderBlock}",
+        )
+      } finally {
+        remove(tempPath())
+      }
+    }
+  }
+
+  // Req 5.1: --check has no layout gate. Even with no installer symlink under
+  // HOME at all, check still answers a version comparison result.
+  @Test
+  fun installerLayoutMismatchIsIrrelevantToCheck() {
+    remove(tempPath())
+    val home = tempHome()
+    removeDirectoryRecursive(home)
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.21.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    startOk(json).use { server ->
+      try {
+        val outcome =
+          updater(server, home = home, currentVersion = "0.20.0").check().get()
+            ?: fail("check must not depend on installer layout")
+        assertIs<CheckOutcome.UpdateAvailable>(outcome)
+      } finally {
+        remove(tempPath())
+        removeDirectoryRecursive(home)
+      }
+    }
+  }
+
+  // Req 2.5: --check performs zero install-layout filesystem writes. No
+  // staging dir, no share root, no bin symlink dir is created under HOME, and
+  // the only side effect on `out` is whatever the caller chooses to print.
+  @Test
+  fun checkPerformsNoInstallLayoutWrites() {
+    remove(tempPath())
+    val home = tempHome()
+    removeDirectoryRecursive(home)
+    val captured = mutableListOf<String>()
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.21.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    startOk(json).use { server ->
+      try {
+        updater(server, home = home, currentVersion = "0.20.0", out = { captured.add(it) })
+          .check()
+          .get() ?: fail("check should succeed")
+
+        assertFalse(fileExists("$home/.local/share/kolt"), "check must not create the share root")
+        assertFalse(
+          fileExists("$home/.local/bin/kolt"),
+          "check must not create or touch the bin symlink",
+        )
+        assertFalse(
+          fileExists("$home/.local/share/kolt/.staging-${getpid()}"),
+          "check must not create a staging dir",
+        )
+        assertEquals(
+          emptyList(),
+          captured,
+          "check itself must not print; formatting is the caller's job",
+        )
+      } finally {
+        remove(tempPath())
+        removeDirectoryRecursive(home)
+      }
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/selfupdate/SelfUpdaterLayoutTest.kt
+++ b/src/nativeTest/kotlin/kolt/selfupdate/SelfUpdaterLayoutTest.kt
@@ -1,0 +1,214 @@
+package kolt.selfupdate
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.downloadFile
+import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.removeDirectoryRecursive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.close
+import platform.posix.getpid
+import platform.posix.open
+import platform.posix.symlink
+
+@OptIn(ExperimentalForeignApi::class)
+class SelfUpdaterLayoutTest {
+
+  private fun tempHome(): String = "/tmp/kolt_selfupdate_layout_${getpid()}"
+
+  private fun touch(path: String) {
+    val fd = open(path, 0x40 /* O_CREAT */ or 0x1 /* O_WRONLY */, 0b111100100u /* 0644 */)
+    if (fd < 0) fail("could not create $path")
+    close(fd)
+  }
+
+  private fun releases(): GithubReleasesClient =
+    GithubReleasesClient(
+      downloader = ::downloadFile,
+      userAgent = "kolt/test",
+      tempPathFactory = { "/tmp/kolt_selfupdate_layout_unused_${getpid()}" },
+    )
+
+  private fun updater(
+    home: String,
+    currentVersion: String = "0.20.0",
+    canWrite: (String) -> Boolean = { true },
+    uname: () -> Pair<String, String> = { "Linux" to "x86_64" },
+  ): SelfUpdater =
+    SelfUpdater(
+      releases = releases(),
+      home = home,
+      currentVersion = currentVersion,
+      canWrite = canWrite,
+      uname = uname,
+    )
+
+  // The installer layout: ~/.local/bin/kolt is a symlink whose target lives
+  // under ~/.local/share/kolt/<ver>/bin/kolt. detectLayout must accept it and
+  // hand back the three resolved paths the rest of update() relies on.
+  @Test
+  fun detectLayoutAcceptsInstallerSymlink() {
+    val home = tempHome()
+    removeDirectoryRecursive(home)
+    try {
+      ensureDirectoryRecursive("$home/.local/bin").getOrElse { fail("mkdir bin failed") }
+      ensureDirectoryRecursive("$home/.local/share/kolt/0.20.0/bin").getOrElse {
+        fail("mkdir share failed")
+      }
+      val realBin = "$home/.local/share/kolt/0.20.0/bin/kolt"
+      touch(realBin)
+      val link = "$home/.local/bin/kolt"
+      if (symlink(realBin, link) != 0) fail("setup symlink failed")
+
+      val layout =
+        updater(home).detectLayout().get() ?: fail("detectLayout should accept installer layout")
+
+      assertEquals("$home/.local/bin/kolt", layout.binSymlink)
+      assertEquals("$home/.local/share/kolt/0.20.0", layout.currentInstallDir)
+      assertEquals("$home/.local/share/kolt", layout.shareRoot)
+    } finally {
+      removeDirectoryRecursive(home)
+    }
+  }
+
+  // A plain regular file at ~/.local/bin/kolt is not the installer layout.
+  @Test
+  fun detectLayoutRejectsRegularFile() {
+    val home = tempHome()
+    removeDirectoryRecursive(home)
+    try {
+      ensureDirectoryRecursive("$home/.local/bin").getOrElse { fail("mkdir bin failed") }
+      touch("$home/.local/bin/kolt")
+
+      val err = updater(home).detectLayout().getError() ?: fail("expected Layout error")
+      assertIs<SelfUpdateError.Layout>(err)
+      assertTrue(
+        err.detail.contains("install.sh"),
+        "guidance must mention install.sh, got: ${err.detail}",
+      )
+    } finally {
+      removeDirectoryRecursive(home)
+    }
+  }
+
+  // A dangling symlink (target missing) is not the installer layout.
+  @Test
+  fun detectLayoutRejectsDanglingSymlink() {
+    val home = tempHome()
+    removeDirectoryRecursive(home)
+    try {
+      ensureDirectoryRecursive("$home/.local/bin").getOrElse { fail("mkdir bin failed") }
+      val link = "$home/.local/bin/kolt"
+      if (symlink("$home/.local/share/kolt/0.20.0/bin/kolt", link) != 0) {
+        fail("setup symlink failed")
+      }
+
+      val err = updater(home).detectLayout().getError() ?: fail("expected Layout error")
+      assertIs<SelfUpdateError.Layout>(err)
+    } finally {
+      removeDirectoryRecursive(home)
+    }
+  }
+
+  // A symlink whose target escapes ~/.local/share/kolt/ is not the installer
+  // layout — a root-owned /usr/local/bin/kolt-style target must be refused.
+  @Test
+  fun detectLayoutRejectsTargetOutsideShareRoot() {
+    val home = tempHome()
+    removeDirectoryRecursive(home)
+    try {
+      ensureDirectoryRecursive("$home/.local/bin").getOrElse { fail("mkdir bin failed") }
+      ensureDirectoryRecursive("$home/elsewhere").getOrElse { fail("mkdir elsewhere failed") }
+      val realBin = "$home/elsewhere/kolt"
+      touch(realBin)
+      val link = "$home/.local/bin/kolt"
+      if (symlink(realBin, link) != 0) fail("setup symlink failed")
+
+      val err = updater(home).detectLayout().getError() ?: fail("expected Layout error")
+      assertIs<SelfUpdateError.Layout>(err)
+      assertTrue(
+        err.detectedPath.contains("elsewhere"),
+        "error should carry the detected real path, got: ${err.detectedPath}",
+      )
+    } finally {
+      removeDirectoryRecursive(home)
+    }
+  }
+
+  // verifyWritable refuses when the share root or the bin symlink is not
+  // writable by the current user (canWrite seam returns false).
+  @Test
+  fun verifyWritableRejectsUnwritableShareRoot() {
+    val home = tempHome()
+    val shareRoot = "$home/.local/share/kolt"
+    val layout =
+      SelfUpdater.Layout(
+        binSymlink = "$home/.local/bin/kolt",
+        currentInstallDir = "$shareRoot/0.20.0",
+        shareRoot = shareRoot,
+      )
+
+    val err =
+      updater(home, canWrite = { it != shareRoot }).verifyWritable(layout).getError()
+        ?: fail("expected Layout error for unwritable share root")
+    assertIs<SelfUpdateError.Layout>(err)
+    assertTrue(
+      err.detectedPath.contains(shareRoot),
+      "error should name the unwritable path, got: ${err.detectedPath}",
+    )
+  }
+
+  @Test
+  fun verifyWritableAcceptsWritableLayout() {
+    val home = tempHome()
+    val shareRoot = "$home/.local/share/kolt"
+    val layout =
+      SelfUpdater.Layout(
+        binSymlink = "$home/.local/bin/kolt",
+        currentInstallDir = "$shareRoot/0.20.0",
+        shareRoot = shareRoot,
+      )
+
+    val ok = updater(home, canWrite = { true }).verifyWritable(layout)
+    assertEquals(Unit, ok.get(), "all-writable layout should pass verifyWritable")
+  }
+
+  // Platform gate: non-Linux sysname or non-x86_64 machine is refused with the
+  // detected platform identifiers; Linux/x86_64 passes.
+  @Test
+  fun ensureLinuxX64RejectsNonLinux() {
+    val err =
+      updater(tempHome(), uname = { "Darwin" to "arm64" }).ensureLinuxX64().getError()
+        ?: fail("expected Platform error on non-Linux")
+    assertIs<SelfUpdateError.Platform>(err)
+    assertEquals("Darwin", err.sysname)
+    assertEquals("arm64", err.machine)
+  }
+
+  @Test
+  fun ensureLinuxX64RejectsNonX86() {
+    val err =
+      updater(tempHome(), uname = { "Linux" to "aarch64" }).ensureLinuxX64().getError()
+        ?: fail("expected Platform error on non-x86_64")
+    assertIs<SelfUpdateError.Platform>(err)
+    assertEquals("aarch64", err.machine)
+  }
+
+  @Test
+  fun ensureLinuxX64AcceptsLinuxX86() {
+    val ok = updater(tempHome(), uname = { "Linux" to "x86_64" }).ensureLinuxX64()
+    assertEquals(Unit, ok.get(), "Linux/x86_64 should pass the platform gate")
+  }
+
+  @Test
+  fun ensureLinuxX64AcceptsLinuxAmd64() {
+    val ok = updater(tempHome(), uname = { "Linux" to "amd64" }).ensureLinuxX64()
+    assertEquals(Unit, ok.get(), "Linux/amd64 alias should pass the platform gate")
+  }
+}

--- a/src/nativeTest/kotlin/kolt/selfupdate/SelfUpdaterStagingIsolationTest.kt
+++ b/src/nativeTest/kotlin/kolt/selfupdate/SelfUpdaterStagingIsolationTest.kt
@@ -1,0 +1,154 @@
+package kolt.selfupdate
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.DownloadError
+import kolt.infra.copyFile
+import kolt.infra.downloadFile
+import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.fileExists
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.testfixture.LoopbackHttpServer
+import kolt.infra.writeFileAsString
+import kolt.selfupdate.testfixture.GithubReleasesFixture
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.getpid
+import platform.posix.getppid
+import platform.posix.remove
+import platform.posix.symlink
+
+@OptIn(ExperimentalForeignApi::class)
+class SelfUpdaterStagingIsolationTest {
+
+  private fun tempPath(): String = "/tmp/kolt_selfupdate_staging_${getpid()}.json"
+
+  private fun tempHome(): String = "/tmp/kolt_selfupdate_staging_home_${getpid()}"
+
+  private fun releasesClient(): GithubReleasesClient =
+    GithubReleasesClient(
+      downloader = ::downloadFile,
+      userAgent = "kolt/test",
+      tempPathFactory = ::tempPath,
+    )
+
+  private fun startOk(body: String): LoopbackHttpServer =
+    LoopbackHttpServer.start(LoopbackHttpServer.Response.ok(body)).getOrElse {
+      fail("LoopbackHttpServer.start failed: $it")
+    }
+
+  private fun fixtureDownloader(release: GithubReleasesFixture.Release): Downloader =
+    Downloader { url, destPath, _ ->
+      val src =
+        when {
+          url.endsWith(".sha256") -> release.sha256Path
+          url.endsWith(".tar.gz") -> release.tarballPath
+          else -> return@Downloader Err(DownloadError.NetworkError(url, "unexpected asset url"))
+        }
+      copyFile(src, destPath).getOrElse {
+        return@Downloader Err(DownloadError.WriteFailed(destPath))
+      }
+      Ok(Unit)
+    }
+
+  private fun updater(
+    server: LoopbackHttpServer,
+    home: String,
+    downloader: Downloader,
+  ): SelfUpdater =
+    SelfUpdater(
+      releases = releasesClient(),
+      home = home,
+      currentVersion = "0.20.0",
+      downloader = downloader,
+      uname = { "Linux" to "x86_64" },
+      out = {},
+      releasesUrl = "http://127.0.0.1:${server.port}/releases/latest",
+    )
+
+  private fun installInstallerLayout(home: String, version: String) {
+    ensureDirectoryRecursive("$home/.local/bin").getOrElse { fail("mkdir bin failed") }
+    ensureDirectoryRecursive("$home/.local/share/kolt/$version/bin").getOrElse {
+      fail("mkdir share failed")
+    }
+    val realBin = "$home/.local/share/kolt/$version/bin/kolt"
+    writeFileAsString(realBin, "#!/bin/sh\necho old kolt $version\n").getOrElse {
+      fail("write fake binary failed")
+    }
+    val link = "$home/.local/bin/kolt"
+    if (symlink(realBin, link) != 0) fail("setup symlink failed")
+  }
+
+  private fun seedStagingDir(shareRoot: String, pid: Int) {
+    val dir = "$shareRoot/.staging-$pid"
+    ensureDirectoryRecursive(dir).getOrElse { fail("seed staging dir failed for $dir") }
+    writeFileAsString("$dir/junk", "stale\n").getOrElse { fail("seed junk failed for $dir") }
+  }
+
+  // Req 4.5: a `.staging-<pid>` left by a process that is no longer alive must
+  // be best-effort swept on the next run, while a `.staging-<pid>` belonging to
+  // a live process (here: this test process's own pid is alive, used as a
+  // stand-in for a concurrent updater) must NOT be touched. The own-pid staging
+  // dir is recreated and removed after a successful switch, and the update
+  // still succeeds (Switched) — the sweep does not derail the pipeline.
+  @Test
+  fun deadPidStagingSweptLivePidStagingUntouched() {
+    remove(tempPath())
+    val home = tempHome()
+    removeDirectoryRecursive(home)
+    val shareRoot = "$home/.local/share/kolt"
+    val release = GithubReleasesFixture.buildRelease(version = "0.21.0")
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.21.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    // 99999 is verified-dead in the test/CI environment. The parent (test
+    // runner) pid is unambiguously alive and is distinct from this process's
+    // own pid, so it stands in for a concurrent updater whose staging dir the
+    // sweep must spare without colliding with the own-pid staging the pipeline
+    // recreates-then-removes.
+    val deadPid = 99999
+    val liveOtherPid = getppid()
+    startOk(json).use { server ->
+      try {
+        installInstallerLayout(home, "0.20.0")
+        seedStagingDir(shareRoot, deadPid)
+        seedStagingDir(shareRoot, liveOtherPid)
+
+        val outcome =
+          updater(server, home, fixtureDownloader(release)).update().getOrElse {
+            fail("update should still succeed while sweeping dead-pid staging: $it")
+          }
+
+        assertIs<UpdateOutcome.Switched>(outcome)
+
+        assertFalse(
+          fileExists("$shareRoot/.staging-$deadPid"),
+          "a dead pid's .staging dir must be best-effort swept on update",
+        )
+        assertTrue(
+          fileExists("$shareRoot/.staging-$liveOtherPid"),
+          "a live pid's .staging dir must never be touched by the sweep",
+        )
+        assertFalse(
+          fileExists("$shareRoot/.staging-${getpid()}"),
+          "the own pid staging dir must be removed after a successful update",
+        )
+        assertTrue(
+          fileExists("$shareRoot/0.21.0/bin/kolt"),
+          "the new version payload must still land despite the sweep",
+        )
+      } finally {
+        remove(tempPath())
+        removeDirectoryRecursive(home)
+        removeDirectoryRecursive(release.workDir)
+      }
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/selfupdate/SelfUpdaterUpdateChecksumMismatchTest.kt
+++ b/src/nativeTest/kotlin/kolt/selfupdate/SelfUpdaterUpdateChecksumMismatchTest.kt
@@ -1,0 +1,157 @@
+package kolt.selfupdate
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.DownloadError
+import kolt.infra.copyFile
+import kolt.infra.downloadFile
+import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.fileExists
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.testfixture.LoopbackHttpServer
+import kolt.infra.writeFileAsString
+import kolt.selfupdate.testfixture.GithubReleasesFixture
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.fail
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.set
+import kotlinx.cinterop.toKString
+import platform.posix.PATH_MAX
+import platform.posix.getpid
+import platform.posix.readlink
+import platform.posix.remove
+import platform.posix.symlink
+
+@OptIn(ExperimentalForeignApi::class)
+class SelfUpdaterUpdateChecksumMismatchTest {
+
+  private fun tempPath(): String = "/tmp/kolt_selfupdate_mismatch_${getpid()}.json"
+
+  private fun tempHome(): String = "/tmp/kolt_selfupdate_mismatch_home_${getpid()}"
+
+  private fun releasesClient(): GithubReleasesClient =
+    GithubReleasesClient(
+      downloader = ::downloadFile,
+      userAgent = "kolt/test",
+      tempPathFactory = ::tempPath,
+    )
+
+  private fun startOk(body: String): LoopbackHttpServer =
+    LoopbackHttpServer.start(LoopbackHttpServer.Response.ok(body)).getOrElse {
+      fail("LoopbackHttpServer.start failed: $it")
+    }
+
+  // Same on-disk asset transport as the happy path, but the served `.sha256`
+  // hex is overwritten with a value that does not match the tarball so the
+  // verify step's mismatch branch is exercised end-to-end.
+  private fun mismatchDownloader(
+    release: GithubReleasesFixture.Release,
+    bogusSha256Path: String,
+  ): Downloader = Downloader { url, destPath, _ ->
+    val src =
+      when {
+        url.endsWith(".sha256") -> bogusSha256Path
+        url.endsWith(".tar.gz") -> release.tarballPath
+        else -> return@Downloader Err(DownloadError.NetworkError(url, "unexpected asset url"))
+      }
+    copyFile(src, destPath).getOrElse {
+      return@Downloader Err(DownloadError.WriteFailed(destPath))
+    }
+    Ok(Unit)
+  }
+
+  private fun updater(
+    server: LoopbackHttpServer,
+    home: String,
+    downloader: Downloader,
+  ): SelfUpdater =
+    SelfUpdater(
+      releases = releasesClient(),
+      home = home,
+      currentVersion = "0.20.0",
+      downloader = downloader,
+      uname = { "Linux" to "x86_64" },
+      out = {},
+      releasesUrl = "http://127.0.0.1:${server.port}/releases/latest",
+    )
+
+  private fun installInstallerLayout(home: String, version: String) {
+    ensureDirectoryRecursive("$home/.local/bin").getOrElse { fail("mkdir bin failed") }
+    ensureDirectoryRecursive("$home/.local/share/kolt/$version/bin").getOrElse {
+      fail("mkdir share failed")
+    }
+    val realBin = "$home/.local/share/kolt/$version/bin/kolt"
+    writeFileAsString(realBin, "#!/bin/sh\necho old kolt $version\n").getOrElse {
+      fail("write fake binary failed")
+    }
+    val link = "$home/.local/bin/kolt"
+    if (symlink(realBin, link) != 0) fail("setup symlink failed")
+  }
+
+  private fun readSymlink(path: String): String = memScoped {
+    val buf = allocArray<ByteVar>(PATH_MAX)
+    val n = readlink(path, buf, (PATH_MAX - 1).toULong())
+    if (n < 0) fail("readlink failed for $path")
+    buf[n] = 0
+    buf.toKString()
+  }
+
+  // Req 4.3 / 7.2 / 7.3: when the `.sha256` does not match the tarball the
+  // update aborts with Asset(name) carrying the offending asset, no
+  // `<shareRoot>/<new>/` dir is created, and the bin symlink still points at
+  // the old version (no Switched outcome).
+  @Test
+  fun checksumMismatchAbortsWithoutInstallOrSymlinkChange() {
+    remove(tempPath())
+    val home = tempHome()
+    removeDirectoryRecursive(home)
+    val shareRoot = "$home/.local/share/kolt"
+    val release = GithubReleasesFixture.buildRelease(version = "0.21.0")
+    val tarball = GithubReleasesFixture.tarballName("0.21.0")
+    val bogusSha256Path = "${release.workDir}/bogus.sha256"
+    writeFileAsString(bogusSha256Path, "${"0".repeat(64)}  $tarball\n").getOrElse {
+      fail("could not write bogus sha256")
+    }
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.21.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    startOk(json).use { server ->
+      try {
+        installInstallerLayout(home, "0.20.0")
+        val originalTarget = readSymlink("$home/.local/bin/kolt")
+
+        val result = updater(server, home, mismatchDownloader(release, bogusSha256Path)).update()
+
+        val error =
+          result.getError()
+            ?: fail("update must fail on checksum mismatch, got Ok: ${result.getOrElse { null }}")
+        val asset = assertIs<SelfUpdateError.Asset>(error)
+        assertEquals(tarball, asset.name, "the Asset error must name the offending tarball")
+
+        assertFalse(
+          fileExists("$shareRoot/0.21.0"),
+          "no new version dir may be created when the checksum mismatches (Req 4.3)",
+        )
+        assertEquals(
+          originalTarget,
+          readSymlink("$home/.local/bin/kolt"),
+          "the bin symlink must still point at the old version on extract/verify failure (Req 7.3)",
+        )
+      } finally {
+        remove(tempPath())
+        removeDirectoryRecursive(home)
+        removeDirectoryRecursive(release.workDir)
+      }
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/selfupdate/SelfUpdaterUpdateTest.kt
+++ b/src/nativeTest/kotlin/kolt/selfupdate/SelfUpdaterUpdateTest.kt
@@ -1,0 +1,227 @@
+package kolt.selfupdate
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getOrElse
+import kolt.infra.DownloadError
+import kolt.infra.copyFile
+import kolt.infra.downloadFile
+import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.fileExists
+import kolt.infra.removeDirectoryRecursive
+import kolt.infra.testfixture.LoopbackHttpServer
+import kolt.selfupdate.testfixture.GithubReleasesFixture
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.set
+import kotlinx.cinterop.toKString
+import platform.posix.PATH_MAX
+import platform.posix.getpid
+import platform.posix.readlink
+import platform.posix.remove
+import platform.posix.symlink
+
+@OptIn(ExperimentalForeignApi::class)
+class SelfUpdaterUpdateTest {
+
+  private fun tempPath(): String = "/tmp/kolt_selfupdate_update_${getpid()}.json"
+
+  private fun tempHome(): String = "/tmp/kolt_selfupdate_update_home_${getpid()}"
+
+  private fun releasesClient(): GithubReleasesClient =
+    GithubReleasesClient(
+      downloader = ::downloadFile,
+      userAgent = "kolt/test",
+      tempPathFactory = ::tempPath,
+    )
+
+  private fun startOk(body: String): LoopbackHttpServer =
+    LoopbackHttpServer.start(LoopbackHttpServer.Response.ok(body)).getOrElse {
+      fail("LoopbackHttpServer.start failed: $it")
+    }
+
+  // The binary tarball / .sha256 cannot round-trip through the loopback
+  // server's String body (UTF-8 re-encoding mangles gzip bytes), so the
+  // asset transport is faked by copying the fixture's on-disk artifacts.
+  // The real network transport for assets is out of this spec's boundary;
+  // computeSha256 / extractArchive / replaceSymlinkAtomically all run for real.
+  private fun fixtureDownloader(release: GithubReleasesFixture.Release): Downloader =
+    Downloader { url, destPath, _ ->
+      val src =
+        when {
+          url.endsWith(".sha256") -> release.sha256Path
+          url.endsWith(".tar.gz") -> release.tarballPath
+          else -> return@Downloader Err(DownloadError.NetworkError(url, "unexpected asset url"))
+        }
+      copyFile(src, destPath).getOrElse {
+        return@Downloader Err(DownloadError.WriteFailed(destPath))
+      }
+      Ok(Unit)
+    }
+
+  private fun updater(
+    server: LoopbackHttpServer,
+    home: String,
+    downloader: Downloader,
+    currentVersion: String = "0.20.0",
+    out: (String) -> Unit = {},
+  ): SelfUpdater =
+    SelfUpdater(
+      releases = releasesClient(),
+      home = home,
+      currentVersion = currentVersion,
+      downloader = downloader,
+      uname = { "Linux" to "x86_64" },
+      out = out,
+      releasesUrl = "http://127.0.0.1:${server.port}/releases/latest",
+    )
+
+  private fun installInstallerLayout(home: String, version: String) {
+    ensureDirectoryRecursive("$home/.local/bin").getOrElse { fail("mkdir bin failed") }
+    ensureDirectoryRecursive("$home/.local/share/kolt/$version/bin").getOrElse {
+      fail("mkdir share failed")
+    }
+    val realBin = "$home/.local/share/kolt/$version/bin/kolt"
+    kolt.infra.writeFileAsString(realBin, "#!/bin/sh\necho old kolt $version\n").getOrElse {
+      fail("write fake binary failed")
+    }
+    val link = "$home/.local/bin/kolt"
+    if (symlink(realBin, link) != 0) fail("setup symlink failed")
+  }
+
+  private fun readSymlink(path: String): String = memScoped {
+    val buf = allocArray<ByteVar>(PATH_MAX)
+    val n = readlink(path, buf, (PATH_MAX - 1).toULong())
+    if (n < 0) fail("readlink failed for $path")
+    buf[n] = 0
+    buf.toKString()
+  }
+
+  // Req 3.1 / 3.3 / 3.4 / 3.5 / 3.6 / 4.1 / 4.2 / 4.5: a newer release runs the
+  // full pipeline. The 5 progress lines appear in order, the new version dir is
+  // placed, the bin symlink is retargeted via a single rename, the old version
+  // dir survives, the own pid staging dir is gone after success, and the
+  // outcome carries from/to.
+  @Test
+  fun newerReleaseRunsFullUpdatePipeline() {
+    remove(tempPath())
+    val home = tempHome()
+    removeDirectoryRecursive(home)
+    val release = GithubReleasesFixture.buildRelease(version = "0.21.0")
+    val captured = mutableListOf<String>()
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.21.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    startOk(json).use { server ->
+      try {
+        installInstallerLayout(home, "0.20.0")
+
+        val outcome =
+          updater(server, home, fixtureDownloader(release), out = { captured.add(it) })
+            .update()
+            .getOrElse { fail("update should succeed on a newer release: $it") }
+
+        val switched = assertIs<UpdateOutcome.Switched>(outcome)
+        assertEquals("0.20.0", switched.from)
+        assertEquals("0.21.0", switched.to)
+
+        assertEquals(
+          listOf(
+            "fetching release metadata",
+            "downloading tarball",
+            "verifying checksum",
+            "extracting",
+            "switching to new version",
+          ),
+          captured,
+          "the 5 progress stages must be emitted once each, in order",
+        )
+
+        assertTrue(
+          fileExists("$home/.local/share/kolt/0.21.0/bin/kolt"),
+          "the new version payload must land at <shareRoot>/0.21.0/bin/kolt",
+        )
+        assertTrue(
+          fileExists("$home/.local/share/kolt/0.20.0/bin/kolt"),
+          "the old version dir must survive (Req 3.5)",
+        )
+        assertEquals(
+          "$home/.local/share/kolt/0.21.0/bin/kolt",
+          readSymlink("$home/.local/bin/kolt"),
+          "the bin symlink must now point at the new version target",
+        )
+        assertFalse(
+          fileExists("$home/.local/share/kolt/.staging-${getpid()}"),
+          "the own pid staging dir must be removed after a successful update",
+        )
+      } finally {
+        remove(tempPath())
+        removeDirectoryRecursive(home)
+        removeDirectoryRecursive(release.workDir)
+      }
+    }
+  }
+
+  // Req 3.2: latest == current is a no-op. The outcome is NoOp, the bin
+  // symlink and version dirs are untouched, and no staging dir is created.
+  @Test
+  fun latestEqualToCurrentIsNoOpWithNoFilesystemMutation() {
+    remove(tempPath())
+    val home = tempHome()
+    removeDirectoryRecursive(home)
+    val release = GithubReleasesFixture.buildRelease(version = "0.20.0")
+    val captured = mutableListOf<String>()
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.20.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    startOk(json).use { server ->
+      try {
+        installInstallerLayout(home, "0.20.0")
+        val originalTarget = readSymlink("$home/.local/bin/kolt")
+
+        val outcome =
+          updater(server, home, fixtureDownloader(release), out = { captured.add(it) })
+            .update()
+            .getOrElse { fail("update should succeed (no-op) when already latest: $it") }
+
+        val noOp = assertIs<UpdateOutcome.NoOp>(outcome)
+        assertEquals("0.20.0", noOp.current)
+
+        assertFalse(
+          fileExists("$home/.local/share/kolt/.staging-${getpid()}"),
+          "a no-op update must not create a staging dir",
+        )
+        assertEquals(
+          originalTarget,
+          readSymlink("$home/.local/bin/kolt"),
+          "a no-op update must not retarget the bin symlink",
+        )
+        assertFalse(
+          fileExists("$home/.local/share/kolt/0.20.0/bin/kolt".replace("0.20.0", "9.9.9")),
+          "a no-op update must not create any other version dir",
+        )
+        assertTrue(
+          captured.contains("Already at latest version (0.20.0)"),
+          "a no-op must announce the already-latest state, got: $captured",
+        )
+      } finally {
+        remove(tempPath())
+        removeDirectoryRecursive(home)
+        removeDirectoryRecursive(release.workDir)
+      }
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/selfupdate/testfixture/GithubReleasesFixture.kt
+++ b/src/nativeTest/kotlin/kolt/selfupdate/testfixture/GithubReleasesFixture.kt
@@ -1,0 +1,131 @@
+package kolt.selfupdate.testfixture
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.infra.computeSha256
+import kolt.infra.ensureDirectoryRecursive
+import kolt.infra.executeCommand
+import kolt.infra.writeFileAsString
+import kotlin.test.fail
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.chmod
+import platform.posix.mkdtemp
+
+// Test fixture for self-update tests: produces the two artifacts the real
+// GitHub release path consumes — a canned `releases/latest` JSON body and an
+// on-disk `kolt-<ver>-linux-x64.tar.gz` plus its adjacent standard-format
+// `.sha256`. The tarball is built by shelling out to `tar` (test-only,
+// mirroring scripts/regen-archive-fixtures.sh) so no libarchive write cinterop
+// surface is introduced. The produced archive is extractable by the existing
+// `extractArchive` and the `.sha256` matches `computeSha256` of the tarball.
+@OptIn(ExperimentalForeignApi::class)
+object GithubReleasesFixture {
+
+  data class Release(
+    val version: String,
+    val workDir: String,
+    val tarballName: String,
+    val tarballPath: String,
+    val sha256Path: String,
+    val sha256Hex: String,
+  )
+
+  // Canned `releases/latest` JSON parametrized by version and asset base URL.
+  // Carries `tag_name` plus the tarball and `.sha256` assets, each with `name`
+  // and `browser_download_url`, so it can be served via LoopbackHttpServer.
+  fun releasesLatestJson(version: String, assetBaseUrl: String): String {
+    val base = assetBaseUrl.trimEnd('/')
+    val tarball = tarballName(version)
+    val sha = "$tarball.sha256"
+    return """
+      {
+        "tag_name": "v$version",
+        "name": "v$version",
+        "draft": false,
+        "prerelease": false,
+        "assets": [
+          {
+            "name": "$tarball",
+            "browser_download_url": "$base/$tarball"
+          },
+          {
+            "name": "$sha",
+            "browser_download_url": "$base/$sha"
+          }
+        ]
+      }
+    """
+      .trimIndent()
+  }
+
+  // Builds `kolt-<ver>-linux-x64.tar.gz` (containing at least `bin/kolt`) and
+  // the adjacent `<tarball>.sha256` in standard `sha256sum` format
+  // (`<64-hex>  <filename>\n`) under a fresh temp directory. Caller owns
+  // cleanup of `Release.workDir`.
+  fun buildRelease(version: String): Release {
+    val workDir = createTempDir("kolt_release_fixture_")
+    val payloadDir = "$workDir/payload"
+    if (ensureDirectoryRecursive("$payloadDir/bin").getError() != null) {
+      fail("could not create payload dir under $payloadDir")
+    }
+    val fakeBinary = "$payloadDir/bin/kolt"
+    if (writeFileAsString(fakeBinary, "#!/bin/sh\necho fake kolt $version\n").getError() != null) {
+      fail("could not write fake binary at $fakeBinary")
+    }
+    chmod(fakeBinary, FAKE_BINARY_MODE)
+
+    val tarball = tarballName(version)
+    val tarballPath = "$workDir/$tarball"
+    val tarResult =
+      executeCommand(
+        listOf(
+          "tar",
+          "-C",
+          payloadDir,
+          "--sort=name",
+          "--mtime=@0",
+          "--owner=0",
+          "--group=0",
+          "--numeric-owner",
+          "--format=ustar",
+          "-czf",
+          tarballPath,
+          "bin",
+        )
+      )
+    if (tarResult.getError() != null) {
+      fail("tar failed building $tarballPath: ${tarResult.getError()}")
+    }
+
+    val hex = computeSha256(tarballPath).get() ?: fail("computeSha256 failed for $tarballPath")
+    val sha256Path = "$tarballPath.sha256"
+    if (writeFileAsString(sha256Path, "$hex  $tarball\n").getError() != null) {
+      fail("could not write $sha256Path")
+    }
+
+    return Release(
+      version = version,
+      workDir = workDir,
+      tarballName = tarball,
+      tarballPath = tarballPath,
+      sha256Path = sha256Path,
+      sha256Hex = hex,
+    )
+  }
+
+  fun tarballName(version: String): String = "kolt-$version-linux-x64.tar.gz"
+
+  private const val FAKE_BINARY_MODE: UInt = 0b111101101u // 0755
+
+  private fun createTempDir(prefix: String): String {
+    val template = "/tmp/${prefix}XXXXXX"
+    val buf = template.encodeToByteArray().copyOf(template.length + 1)
+    buf.usePinned { pinned ->
+      val result = mkdtemp(pinned.addressOf(0)) ?: error("mkdtemp failed")
+      return result.toKString()
+    }
+  }
+}

--- a/src/nativeTest/kotlin/kolt/selfupdate/testfixture/GithubReleasesFixtureTest.kt
+++ b/src/nativeTest/kotlin/kolt/selfupdate/testfixture/GithubReleasesFixtureTest.kt
@@ -1,0 +1,94 @@
+package kolt.selfupdate.testfixture
+
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import kolt.infra.computeSha256
+import kolt.infra.extractArchive
+import kolt.infra.isRegularFile
+import kolt.infra.removeDirectoryRecursive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+class GithubReleasesFixtureTest {
+
+  @Test
+  fun producedTarballIsExtractableByExtractArchive() {
+    val release = GithubReleasesFixture.buildRelease(version = "0.21.0")
+    val destDir = "${release.workDir}/extracted"
+    kolt.infra.ensureDirectoryRecursive(destDir)
+    try {
+      val result = extractArchive(release.tarballPath, destDir)
+      if (result.getError() != null) fail("extractArchive failed: ${result.getError()}")
+      assertTrue(
+        isRegularFile("$destDir/bin/kolt"),
+        "bin/kolt should exist as a regular file after extraction",
+      )
+    } finally {
+      removeDirectoryRecursive(release.workDir)
+    }
+  }
+
+  @Test
+  fun sha256FileMatchesComputeSha256OfTarball() {
+    val release = GithubReleasesFixture.buildRelease(version = "0.21.0")
+    try {
+      val computed =
+        computeSha256(release.tarballPath).get()
+          ?: fail("computeSha256 failed for ${release.tarballPath}")
+      assertEquals(
+        computed,
+        release.sha256Hex,
+        "the .sha256 file must carry computeSha256 of the tarball",
+      )
+      assertEquals(
+        "$computed  ${release.tarballName}\n",
+        kolt.infra.readFileAsString(release.sha256Path).get(),
+        ".sha256 file must be in standard sha256sum format",
+      )
+    } finally {
+      removeDirectoryRecursive(release.workDir)
+    }
+  }
+
+  @Test
+  fun cannedJsonParsesWithExpectedTagAndAssets() {
+    val json =
+      GithubReleasesFixture.releasesLatestJson(
+        version = "0.21.0",
+        assetBaseUrl = "https://example.test/dl",
+      )
+    val decoded = Json { ignoreUnknownKeys = true }.decodeFromString<ProbeRelease>(json)
+    assertEquals("v0.21.0", decoded.tagName)
+    val names = decoded.assets.map { it.name }.toSet()
+    assertTrue(
+      "kolt-0.21.0-linux-x64.tar.gz" in names,
+      "canned JSON must list the tarball asset, got $names",
+    )
+    assertTrue(
+      "kolt-0.21.0-linux-x64.tar.gz.sha256" in names,
+      "canned JSON must list the .sha256 asset, got $names",
+    )
+    val tarballAsset = decoded.assets.first { it.name == "kolt-0.21.0-linux-x64.tar.gz" }
+    assertEquals(
+      "https://example.test/dl/kolt-0.21.0-linux-x64.tar.gz",
+      tarballAsset.browserDownloadUrl,
+    )
+  }
+
+  @Serializable
+  private data class ProbeRelease(
+    @SerialName("tag_name") val tagName: String,
+    val assets: List<ProbeAsset>,
+  )
+
+  @Serializable
+  private data class ProbeAsset(
+    val name: String,
+    @SerialName("browser_download_url") val browserDownloadUrl: String,
+  )
+}


### PR DESCRIPTION
Closes #27.

`kolt self update` と `kolt self update --check` を追加。新規 package `kolt.selfupdate` (`SelfUpdater` / `SelfUpdateError` / `GithubReleasesClient`)、`kolt.cli.SelfCommands`、infra に `Symlink.replaceSymlinkAtomically` と `FileSystem.canWrite` の 2 プリミティブ、`Main.kt` 配線。

## レビューで見てほしい判断ポイント

**スコープ圧縮の判断 (最重要)**: 当初 design は M (12 新規ファイル、並行 advisory lock、SIGINT 中断回復、layout 4 分類) だったが、priority: nice に対する投資量として過大と判断し、**install.sh が POSIX sh で持つのと同等のスコープ**に圧縮した。並行排他 lock と中断回復専用機構は意図的に scope 外 (install.sh も持たない)。圧縮の rationale と切った/残した線引きは `research.md` 末尾「スコープ圧縮の判断」に記録。この線引き自体が妥当かが第一の観点。

**design 記述の不正確を実コード idiom に寄せた箇所**: design が `Downloader` を型として書いていたが kolt の実体は top-level `downloadFile` 関数 → `GithubReleasesClient` 内に `fun interface Downloader` seam を導入 (既存 `ResolverDeps`/`PluginFetcherDeps` と同 idiom)。同様に design の "ExitCode enum" は実在せず、kolt の `Result<Unit, Int>` + `EXIT_*` 定数 idiom に合わせた。production 配線は不変、test 注入用の defaulted seam のみ。

**feature-level validation で見つけた seam defect**: per-task review を全タスク通過後、`/kiro-validate-impl` が cross-task defect を検出した — `kolt self update` が既に最新のとき "Already at latest version" が二重 print。`SelfUpdater.update()` と `SelfCommands.runUpdate` が両方 print しており、SelfCommands 側の unit test は `SelfRunner` を stub、SelfUpdater 側の unit test は `doSelf` をバイパスしていたため、両 test が seam の片側だけを見て見逃していた。design の Requirements Traceability (3.2 = SelfUpdater が no-op message 所有、3.3 = SelfCommands は成功 arrow のみ) に従い SelfCommands の NoOp 再 print を除去。実 `SelfUpdater` を実 `doSelf` 経由で通す integration test を 1 本追加して seam を lock した (`SelfCommandsIntegrationTest`)。`bf48df2` がこの修正。

**nativeTest の落とし穴**: 上記 seam test を最初 実 libcurl + `LoopbackHttpServer` (pthread) で書いたところ、full `kolt test` で後続の `fork()` する test (`PromptTest`) が futex deadlock し suite が ~2h 完了しなくなった。in-memory fake `Downloader` を注入する形に書き換えて回避 (seam の本質は network 透過でなく SelfUpdater↔SelfCommands の出力所有なので、実コンポーネントは通しつつ transport だけ fake)。

## 動作の前提

- installer spec のレイアウト (`~/.local/bin/kolt` が `~/.local/share/kolt/<ver>/bin/kolt` を指す symlink) でない構成は refuse し「install.sh で入れ直してください」と案内する。`--check` は layout gate を通さず version 比較だけ答える (update 経路のみ layout 検証)。
- atomic 性は `rename(2)` 1 回のみ。並行 `kolt self update` の排他はしない (best-effort、staging は pid 別ディレクトリ + 死 pid の best-effort 掃除で相互破壊と残骸累積を防ぐ)。
- linuxX64 以外は最初の gate で明示拒否。macOS port 時に `expect-actual` で差し替える seam として `ensureLinuxX64` を置いた。

full `kolt test` 2145 green、`scripts/` / `install.sh` / `.github/` は不変 (self-host 非影響)。
